### PR TITLE
fabric-sdk: use orderers set in the config block

### DIFF
--- a/integration/fabric/iou/iou_test.go
+++ b/integration/fabric/iou/iou_test.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package iou_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -34,6 +36,8 @@ var _ = Describe("EndToEnd", func() {
 			Expect(err).NotTo(HaveOccurred())
 			// Start the integration ii
 			ii.Start()
+			// Sleep for a while to allow the networks to be ready
+			time.Sleep(20 * time.Second)
 		})
 
 		It("succeeded", func() {

--- a/integration/nwo/fabric/topology/core_template.go
+++ b/integration/nwo/fabric/topology/core_template.go
@@ -290,13 +290,6 @@ fabric:
          interval: 60s
          timeout: 600s
          minInterval: 60s 
-    orderers: {{ range Orderers }}
-      - address: {{ OrdererAddress . "Listen" }}
-        connectionTimeout: 10s
-        tlsEnabled: true        
-        tlsRootCertFile: {{ CACertsBundlePath }}
-        serverNameOverride:
-    {{- end }} 
     peers: {{ range Peers }}
       - address: {{ PeerAddress . "Listen" }}
         connectionTimeout: 10s


### PR DESCRIPTION
Currently, the FSC node uses only the orderers defined
in the configuration file. But, orderers can change
with a configuration update.
Thefore, this PR let the fabric-sdk to use the orderers
defined in the configuration block.

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>