### PR TITLE
Revert "Make default KA in CreateGRPCClient zero value"

### DIFF
--- a/platform/view/services/grpc/client.go
+++ b/platform/view/services/grpc/client.go
@@ -246,6 +246,13 @@ func CreateGRPCClient(config *ConnectionConfig) (*Client, error) {
 		timeout = DefaultConnectionTimeout
 	}
 	clientConfig := ClientConfig{
+		KaOpts: KeepaliveOptions{
+			ClientInterval:    60 * time.Second,
+			ClientTimeout:     60 * time.Second,
+			ServerInterval:    30 * time.Second,
+			ServerTimeout:     60 * time.Second,
+			ServerMinInterval: 60 * time.Second,
+		},
 		Timeout: timeout,
 	}
 


### PR DESCRIPTION
Reverts hyperledger-labs/fabric-smart-client#199