### PR TITLE
Reduce staticcheck warnings (SA4023)

### DIFF
--- a/platform/fabric/services/chaincode/endorse.go
+++ b/platform/fabric/services/chaincode/endorse.go
@@ -65,11 +65,7 @@ func (i *endorseChaincodeView) Endorse(context view.Context) (*fabric.Envelope, 
 		i.SignerIdentity = fNetwork.IdentityProvider().DefaultIdentity()
 	}
 
-	var chaincode Chaincode
-	chaincode = &stdChaincode{ch: channel.Chaincode(i.ChaincodeName)}
-	if chaincode == nil {
-		return nil, errors.Errorf("fabric chaincode [%s:%s:%s] not found", i.Network, i.Channel, i.ChaincodeName)
-	}
+	var chaincode Chaincode = &stdChaincode{ch: channel.Chaincode(i.ChaincodeName)}
 	if chaincode.IsPrivate() {
 		logger.Debugf("chaincode [%s:%s:%s] is a FPC", i.Network, i.Channel, i.ChaincodeName)
 		// This is a Fabric Private Chaincode, use the corresponding service

--- a/platform/fabric/services/chaincode/query.go
+++ b/platform/fabric/services/chaincode/query.go
@@ -48,12 +48,8 @@ func (i *queryChaincodeView) Query(context view.Context) ([]byte, error) {
 	if i.InvokerIdentity.IsNone() {
 		i.InvokerIdentity = fNetwork.IdentityProvider().DefaultIdentity()
 	}
-	var chaincode Chaincode
 
-	chaincode = &stdChaincode{ch: channel.Chaincode(i.ChaincodeName)}
-	if chaincode == nil {
-		return nil, errors.Errorf("fabric chaincode [%s:%s:%s] not found", i.Network, i.Channel, i.ChaincodeName)
-	}
+	var chaincode Chaincode = &stdChaincode{ch: channel.Chaincode(i.ChaincodeName)}
 	if chaincode.IsPrivate() {
 		logger.Debugf("chaincode [%s:%s:%s] is a FPC", i.Network, i.Channel, i.ChaincodeName)
 		// This is a Fabric Private Chaincode, use the corresponding service


### PR DESCRIPTION
As part of issue #50, removed warnings related to:
* SA4023: replaced unnecessary null checks

Signed-off-by: Alexandros Filios <alexandros.filios@ibm.com>