### PR TITLE
committer improvements

### DIFF
--- a/platform/fabric/core/generic/committer.go
+++ b/platform/fabric/core/generic/committer.go
@@ -59,9 +59,13 @@ func (c *channel) DiscardTx(txid string) error {
 		return nil
 	}
 
-	c.vault.DiscardTx(txid)
+	if err := c.vault.DiscardTx(txid); err != nil {
+		logger.Errorf("failed discarding tx [%s] in vault: %s", txid, err)
+	}
 	for _, dep := range deps {
-		c.vault.DiscardTx(dep)
+		if err := c.vault.DiscardTx(dep); err != nil {
+			logger.Errorf("failed discarding dependant tx [%s] of [%s] in vault: %s", dep, txid, err)
+		}
 	}
 	return nil
 }

--- a/platform/fabric/core/generic/committer/endorsertx.go
+++ b/platform/fabric/core/generic/committer/endorsertx.go
@@ -89,6 +89,12 @@ func (c *committer) handleEndorserTransaction(block *common.Block, i int, event 
 			}
 			// Nothing to commit
 			return
+		case driver.Unknown:
+			if logger.IsEnabledFor(zapcore.DebugLevel) {
+				logger.Debugf("transaction [%s] in block [%d] is marked as unknown, skipping", txID, blockNum)
+			}
+			// Nothing to commit
+			return
 		default:
 			event.Err = errors.Errorf("transaction [%s] status is not valid: %d", txID, validationCode)
 			err = committer.DiscardTx(event.Txid)

--- a/platform/fabric/core/generic/committer/endorsertx.go
+++ b/platform/fabric/core/generic/committer/endorsertx.go
@@ -18,89 +18,107 @@ import (
 type ValidationFlags []uint8
 
 func (c *committer) handleEndorserTransaction(block *common.Block, i int, event *TxEvent, env *common.Envelope, chHdr *common.ChannelHeader) {
+	txID := chHdr.TxId
+	event.Txid = txID
+
+	validationCode := pb.TxValidationCode(ValidationFlags(block.Metadata.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER])[i])
+	switch validationCode {
+	case pb.TxValidationCode_VALID:
+		if err := c.CommitEndorserTransaction(txID, block, i, env, event); err != nil {
+			logger.Panicf("failed committing transaction [%s] with err [%s]", txID, err)
+		}
+	default:
+		if err := c.DiscardEndorserTransaction(txID, block, event, validationCode); err != nil {
+			logger.Panicf("failed discarding transaction [%s] with err [%s]", txID, err)
+		}
+	}
+}
+
+// CommitEndorserTransaction commits the transaction to the vault
+func (c *committer) CommitEndorserTransaction(txID string, block *common.Block, indexInBlock int, env *common.Envelope, event *TxEvent) error {
 	committer, err := c.network.Committer(c.channel)
 	if err != nil {
 		logger.Panicf("Cannot get Committer [%s]", err)
 	}
 
-	txID := chHdr.TxId
-	event.Txid = txID
-
-	validationCode := ValidationFlags(block.Metadata.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER])[i]
 	blockNum := block.Header.Number
