### PR TITLE
Use time.NewTimer instead of time.After

### DIFF
--- a/platform/fabric/core/generic/committer/committer.go
+++ b/platform/fabric/core/generic/committer/committer.go
@@ -306,13 +306,17 @@ func (c *committer) listenTo(txid string, timeout time.Duration) error {
 		iterations = 1
 	}
 	for i := 0; i < iterations; i++ {
+		timeout := time.NewTimer(c.pollingTimeout)
+
 		select {
 		case event := <-ch:
 			if logger.IsEnabledFor(zapcore.DebugLevel) {
 				logger.Debugf("Got an answer to finality of [%s]: [%s]", txid, event.Err)
 			}
+			timeout.Stop()
 			return event.Err
-		case <-time.After(c.pollingTimeout):
+		case <-timeout.C:
+			timeout.Stop()
 			if logger.IsEnabledFor(zapcore.DebugLevel) {
 				logger.Debugf("Got a timeout for finality of [%s], check the status", txid)
 			}

--- a/platform/fabric/core/generic/msp/cache.go
+++ b/platform/fabric/core/generic/msp/cache.go
@@ -40,6 +40,9 @@ func NewIdentityCache(backed IdentityCacheBackendFunc, size int) *IdentityCache 
 }
 
 func (c *IdentityCache) Identity(opts *driver2.IdentityOptions) (view.Identity, []byte, error) {
+	timeout := time.NewTimer(c.timeout)
+	defer timeout.Stop()
+
 	if opts == nil {
 		if logger.IsEnabledFor(zapcore.DebugLevel) {
 			logger.Debugf("fetch identity from producer channel...")
@@ -50,7 +53,7 @@ func (c *IdentityCache) Identity(opts *driver2.IdentityOptions) (view.Identity, 
 				logger.Debugf("fetch identity from producer channel done [%s][%d]", entry.Identity, len(entry.Audit))
 			}
 			return entry.Identity, entry.Audit, nil
-		case <-time.After(c.timeout):
+		case <-timeout.C:
 			if logger.IsEnabledFor(zapcore.DebugLevel) {
 				logger.Debugf("fetch identity from producer channel timeout")
 			}

--- a/platform/fabric/services/endorser/endorsement.go
+++ b/platform/fabric/services/endorser/endorsement.go
@@ -94,12 +94,16 @@ func (c *collectEndorsementsView) Call(context view.Context) (interface{}, error
 			return nil, errors.Wrap(err, "failed sending transaction content")
 		}
 
+		timeout := time.NewTimer(time.Minute)
+
 		// Wait for the answer
 		var msg *view.Message
 		select {
 		case msg = <-ch:
+			timeout.Stop()
 			tracker.Report(fmt.Sprintf("collectEndorsementsView: reply received from [%s]", party))
-		case <-time.After(60 * time.Second):
+		case <-timeout.C:
+			timeout.Stop()
 			return nil, errors.Errorf("Timeout from party %s", party)
 		}
 		if msg.Status == view.ERROR {

--- a/platform/fabric/services/state/flow.go
+++ b/platform/fabric/services/state/flow.go
@@ -29,6 +29,9 @@ func (s receiveView) Call(context view.Context) (interface{}, error) {
 	// Wait to receive a state
 	ch := session.Receive()
 
+	timeout := time.NewTimer(time.Second * 30)
+	defer timeout.Stop()
+
 	select {
 	case msg := <-ch:
 		if msg.Status == view.ERROR {
@@ -41,7 +44,7 @@ func (s receiveView) Call(context view.Context) (interface{}, error) {
 		}
 
 		return s.state, nil
-	case <-time.After(30 * time.Second):
+	case <-timeout.C:
 		return nil, errors.New("timeout reading from session")
 	}
 
@@ -58,13 +61,16 @@ func (s payloadReceiveView) Call(context view.Context) (interface{}, error) {
 	// Wait to receive a state
 	ch := context.Session().Receive()
 
+	timeout := time.NewTimer(time.Second * 30)
+	defer timeout.Stop()
+
 	select {
 	case msg := <-ch:
 		if msg.Status == view.ERROR {
 			return nil, errors.New(string(msg.Payload))
 		}
 		return msg.Payload, nil
-	case <-time.After(30 * time.Second):
+	case <-timeout.C:
 		return nil, errors.New("timeout reading from session")
 	}
 }
@@ -94,6 +100,9 @@ func (s *sendReceiveView) Call(context view.Context) (interface{}, error) {
 		return nil, err
 	}
 
+	timeout := time.NewTimer(time.Second * 30)
+	defer timeout.Stop()
+
 	// Receive another state
 	select {
 	case msg := <-ch:
@@ -106,7 +115,7 @@ func (s *sendReceiveView) Call(context view.Context) (interface{}, error) {
 			return nil, err
 		}
 		return s.receiveState, nil
-	case <-time.After(30 * time.Second):
+	case <-timeout.C:
 		return nil, errors.New("timeout reading from session")
 	}
 }

--- a/platform/fabric/services/state/recipients.go
+++ b/platform/fabric/services/state/recipients.go
@@ -99,13 +99,16 @@ func (f RequestRecipientIdentityView) Call(context view.Context) (interface{}, e
 		return nil, err
 	}
 
+	timeout := time.NewTimer(time.Minute)
+	defer timeout.Stop()
+
 	// Wait to receive an identity
 	ch := session.Receive()
 	var payload []byte
 	select {
 	case msg := <-ch:
 		payload = msg.Payload
-	case <-time.After(60 * time.Second):
+	case <-timeout.C:
 		return nil, errors.New("time out reached")
 	}
 

--- a/platform/fabric/services/state/transaction.go
+++ b/platform/fabric/services/state/transaction.go
@@ -135,6 +135,9 @@ func (f *receiveTransactionView) Call(context view.Context) (interface{}, error)
 		ch = s.Receive()
 	}
 
+	timeout := time.NewTimer(time.Second * 10)
+	defer timeout.Stop()
+
 	select {
 	case msg := <-ch:
 		if msg.Status == view.ERROR {
@@ -145,7 +148,7 @@ func (f *receiveTransactionView) Call(context view.Context) (interface{}, error)
 			return nil, err
 		}
 		return tx, nil
-	case <-time.After(10 * time.Second):
+	case <-timeout.C:
 		return nil, errors.New("timeout reached")
 	}
 }

--- a/platform/orion/core/generic/committer/committer.go
+++ b/platform/orion/core/generic/committer/committer.go
@@ -312,13 +312,17 @@ func (c *committer) listenToFinality(txID string, timeout time.Duration) error {
 		iterations = 1
 	}
 	for i := 0; i < iterations; i++ {
+		timeout := time.NewTimer(c.pollingTimeout)
+
 		select {
 		case event := <-ch:
 			if logger.IsEnabledFor(zapcore.DebugLevel) {
 				logger.Debugf("Got an answer to finality of [%s]: [%s]", txID, event.Err)
 			}
+			timeout.Stop()
 			return event.Err
-		case <-time.After(c.pollingTimeout):
+		case <-timeout.C:
+			timeout.Stop()
 			if logger.IsEnabledFor(zapcore.DebugLevel) {
 				logger.Debugf("Got a timeout for finality of [%s], check the status", txID)
 			}

--- a/platform/view/services/id/ecdsa/view.go
+++ b/platform/view/services/id/ecdsa/view.go
@@ -54,6 +54,10 @@ func (f twoPartyCollectEphemeralKeyView) Call(context view.Context) (interface{}
 	if err != nil {
 		return nil, err
 	}
+
+	timeout := time.NewTimer(time.Second * 30)
+	defer timeout.Stop()
+
 	select {
 	case msg := <-ch:
 		if msg.Status == view.ERROR {
@@ -86,7 +90,7 @@ func (f twoPartyCollectEphemeralKeyView) Call(context view.Context) (interface{}
 		}
 
 		return []view.Identity{id, id2}, nil
-	case <-time.After(30 * time.Second):
+	case <-timeout.C:
 		return nil, errors.New("timeout reading from session")
 	}
 }

--- a/platform/view/services/session/json.go
+++ b/platform/view/services/session/json.go
@@ -43,6 +43,9 @@ func JSON(context view.Context) *jsonSession {
 }
 
 func (j *jsonSession) Receive(state interface{}) error {
+	timeout := time.NewTimer(time.Second * 10)
+	defer timeout.Stop()
+
 	ch := j.s.Receive()
 	var raw []byte
 	select {
@@ -51,7 +54,7 @@ func (j *jsonSession) Receive(state interface{}) error {
 			return errors.Errorf("received error from remote [%s]", string(msg.Payload))
 		}
 		raw = msg.Payload
-	case <-time.After(10 * time.Second):
+	case <-timeout.C:
 		return errors.New("time out reached")
 	case <-j.context.Done():
 		return errors.Errorf("context done [%s]", j.context.Err())
@@ -61,6 +64,9 @@ func (j *jsonSession) Receive(state interface{}) error {
 }
 
 func (j *jsonSession) ReceiveWithTimeout(state interface{}, d time.Duration) error {
+	timeout := time.NewTimer(d)
+	defer timeout.Stop()
+
 	// TODO: use opts
 	ch := j.s.Receive()
 	var raw []byte
@@ -70,7 +76,7 @@ func (j *jsonSession) ReceiveWithTimeout(state interface{}, d time.Duration) err
 			return errors.Errorf("received error from remote [%s]", string(msg.Payload))
 		}
 		raw = msg.Payload
-	case <-time.After(d):
+	case <-timeout.C:
 		return errors.New("time out reached")
 	case <-j.context.Done():
 		return errors.Errorf("context done [%s]", j.context.Err())


### PR DESCRIPTION
Using time.After enqueues an entry in Go's runtime scheduler and doesn't garbage collect it even if the function the timer was fired from terminates.
As a result, there can be a temporary high memory pressure and it degrades performance.

Replaced all places where time.After was used except in places that are used as samples or tests.

Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>