### PR TITLE
Remove wrong rlock release

### DIFF
--- a/platform/view/services/kvs/kvs.go
+++ b/platform/view/services/kvs/kvs.go
@@ -79,7 +79,6 @@ func (o *KVS) Exists(id string) bool {
 	// is in cache, first?
 	v, ok = o.cache[id]
 	if ok {
-		o.putMutex.RUnlock()
 		return len(v) != 0
 	}
 	// get from store and store in cache


### PR DESCRIPTION
This PR addresses a bug in the KVS, where a RLock release is called on a unlocked lock.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>