### PR TITLE
Make ATSA Chaincode receipt struct fields public

### DIFF
--- a/integration/fabric/atsa/chaincode/chaincode/asset_transfer.go
+++ b/integration/fabric/atsa/chaincode/chaincode/asset_transfer.go
@@ -42,8 +42,8 @@ type Asset struct {
 }
 
 type receipt struct {
-	price     int
-	timestamp time.Time
+	Price     int
+	Timestamp time.Time
 }
 
 // CreateAsset creates an asset and sets it as owned by the client's org
@@ -448,8 +448,8 @@ func transferAssetState(ctx contractapi.TransactionContextInterface, asset *Asse
 	timestamp := txTimestamp.AsTime()
 
 	assetReceipt := receipt{
-		price:     price,
-		timestamp: timestamp,
+		Price:     price,
+		Timestamp: timestamp,
 	}
 	receipt, err := json.Marshal(assetReceipt)
 	if err != nil {


### PR DESCRIPTION
As part of issue https://github.com/hyperledger-labs/fabric-smart-client/issues/50, removed warnings related to:

SA9005: missing marshaling mechanism

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>