### PR TITLE
Extensions

### DIFF
--- a/platform/fabric/channel.go
+++ b/platform/fabric/channel.go
@@ -61,3 +61,7 @@ func (c *Channel) Delivery() *Delivery {
 func (c *Channel) MetadataService() *MetadataService {
 	return &MetadataService{ms: c.ch.MetadataService()}
 }
+
+func (c *Channel) EnvelopeService() *EnvelopeService {
+	return &EnvelopeService{ms: c.ch.EnvelopeService()}
+}

--- a/platform/fabric/core/generic/committer.go
+++ b/platform/fabric/core/generic/committer.go
@@ -158,6 +158,14 @@ func (c *channel) commitUnknown(txID string, block uint64, indexInBlock int) err
 
 func (c *channel) commitStoredEnvelope(txID string, block uint64, indexInBlock int) error {
 	logger.Debugf("found envelope for transaction [%s], committing it...", txID)
+	if err := c.extractStoredEnvelopeToVault(txID); err != nil {
+		return err
+	}
+	// commit
+	return c.commitLocal(txID, block, indexInBlock, nil)
+}
+
+func (c *channel) extractStoredEnvelopeToVault(txID string) error {
 	// extract envelope
 	envRaw, err := c.EnvelopeService().LoadEnvelope(txID)
 	if err != nil {
@@ -177,8 +185,7 @@ func (c *channel) commitStoredEnvelope(txID string, block uint64, indexInBlock i
 		return errors.WithMessagef(err, "failed to parse fabric envelope's rws for [%s][%s]", txID, hash.Hashable(envRaw).String())
 	}
 	rws.Done()
-	// commit
-	return c.commitLocal(txID, block, indexInBlock, nil)
+	return nil
 }
 
 func (c *channel) commit(txid string, deps []string, block uint64, indexInBlock int, envelope *common.Envelope) error {
@@ -266,6 +273,12 @@ func (c *channel) commitLocal(txid string, block uint64, indexInBlock int, envel
 		if err != nil {
 			logger.Error("[%s] failed to unmarshal envelope [%s]", txid, err)
 			return err
+		}
+
+		if !c.vault.RWSExists(txid) {
+			if err := c.extractStoredEnvelopeToVault(txid); err != nil {
+				return errors.WithMessagef(err, "failed to load stored enveloper into the vault")
+			}
 		}
 
 		if err := c.vault.Match(txid, pt.Results()); err != nil {

--- a/platform/fabric/core/generic/committer.go
+++ b/platform/fabric/core/generic/committer.go
@@ -56,6 +56,7 @@ func (c *channel) DiscardTx(txid string) error {
 		return errors.WithMessagef(err, "failed getting tx's status in state db [%s]", txid)
 	}
 	if vc == driver.Unknown {
+		logger.Debugf("Discarding transaction [%s] skipped, tx is unknown", txid)
 		return nil
 	}
 

--- a/platform/fabric/core/generic/vault/txidstore/simpletxidstore.go
+++ b/platform/fabric/core/generic/vault/txidstore/simpletxidstore.go
@@ -173,7 +173,7 @@ func (s *SimpleTXIDStore) Set(txid string, code fdriver.ValidationCode) error {
 		return errors.Errorf("error storing ByTxid for txid %s [%s]", txid, err.Error())
 	}
 
-	if code != fdriver.Busy {
+	if code == fdriver.Valid {
 		err = s.persistence.SetState(txidNamespace, lastTX, []byte(txid))
 		if err != nil {
 			s.persistence.Discard()

--- a/platform/fabric/core/generic/vault/vault.go
+++ b/platform/fabric/core/generic/vault/vault.go
@@ -204,7 +204,16 @@ func (db *Vault) CommitTX(txid string, block uint64, indexInBloc int) error {
 }
 
 func (db *Vault) SetBusy(txid string) error {
-	err := db.store.BeginUpdate()
+	code, err := db.txidStore.Get(txid)
+	if err != nil {
+		return err
+	}
+	if code != fdriver.Unknown {
+		// nothing to set
+		return nil
+	}
+
+	err = db.store.BeginUpdate()
 	if err != nil {
 		return errors.WithMessagef(err, "begin update for txid '%s' failed", txid)
 	}

--- a/platform/fabric/core/generic/vault/vault.go
+++ b/platform/fabric/core/generic/vault/vault.go
@@ -203,6 +203,25 @@ func (db *Vault) CommitTX(txid string, block uint64, indexInBloc int) error {
 	return nil
 }
 
+func (db *Vault) SetBusy(txid string) error {
+	err := db.store.BeginUpdate()
+	if err != nil {
+		return errors.WithMessagef(err, "begin update for txid '%s' failed", txid)
+	}
+
+	err = db.txidStore.Set(txid, fdriver.Busy)
+	if err != nil {
+		return err
+	}
+
+	err = db.store.Commit()
+	if err != nil {
+		return errors.WithMessagef(err, "committing tx for txid '%s' failed", txid)
+	}
+
+	return nil
+}
+
 func (db *Vault) NewRWSet(txid string) (*Interceptor, error) {
 	logger.Debugf("NewRWSet[%s][%d]", txid, db.counter.Load())
 	i := newInterceptor(&interceptorQueryExecutor{db}, db.txidStore, txid)
@@ -211,6 +230,10 @@ func (db *Vault) NewRWSet(txid string) (*Interceptor, error) {
 	if _, in := db.interceptors[txid]; in {
 		db.interceptorsLock.Unlock()
 		return nil, errors.Errorf("duplicate read-write set for txid %s", txid)
+	}
+	if err := db.SetBusy(txid); err != nil {
+		db.interceptorsLock.Unlock()
+		return nil, errors.Errorf("failed to ser status to busy for txid %s", txid)
 	}
 	db.interceptors[txid] = i
 	db.interceptorsLock.Unlock()
@@ -235,6 +258,10 @@ func (db *Vault) GetRWSet(txid string, rwsetBytes []byte) (*Interceptor, error) 
 			db.interceptorsLock.Unlock()
 			return nil, errors.Errorf("programming error: previous read-write set for %s has not been closed", txid)
 		}
+	}
+	if err := db.SetBusy(txid); err != nil {
+		db.interceptorsLock.Unlock()
+		return nil, errors.Errorf("failed to ser status to busy for txid %s", txid)
 	}
 	db.interceptors[txid] = i
 	db.interceptorsLock.Unlock()
@@ -296,4 +323,11 @@ func (db *Vault) Match(txid string, rwsRaw []byte) error {
 
 func (db *Vault) Close() error {
 	return db.store.Close()
+}
+
+func (db *Vault) RWSExists(txid string) bool {
+	db.interceptorsLock.RLock()
+	defer db.interceptorsLock.RUnlock()
+	_, in := db.interceptors[txid]
+	return in
 }

--- a/platform/fabric/core/generic/vault/vault.go
+++ b/platform/fabric/core/generic/vault/vault.go
@@ -76,7 +76,14 @@ func (db *Vault) unmapInterceptor(txid string) (*Interceptor, error) {
 	i, in := db.interceptors[txid]
 
 	if !in {
-		return nil, errors.Errorf("read-write set for txid %s could not be found", txid)
+		vc, err := db.txidStore.Get(txid)
+		if err != nil {
+			return nil, errors.Errorf("read-write set for txid %s could not be found", txid)
+		}
+		if vc == fdriver.Unknown {
+			return nil, errors.Errorf("read-write set for txid %s could not be found", txid)
+		}
+		return nil, nil
 	}
 
 	if !i.closed {
@@ -137,6 +144,9 @@ func (db *Vault) CommitTX(txid string, block uint64, indexInBloc int) error {
 	i, err := db.unmapInterceptor(txid)
 	if err != nil {
 		return err
+	}
+	if i == nil {
+		return errors.Errorf("cannot find rwset for [%s]", txid)
 	}
 
 	logger.Debugf("get lock [%s][%d]", txid, db.counter.Load())

--- a/platform/fabric/ledger.go
+++ b/platform/fabric/ledger.go
@@ -35,6 +35,11 @@ func (pt *ProcessedTransaction) Results() []byte {
 	return pt.pt.Results()
 }
 
+// ValidationCode of this transaction
+func (pt *ProcessedTransaction) ValidationCode() int32 {
+	return pt.pt.ValidationCode()
+}
+
 // Ledger models the ledger stored at a remote Fabric peer
 type Ledger struct {
 	ch *Channel

--- a/platform/fabric/transaction.go
+++ b/platform/fabric/transaction.go
@@ -402,3 +402,11 @@ func (m *MetadataService) LoadTransient(txid string) (TransientMap, error) {
 	}
 	return TransientMap(res), nil
 }
+
+type EnvelopeService struct {
+	ms driver.EnvelopeService
+}
+
+func (m *EnvelopeService) Exists(txid string) bool {
+	return m.ms.Exists(txid)
+}

--- a/platform/orion/core/generic/ledger.go
+++ b/platform/orion/core/generic/ledger.go
@@ -6,7 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package generic
 
-import "github.com/hyperledger-labs/orion-sdk-go/pkg/bcdb"
+import (
+	"github.com/hyperledger-labs/orion-sdk-go/pkg/bcdb"
+	"github.com/hyperledger-labs/orion-server/pkg/types"
+)
 
 type Ledger struct {
 	ledger bcdb.Ledger
@@ -14,4 +17,8 @@ type Ledger struct {
 
 func (l *Ledger) NewBlockHeaderDeliveryService(conf *bcdb.BlockHeaderDeliveryConfig) bcdb.BlockHeaderDelivererService {
 	return l.ledger.NewBlockHeaderDeliveryService(conf)
+}
+
+func (l *Ledger) GetTransactionReceipt(txId string) (*types.TxReceipt, error) {
+	return l.ledger.GetTransactionReceipt(txId)
 }

--- a/platform/orion/core/generic/vault/simpletxidstore.go
+++ b/platform/orion/core/generic/vault/simpletxidstore.go
@@ -173,7 +173,7 @@ func (s *SimpleTXIDStore) Set(txid string, code odriver.ValidationCode) error {
 		return errors.Errorf("error storing ByTxid for txid %s [%s]", txid, err.Error())
 	}
 
-	if code != odriver.Busy {
+	if code == odriver.Valid {
 		err = s.persistence.SetState(txidNamespace, lastTX, []byte(txid))
 		if err != nil {
 			s.persistence.Discard()

--- a/platform/orion/core/generic/vault/simpletxidstore.go
+++ b/platform/orion/core/generic/vault/simpletxidstore.go
@@ -10,11 +10,10 @@ import (
 	"encoding/binary"
 	"math"
 
+	odriver "github.com/hyperledger-labs/fabric-smart-client/platform/orion/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
-
-	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/orion/driver"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver"
 )
 
 const (
@@ -22,6 +21,7 @@ const (
 	ctrKey        = "ctr"
 	byCtrPrefix   = "C"
 	byTxidPrefix  = "T"
+	lastTX        = "last"
 )
 
 type SimpleTXIDStore struct {
@@ -116,20 +116,20 @@ func (s *SimpleTXIDStore) get(txid string) (*ByTxid, error) {
 	return bt, nil
 }
 
-func (s *SimpleTXIDStore) Get(txid string) (fdriver.ValidationCode, error) {
+func (s *SimpleTXIDStore) Get(txid string) (odriver.ValidationCode, error) {
 	bt, err := s.get(txid)
 	if err != nil {
-		return fdriver.Unknown, err
+		return odriver.Unknown, err
 	}
 
 	if bt == nil {
-		return fdriver.Unknown, nil
+		return odriver.Unknown, nil
 	}
 
-	return fdriver.ValidationCode(bt.Code), nil
+	return odriver.ValidationCode(bt.Code), nil
 }
 
-func (s *SimpleTXIDStore) Set(txid string, code fdriver.ValidationCode) error {
+func (s *SimpleTXIDStore) Set(txid string, code odriver.ValidationCode) error {
 	// NOTE: we assume that the commit is in progress so no need to update/commit
 	// err := s.persistence.BeginUpdate()
 	// if err != nil {
@@ -144,20 +144,18 @@ func (s *SimpleTXIDStore) Set(txid string, code fdriver.ValidationCode) error {
 	}
 
 	// 2: store by counter
-	if code != fdriver.Busy {
-		byCtrBytes, err := proto.Marshal(&ByNum{
-			Txid: txid,
-			Code: int32(code),
-		})
-		if err != nil {
-			s.persistence.Discard()
-			return errors.Errorf("error marshalling ByNum for txid %s [%s]", txid, err.Error())
-		}
-		err = s.persistence.SetState(txidNamespace, keyByCtr(s.ctr), byCtrBytes)
-		if err != nil {
-			s.persistence.Discard()
-			return errors.Errorf("error storing ByNum for txid %s [%s]", txid, err.Error())
-		}
+	byCtrBytes, err := proto.Marshal(&ByNum{
+		Txid: txid,
+		Code: int32(code),
+	})
+	if err != nil {
+		s.persistence.Discard()
+		return errors.Errorf("error marshalling ByNum for txid %s [%s]", txid, err.Error())
+	}
+	err = s.persistence.SetState(txidNamespace, keyByCtr(s.ctr), byCtrBytes)
+	if err != nil {
+		s.persistence.Discard()
+		return errors.Errorf("error storing ByNum for txid %s [%s]", txid, err.Error())
 	}
 
 	// 3: store by txid
@@ -175,6 +173,13 @@ func (s *SimpleTXIDStore) Set(txid string, code fdriver.ValidationCode) error {
 		return errors.Errorf("error storing ByTxid for txid %s [%s]", txid, err.Error())
 	}
 
+	if code != odriver.Busy {
+		err = s.persistence.SetState(txidNamespace, lastTX, []byte(txid))
+		if err != nil {
+			s.persistence.Discard()
+			return errors.Errorf("error storing ByTxid for txid %s [%s]", txid, err.Error())
+		}
+	}
 	// NOTE: we assume that the commit is in progress so no need to update/commit
 	// err = s.persistence.Commit()
 	// if err != nil {
@@ -187,31 +192,25 @@ func (s *SimpleTXIDStore) Set(txid string, code fdriver.ValidationCode) error {
 }
 
 func (s *SimpleTXIDStore) GetLastTxID() (string, error) {
-	it, err := s.Iterator(&fdriver.SeekEnd{})
+	v, err := s.persistence.GetState(txidNamespace, lastTX)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to get txid store iterator")
+		return "", errors.Wrapf(err, "failed to get last TxID")
 	}
-	defer it.Close()
-	next, err := it.Next()
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to get next from txid store iterator")
-	}
-	if next == nil {
+	if len(v) == 0 {
 		return "", nil
 	}
-	// code must be either valid or invalid, not busy
-	return next.Txid, nil
+	return string(v), nil
 }
 
-func (s *SimpleTXIDStore) Iterator(pos interface{}) (fdriver.TxidIterator, error) {
+func (s *SimpleTXIDStore) Iterator(pos interface{}) (odriver.TxidIterator, error) {
 	var startKey string
 	var endKey string
 
 	switch ppos := pos.(type) {
-	case *fdriver.SeekStart:
+	case *odriver.SeekStart:
 		startKey = keyByCtr(0)
 		endKey = keyByCtr(math.MaxUint64)
-	case *fdriver.SeekEnd:
+	case *odriver.SeekEnd:
 		ctr, err := getCtr(s.persistence)
 		if err != nil {
 			return nil, err
@@ -219,7 +218,7 @@ func (s *SimpleTXIDStore) Iterator(pos interface{}) (fdriver.TxidIterator, error
 
 		startKey = keyByCtr(ctr - 1)
 		endKey = keyByCtr(math.MaxUint64)
-	case *fdriver.SeekPos:
+	case *odriver.SeekPos:
 		bt, err := s.get(ppos.Txid)
 		if err != nil {
 			return nil, err
@@ -247,7 +246,7 @@ type SimpleTxidIterator struct {
 	t driver.ResultsIterator
 }
 
-func (i *SimpleTxidIterator) Next() (*fdriver.ByNum, error) {
+func (i *SimpleTxidIterator) Next() (*odriver.ByNum, error) {
 	d, err := i.t.Next()
 	if err != nil {
 		return nil, err
@@ -263,9 +262,9 @@ func (i *SimpleTxidIterator) Next() (*fdriver.ByNum, error) {
 		return nil, err
 	}
 
-	return &fdriver.ByNum{
+	return &odriver.ByNum{
 		Txid: bn.Txid,
-		Code: fdriver.ValidationCode(bn.Code),
+		Code: odriver.ValidationCode(bn.Code),
 	}, nil
 }
 

--- a/platform/orion/driver/sm.go
+++ b/platform/orion/driver/sm.go
@@ -32,6 +32,7 @@ type LoadedDataTx interface {
 
 type Ledger interface {
 	NewBlockHeaderDeliveryService(conf *bcdb.BlockHeaderDeliveryConfig) bcdb.BlockHeaderDelivererService
+	GetTransactionReceipt(txId string) (*types.TxReceipt, error)
 }
 
 // Session let the developer access orion

--- a/platform/orion/ledger.go
+++ b/platform/orion/ledger.go
@@ -8,20 +8,21 @@ package orion
 
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/orion/driver"
+	"github.com/hyperledger-labs/orion-server/pkg/types"
 	"github.com/pkg/errors"
 )
 
-type Flag int32
+type Flag = types.Flag
 
 const (
-	Flag_VALID                                      Flag = 0
-	Flag_INVALID_MVCC_CONFLICT_WITHIN_BLOCK         Flag = 1
-	Flag_INVALID_MVCC_CONFLICT_WITH_COMMITTED_STATE Flag = 2
-	Flag_INVALID_DATABASE_DOES_NOT_EXIST            Flag = 3
-	Flag_INVALID_NO_PERMISSION                      Flag = 4
-	Flag_INVALID_INCORRECT_ENTRIES                  Flag = 5
-	Flag_INVALID_UNAUTHORISED                       Flag = 6
-	Flag_INVALID_MISSING_SIGNATURE                  Flag = 7
+	VALID = types.Flag_VALID
+	INVALID_MVCC_CONFLICT_WITHIN_BLOCK
+	INVALID_MVCC_CONFLICT_WITH_COMMITTED_STATE
+	INVALID_DATABASE_DOES_NOT_EXIST
+	INVALID_NO_PERMISSION
+	INVALID_INCORRECT_ENTRIES
+	INVALID_UNAUTHORISED
+	INVALID_MISSING_SIGNATURE
 )
 
 // ProcessedTransaction models a transaction that has been processed by Fabric
@@ -36,8 +37,8 @@ func (pt *ProcessedTransaction) TxID() string {
 }
 
 // ValidationCode returns the transaction's validation code
-func (pt *ProcessedTransaction) ValidationCode() string {
-	return pt.txID
+func (pt *ProcessedTransaction) ValidationCode() Flag {
+	return pt.vc
 }
 
 type Ledger struct {

--- a/platform/orion/ledger.go
+++ b/platform/orion/ledger.go
@@ -1,0 +1,56 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package orion
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/platform/orion/driver"
+	"github.com/pkg/errors"
+)
+
+type Flag int32
+
+const (
+	Flag_VALID                                      Flag = 0
+	Flag_INVALID_MVCC_CONFLICT_WITHIN_BLOCK         Flag = 1
+	Flag_INVALID_MVCC_CONFLICT_WITH_COMMITTED_STATE Flag = 2
+	Flag_INVALID_DATABASE_DOES_NOT_EXIST            Flag = 3
+	Flag_INVALID_NO_PERMISSION                      Flag = 4
+	Flag_INVALID_INCORRECT_ENTRIES                  Flag = 5
+	Flag_INVALID_UNAUTHORISED                       Flag = 6
+	Flag_INVALID_MISSING_SIGNATURE                  Flag = 7
+)
+
+// ProcessedTransaction models a transaction that has been processed by Fabric
+type ProcessedTransaction struct {
+	txID string
+	vc   Flag
+}
+
+// TxID returns the transaction's id
+func (pt *ProcessedTransaction) TxID() string {
+	return pt.txID
+}
+
+// ValidationCode returns the transaction's validation code
+func (pt *ProcessedTransaction) ValidationCode() string {
+	return pt.txID
+}
+
+type Ledger struct {
+	l driver.Ledger
+}
+
+func (l *Ledger) GetTransactionByID(txID string) (*ProcessedTransaction, error) {
+	r, err := l.l.GetTransactionReceipt(txID)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to get transaction receipt for [%s]", txID)
+	}
+	return &ProcessedTransaction{
+		txID: txID,
+		vc:   Flag(r.Header.ValidationInfo[r.TxIndex].Flag),
+	}, nil
+}

--- a/platform/orion/session.go
+++ b/platform/orion/session.go
@@ -64,6 +64,14 @@ func (s *Session) QueryExecutor(db string) (*SessionQueryExecutor, error) {
 	return &SessionQueryExecutor{dataTx: dataTx, db: db, query: query}, nil
 }
 
+func (s *Session) Ledger() (*Ledger, error) {
+	ledger, err := s.s.Ledger()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get the ledger")
+	}
+	return &Ledger{l: ledger}, nil
+}
+
 // SessionManager is a session manager that allows the developer to access orion directly
 type SessionManager struct {
 	sm driver.SessionManager

--- a/platform/orion/vault.go
+++ b/platform/orion/vault.go
@@ -253,3 +253,7 @@ func (v *Vault) Status(txID string) (ValidationCode, error) {
 	vc, err := v.ons.Vault().Status(txID)
 	return ValidationCode(vc), err
 }
+
+func (v *Vault) DiscardTx(txID string) error {
+	return v.ons.Vault().DiscardTx(txID)
+}

--- a/platform/orion/vault.go
+++ b/platform/orion/vault.go
@@ -257,3 +257,7 @@ func (v *Vault) Status(txID string) (ValidationCode, error) {
 func (v *Vault) DiscardTx(txID string) error {
 	return v.ons.Vault().DiscardTx(txID)
 }
+
+func (v *Vault) CommitTX(txid string, block uint64, indexInBloc int) error {
+	return v.ons.Vault().CommitTX(txid, block, indexInBloc)
+}


### PR DESCRIPTION
- Fabric: 
  - Export Envelope Service
  - Export Transaction Validation Code
  - TxIDStore stores now also busy transactions
  - Restart delivery from the last block seen, if available.
- Orion:
  - Ledger Support 
  - Export Discard Tx
  - TxIDStore stores now also busy transactions

Used by: https://github.com/hyperledger-labs/fabric-token-sdk/pull/406
