### PR TITLE
Remove cleaning of non-generated file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,6 @@ clean:
 	rm -rf ./integration/fabric/fpc/echo/cmd
 	rm -rf ./integration/fabric/stoprestart/cmd
 	rm -rf ./integration/fsc/stoprestart/cmd
-	rm -rf ./integration/fsc/pingpong/cmd/responder
 	rm -rf ./integration/orion/cars/cmd
 	rm -rf ./integration/fscnodes
 	rm -rf ./cmd/fsccli/cmd


### PR DESCRIPTION
The main.go under
/integration/fsc/pingpong/cmd/responder
is not generated automatically, hence it should not be cleaned when make clean is invoked

Signed-off-by: Alexandros Filios <alexandros.filios@ibm.com>