### PR TITLE
Reduce staticcheck warnings (SA1019)

### DIFF
--- a/integration/nwo/fabric/network/configblock.go
+++ b/integration/nwo/fabric/network/configblock.go
@@ -14,8 +14,7 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/commands"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/topology"
-
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/msp"
 	protosorderer "github.com/hyperledger/fabric-protos-go/orderer"

--- a/integration/nwo/fabric/network/update.go
+++ b/integration/nwo/fabric/network/update.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric/protoutil"
 )

--- a/pkg/utils/proto/proto.go
+++ b/pkg/utils/proto/proto.go
@@ -1,0 +1,36 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package proto
+
+import (
+	//lint:ignore SA1019 Dependency to be updated to google.golang.org/protobuf/proto
+	protoV1 "github.com/golang/protobuf/proto"
+)
+
+/*
+This package delegates the protobuf/proto functionality to the deprecated package. This way, we:
+- temporarily handle the linting warnings, and
+- allow for an easier update of the dependency by updating this single package
+*/
+
+type Message = protoV1.Message
+
+func Unmarshal(b []byte, m Message) error {
+	return protoV1.Unmarshal(b, m)
+}
+
+func Marshal(m Message) ([]byte, error) {
+	return protoV1.Marshal(m)
+}
+
+func Equal(x, y Message) bool {
+	return protoV1.Equal(x, y)
+}
+
+func Clone(src Message) Message {
+	return protoV1.Clone(src)
+}

--- a/platform/fabric/core/generic/channel.go
+++ b/platform/fabric/core/generic/channel.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/committer"
 	config2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
 	delivery2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/delivery"

