### PR TITLE
Reduce staticcheck warnings (SA1019)

### DIFF
--- a/integration/fabric/atsa/chaincode/chaincode/asset_transfer.go
+++ b/integration/fabric/atsa/chaincode/chaincode/asset_transfer.go
@@ -17,7 +17,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/hyperledger/fabric-chaincode-go/pkg/statebased"
 	"github.com/hyperledger/fabric-chaincode-go/shim"
 	"github.com/hyperledger/fabric-contract-api-go/contractapi"
@@ -443,10 +442,11 @@ func transferAssetState(ctx contractapi.TransactionContextInterface, asset *Asse
 		return fmt.Errorf("failed to create timestamp for receipt: %v", err)
 	}
 
-	timestamp, err := ptypes.Timestamp(txTimestamp)
-	if err != nil {
+	if err := txTimestamp.CheckValid(); err != nil {
 		return err
 	}
+	timestamp := txTimestamp.AsTime()
+
 	assetReceipt := receipt{
 		price:     price,
 		timestamp: timestamp,

--- a/integration/fabric/atsa/chaincode/chaincode/asset_transfer_queries.go
+++ b/integration/fabric/atsa/chaincode/chaincode/asset_transfer_queries.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/hyperledger/fabric-contract-api-go/contractapi"
 )
 
@@ -165,10 +164,11 @@ func (s *SmartContract) QueryAssetHistory(ctx contractapi.TransactionContextInte
 			return nil, err
 		}
 
-		timestamp, err := ptypes.Timestamp(response.Timestamp)
-		if err != nil {
+		if err := response.Timestamp.CheckValid(); err != nil {
 			return nil, err
 		}
+		timestamp := response.Timestamp.AsTime()
+
 		record := QueryResult{
 			TxId:      response.TxId,
 			Timestamp: timestamp,

--- a/platform/fabric/core/generic/delivery/deliverclient.go
+++ b/platform/fabric/core/generic/delivery/deliverclient.go
@@ -10,10 +10,8 @@ import (
 	"context"
 	"crypto/tls"
 	"math"
-	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/peer"
 	grpc2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
 	"github.com/hyperledger/fabric-protos-go/common"
@@ -24,6 +22,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type Hasher interface {
@@ -245,10 +244,7 @@ func DeliverWaitForResponse(ctx context.Context, eventCh <-chan TxEvent, txid st
 // CreateHeader creates common.Header for a token transaction
 // tlsCertHash is for client TLS cert, only applicable when ClientAuthRequired is true
 func CreateHeader(txType common.HeaderType, channelID string, creator []byte, tlsCertHash []byte) (string, *common.Header, error) {
-	ts, err := ptypes.TimestampProto(time.Now())
-	if err != nil {
-		return "", nil, err
-	}
+	ts := timestamppb.Now()
 
 	nonce, err := GetRandomNonce()
 	if err != nil {

--- a/platform/view/services/client/view/client.go
+++ b/platform/view/services/client/view/client.go
@@ -14,17 +14,15 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/api"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
+	grpc2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
+	hash2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"
+	protos2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/server/view/protos"
 	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
-
-	"github.com/hyperledger-labs/fabric-smart-client/pkg/api"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
-	protos2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/server/view/protos"
-
-	grpc2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
-	hash2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 var logger = flogging.MustGetLogger("view-sdk.client")
@@ -279,8 +277,8 @@ func (s *client) CreateSignedCommand(payload interface{}, signingIdentity Signin
 		return nil, err
 	}
 
-	ts, err := ptypes.TimestampProto(s.Time())
-	if err != nil {
+	ts := timestamppb.New(s.Time())
+	if err := ts.CheckValid(); err != nil {
 		return nil, err
 	}
 

--- a/platform/view/services/flogging/global.go
+++ b/platform/view/services/flogging/global.go
@@ -28,7 +28,7 @@ func init() {
 
 	Global = logging
 	grpcLogger := Global.ZapLogger("grpc")
-	grpclog.SetLogger(NewGRPCLogger(grpcLogger))
+	grpclog.SetLoggerV2(NewGRPCLogger(grpcLogger))
 }
 
 // Init initializes logging with the provided config.

--- a/platform/view/services/server/view/marshal.go
+++ b/platform/view/services/server/view/marshal.go
@@ -11,13 +11,12 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/pkg/errors"
-
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
 	hash2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"
 	protos2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/server/view/protos"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // UnmarshalCommand unmarshal Command messages
@@ -52,8 +51,8 @@ func (s *ResponseMarshaler) MarshalCommandResponse(command []byte, responsePaylo
 		return nil, err
 	}
 
-	ts, err := ptypes.TimestampProto(s.time())
-	if err != nil {
+	ts := timestamppb.New(s.time())
+	if err := ts.CheckValid(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
As part of issue #50, removed warnings related to:
* SA1019: removed deprecated grpclog.SetLogger and ptypes

Signed-off-by: Alexandros Filios <alexandros.filios@ibm.com>