### PR TITLE
Reduce staticcheck warnings (S1021, S1038, S1025, SA4009, S1005, SA9003)

### DIFF
--- a/integration/integration.go
+++ b/integration/integration.go
@@ -78,8 +78,7 @@ func New(startPort int, path string, topologies ...api.Topology) (*Infrastructur
 
 	buildServer := common.NewBuildServer()
 	buildServer.Serve()
-	var builder api.Builder
-	builder = buildServer.Client()
+	builder := buildServer.Client()
 
 	n := &Infrastructure{
 		TestDir:      testDir,

--- a/integration/nwo/cmd/main.go
+++ b/integration/nwo/cmd/main.go
@@ -70,10 +70,8 @@ func VersionCmd(pName string) *cobra.Command {
 			}
 			// Parsing of the command line is done so silence cmd usage
 			cmd.SilenceUsage = true
-			fmt.Print(fmt.Sprintf("%s:\n Go version: %s\n"+
-				" OS/Arch: %s\n",
-				pName, runtime.Version(),
-				fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)))
+			fmt.Printf("%s:\n Go version: %s\n  OS/Arch: %s/%s\n",
+				pName, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 			return nil
 		},
 	}

--- a/integration/nwo/common/builder.go
+++ b/integration/nwo/common/builder.go
@@ -42,7 +42,7 @@ func (c *BuilderClient) Build(path string) string {
 	Expect(err).NotTo(HaveOccurred())
 
 	if resp.StatusCode != http.StatusOK {
-		Expect(resp.StatusCode).To(Equal(http.StatusOK), fmt.Sprintf("%s", body))
+		Expect(resp.StatusCode).To(Equal(http.StatusOK), string(body))
 	}
 
 	return string(body)

--- a/integration/nwo/fabric/fpc/fpc.go
+++ b/integration/nwo/fabric/fpc/fpc.go
@@ -118,7 +118,7 @@ func (n *Extension) PostRun(load bool) {
 	}
 
 	if load {
-		// run docker containers
+		panic("Load is not supported. Restart from scratch.")
 	}
 
 	// deploy and run containers

--- a/integration/nwo/weaver/util.go
+++ b/integration/nwo/weaver/util.go
@@ -180,8 +180,11 @@ func gzipDir(dir, dest string) error {
 	defer t.Flush()
 
 	err = filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
-		var f *os.File
-		f, err = os.Open(path)
+		if err != nil {
+			return fmt.Errorf("failed accessing %s: %v", path, err)
+		}
+
+		f, err := os.Open(path)
 		if err != nil {
 			return fmt.Errorf("failed opening %s: %v", path, err)
 		}

--- a/platform/fabric/core/generic/delivery/deliverclient.go
+++ b/platform/fabric/core/generic/delivery/deliverclient.go
@@ -230,7 +230,7 @@ read:
 // If an eventCh is shared by multiple transactions, a loop should be used to listen to events from multiple transactions
 func DeliverWaitForResponse(ctx context.Context, eventCh <-chan TxEvent, txid string) (bool, uint64, int, error) {
 	select {
-	case event, _ := <-eventCh:
+	case event := <-eventCh:
 		if txid == event.Txid {
 			return event.Committed, event.Block, event.IndexInBlock, event.Err
 		}


### PR DESCRIPTION
As part of issue #50, removed warnings related to:
* S1021: merge var assignment and declaration
* S1038, S1025: remove redundant sprintf's
* SA4009: remove overwritten assignment
* S1005: removed unnecessary assignment to blank identifier
* SA9003: removed empty branch

Signed-off-by: Alexandros Filios <alexandros.filios@ibm.com>