### PR TITLE
Reduce staticcheck warnings (S1000)

### DIFF
--- a/platform/fabric/sdk/sdk.go
+++ b/platform/fabric/sdk/sdk.go
@@ -102,11 +102,9 @@ func (p *p) Start(ctx context.Context) error {
 	}
 
 	go func() {
-		select {
-		case <-ctx.Done():
-			if err := p.fnsProvider.Stop(); err != nil {
-				logger.Errorf("failed stopping fabric network service provider [%s]", err)
-			}
+		<-ctx.Done()
+		if err := p.fnsProvider.Stop(); err != nil {
+			logger.Errorf("failed stopping fabric network service provider [%s]", err)
 		}
 	}()
 

--- a/platform/orion/sdk/sdk.go
+++ b/platform/orion/sdk/sdk.go
@@ -69,11 +69,9 @@ func (p *SDK) Start(ctx context.Context) error {
 	}
 
 	go func() {
-		select {
-		case <-ctx.Done():
-			if err := p.onsProvider.Stop(); err != nil {
-				logger.Errorf("failed stopping orion network service provider [%s]", err)
-			}
+		<-ctx.Done()
+		if err := p.onsProvider.Stop(); err != nil {
+			logger.Errorf("failed stopping orion network service provider [%s]", err)
 		}
 	}()
 

--- a/platform/view/sdk/sdk.go
+++ b/platform/view/sdk/sdk.go
@@ -310,29 +310,27 @@ func (p *p) serve() error {
 		}
 	}()
 	go func() {
-		select {
-		case <-p.context.Done():
-			if p.webServer != nil {
-				logger.Info("web server stopping...")
-				if err := p.webServer.Stop(); err != nil {
-					logger.Errorf("failed stopping web server [%s]", err)
-				}
+		<-p.context.Done()
+		if p.webServer != nil {
+			logger.Info("web server stopping...")
+			if err := p.webServer.Stop(); err != nil {
+				logger.Errorf("failed stopping web server [%s]", err)
 			}
-			logger.Info("web server stopping...done")
+		}
+		logger.Info("web server stopping...done")
 
-			logger.Info("grpc server stopping...")
-			p.grpcServer.Stop()
-			logger.Info("grpc server stopping...done")
+		logger.Info("grpc server stopping...")
+		p.grpcServer.Stop()
+		logger.Info("grpc server stopping...done")
 
-			logger.Info("kvs stopping...")
-			kvs.GetService(p.registry).Stop()
-			logger.Info("kvs stopping...done")
+		logger.Info("kvs stopping...")
+		kvs.GetService(p.registry).Stop()
+		logger.Info("kvs stopping...done")
 
-			logger.Infof("operations system stopping...")
-			if p.operationsSystem != nil {
-				if err := p.operationsSystem.Stop(); err != nil {
-					logger.Errorf("failed stopping operations system [%s]", err)
-				}
+		logger.Infof("operations system stopping...")
+		if p.operationsSystem != nil {
+			if err := p.operationsSystem.Stop(); err != nil {
+				logger.Errorf("failed stopping operations system [%s]", err)
 			}
 		}
 	}()

--- a/platform/view/services/comm/io/msgconn.go
+++ b/platform/view/services/comm/io/msgconn.go
@@ -59,21 +59,19 @@ func (c *commSCCMsgConn) Write(data []byte) (n int, err error) {
 func (c *commSCCMsgConn) Read() ([]byte, error) {
 	c.readCounter++
 	logger.Debugf("[commSCCMsgConn] Reading at counter [%d]", c.readCounter)
-	select {
-	case msg := <-c.ch:
-		if msg.Status == view.ERROR {
-			return nil, errors.New(string(msg.Payload))
-		}
-
-		if len(msg.Payload) == 0 {
-			logger.Error("failed receiving message [%s][%s]", "", "")
-			errMsg := fmt.Errorf("failed receiving message [%s][%s]", "", "")
-			return nil, errMsg
-		}
-
-		logger.Debugf("[commSCCMsgConn] [%d] Read [%d][%s]\n", c.readCounter, len(msg.Payload), base64.StdEncoding.EncodeToString(MD5Hash(msg.Payload)))
-		return msg.Payload, nil
+	msg := <-c.ch
+	if msg.Status == view.ERROR {
+		return nil, errors.New(string(msg.Payload))
 	}
+
+	if len(msg.Payload) == 0 {
+		logger.Error("failed receiving message [%s][%s]", "", "")
+		errMsg := fmt.Errorf("failed receiving message [%s][%s]", "", "")
+		return nil, errMsg
+	}
+
+	logger.Debugf("[commSCCMsgConn] [%d] Read [%d][%s]\n", c.readCounter, len(msg.Payload), base64.StdEncoding.EncodeToString(MD5Hash(msg.Payload)))
+	return msg.Payload, nil
 }
 
 func (c *commSCCMsgConn) Flush() error {


### PR DESCRIPTION
As part of issue #50, removed warnings related to:
* S1000: removed redundant single-case selects for channels

Signed-off-by: Alexandros Filios <alexandros.filios@ibm.com>