### PR TITLE
Reduce staticcheck warnings (SA4006)

### DIFF
--- a/platform/view/sdk/sdk.go
+++ b/platform/view/sdk/sdk.go
@@ -8,7 +8,6 @@ package view
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -238,19 +237,6 @@ func (p *p) initGRPCServer() error {
 		grpclogging.StreamServerInterceptor(flogging.MustGetLogger("comm.grpc.server").Zap()),
 	)
 
-	cs := grpc2.NewCredentialSupport()
-	if serverConfig.SecOpts.UseTLS {
-		logger.Info("Starting peer with TLS enabled")
-		cs = grpc2.NewCredentialSupport(serverConfig.SecOpts.ServerRootCAs...)
-
-		// set the cert to use if client auth is requested by remote endpoints
-		clientCert, err := p.getClientCertificate()
-		if err != nil {
-			logger.Fatalf("Failed to set TLS client certificate (%s)", err)
-		}
-		cs.SetClientCertificate(clientCert)
-	}
-
 	p.grpcServer, err = grpc2.NewGRPCServer(listenAddr, serverConfig)
 	assert.NoError(err, "failed creating grpc server")
 
@@ -428,62 +414,6 @@ func (p *p) getServerConfig() (grpc2.ServerConfig, error) {
 		serverConfig.KaOpts.ServerMinInterval = configProvider.GetDuration("fsc.keepalive.minInterval")
 	}
 	return serverConfig, nil
-}
-
-func (p *p) getClientCertificate() (tls.Certificate, error) {
-	configProvider := view.GetConfigService(p.registry)
-
-	cert := tls.Certificate{}
-
-	keyPath := configProvider.GetString("fsc.tls.clientKey.file")
-	certPath := configProvider.GetString("fsc.tls.clientCert.file")
-
-	if keyPath != "" || certPath != "" {
-		// need both keyPath and certPath to be set
-		if keyPath == "" || certPath == "" {
-			return cert, errors.New("fsc.tls.clientKey.file and " +
-				"fsc.tls.clientCert.file must both be set or must both be empty")
-		}
-		keyPath = configProvider.GetPath("fsc.tls.clientKey.file")
-		certPath = configProvider.GetPath("fsc.tls.clientCert.file")
-
-	} else {
-		// use the TLS server keypair
-		keyPath = configProvider.GetString("fsc.tls.key.file")
-		certPath = configProvider.GetString("fsc.tls.cert.file")
-
-		if keyPath != "" || certPath != "" {
-			// need both keyPath and certPath to be set
-			if keyPath == "" || certPath == "" {
-				return cert, errors.New("fsc.tls.key.file and " +
-					"fsc.tls.cert.file must both be set or must both be empty")
-			}
-			keyPath = configProvider.GetPath("fsc.tls.key.file")
-			certPath = configProvider.GetPath("fsc.tls.cert.file")
-		} else {
-			return cert, errors.New("must set either " +
-				"[fsc.tls.key.file and fsc.tls.cert.file] or " +
-				"[fsc.tls.clientKey.file and fsc.tls.clientCert.file]" +
-				"when fsc.tls.clientAuthEnabled is set to true")
-		}
-	}
-	// get the keypair from the file system
-	clientKey, err := ioutil.ReadFile(keyPath)
-	if err != nil {
-		return cert, errors.WithMessage(err,
-			"error loading client TLS key")
-	}
-	clientCert, err := ioutil.ReadFile(certPath)
-	if err != nil {
-		return cert, errors.WithMessage(err,
-			"error loading client TLS certificate")
-	}
-	cert, err = tls.X509KeyPair(clientCert, clientKey)
-	if err != nil {
-		return cert, errors.WithMessage(err,
-			"error parsing client TLS key pair")
-	}
-	return cert, nil
 }
 
 func (p *p) installTracing() error {


### PR DESCRIPTION
As part of issue #50, removed warnings related to:
* SA4006: unused var and function

Signed-off-by: Alexandros Filios <alexandros.filios@ibm.com>