### PR TITLE
Enable staticcheck via make checks

### DIFF
--- a/checks.mk
+++ b/checks.mk
@@ -1,5 +1,5 @@
 .PHONY: checks
-checks: licensecheck gofmt goimports govet misspell ineffassign
+checks: licensecheck gofmt goimports govet misspell ineffassign staticcheck
 
 .PHONY: licensecheck
 licensecheck:


### PR DESCRIPTION
Runs staticcheck with `make checks`.

Currently, this is supposed to fail via CI until #50 is resolved.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>