### PR TITLE
Make IsFinal work for real

### DIFF
--- a/integration/fabric/iou/views/approver.go
+++ b/integration/fabric/iou/views/approver.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package views
 
 import (
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	"github.com/pkg/errors"
 
 	"github.com/hyperledger-labs/fabric-smart-client/integration/fabric/iou/states"
@@ -69,6 +70,12 @@ func (i *ApproverView) Call(context view.Context) (interface{}, error) {
 	// The approver is ready to send back the transaction signed
 	_, err = context.RunView(state.NewEndorseView(tx))
 	assert.NoError(err)
+
+	fns := fabric.GetFabricNetworkService(context, tx.Network())
+	assert.NotNil(fns)
+	ch, err := fns.Channel(tx.Channel())
+	assert.NoError(err)
+	ch.Subscribe(tx.ID())
 
 	// Finally, the approver waits that the transaction completes its lifecycle
 	return context.RunView(state.NewFinalityView(tx))

--- a/integration/fabric/iou/views/lender.go
+++ b/integration/fabric/iou/views/lender.go
@@ -60,6 +60,12 @@ func (i *CreateIOUResponderView) Call(context view.Context) (interface{}, error)
 	_, err = context.RunView(state.NewEndorseView(tx))
 	assert.NoError(err)
 
+	fns := fabric.GetFabricNetworkService(context, tx.Network())
+	assert.NotNil(fns)
+	ch, err := fns.Channel(tx.Channel())
+	assert.NoError(err)
+	ch.Subscribe(tx.ID())
+
 	// Finally, the lender waits that the transaction completes its lifecycle
 	return context.RunView(state.NewFinalityView(tx))
 }
@@ -114,6 +120,13 @@ func (i *UpdateIOUResponderView) Call(context view.Context) (interface{}, error)
 	// The lender is ready to send back the transaction signed
 	_, err = context.RunView(state.NewEndorseView(tx))
 	assert.NoError(err)
+
+	fns := fabric.GetFabricNetworkService(context, tx.Network())
+	assert.NotNil(fns)
+	ch, err := fns.Channel(tx.Channel())
+	assert.NoError(err)
+
+	ch.Subscribe(tx.ID())
 
 	// Finally, the lender waits that the transaction completes its lifecycle
 	return context.RunView(state.NewFinalityView(tx))

--- a/platform/fabric/channel.go
+++ b/platform/fabric/channel.go
@@ -18,6 +18,10 @@ type Channel struct {
 	ch  driver.Channel
 }
 
+func (c *Channel) Subscribe(txID string) {
+	c.ch.Subscribe(txID)
+}
+
 func (c *Channel) Name() string {
 	return c.ch.Name()
 }

--- a/platform/fabric/driver/finality.go
+++ b/platform/fabric/driver/finality.go
@@ -12,6 +12,8 @@ type Finality interface {
 	// IsFinal takes in input a transaction id and waits for its confirmation.
 	IsFinal(txID string) error
 
+	Subscribe(txID string)
+
 	// IsFinalForParties takes in input a transaction id and an array of identities.
 	// The identities are contacted to gather information about the finality of the
 	// passed transaction


### PR DESCRIPTION
The way how we implement broadcasting a transaction and then waiting for it to commit is inherently flawed:

1. We send it to the orderer
2. We connect to the orderer and start listening for blocks starting from the last block.

After (1) and before (2) the transaction might already enter a block and then (2) will miss it.
Moreover, the way (2) is implemented is connecting to the peer's delivery service and it just doesn't scale well when many transactions should be sent and waited for.

Implemented a pub-sub mechanism that is piggybacking on the already existing background task that pulls blocks and parses them. 


Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>