-	switch pb.TxValidationCode(validationCode) {
-	case pb.TxValidationCode_VALID:
+	if logger.IsEnabledFor(zapcore.DebugLevel) {
+		logger.Debugf("transaction [%s] in block [%d] is valid for fabric, commit!", txID, blockNum)
+	}
+
+	event.Committed = true
+	event.Block = blockNum
+	event.IndexInBlock = indexInBlock
+
+	vc, deps, err := committer.Status(txID)
+	if err != nil {
+		logger.Panicf("failed getting tx's status [%s], with err [%s]", txID, err)
+	}
+	event.DependantTxIDs = append(event.DependantTxIDs, deps...)
+
+	switch vc {
+	case driver.Valid:
 		if logger.IsEnabledFor(zapcore.DebugLevel) {
-			logger.Debugf("transaction [%s] in block [%d] is valid for fabric, commit!", txID, blockNum)
+			logger.Debugf("transaction [%s] in block [%d] is already marked as valid, skipping", txID, blockNum)
 		}
-
-		event.Committed = true
-		event.Block = blockNum
-		event.IndexInBlock = i
-
-		vc, deps, err := committer.Status(txID)
-		if err != nil {
-			logger.Panicf("failed getting tx's status [%s], with err [%s]", txID, err)
+		// Nothing to commit
+	case driver.Invalid:
+		if logger.IsEnabledFor(zapcore.DebugLevel) {
+			logger.Debugf("transaction [%s] in block [%d] is marked as invalid, skipping", txID, blockNum)
 		}
-		event.DependantTxIDs = append(event.DependantTxIDs, deps...)
-
-		switch vc {
-		case driver.Valid:
-			if logger.IsEnabledFor(zapcore.DebugLevel) {
-				logger.Debugf("transaction [%s] in block [%d] is already marked as valid, skipping", txID, blockNum)
-			}
-			// Nothing to commit
-			return
-		case driver.Invalid:
-			if logger.IsEnabledFor(zapcore.DebugLevel) {
-				logger.Debugf("transaction [%s] in block [%d] is marked as invalid, skipping", txID, blockNum)
-			}
-			// Nothing to commit
-			return
-		default:
-			if block != nil {
-				if err := committer.CommitTX(event.Txid, event.Block, event.IndexInBlock, env); err != nil {
-					logger.Panicf("failed committing transaction [%s] with deps [%v] with err [%s]", txID, deps, err)
-				}
-				return
-			}
-
-			if err := committer.CommitTX(event.Txid, event.Block, event.IndexInBlock, nil); err != nil {
+		// Nothing to commit
+	default:
+		if block != nil {
+			if err := committer.CommitTX(event.Txid, event.Block, event.IndexInBlock, env); err != nil {
 				logger.Panicf("failed committing transaction [%s] with deps [%v] with err [%s]", txID, deps, err)
 			}
-		}
-	default:
-		if logger.IsEnabledFor(zapcore.DebugLevel) {
-			logger.Debugf("transaction [%s] in block [%d] is not valid for fabric [%s], discard!", txID, blockNum, validationCode)
+			return nil
 		}
 
-		vc, deps, err := committer.Status(txID)
-		if err != nil {
-			logger.Panicf("failed getting tx's status [%s], with err [%s]", txID, err)
-		}
-		event.DependantTxIDs = append(event.DependantTxIDs, deps...)
-		switch vc {
-		case driver.Valid:
-			// TODO: this might be due the fact that there are transactions with the same tx-id, the first is valid, the others are all invalid
-			logger.Warnf("transaction [%s] in block [%d] is marked as valid but for fabric is invalid", txID, blockNum)
-		case driver.Invalid:
-			if logger.IsEnabledFor(zapcore.DebugLevel) {
-				logger.Debugf("transaction [%s] in block [%d] is marked as invalid, skipping", txID, blockNum)
-			}
-			// Nothing to commit
-			return
-		case driver.Unknown:
-			if logger.IsEnabledFor(zapcore.DebugLevel) {
-				logger.Debugf("transaction [%s] in block [%d] is marked as unknown, skipping", txID, blockNum)
-			}
-			// Nothing to commit
-			return
-		default:
-			event.Err = errors.Errorf("transaction [%s] status is not valid: %d", txID, validationCode)
-			err = committer.DiscardTx(event.Txid)
-			if err != nil {
-				logger.Errorf("failed discarding tx in state db with err [%s]", err)
-			}
+		if err := committer.CommitTX(event.Txid, event.Block, event.IndexInBlock, nil); err != nil {
+			logger.Panicf("failed committing transaction [%s] with deps [%v] with err [%s]", txID, deps, err)
 		}
 	}
+	return nil
+}
+
+// DiscardEndorserTransaction discards the transaction from the vault
+func (c *committer) DiscardEndorserTransaction(txID string, block *common.Block, event *TxEvent, validationCode pb.TxValidationCode) error {
+	committer, err := c.network.Committer(c.channel)
+	if err != nil {
+		logger.Panicf("Cannot get Committer [%s]", err)
+	}
+
+	blockNum := block.Header.Number
+	if logger.IsEnabledFor(zapcore.DebugLevel) {
+		logger.Debugf("transaction [%s] in block [%d] is not valid for fabric [%s], discard!", txID, blockNum, validationCode)
+	}
+
+	vc, deps, err := committer.Status(txID)
+	if err != nil {
+		logger.Panicf("failed getting tx's status [%s], with err [%s]", txID, err)
+	}
+	event.DependantTxIDs = append(event.DependantTxIDs, deps...)
+	switch vc {
+	case driver.Valid:
+		// TODO: this might be due the fact that there are transactions with the same tx-id, the first is valid, the others are all invalid
+		logger.Warnf("transaction [%s] in block [%d] is marked as valid but for fabric is invalid", txID, blockNum)
+	case driver.Invalid:
+		if logger.IsEnabledFor(zapcore.DebugLevel) {
+			logger.Debugf("transaction [%s] in block [%d] is marked as invalid, skipping", txID, blockNum)
+		}
+		// Nothing to commit
+	case driver.Unknown:
+		if logger.IsEnabledFor(zapcore.DebugLevel) {
+			logger.Debugf("transaction [%s] in block [%d] is marked as unknown, skipping", txID, blockNum)
+		}
+		// Nothing to commit
+	default:
+		event.Err = errors.Errorf("transaction [%s] status is not valid: %d", txID, validationCode)
+		err = committer.DiscardTx(event.Txid)
+		if err != nil {
+			logger.Errorf("failed discarding tx in state db with err [%s]", err)
+		}
+	}
+	return nil
 }

--- a/platform/orion/core/generic/committer/committer.go
+++ b/platform/orion/core/generic/committer/committer.go
@@ -99,74 +99,80 @@ func (c *committer) Commit(block *types.AugmentedBlockHeader) error {
 	for i, txID := range block.TxIds {
 		var event TxEvent
 		event.Txid = txID
-		event.Block = block.Header.BaseHeader.Number
+		event.Block = bn
 		event.IndexInBlock = i
 
 		validationCode := block.Header.ValidationInfo[i].Flag
 		switch validationCode {
 		case types.Flag_VALID:
-			// if is already committed, do nothing
-			vc, err := c.vault.Status(txID)
-			if err != nil {
-				return errors.Wrapf(err, "failed to get status of tx %s", txID)
+			if err := c.CommitTX(txID, bn, i, &event); err != nil {
+				return errors.Wrapf(err, "failed to commit tx %s", txID)
 			}
-			switch vc {
-			case driver.Valid:
-				logger.Debugf("tx %s is already committed", txID)
-				continue
-			case driver.Invalid:
-				logger.Debugf("tx %s is already invalid", txID)
-				return errors.Errorf("tx %s is already invalid but it is marked as valid by orion", txID)
-			case driver.Unknown:
-				logger.Debugf("tx %s is unknown, ignore it", txID)
-				continue
-			}
-
-			// post process
-			if err := c.pm.ProcessByID(txID); err != nil {
-				return errors.Wrapf(err, "failed to process tx %s", txID)
-			}
-
-			// commit
-			if err := c.vault.CommitTX(txID, bn, i); err != nil {
-				return errors.WithMessagef(err, "failed to commit tx %s", txID)
-			}
-			event.Committed = true
 		default:
-			blockNum := block.Header.BaseHeader.Number
-			if logger.IsEnabledFor(zapcore.DebugLevel) {
-				logger.Debugf("transaction [%s] in block [%d] is not valid for fabric [%s], discard!", txID, blockNum, validationCode)
-			}
-
-			vc, err := c.vault.Status(txID)
-			if err != nil {
-				logger.Panicf("failed getting tx's status [%s], with err [%s]", txID, err)
-			}
-			switch vc {
-			case driver.Valid:
-				// TODO: this might be due the fact that there are transactions with the same tx-id, the first is valid, the others are all invalid
-				logger.Warnf("transaction [%s] in block [%d] is marked as valid but for fabric is invalid", txID, blockNum)
-			case driver.Invalid:
-				if logger.IsEnabledFor(zapcore.DebugLevel) {
-					logger.Debugf("transaction [%s] in block [%d] is marked as invalid, skipping", txID, blockNum)
-				}
-				// Nothing to commit
-				continue
-			case driver.Unknown:
-				if logger.IsEnabledFor(zapcore.DebugLevel) {
-					logger.Debugf("transaction [%s] in block [%d] is marked as unknown, skipping", txID, blockNum)
-				}
-				// Nothing to commit
-				continue
-			default:
-				event.Err = errors.Errorf("transaction [%s] status is not valid: %d", txID, validationCode)
-				// rollback
-				if err := c.vault.DiscardTx(txID); err != nil {
-					return errors.WithMessagef(err, "failed to discard tx %s", txID)
-				}
+			if err := c.DiscardTX(txID, bn, validationCode, &event); err != nil {
+				return errors.Wrapf(err, "failed to discard tx %s", txID)
 			}
 		}
 		c.notifyFinality(event)
+	}
+	return nil
+}
+
+func (c *committer) CommitTX(txID string, bn uint64, index int, event *TxEvent) error {
+	logger.Debugf("transaction [%s] in block [%d] is valid for orion", txID, bn)
+
+	// if is already committed, do nothing
+	vc, err := c.vault.Status(txID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get status of tx %s", txID)
+	}
+	switch vc {
+	case driver.Valid:
+		logger.Debugf("tx %s is already committed", txID)
+		return nil
+	case driver.Invalid:
+		logger.Debugf("tx %s is already invalid", txID)
+		return errors.Errorf("tx %s is already invalid but it is marked as valid by orion", txID)
+	case driver.Unknown:
+		logger.Debugf("tx %s is unknown, ignore it", txID)
+		return nil
+	}
+
+	// post process
+	if err := c.pm.ProcessByID(txID); err != nil {
+		return errors.Wrapf(err, "failed to process tx %s", txID)
+	}
+
+	// commit
+	if err := c.vault.CommitTX(txID, bn, index); err != nil {
+		return errors.WithMessagef(err, "failed to commit tx %s", txID)
+	}
+
+	event.Committed = true
+	return nil
+}
+
+func (c *committer) DiscardTX(txID string, blockNum uint64, validationCode types.Flag, event *TxEvent) error {
+	logger.Debugf("transaction [%s] in block [%d] is not valid for orion [%s], discard!", txID, blockNum, validationCode)
+
+	vc, err := c.vault.Status(txID)
+	if err != nil {
+		logger.Panicf("failed getting tx's status [%s], with err [%s]", txID, err)
+	}
+	switch vc {
+	case driver.Valid:
+		// TODO: this might be due the fact that there are transactions with the same tx-id, the first is valid, the others are all invalid
+		logger.Warnf("transaction [%s] in block [%d] is marked as valid but for orion is invalid", txID, blockNum)
+	case driver.Invalid:
+		logger.Debugf("transaction [%s] in block [%d] is marked as invalid, skipping", txID, blockNum)
+	case driver.Unknown:
+		logger.Debugf("transaction [%s] in block [%d] is marked as unknown, skipping", txID, blockNum)
+	default:
+		event.Err = errors.Errorf("transaction [%s] status is not valid: %d", txID, validationCode)
+		// rollback
+		if err := c.vault.DiscardTx(txID); err != nil {
+			return errors.WithMessagef(err, "failed to discard tx %s", txID)
+		}
 	}
 	return nil
 }

--- a/platform/orion/core/generic/vault.go
+++ b/platform/orion/core/generic/vault.go
@@ -51,7 +51,7 @@ func (v *Vault) Status(txID string) (odriver.ValidationCode, error) {
 func (v *Vault) DiscardTx(txid string) error {
 	vc, err := v.Vault.Status(txid)
 	if err != nil {
-		return errors.WithMessagef(err, "failed getting tx's status in state db [%s]", txid)
+		return errors.Wrapf(err, "failed getting tx's status in state db [%s]", txid)
 	}
 	if vc == odriver.Unknown {
 		return nil

--- a/platform/orion/core/generic/vault.go
+++ b/platform/orion/core/generic/vault.go
@@ -49,6 +49,14 @@ func (v *Vault) Status(txID string) (odriver.ValidationCode, error) {
 }
 
 func (v *Vault) DiscardTx(txid string) error {
+	vc, err := v.Vault.Status(txid)
+	if err != nil {
+		return errors.WithMessagef(err, "failed getting tx's status in state db [%s]", txid)
+	}
+	if vc == odriver.Unknown {
+		return nil
+	}
+
 	return v.Vault.DiscardTx(txid)
 }
 


### PR DESCRIPTION
if a transaction is unknown and is marked as valid by the backend, then there is no need to discard anything from the vault

https://github.com/hyperledger-labs/fabric-token-sdk/pull/335 depends on this PR.

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>