### PR TITLE
Removed simple gogo/protobuf/proto dependencies

### DIFF
--- a/platform/fabric/core/generic/rwset/envelope.go
+++ b/platform/fabric/core/generic/rwset/envelope.go
@@ -9,7 +9,7 @@ package rwset
 import (
 	"fmt"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/protoutil"

--- a/platform/fabric/core/generic/rwset/processor.go
+++ b/platform/fabric/core/generic/rwset/processor.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package rwset
 
 import (
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/pkg/errors"
 

--- a/platform/fabric/core/generic/transaction/envelope.go
+++ b/platform/fabric/core/generic/transaction/envelope.go
@@ -9,7 +9,7 @@ package transaction
 import (
 	"fmt"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/protoutil"

--- a/platform/fabric/core/generic/transaction/pr.go
+++ b/platform/fabric/core/generic/transaction/pr.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package transaction
 
 import (
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"

--- a/platform/view/services/comm/p2p.go
+++ b/platform/view/services/comm/p2p.go
@@ -16,7 +16,6 @@ import (
 	"sync/atomic"
 
 	"github.com/gogo/protobuf/io"
-	protoio "github.com/gogo/protobuf/io"
 	"github.com/gogo/protobuf/proto"
 	proto2 "github.com/golang/protobuf/proto"
 	"github.com/libp2p/go-libp2p-core/host"
@@ -224,8 +223,8 @@ func (p *P2PNode) Lookup(peerID string) (peer.AddrInfo, bool) {
 type streamHandler struct {
 	lock   sync.Mutex
 	stream network.Stream
-	reader protoio.ReadCloser
-	writer protoio.WriteCloser
+	reader io.ReadCloser
+	writer io.WriteCloser
 	node   *P2PNode
 	wg     sync.WaitGroup
 	refCtr int


### PR DESCRIPTION
As part of issue #174, replaced most dependencies of gogo/protobuf/proto with golang/protobuf/proto. The remaining occurrences reside in p2p.go and their removal requires handling of the dependency from the package gogo/protobuf/io.

Signed-off-by: Alexandros Filios <alexandros.filios@ibm.com>