### PR TITLE
vault rws comparison fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.16.0
 	golang.org/x/mod v0.5.1 // indirect
-	golang.org/x/sys v0.0.0-20211023085530-d6a326fbbf70 // indirect
+	golang.org/x/sys v0.0.0-20211102192858-4dd72447c267 // indirect
 	golang.org/x/tools v0.1.7 // indirect
 	google.golang.org/genproto v0.0.0-20210201184850-646a494a81ea // indirect
 	google.golang.org/grpc v1.39.1

--- a/go.sum
+++ b/go.sum
@@ -1485,6 +1485,8 @@ golang.org/x/sys v0.0.0-20211020174200-9d6173849985 h1:LOlKVhfDyahgmqa97awczplwk
 golang.org/x/sys v0.0.0-20211020174200-9d6173849985/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211023085530-d6a326fbbf70 h1:SeSEfdIxyvwGJliREIJhRPPXvW6sDlLT+UQ3B0hD0NA=
 golang.org/x/sys v0.0.0-20211023085530-d6a326fbbf70/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211102192858-4dd72447c267 h1:7zYaz3tjChtpayGDzu6H0hDAUM5zIGA2XW7kRNgQ0jc=
+golang.org/x/sys v0.0.0-20211102192858-4dd72447c267/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/platform/fabric/core/generic/committer.go
+++ b/platform/fabric/core/generic/committer.go
@@ -224,14 +224,19 @@ func (c *channel) commitLocal(txid string, block uint64, indexInBlock int, envel
 
 	// Match rwsets if envelope is not empty
 	if len(envelope) != 0 {
+		logger.Debugf("[%s] Matching rwsets", txid)
+
 		pt, err := newProcessedTransactionFromEnvelopeRaw(envelope)
 		if err != nil {
+			logger.Error("[%s] failed to unmarshal envelope [%s]", txid, err)
 			return err
 		}
 
 		if err := c.vault.Match(txid, pt.Results()); err != nil {
+			logger.Error("[%s] rwsets do not match [%s]", txid, err)
 			return err
 		}
+
 	}
 
 	// Post-Processes

--- a/platform/fabric/core/generic/rwset/processor.go
+++ b/platform/fabric/core/generic/rwset/processor.go
@@ -100,7 +100,7 @@ func (r *processorManager) ProcessByID(channel, txid string) error {
 					return err
 				}
 			}
-			logger.Debugf("no processors found for namespace [%s,%s,%d]", channel, txid, ns)
+			logger.Debugf("no processors found for namespace [%s,%s,%s]", channel, txid, ns)
 		}
 	}
 	return nil

--- a/platform/fabric/core/generic/vault/interceptor.go
+++ b/platform/fabric/core/generic/vault/interceptor.go
@@ -393,21 +393,30 @@ func (i *Interceptor) Bytes() ([]byte, error) {
 }
 
 func (i *Interceptor) Equals(other interface{}, nss ...string) error {
-	o, ok := other.(*Interceptor)
-	if !ok {
+	switch o := other.(type) {
+	case *Interceptor:
+		if err := i.rws.reads.equals(o.rws.reads, nss...); err != nil {
+			return errors.Wrap(err, "reads do not match")
+		}
+		if err := i.rws.writes.equals(o.rws.writes, nss...); err != nil {
+			return errors.Wrap(err, "writes do not match")
+		}
+		if err := i.rws.metawrites.equals(o.rws.metawrites, nss...); err != nil {
+			return errors.Wrap(err, "meta writes do not match")
+		}
+	case *Inspector:
+		if err := i.rws.reads.equals(o.rws.reads, nss...); err != nil {
+			return errors.Wrap(err, "reads do not match")
+		}
+		if err := i.rws.writes.equals(o.rws.writes, nss...); err != nil {
+			return errors.Wrap(err, "writes do not match")
+		}
+		if err := i.rws.metawrites.equals(o.rws.metawrites, nss...); err != nil {
+			return errors.Wrap(err, "meta writes do not match")
+		}
+	default:
 		return errors.Errorf("cannot compare to the passed value [%v]", other)
 	}
-
-	if err := i.rws.reads.equals(o.rws.reads, nss...); err != nil {
-		return errors.Wrap(err, "reads do not match")
-	}
-	if err := i.rws.writes.equals(o.rws.writes, nss...); err != nil {
-		return errors.Wrap(err, "writes do not match")
-	}
-	if err := i.rws.metawrites.equals(o.rws.metawrites, nss...); err != nil {
-		return errors.Wrap(err, "meta writes do not match")
-	}
-
 	return nil
 }
 

--- a/platform/fabric/core/generic/vault/rwset.go
+++ b/platform/fabric/core/generic/vault/rwset.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 
 	"github.com/golang/protobuf/proto"
-	cmp "github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
 	"github.com/pkg/errors"

--- a/platform/fabric/core/generic/vault/vault.go
+++ b/platform/fabric/core/generic/vault/vault.go
@@ -287,7 +287,15 @@ func (db *Vault) Match(txid string, rwsRaw []byte) error {
 	}
 
 	if !bytes.Equal(rwsRaw, rwsRaw2) {
-		return errors.Errorf("rwsets do not match")
+		target, err := db.InspectRWSet(rwsRaw)
+		if err != nil {
+			return errors.Wrapf(err, "rwsets do not match")
+		}
+		if err2 := i.Equals(target); err2 != nil {
+			return errors.Wrapf(err2, "rwsets do not match")
+		}
+		// TODO: vault should support Fabric's rwset fully
+		logger.Debugf("byte representation differs, but rwsets match [%s]", txid)
 	}
 	return nil
 }


### PR DESCRIPTION
- compare a rws against an inspector
- does not fail if the rws bytes are different
but rwsets are equal
- todo: extend vault support for Fabric's rws

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>