### PR TITLE
Add missing mutex

### DIFF
--- a/platform/view/services/comm/master.go
+++ b/platform/view/services/comm/master.go
@@ -27,11 +27,13 @@ func (p *P2PNode) getOrCreateSession(sessionID, endpointAddress, contextID, call
 		if logger.IsEnabledFor(zapcore.DebugLevel) {
 			logger.Debugf("session [%s] exists, returning it", internalSessionID)
 		}
+		session.mutex.Lock()
 		session.callerViewID = callerViewID
 		session.contextID = contextID
 		session.caller = caller
 		session.endpointAddress = endpointAddress
 		session.endpointID = endpointID
+		session.mutex.Lock()
 		return session, nil
 	}
 


### PR DESCRIPTION
- NetworkStreamSession uses a mutex to allow multiple goroutines. The
  function sendWithStatus was missing the use of it's mutex.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>