### PR TITLE
Add FPC external builder detector for FSC network

### DIFF
--- a/integration/nwo/fabric/fpc/builder_detector.go
+++ b/integration/nwo/fabric/fpc/builder_detector.go
@@ -1,0 +1,150 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fpc
+
+import (
+	"encoding/json"
+	. "github.com/onsi/gomega"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	fscRoot            = "github.com/hyperledger-labs/fabric-smart-client"
+	relExternalBuilder = "integration/nwo/fabric/fpc/externalbuilders/chaincode_server"
+)
+
+type goDep struct {
+	Path  string
+	Dir   string
+	Error string
+}
+
+type goModule struct {
+	Path    string
+	Version string
+}
+
+type goReplace struct {
+	Old goModule
+	New goModule
+}
+
+type mods struct {
+	Module  goModule
+	Require []goModule
+	Replace []goReplace
+}
+
+func (m *mods) requiresModule(path string) (bool, *goModule) {
+	for _, mod := range m.Require {
+		if mod.Path == path {
+			return true, &mod
+		}
+	}
+	return false, nil
+}
+
+func (m *mods) isReplacedModule(path string) (bool, *goModule) {
+	for _, r := range m.Replace {
+		if r.Old.Path == path {
+			return true, &r.New
+		}
+	}
+	return false, nil
+}
+
+func buildersExist(path string) error {
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return err
+	}
+
+	// TODO let's also check if the scripts are there
+
+	logger.Debugf("found external builder at %s\n", path)
+	return nil
+}
+
+func externalBuilderFromGoPath() string {
+	cmd := exec.Command("go", "env", "GOPATH")
+	cmd.Env = append(os.Environ(), "GO111MODULE=on")
+	out, err := cmd.Output()
+	Expect(err).ToNot(HaveOccurred())
+	goPathDir := filepath.Clean(strings.TrimSpace(string(out)))
+
+	path := filepath.Join(goPathDir, "src", fscRoot, filepath.Join(strings.Split(relExternalBuilder, "/")...))
+	if err := buildersExist(path); err == nil {
+		return path
+	}
+
+	return ""
+}
+
+func externalBuilderFromGoModule() string {
+	cmd := exec.Command("go", "mod", "edit", "-json")
+	cmd.Env = append(os.Environ(), "GO111MODULE=on")
+	out, _ := cmd.Output()
+
+	if strings.TrimSpace(string(out)) == "" {
+		// not a go module
+		return ""
+	}
+
+	mods := &mods{}
+	err := json.Unmarshal(out, mods)
+	Expect(err).ToNot(HaveOccurred())
+
+	// let's check if we are in FSC
+	if mods.Module.Path == fscRoot {
+		cmd := exec.Command("go", "env", "GOMOD")
+		cmd.Env = append(os.Environ(), "GO111MODULE=on")
+		out, err := cmd.Output()
+		Expect(err).ToNot(HaveOccurred())
+		moduleRootDir := filepath.Dir(string(out))
+
+		path := filepath.Join(moduleRootDir, filepath.Join(strings.Split(relExternalBuilder, "/")...))
+		if err := buildersExist(path); err == nil {
+			// found external builders in our project
+			return path
+		}
+	}
+
+	// check if FSC is a go mod dependency, let's see if it is in the cache
+	if requires, _ := mods.requiresModule(fscRoot); !requires {
+		// FSC is not a go dependency
+		return ""
+	}
+
+	// check if dep is replaced
+	if replaced, mod := mods.isReplacedModule(fscRoot); replaced {
+		// search in the replacement path
+		path := filepath.Join(mod.Path, filepath.Join(strings.Split(relExternalBuilder, "/")...))
+		if err := buildersExist(path); err == nil {
+			return path
+		}
+	}
+
+	// check if we find FSC in mod cache
+	cmd = exec.Command("go", "mod", "download", "-json", fscRoot)
+	cmd.Env = append(os.Environ(), "GO111MODULE=on")
+	out, _ = cmd.Output()
+
+	dep := &goDep{}
+	err = json.Unmarshal(out, dep)
+	Expect(err).ToNot(HaveOccurred())
+
+	path := filepath.Join(dep.Dir, filepath.Join(strings.Split(relExternalBuilder, "/")...))
+	if err := buildersExist(path); err == nil {
+		return path
+	}
+
+	// we did everything to find FSC external builders, no luck
+	return ""
+}

