### PR TITLE
Enable FSC SGX HW support

### DIFF
--- a/integration/nwo/fabric/topology/chaincode.go
+++ b/integration/nwo/fabric/topology/chaincode.go
@@ -42,7 +42,10 @@ func (c *Chaincode) SetPackageIDFromPackageFile() {
 }
 
 type PrivateChaincode struct {
-	Image string
+	Image         string
+	SGXMode       string
+	SGXDevicePath string
+	MREnclave     string
 }
 
 type namespace struct {


### PR DESCRIPTION
This PR enables SGX HW support for the FPC integration. In particular, it extends the AddFPC methods with additional optional parameters, such as SGX_MODE, MRENCLAVE, and SGX_DEVICE_PATH, which are required to run the FPC chaincode in HW mode. By default, the FPC chaincode is started in SGX simulation mode. 

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>