--- a/platform/fabric/core/generic/delivery/deliverclient.go
+++ b/platform/fabric/core/generic/delivery/deliverclient.go
@@ -11,7 +11,7 @@ import (
 	"crypto/tls"
 	"math"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/peer"
 	grpc2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
 	"github.com/hyperledger/fabric-protos-go/common"

--- a/platform/fabric/core/generic/endpoint/pki.go
+++ b/platform/fabric/core/generic/endpoint/pki.go
@@ -11,12 +11,11 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
-
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
 type pkiResolver struct {

--- a/platform/fabric/core/generic/ledger.go
+++ b/platform/fabric/core/generic/ledger.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package generic
 
 import (
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/peer"

--- a/platform/fabric/core/generic/msp/idemix/audit.go
+++ b/platform/fabric/core/generic/msp/idemix/audit.go
@@ -10,7 +10,7 @@ import (
 	"encoding/json"
 
 	csp "github.com/IBM/idemix/bccsp/schemes"
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	m "github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/pkg/errors"
 )

--- a/platform/fabric/core/generic/msp/idemix/common.go
+++ b/platform/fabric/core/generic/msp/idemix/common.go
@@ -8,7 +8,7 @@ package idemix
 
 import (
 	bccsp "github.com/IBM/idemix/bccsp/schemes"
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	m "github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/pkg/errors"
 )

--- a/platform/fabric/core/generic/msp/idemix/id.go
+++ b/platform/fabric/core/generic/msp/idemix/id.go
@@ -11,10 +11,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
-
 	csp "github.com/IBM/idemix/bccsp/schemes"
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
 	m "github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric/msp"
 	"github.com/pkg/errors"

--- a/platform/fabric/core/generic/msp/idemix/provider.go
+++ b/platform/fabric/core/generic/msp/idemix/provider.go
@@ -18,18 +18,16 @@ import (
 	idemix2 "github.com/IBM/idemix/bccsp/schemes/dlog/crypto"
 	"github.com/IBM/idemix/bccsp/schemes/dlog/crypto/translator/amcl"
 	math "github.com/IBM/mathlib"
-	"github.com/golang/protobuf/proto"
-	m "github.com/hyperledger/fabric-protos-go/msp"
-	"github.com/pkg/errors"
-
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/kvs"
-
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/kvs"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	m "github.com/hyperledger/fabric-protos-go/msp"
+	"github.com/pkg/errors"
 )
 
 var logger = flogging.MustGetLogger("fabric-sdk.msp.idemix")

--- a/platform/fabric/core/generic/msp/x509/deserializer.go
+++ b/platform/fabric/core/generic/msp/x509/deserializer.go
@@ -10,12 +10,11 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/hyperledger/fabric-protos-go/msp"
-	"github.com/pkg/errors"
-
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/hyperledger/fabric-protos-go/msp"
+	"github.com/pkg/errors"
 )
 
 type Deserializer struct{}

--- a/platform/fabric/core/generic/msp/x509/ecdsa.go
+++ b/platform/fabric/core/generic/msp/x509/ecdsa.go
@@ -18,14 +18,12 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
-
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric/bccsp/utils"
 	"github.com/pkg/errors"
-
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
 var (

--- a/platform/fabric/core/generic/msp/x509/identity.go
+++ b/platform/fabric/core/generic/msp/x509/identity.go
@@ -11,7 +11,7 @@ import (
 	"encoding/pem"
 	"io/ioutil"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/pkg/errors"
 )

--- a/platform/fabric/core/generic/msp/x509/loader.go
+++ b/platform/fabric/core/generic/msp/x509/loader.go
@@ -11,7 +11,7 @@ import (
 	"encoding/pem"
 	"path/filepath"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	msp2 "github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric/bccsp/sw"
 	"github.com/hyperledger/fabric/msp"

--- a/platform/fabric/core/generic/msp/x509/provider.go
+++ b/platform/fabric/core/generic/msp/x509/provider.go
@@ -10,13 +10,12 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/hyperledger/fabric-protos-go/msp"
-	"github.com/pkg/errors"
-
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	api2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/hyperledger/fabric-protos-go/msp"
+	"github.com/pkg/errors"
 )
 
 type SignerService interface {

--- a/platform/fabric/core/generic/ordering/ordering.go
+++ b/platform/fabric/core/generic/ordering/ordering.go
@@ -15,19 +15,17 @@ import (
 
 	"go.uber.org/zap/zapcore"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/transaction"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
-
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	common2 "github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
-
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
 var logger = flogging.MustGetLogger("fabric-sdk.ordering")

--- a/platform/fabric/core/generic/rwset/envelope.go
+++ b/platform/fabric/core/generic/rwset/envelope.go
@@ -9,7 +9,7 @@ package rwset
 import (
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/protoutil"

--- a/platform/fabric/core/generic/rwset/processor.go
+++ b/platform/fabric/core/generic/rwset/processor.go
@@ -7,14 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package rwset
 
 import (
-	"github.com/golang/protobuf/proto"
-	"github.com/hyperledger/fabric-protos-go/common"
-	"github.com/pkg/errors"
-
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
-
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
+	"github.com/hyperledger/fabric-protos-go/common"
+	"github.com/pkg/errors"
 )
 
 var logger = flogging.MustGetLogger("fabric-sdk.rwset")

--- a/platform/fabric/core/generic/transaction/envelope.go
+++ b/platform/fabric/core/generic/transaction/envelope.go
@@ -9,7 +9,7 @@ package transaction
 import (
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/protoutil"

--- a/platform/fabric/core/generic/transaction/pr.go
+++ b/platform/fabric/core/generic/transaction/pr.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package transaction
 
 import (
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"

--- a/platform/fabric/core/generic/transaction/proposal.go
+++ b/platform/fabric/core/generic/transaction/proposal.go
@@ -9,15 +9,14 @@ package transaction
 import (
 	"crypto/sha256"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	cb "github.com/hyperledger/fabric-protos-go/common"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/core/common/ccprovider"
 	"github.com/hyperledger/fabric/msp"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
-
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 )
 
 // UnpackedProposal contains the interesting artifacts from inside the proposal.

--- a/platform/fabric/core/generic/transaction/transasction.go
+++ b/platform/fabric/core/generic/transaction/transasction.go
@@ -10,7 +10,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"

--- a/platform/fabric/core/generic/vault/interceptor.go
+++ b/platform/fabric/core/generic/vault/interceptor.go
@@ -9,15 +9,13 @@ package vault
 import (
 	"encoding/json"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"
-
-	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset"
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset/kvrwset"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
 	"github.com/pkg/errors"
-
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 )
 
 type QueryExecutor interface {

--- a/platform/fabric/core/generic/vault/rwset.go
+++ b/platform/fabric/core/generic/vault/rwset.go
@@ -10,8 +10,8 @@ import (
 	"bytes"
 	"sort"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/keys"
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"

--- a/platform/fabric/services/state/sbe.go
+++ b/platform/fabric/services/state/sbe.go
@@ -10,14 +10,13 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/pkg/errors"
-
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
 type sbeMetaHandler struct {

--- a/platform/fabric/services/weaver/relay/fabric/proof.go
+++ b/platform/fabric/services/weaver/relay/fabric/proof.go
@@ -10,13 +10,12 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	"github.com/hyperledger-labs/weaver-dlt-interoperability/common/protos-go/common"
 	fabric2 "github.com/hyperledger-labs/weaver-dlt-interoperability/common/protos-go/fabric"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
-
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 )
 
 // ProofMessage models a Relay proof for a Fabric Query

--- a/platform/fabric/services/weaver/relay/fabric/query.go
+++ b/platform/fabric/services/weaver/relay/fabric/query.go
@@ -13,9 +13,10 @@ import (
 	"net"
 	"strconv"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
-
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/weaver-dlt-interoperability/common/protos-go/common"
 	fabric2 "github.com/hyperledger-labs/weaver-dlt-interoperability/common/protos-go/fabric"
 	"github.com/hyperledger-labs/weaver-dlt-interoperability/sdks/fabric/go-sdk/interoperablehelper"
@@ -23,9 +24,6 @@ import (
 	"github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
-
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 )
 
 var logger = flogging.MustGetLogger("weaver-relay-fabric")

--- a/platform/fabric/services/weaver/relay/fabric/rwset.go
+++ b/platform/fabric/services/weaver/relay/fabric/rwset.go
@@ -10,13 +10,12 @@ import (
 	"bytes"
 	"sort"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/keys"
 	"github.com/hyperledger/fabric-protos-go/ledger/rwset"
 	"github.com/hyperledger/fabric/core/ledger/kvledger/txmgmt/rwsetutil"
 	"github.com/pkg/errors"
-
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/keys"
 )
 
 type readWriteSet struct {

--- a/platform/orion/core/generic/session.go
+++ b/platform/orion/core/generic/session.go
@@ -9,7 +9,7 @@ package generic
 import (
 	"time"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	config2 "github.com/hyperledger-labs/fabric-smart-client/platform/orion/core/generic/config"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/orion/driver"
 	"github.com/hyperledger-labs/orion-sdk-go/pkg/bcdb"

--- a/platform/orion/core/generic/transaction/manager.go
+++ b/platform/orion/core/generic/transaction/manager.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package transaction
 
 import (
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/orion/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/orion-server/pkg/types"

--- a/platform/orion/core/generic/vault/rwset.go
+++ b/platform/orion/core/generic/vault/rwset.go
@@ -10,8 +10,8 @@ import (
 	"bytes"
 	"sort"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/keys"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
 	"github.com/pkg/errors"

--- a/platform/orion/transaction.go
+++ b/platform/orion/transaction.go
@@ -11,7 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/orion/driver"
 	"github.com/hyperledger-labs/orion-server/pkg/types"
 	"github.com/pkg/errors"

--- a/platform/view/core/id/x509/ecdsa.go
+++ b/platform/view/core/id/x509/ecdsa.go
@@ -18,13 +18,11 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
-
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/pkg/errors"
-
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
 var (

--- a/platform/view/services/client/view/client.go
+++ b/platform/view/services/client/view/client.go
@@ -13,8 +13,8 @@ import (
 	"io"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/api"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	grpc2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
 	hash2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"

--- a/platform/view/services/comm/p2p.go
+++ b/platform/view/services/comm/p2p.go
@@ -17,7 +17,9 @@ import (
 
 	"github.com/gogo/protobuf/io"
 	"github.com/gogo/protobuf/proto"
-	proto2 "github.com/golang/protobuf/proto"
+	proto2 "github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -26,9 +28,6 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/discovery/routing"
 	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
-
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
 const (

--- a/platform/view/services/db/driver/badger/badger.go
+++ b/platform/view/services/db/driver/badger/badger.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger/v3"
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	dbproto "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/badger/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/keys"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"

--- a/platform/view/services/grpc/util.go
+++ b/platform/view/services/grpc/util.go
@@ -14,7 +14,7 @@ import (
 	"encoding/pem"
 	"net"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"

--- a/platform/view/services/server/view/marshal.go
+++ b/platform/view/services/server/view/marshal.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
 	hash2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"


### PR DESCRIPTION
As part of issue #50, removed warnings related to:
* SA1019: replaced deprecated protobuf with an adapter package

Signed-off-by: Alexandros Filios <alexandros.filios@ibm.com>