### PR TITLE
Reduce staticcheck warnings (S1011)

### DIFF
--- a/platform/fabric/core/generic/transaction/transasction.go
+++ b/platform/fabric/core/generic/transaction/transasction.go
@@ -562,10 +562,7 @@ func (t *Transaction) ProposalResponse() ([]byte, error) {
 func (t *Transaction) generateProposal(signer SerializableSigner) error {
 	logger.Debugf("generate proposal...")
 	// Build the spec
-	params := [][]byte{[]byte(t.TFunction)}
-	for _, parameter := range t.TParameters {
-		params = append(params, parameter)
-	}
+	params := append([][]byte{[]byte(t.TFunction)}, t.TParameters...)
 	input := pb.ChaincodeInput{
 		Args:        params,
 		Decorations: nil,

--- a/platform/fabric/services/state/certification.go
+++ b/platform/fabric/services/state/certification.go
@@ -89,10 +89,7 @@ func certificationKey(key string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	elems := []string{prefix}
-	for _, attr := range attrs {
-		elems = append(elems, attr)
-	}
+	elems := append([]string{prefix}, attrs...)
 	return rwset.CreateCompositeKey(Certification, elems)
 }
 

--- a/platform/fabric/services/state/tags.go
+++ b/platform/fabric/services/state/tags.go
@@ -188,9 +188,6 @@ func fieldMappingKey(ns, key string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	elems := []string{ns, prefix}
-	for _, attr := range attrs {
-		elems = append(elems, attr)
-	}
+	elems := append([]string{ns, prefix}, attrs...)
 	return rwset.CreateCompositeKey("field_mapping", elems)
 }


### PR DESCRIPTION
As part of issue #50, removed warnings related to:
* S1011: replaced append loops with varargs

Signed-off-by: Alexandros Filios <alexandros.filios@ibm.com>