### PR TITLE
EnableLogPeersToFile on Fabric Topology to enable peer's logs

### DIFF
--- a/integration/nwo/fabric/topology/topology.go
+++ b/integration/nwo/fabric/topology/topology.go
@@ -39,6 +39,7 @@ type Topology struct {
 	NodeOUs           bool                `yaml:"nodeous,omitempty"`
 	FPC               bool                `yaml:"fpc,omitempty"`
 	Weaver            bool                `yaml:"weaver,omitempty"`
+	LogPeersToFile    bool                `yaml:"logPeersToFile,omitempty"`
 }
 
 func (c *Topology) Name() string {
@@ -329,4 +330,8 @@ func (c *Topology) SetNamespaceApproverOrgsOR(orgs ...string) {
 			return
 		}
 	}
+}
+
+func (c *Topology) EnableLogPeersToFile() {
+	c.LogPeersToFile = true
 }


### PR DESCRIPTION
to be stored on file. The logs can be found under logs/peers

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>