### PR TITLE
Reduce staticcheck warnings (S1034)

### DIFF
--- a/integration/nwo/common/json.go
+++ b/integration/nwo/common/json.go
@@ -40,12 +40,12 @@ func JSONUnmarshalString(v interface{}) string {
 
 func JSONUnmarshalInt(v interface{}) int {
 	var s int
-	switch v.(type) {
+	switch v := v.(type) {
 	case []byte:
-		err := json.Unmarshal(v.([]byte), &s)
+		err := json.Unmarshal(v, &s)
 		Expect(err).NotTo(HaveOccurred())
 	case string:
-		err := json.Unmarshal([]byte(v.(string)), &s)
+		err := json.Unmarshal([]byte(v), &s)
 		Expect(err).NotTo(HaveOccurred())
 	default:
 		panic(fmt.Sprintf("type not recognized [%T]", v))

--- a/platform/view/services/assert/assert.go
+++ b/platform/view/services/assert/assert.go
@@ -77,9 +77,9 @@ func extractReleasers(msgAndArgs ...interface{}) ([]interface{}, []func()) {
 	var output []interface{}
 	var releasers []func()
 	for _, arg := range msgAndArgs {
-		switch arg.(type) {
+		switch arg := arg.(type) {
 		case func():
-			releasers = append(releasers, arg.(func()))
+			releasers = append(releasers, arg)
 		default:
 			output = append(output, arg)
 		}


### PR DESCRIPTION
As part of issue #50, removed warnings related to:
* S1034: removed redundant assertions in switch statements

Signed-off-by: Alexandros Filios <alexandros.filios@ibm.com>