### PR TITLE
Add WithEndorsersByMSPIDs to query chaincode view

### DIFF
--- a/platform/fabric/services/chaincode/query.go
+++ b/platform/fabric/services/chaincode/query.go
@@ -101,6 +101,11 @@ func (i *queryChaincodeView) WithChannel(name string) *queryChaincodeView {
 	return i
 }
 
+func (i *queryChaincodeView) WithEndorsersByMSPIDs(mspIDs ...string) *queryChaincodeView {
+	i.InvokeCall.EndorsersMSPIDs = mspIDs
+	return i
+}
+
 func (i *queryChaincodeView) WithEndorsersFromMyOrg() *queryChaincodeView {
 	i.EndorsersFromMyOrg = true
 	return i


### PR DESCRIPTION
This adds a missing option to select the endorsing peers via MSPIDs when
performing a query. We already have this option for invoke.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>