--- a/integration/nwo/fabric/fpc/builder_detector_test.go
+++ b/integration/nwo/fabric/fpc/builder_detector_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fpc
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestEndToEnd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "External builder test suite")
+}
+
+var _ = Describe("Find external builder path", func() {
+	var (
+		extension Extension
+		tmpDir    string
+		err       error
+	)
+
+	When("calling from FSC project", func() {
+		It("should return path", func() {
+			p, err := extension.FindExternalBuilder()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(p).NotTo(BeEmpty())
+		})
+	})
+
+	When("calling from another go project", func() {
+
+		BeforeEach(func() {
+			tmpDir, err = ioutil.TempDir("/tmp", "external-builder-test")
+			Expect(err).ToNot(HaveOccurred())
+
+			// switch to our tmp directory
+			err = os.Chdir(tmpDir)
+			Expect(err).ToNot(HaveOccurred())
+
+			// just unset gopath for the moment
+			err = os.Unsetenv("GOPATH")
+			Expect(err).ToNot(HaveOccurred())
+
+			cmd := exec.Command("go", "mod", "init", "example.com/test-lab/test")
+			_, err := cmd.Output()
+			Expect(err).ToNot(HaveOccurred())
+
+			main := `package main
+
+import "github.com/hyperledger-labs/fabric-smart-client/integration"
+
+func main() {
+	_ = integration.FPCEchoPort
+}
+`
+			err = os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte(main), 0644)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			err = os.RemoveAll(tmpDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return error if not found in go.mod", func() {
+			_, err := extension.FindExternalBuilder()
+			Expect(err).To(HaveOccurred())
+		})
+
+		When("FSC is in go.mod", func() {
+			BeforeEach(func() {
+				// get FSC in the mod cache
+				cmd := exec.Command("go", "mod", "tidy")
+				_, err = cmd.Output()
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should return the path in mod cache", func() {
+				p, err := extension.FindExternalBuilder()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(p).NotTo(BeEmpty())
+			})
+
+		})
+
+		When("FSC is in go mod but replaced", func() {
+			BeforeEach(func() {
+				// get FSC in the mod cache
+				cmd := exec.Command("go", "mod", "tidy")
+				_, err = cmd.Output()
+				Expect(err).ToNot(HaveOccurred())
+
+				// create builder directory at replacement location
+				replacePath := filepath.Join(tmpDir, fscRoot)
+				builderPath := filepath.Join(replacePath, relExternalBuilder)
+				err = os.MkdirAll(builderPath, 0755)
+				Expect(err).ToNot(HaveOccurred())
+
+				cmd = exec.Command("go", "mod", "edit", fmt.Sprintf("-replace=%s=%s", fscRoot, replacePath))
+				_, err = cmd.Output()
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should return the path", func() {
+				p, err := extension.FindExternalBuilder()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(p).NotTo(BeEmpty())
+			})
+
+		})
+
+	})
+
+	When("calling from somewhere else (not in a go module)", func() {
+		BeforeEach(func() {
+			tmpDir, err = ioutil.TempDir("/tmp", "external-builder-test")
+			Expect(err).ToNot(HaveOccurred())
+
+			// switch to our tmp directory
+			err = os.Chdir(tmpDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			err = os.RemoveAll(tmpDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return path on the gopath", func() {
+			// let's create our expected external builder path
+			err = os.MkdirAll(filepath.Join(tmpDir, "src", fscRoot, relExternalBuilder), 0755)
+			Expect(err).ToNot(HaveOccurred())
+
+			os.Setenv("GOPATH", tmpDir)
+
+			p, err := extension.FindExternalBuilder()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(p).NotTo(BeEmpty())
+		})
+
+		It("should return error if not on gopath", func() {
+			// we set our gopath to the tmp directory
+			os.Unsetenv("GOPATH")
+
+			_, err = extension.FindExternalBuilder()
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
This PR fixes an issue with the external builder configuration in a FSC network.

The current code base assumes the FPC external builder scripts are available in the "current" project, that is, the FSC project. This leads to a problem when FSC is used in another project (i.e., used as go dependency). In that case, the current code tries to find the external builder in current project and will fail. 

To overcome this limitation, this PR contains an external builder detector that implements the following strategy:

First, it tries to locate the external builder scripts in the current go project. If the project is FSC, we will try to find it directly in the project source. Otherwise, the project go dependencies are checked. It first checks for any go mod replacements and then scrapes the go mod cache. Alternatively, if FSC is used outside of a go project (i.e., no go.mod available), the detector tries to locate the external builders on the gopath. Finally, if no external builders are found we panic.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>