### PR TITLE
go packager: prefix fix

### DIFF
--- a/integration/nwo/fabric/packager/golang/platform.go
+++ b/integration/nwo/fabric/packager/golang/platform.go
@@ -348,7 +348,7 @@ func moduleInfo(path string) (*ModuleInfo, error) {
 	}
 
 	moduleRootDir := filepath.Dir(string(moduleRoot))
-	index := strings.Index(moduleRootDir, "github.com")
+	index := strings.Index(moduleRootDir, "github.")
 	path = moduleRootDir[:index] + path
 
 	// directory doesn't exist so unlikely to be a module


### PR DESCRIPTION
use "github." as prefix to identity the modeule root dir rather "github.com".

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>