### PR TITLE
Reduce staticcheck warnings (S1039)

### DIFF
--- a/integration/nwo/fsc/fsc.go
+++ b/integration/nwo/fsc/fsc.go
@@ -427,9 +427,7 @@ func (p *Platform) GenerateCoreConfig(peer *node2.Peer) {
 			Expect(err).NotTo(HaveOccurred())
 			extensions = append(extensions, string(bs))
 		} else {
-			for _, s := range extensionsByPeerID {
-				extensions = append(extensions, s)
-			}
+			extensions = append(extensions, extensionsByPeerID...)
 		}
 	}
 
@@ -481,7 +479,7 @@ func (p *Platform) FSCNodeRunner(node *node2.Peer, env ...string) *runner2.Runne
 		commands.NodeStart{NodeID: node.ID()},
 		"",
 		fmt.Sprintf("FSCNODE_CFG_PATH=%s", p.NodeDir(node)),
-		fmt.Sprintf("FSCNODE_PROFILER=true"),
+		"FSCNODE_PROFILER=true",
 	)
 	cmd.Env = append(cmd.Env, env...)
 

--- a/integration/nwo/weaver/interopcc.go
+++ b/integration/nwo/weaver/interopcc.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package weaver
 
 import (
-	"fmt"
 	"path/filepath"
 	"sync"
 
@@ -28,7 +27,7 @@ func (p *Platform) InteropChaincodeFile() string {
 }
 
 func (p *Platform) interopccSetup(relay *RelayServer, cc *topology.ChannelChaincode) (*topology.ChannelChaincode, error) {
-	cc.Chaincode.Ctor = fmt.Sprintf(`{"Args":["initLedger","applicationCCID"]}`)
+	cc.Chaincode.Ctor = `{"Args":["initLedger","applicationCCID"]}`
 
 	packageLock.Lock()
 	defer packageLock.Unlock()

--- a/platform/fabric/core/generic/msp/x509/deserializer.go
+++ b/platform/fabric/core/generic/msp/x509/deserializer.go
@@ -55,5 +55,5 @@ func (i *Deserializer) Info(raw []byte, auditInfo []byte) (string, error) {
 }
 
 func (i *Deserializer) String() string {
-	return fmt.Sprintf("Generic X509 Verifier Deserializer")
+	return "Generic X509 Verifier Deserializer"
 }

--- a/platform/fabric/core/generic/ordering/client.go
+++ b/platform/fabric/core/generic/ordering/client.go
@@ -9,7 +9,6 @@ package ordering
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"io"
 	"strings"
 
@@ -170,7 +169,7 @@ func toError(errs []error) error {
 		return errs[0]
 	}
 
-	errmsgs := []string{fmt.Sprint("Multiple errors occurred in order broadcast stream: ")}
+	errmsgs := []string{"Multiple errors occurred in order broadcast stream: "}
 	for _, err := range errs {
 		errmsgs = append(errmsgs, err.Error())
 	}

--- a/platform/fabric/services/endorser/endorsement.go
+++ b/platform/fabric/services/endorser/endorsement.go
@@ -166,7 +166,7 @@ func (c *collectEndorsementsView) Call(context view.Context) (interface{}, error
 
 		tracker.Report(fmt.Sprintf("collectEndorsementsView: collected signature from %s", party))
 	}
-	tracker.Report(fmt.Sprintf("collectEndorsementsView done."))
+	tracker.Report("collectEndorsementsView done.")
 	return c.tx, nil
 }
 


### PR DESCRIPTION
As part of issue #50, removed warnings related to:
* S1039: removed unnecessary formatting

Signed-off-by: Alexandros Filios <alexandros.filios@ibm.com>