### PR TITLE
view-sdk: enhancements 

### DIFF
--- a/platform/fabric/core/generic/network.go
+++ b/platform/fabric/core/generic/network.go
@@ -61,6 +61,7 @@ func NewNetwork(
 	sigService driver.SignerService,
 ) (*network, error) {
 	// Load configuration
+	logger.Debugf("new fabric network for [%s]", name)
 	fsp := &network{
 		ctx:             ctx,
 		sp:              sp,

--- a/platform/fabric/core/generic/network.go
+++ b/platform/fabric/core/generic/network.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"io/ioutil"
 	"math/rand"
-	"runtime/debug"
 	"sync"
 
 	config2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
@@ -62,7 +61,6 @@ func NewNetwork(
 	sigService driver.SignerService,
 ) (*network, error) {
 	// Load configuration
-	logger.Debugf("new fabric network for [%s][%s]", name, debug.Stack())
 	fsp := &network{
 		ctx:             ctx,
 		sp:              sp,

--- a/platform/fabric/core/generic/network.go
+++ b/platform/fabric/core/generic/network.go
@@ -99,6 +99,9 @@ func (f *network) Orderers() []*grpc.ConnectionConfig {
 }
 
 func (f *network) PickOrderer() *grpc.ConnectionConfig {
+	if len(f.orderers) == 0 {
+		return nil
+	}
 	return f.orderers[rand.Intn(len(f.orderers))]
 }
 
@@ -246,6 +249,7 @@ func (f *network) setConfigOrderers(orderers []*grpc.ConnectionConfig) {
 	// the first configuredOrderers are from the configuration, keep them
 	// and append the new ones
 	f.orderers = append(f.orderers[:f.configuredOrderers], orderers...)
+	logger.Debugf("New Orderers [%d]", len(f.orderers))
 }
 
 func loadFile(path string) ([]byte, error) {

--- a/platform/fabric/core/generic/network.go
+++ b/platform/fabric/core/generic/network.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"io/ioutil"
 	"math/rand"
+	"runtime/debug"
 	"sync"
 
 	config2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
@@ -61,7 +62,7 @@ func NewNetwork(
 	sigService driver.SignerService,
 ) (*network, error) {
 	// Load configuration
-	logger.Debugf("new fabric network for [%s]", name)
+	logger.Debugf("new fabric network for [%s][%s]", name, debug.Stack())
 	fsp := &network{
 		ctx:             ctx,
 		sp:              sp,

--- a/platform/fabric/core/generic/ordering/ordering.go
+++ b/platform/fabric/core/generic/ordering/ordering.go
@@ -171,18 +171,20 @@ func (o *service) getOrSetOrdererClient() (Broadcast, error) {
 		return o.oStream, nil
 	}
 
-	// TODO: pick orderer randomly
 	ordererConfig := o.network.PickOrderer()
+	if ordererConfig == nil {
+		return nil, errors.New("no orderer configured")
+	}
 
 	oClient, err := NewOrdererClient(ordererConfig)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed creating orderer client for %s", ordererConfig.Address)
 	}
 
 	stream, err := oClient.NewBroadcast(context.Background())
 	if err != nil {
 		oClient.Close()
-		return nil, err
+		return nil, errors.Wrapf(err, "failed creating orderer client for %s", ordererConfig.Address)
 	}
 
 	o.oStream = stream

--- a/platform/fabric/core/generic/txconfig.go
+++ b/platform/fabric/core/generic/txconfig.go
@@ -102,9 +102,7 @@ func (c *channel) ReloadConfigTransactions() error {
 				capabilitiesSupportedOrPanic(bundle)
 			}
 
-			c.lock.Lock()
-			c.resources = bundle
-			c.lock.Unlock()
+			c.applyBundle(bundle)
 
 			sequence = sequence + 1
 			continue

--- a/platform/fabric/core/provider.go
+++ b/platform/fabric/core/provider.go
@@ -124,6 +124,7 @@ func (p *fnsProvider) InstallViews() error {
 }
 
 func (p *fnsProvider) newFNS(network string) (driver.FabricNetworkService, error) {
+	logger.Debugf("creating new fabric network service for network [%s]", network)
 	// bridge services
 	c, err := config.New(view.GetConfigService(p.sp), network, network == p.config.defaultName)
 	if err != nil {

--- a/platform/view/core/manager/manager.go
+++ b/platform/view/core/manager/manager.go
@@ -127,6 +127,9 @@ func (cm *manager) GetResponder(initiatedBy interface{}) (view.View, error) {
 	if len(entries) == 0 {
 		return nil, errors.Errorf("responder not found for [%s], initiator [%s]", responderID, initiatedByID)
 	}
+	// Recall that a responder can be used to respond to multiple initiators.
+	// Therefore, all these entries are for the same responder.
+	// We return the first one.
 	return entries[0].View, nil
 }
 

--- a/platform/view/driver/flowregistry.go
+++ b/platform/view/driver/flowregistry.go
@@ -33,6 +33,9 @@ type Registry interface {
 	// The argument initiatedBy can be a view or a view identifier.
 	// If a view is passed, its identifier is computed and used to register the responder.
 	RegisterResponderWithIdentity(responder view.View, id view.Identity, initiatedBy interface{}) error
+
+	// GetResponder returns the responder for the passed initiator.
+	GetResponder(initiatedBy interface{}) (view.View, error)
 }
 
 func GetRegistry(sp ServiceProvider) Registry {

--- a/platform/view/registry.go
+++ b/platform/view/registry.go
@@ -50,6 +50,11 @@ func (r *Registry) RegisterResponder(responder View, initiatedBy interface{}) er
 	return r.registry.RegisterResponder(responder, initiatedBy)
 }
 
+// GetResponder returns the responder for the passed initiator.
+func (r *Registry) GetResponder(initiatedBy interface{}) (View, error) {
+	return r.registry.GetResponder(initiatedBy)
+}
+
 // RegisterResponderWithIdentity binds the pair <responder, id> to an initiator.
 // The responder is the view that will be called when the initiator (initiatedBy) contacts the FSC node where
 // this RegisterResponderWithIdentity is invoked.


### PR DESCRIPTION
This PR introduces utility functions needed to address https://github.com/hyperledger-labs/fabric-token-sdk/issues/283 

Enhancements:
- add ability to retrive responder from the registry
- additional logging

Bug fix:
- fabric-sdk: update orderers list when apply config blocks after a restart

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>