### PR TITLE
larger keys in rw sets

### DIFF
--- a/platform/view/services/db/keys/utils.go
+++ b/platform/view/services/db/keys/utils.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	nsRegexp  = regexp.MustCompile("^[a-zA-Z0-9._-]{1,20}$")
-	keyRegexp = regexp.MustCompile("^[a-zA-Z0-9._\u0000=" + string(utf8.MaxRune) + "+/-]{1,200}$")
+	nsRegexp  = regexp.MustCompile("^[a-zA-Z0-9._-]{1,50}$")
+	keyRegexp = regexp.MustCompile("^[a-zA-Z0-9._\u0000=" + string(utf8.MaxRune) + "+/-]{1,4096}$")
 )
 
 const NamespaceSeparator = "\u0000"

--- a/platform/view/services/db/keys/utils.go
+++ b/platform/view/services/db/keys/utils.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	nsRegexp  = regexp.MustCompile("^[a-zA-Z0-9._-]{1,50}$")
-	keyRegexp = regexp.MustCompile("^[a-zA-Z0-9._\u0000=" + string(utf8.MaxRune) + "+/-]{1,4096}$")
+	keyRegexp = regexp.MustCompile("^[a-zA-Z0-9._\u0000=" + string(utf8.MaxRune) + "+/-]{1,}$")
 )
 
 const NamespaceSeparator = "\u0000"
@@ -24,6 +24,7 @@ func ValidateKey(key string) error {
 	if !keyRegexp.MatchString(key) {
 		return errors.Errorf("key '%s' is invalid", key)
 	}
+	// TODO: should we enforce a length limit?
 
 	return nil
 }


### PR DESCRIPTION
Fabric does not set a limit on the length of the keys in a RWSet.
This PR is to match the same constraint.

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>