### PR TITLE
restructure fsc and fabric driver core to be more intuitive

### DIFF
--- a/integration/fsc/pingpong/pingpong_test.go
+++ b/integration/fsc/pingpong/pingpong_test.go
@@ -56,7 +56,7 @@ var _ = Describe("EndToEnd", func() {
 
 			time.Sleep(3 * time.Second)
 
-			webClientConfig, err := client.NewWebClientConfigFromFSC("./testdata/fsc/nodes/initiator")
+			webClientConfig, err := client.NewWebClientConfigFromFSC("./testdata/fsc/nodes/webclient")
 			Expect(err).NotTo(HaveOccurred())
 			initiatorWebClient, err := web.NewClient(webClientConfig)
 			Expect(err).NotTo(HaveOccurred())

--- a/integration/fsc/pingpong/testdata/fsc/nodes/initiator/core.yaml
+++ b/integration/fsc/pingpong/testdata/fsc/nodes/initiator/core.yaml
@@ -9,8 +9,6 @@ fsc:
   # The FSC id provides a name for this node instance and is used when
   # naming docker resources.
   id: initiator
-  # This represents the endpoint to other FSC nodes in the same organization.
-  address: 127.0.0.1:20000
   # Identity of this node, used to connect to other nodes
   identity:
     # X.509 certificate used as identity of this node
@@ -23,33 +21,39 @@ fsc:
   admin:
     certs:
     - ./../../crypto/peerOrganizations/fsc.example.com/users/Admin@fsc.example.com/msp/signcerts/Admin@fsc.example.com-cert.pem
-  # TLS Settings
-  # (We use here the same set of properties as Hyperledger Fabric)
-  tls:
-    # Require server-side TLS
-    enabled:  true
-    # Require client certificates / mutual TLS for inbound connections.
-    # Note that clients that are not configured to use a certificate will
-    # fail to connect to the node.
-    clientAuthRequired: false
-    # X.509 certificate used for TLS server
-    cert:
-      file: ./../../crypto/peerOrganizations/fsc.example.com/peers/initiator.fsc.example.com/tls/server.crt
-    # Private key used for TLS server
-    key:
-      file: ./../../crypto/peerOrganizations/fsc.example.com/peers/initiator.fsc.example.com/tls/server.key
-  # Keepalive settings for node server and clients
-  keepalive:
-    # MinInterval is the minimum permitted time between client pings.
-    # If clients send pings more frequently, the peer server will
-    # disconnect them
-    minInterval: 60s
-    # Interval is the duration after which if the server does not see
-    # any activity from the client it pings the client to see if it's alive
-    interval: 300s
-    # Timeout is the duration the server waits for a response
-    # from the client after sending a ping before closing the connection
-    timeout: 600s
+  
+  grpc:
+    # This represents the endpoint to other FSC nodes in the same organization.
+    address: 127.0.0.1:20000
+
+    # TLS Settings
+    tls:
+      # Require server-side TLS
+      enabled:  true
+      # Require client certificates / mutual TLS for inbound connections.
+      # Note that clients that are not configured to use a certificate will
+      # fail to connect to the node.
+      clientAuthRequired: false
+      # X.509 certificate used for TLS server
+      cert:
+        file: ./../../crypto/peerOrganizations/fsc.example.com/peers/initiator.fsc.example.com/tls/server.crt
+      # Private key used for TLS server
+      key:
+        file: ./../../crypto/peerOrganizations/fsc.example.com/peers/initiator.fsc.example.com/tls/server.key
+  
+    # Keepalive settings for node server and clients
+    keepalive:
+      # MinInterval is the minimum permitted time between client pings.
+      # If clients send pings more frequently, the peer server will
+      # disconnect them
+      minInterval: 60s
+      # Interval is the duration after which if the server does not see
+      # any activity from the client it pings the client to see if it's alive
+      interval: 300s
+      # Timeout is the duration the server waits for a response
+      # from the client after sending a ping before closing the connection
+      timeout: 600s
+    
   # P2P configuration
   p2p:
     # Listening address

--- a/integration/fsc/pingpong/testdata/fsc/nodes/responder/core.yaml
+++ b/integration/fsc/pingpong/testdata/fsc/nodes/responder/core.yaml
@@ -9,8 +9,6 @@ fsc:
   # The FSC id provides a name for this node instance and is used when
   # naming docker resources.
   id: responder
-  # This represents the endpoint to other FSC nodes in the same organization.
-  address: 127.0.0.1:20002
   # Identity of this node, used to connect to other nodes
   identity:
     # X.509 certificate used as identity of this node
@@ -23,33 +21,39 @@ fsc:
   admin:
     certs:
     - ./../../crypto/peerOrganizations/fsc.example.com/users/Admin@fsc.example.com/msp/signcerts/Admin@fsc.example.com-cert.pem
-  # TLS Settings
-  # (We use here the same set of properties as Hyperledger Fabric)
-  tls:
-    # Require server-side TLS
-    enabled:  true
-    # Require client certificates / mutual TLS for inbound connections.
-    # Note that clients that are not configured to use a certificate will
-    # fail to connect to the node.
-    clientAuthRequired: false
-    # X.509 certificate used for TLS server
-    cert:
-      file: ./../../crypto/peerOrganizations/fsc.example.com/peers/responder.fsc.example.com/tls/server.crt
-    # Private key used for TLS server
-    key:
-      file: ./../../crypto/peerOrganizations/fsc.example.com/peers/responder.fsc.example.com/tls/server.key
-  # Keepalive settings for node server and clients
-  keepalive:
-    # MinInterval is the minimum permitted time between client pings.
-    # If clients send pings more frequently, the peer server will
-    # disconnect them
-    minInterval: 60s
-    # Interval is the duration after which if the server does not see
-    # any activity from the client it pings the client to see if it's alive
-    interval: 300s
-    # Timeout is the duration the server waits for a response
-    # from the client after sending a ping before closing the connection
-    timeout: 600s
+
+  grpc:
+    # This represents the endpoint to other FSC nodes in the same organization.
+    address: 127.0.0.1:20002
+
+    # TLS Settings
+    tls:
+      # Require server-side TLS
+      enabled:  true
+      # Require client certificates / mutual TLS for inbound connections.
+      # Note that clients that are not configured to use a certificate will
+      # fail to connect to the node.
+      clientAuthRequired: false
+      # X.509 certificate used for TLS server
+      cert:
+        file: ./../../crypto/peerOrganizations/fsc.example.com/peers/responder.fsc.example.com/tls/server.crt
+      # Private key used for TLS server
+      key:
+        file: ./../../crypto/peerOrganizations/fsc.example.com/peers/responder.fsc.example.com/tls/server.key
+
+    # Keepalive settings for node server and clients
+    keepalive:
+      # MinInterval is the minimum permitted time between client pings.
+      # If clients send pings more frequently, the peer server will
+      # disconnect them
+      minInterval: 60s
+      # Interval is the duration after which if the server does not see
+      # any activity from the client it pings the client to see if it's alive
+      interval: 300s
+      # Timeout is the duration the server waits for a response
+      # from the client after sending a ping before closing the connection
+      timeout: 600s
+
   # P2P configuration
   p2p:
     # Listening address

--- a/integration/fsc/pingpong/testdata/fsc/nodes/webclient/core.yaml
+++ b/integration/fsc/pingpong/testdata/fsc/nodes/webclient/core.yaml
@@ -1,0 +1,11 @@
+fsc:  
+  web:
+    address: 127.0.0.1:19999
+    tls:
+      enabled:  true
+      clientCert:
+        file: ./../../crypto/peerOrganizations/fsc.example.com/peers/initiator.fsc.example.com/tls/server.crt
+      clientKey:
+        file: ./../../crypto/peerOrganizations/fsc.example.com/peers/initiator.fsc.example.com/tls/server.key
+      serverRootCert:
+        file: ./../../crypto/peerOrganizations/fsc.example.com/peers/initiator.fsc.example.com/tls/ca.crt

--- a/integration/nwo/client/web.go
+++ b/integration/nwo/client/web.go
@@ -23,13 +23,13 @@ func NewWebClientConfigFromFSC(confDir string) (*web.Config, error) {
 	}
 	if configProvider.GetBool("fsc.web.tls.enabled") {
 		config.URL = fmt.Sprintf("https://%s", configProvider.GetString("fsc.web.address"))
-		clientRootCAFiles := configProvider.GetStringSlice("fsc.web.tls.clientRootCAs.files")
-		if len(clientRootCAFiles) == 0 {
-			return nil, errors.New("web configuration must have 1 clientRootCA file defined when tls is enabled, none found")
+		tlsRootCertFile := configProvider.GetString("fsc.web.tls.serverRootCert.file")
+		if len(tlsRootCertFile) == 0 {
+			return nil, errors.New("web configuration must have serverRootCert with file key defined")
 		}
-		config.CACert = configProvider.TranslatePath(clientRootCAFiles[0])
-		config.TLSCert = configProvider.GetPath("fsc.web.tls.cert.file")
-		config.TLSKey = configProvider.GetPath("fsc.web.tls.key.file")
+		config.CACert = configProvider.TranslatePath(tlsRootCertFile)
+		config.TLSCert = configProvider.GetPath("fsc.web.tls.clientCert.file")
+		config.TLSKey = configProvider.GetPath("fsc.web.tls.clientKey.file")
 	} else {
 		config.URL = fmt.Sprintf("http://%s", configProvider.GetString("fsc.web.address"))
 	}

--- a/integration/nwo/fabric/topology/core_template.go
+++ b/integration/nwo/fabric/topology/core_template.go
@@ -277,30 +277,21 @@ fabric:
     tls:
       enabled:  true
       clientAuthRequired: {{ .ClientAuthRequired }}
+      {{- if .ClientAuthRequired }}
       clientCert:
         file: {{ .PeerLocalTLSDir Peer }}/server.crt
       clientKey:
         file: {{ .PeerLocalTLSDir Peer }}/server.key
-      {{- if .ClientAuthRequired }}
-      clientRootCAs:
-        files:
-        - {{ .PeerLocalTLSDir Peer }}/ca.crt
-      {{- end }}
-      keepalive:
-       client:
-         interval: 60s
-         timeout: 600s
-       server:
-         interval: 60s
-         timeout: 600s
-         minInterval: 60s 
+      {{- end }} 
+    keepalive:
+      interval: 60s
+      timeout: 600s
     ordering:
       numRetries: 3
-      retryInternal: 3s
+      retryInterval: 3s
     peers: {{ range Peers }}
       - address: {{ PeerAddress . "Listen" }}
-        connectionTimeout: 10s
-        tlsEnabled: true        
+        connectionTimeout: 10s        
         tlsRootCertFile: {{ CACertsBundlePath }}
         serverNameOverride:
     {{- end }}
@@ -327,7 +318,7 @@ fabric:
       txidstore:
         cache:
           # Sets the maximum number of cached items 
-          cache: 200
+          size: 200
     endpoint:
       resolvers: {{ range .Resolvers }}
       - name: {{ .Name }}

--- a/integration/nwo/fsc/fsc.go
+++ b/integration/nwo/fsc/fsc.go
@@ -198,7 +198,7 @@ func (p *Platform) PostRun(bool) {
 		Expect(err).NotTo(HaveOccurred())
 
 		cc := &grpc.ConnectionConfig{
-			Address:           v.GetString("fsc.address"),
+			Address:           v.GetString("fsc.grpc.address"),
 			TLSEnabled:        true,
 			TLSRootCertFile:   path.Join(p.NodeLocalTLSDir(peer), "ca.crt"),
 			ConnectionTimeout: 10 * time.Minute,

--- a/integration/nwo/fsc/node/core_template.go
+++ b/integration/nwo/fsc/node/core_template.go
@@ -11,14 +11,10 @@ const CoreTemplate = `---
 logging:
  # Spec
  spec: {{ Topology.Logging.Spec }}
- # Format
- format: {{ Topology.Logging.Format }}
 fsc:
   # The FSC id provides a name for this node instance and is used when
   # naming docker resources.
   id: {{ Peer.ID }}
-  # This represents the endpoint to other FSC nodes in the same organization.
-  address: 127.0.0.1:{{ .NodePort Peer "Listen" }}
   # Identity of this node, used to connect to other nodes
   identity:
     # X.509 certificate used as identity of this node
@@ -33,38 +29,43 @@ fsc:
     {{- range Peer.Admins }}
     - {{ . }} 
     {{- end }}
-  # TLS Settings
-  # (We use here the same set of properties as Hyperledger Fabric)
-  tls:
-    # Require server-side TLS
-    enabled:  true
-    # Require client certificates / mutual TLS for inbound connections.
-    # Note that clients that are not configured to use a certificate will
-    # fail to connect to the node.
-    clientAuthRequired: {{ .ClientAuthRequired }}
-    # X.509 certificate used for TLS server
-    cert:
-      file: {{ .NodeLocalTLSDir Peer }}/server.crt
-    # Private key used for TLS server
-    key:
-      file: {{ .NodeLocalTLSDir Peer }}/server.key
-    # If mutual TLS is enabled, clientRootCAs.files contains a list of additional root certificates
-    # used for verifying certificates of client connections.
-    clientRootCAs:
-      files:
-      - {{ .NodeLocalTLSDir Peer }}/ca.crt
-  # Keepalive settings for node server and clients
-  keepalive:
-    # MinInterval is the minimum permitted time between client pings.
-    # If clients send pings more frequently, the peer server will
-    # disconnect them
-    minInterval: 60s
-    # Interval is the duration after which if the server does not see
-    # any activity from the client it pings the client to see if it's alive
-    interval: 300s
-    # Timeout is the duration the server waits for a response
-    # from the client after sending a ping before closing the connection
-    timeout: 600s
+  grpc:
+    # This represents the endpoint to other FSC nodes in the same organization.
+    address: 127.0.0.1:{{ .NodePort Peer "Listen" }}
+    # TLS Settings
+    # (We use here the same set of properties as Hyperledger Fabric)
+    tls:
+      # Require server-side TLS
+      enabled:  true
+      # Require client certificates / mutual TLS for inbound connections.
+      # Note that clients that are not configured to use a certificate will
+      # fail to connect to the node.
+      clientAuthRequired: {{ .ClientAuthRequired }}
+      # X.509 certificate used for TLS server
+      cert:
+        file: {{ .NodeLocalTLSDir Peer }}/server.crt
+      # Private key used for TLS server
+      key:
+        file: {{ .NodeLocalTLSDir Peer }}/server.key
+      # If mutual TLS is enabled, clientRootCAs.files contains a list of additional root certificates
+      # used for verifying certificates of client connections.
+      {{- if .ClientAuthRequired }}
+      clientRootCAs:
+        files:
+        - {{ .NodeLocalTLSDir Peer }}/ca.crt
+      {{- end }}
+    # Keepalive settings for node server and clients
+    keepalive:
+      # MinInterval is the minimum permitted time between client pings.
+      # If clients send pings more frequently, the peer server will
+      # disconnect them
+      minInterval: 60s
+      # Interval is the duration after which if the server does not see
+      # any activity from the client it pings the client to see if it's alive
+      interval: 300s
+      # Timeout is the duration the server waits for a response
+      # from the client after sending a ping before closing the connection
+      timeout: 600s
   # P2P configuration
   p2p:
     # Listening address

--- a/node/node/start.go
+++ b/node/node/start.go
@@ -149,12 +149,13 @@ func serve() error {
 		callback(err)
 		return err
 	}
+
 	callback(nil)
 
 	cs := view.GetConfigService(node.Registry())
 	logger.Infof("Started peer with ID=[%s], address=[%s]",
 		cs.GetString("fsc.id"),
-		cs.GetString("fsc.address"),
+		cs.GetString("fsc.grpc.address"),
 	)
 	return <-serve
 }

--- a/platform/fabric/core/generic/channel.go
+++ b/platform/fabric/core/generic/channel.go
@@ -236,11 +236,8 @@ func (c *channel) GetClientConfig(tlsRootCerts [][]byte) (*grpc.ClientConfig, st
 	}
 
 	clientConfig.KaOpts = grpc.KeepaliveOptions{
-		ClientInterval:    c.config.KeepAliveClientInterval(),
-		ClientTimeout:     c.config.KeepAliveClientTimeout(),
-		ServerInterval:    c.config.KeepAliveServerInterval(),
-		ServerTimeout:     c.config.KeepAliveServerTimeout(),
-		ServerMinInterval: c.config.KeepAliveServerMinInterval(),
+		ClientInterval: c.config.KeepAliveClientInterval(),
+		ClientTimeout:  c.config.KeepAliveClientTimeout(),
 	}
 
 	return clientConfig, override, nil

--- a/platform/fabric/core/generic/config/config.go
+++ b/platform/fabric/core/generic/config/config.go
@@ -95,23 +95,11 @@ func (c *Config) TLSClientCertFile() string {
 }
 
 func (c *Config) KeepAliveClientInterval() time.Duration {
-	return c.configService.GetDuration("fabric." + c.prefix + "tls.keepalive.client.interval")
+	return c.configService.GetDuration("fabric." + c.prefix + "keepalive.interval")
 }
 
 func (c *Config) KeepAliveClientTimeout() time.Duration {
-	return c.configService.GetDuration("fabric." + c.prefix + "tls.keepalive.client.timeout")
-}
-
-func (c *Config) KeepAliveServerInterval() time.Duration {
-	return c.configService.GetDuration("fabric." + c.prefix + "tls.keepalive.server.interval")
-}
-
-func (c *Config) KeepAliveServerTimeout() time.Duration {
-	return c.configService.GetDuration("fabric." + c.prefix + "tls.keepalive.server.timeout")
-}
-
-func (c *Config) KeepAliveServerMinInterval() time.Duration {
-	return c.configService.GetDuration("fabric." + c.prefix + "tls.keepalive.server.minInterval")
+	return c.configService.GetDuration("fabric." + c.prefix + "keepalive.timeout")
 }
 
 func (c *Config) Orderers() ([]*grpc.ConnectionConfig, error) {
@@ -119,6 +107,11 @@ func (c *Config) Orderers() ([]*grpc.ConnectionConfig, error) {
 	if err := c.configService.UnmarshalKey("fabric."+c.prefix+"orderers", &res); err != nil {
 		return nil, err
 	}
+
+	for _, v := range res {
+		v.TLSEnabled = c.TLSEnabled()
+	}
+
 	return res, nil
 }
 
@@ -127,6 +120,11 @@ func (c *Config) Peers() ([]*grpc.ConnectionConfig, error) {
 	if err := c.configService.UnmarshalKey("fabric."+c.prefix+"peers", &res); err != nil {
 		return nil, err
 	}
+
+	for _, v := range res {
+		v.TLSEnabled = c.TLSEnabled()
+	}
+
 	return res, nil
 }
 
@@ -231,5 +229,5 @@ func (c *Config) BroadcastNumRetries() int {
 }
 
 func (c *Config) BroadcastRetryInterval() time.Duration {
-	return c.configService.GetDuration("fabric." + c.prefix + "ordering.retryInternal")
+	return c.configService.GetDuration("fabric." + c.prefix + "ordering.retryInterval")
 }

--- a/platform/fabric/core/generic/config/testdata/core.yaml
+++ b/platform/fabric/core/generic/config/testdata/core.yaml
@@ -88,18 +88,12 @@ fabric:
         files:
           - /home/vagrant/testdata/fabric.default/crypto/peerOrganizations/org1.example.com/peers/approver.org1.example.com/tls/ca.crt
       rootCertFile: /home/vagrant/testdata/fabric.default/crypto/ca-certs.pem
-      keepalive:
-        client:
-          interval: 60s
-          timeout: 600s
-        server:
-          interval: 60s
-          timeout: 600s
-          minInterval: 60s
+    keepalive:
+      interval: 60s
+      timeout: 600s
     peers:
       - address: 127.0.0.1:22013
         connectionTimeout: 10s
-        tlsEnabled: true
         tlsRootCertFile: /home/vagrant/testdata/fabric.default/crypto/ca-certs.pem
         serverNameOverride:
     channels:

--- a/platform/fabric/core/generic/ordering/ordering.go
+++ b/platform/fabric/core/generic/ordering/ordering.go
@@ -219,12 +219,12 @@ func (o *service) broadcastEnvelope(env *common2.Envelope) error {
 	// send the envelope for ordering
 	var status *ab.BroadcastResponse
 	retries := o.network.Config().BroadcastNumRetries()
-	retryInternal := o.network.Config().BroadcastRetryInterval()
+	retryInterval := o.network.Config().BroadcastRetryInterval()
 	for i := 0; i < retries; i++ {
 		if i > 0 {
 			logger.Debugf("broadcast, retry [%d]...", i)
 			// wait a bit
-			time.Sleep(retryInternal)
+			time.Sleep(retryInterval)
 		}
 
 		if i > 0 || forceConnect {

--- a/platform/view/core/endpoint/resolver.go
+++ b/platform/view/core/endpoint/resolver.go
@@ -81,7 +81,7 @@ func (r *resolverService) LoadResolvers() error {
 		r.config.GetString("fsc.id"),
 		"",
 		map[string]string{
-			string(driver.ViewPort): r.config.GetString("fsc.address"),
+			string(driver.ViewPort): r.config.GetString("fsc.grpc.address"),
 		},
 		nil,
 		r.is.DefaultIdentity(),

--- a/platform/view/services/flogging/logging.go
+++ b/platform/view/services/flogging/logging.go
@@ -85,7 +85,7 @@ func (l *Logging) Apply(c Config) error {
 	}
 
 	if c.LogSpec == "" {
-		c.LogSpec = os.Getenv("FABRIC_LOGGING_SPEC")
+		c.LogSpec = os.Getenv("FSCNODE_LOGGING_SPEC")
 	}
 	if c.LogSpec == "" {
 		c.LogSpec = defaultLevel.String()

--- a/platform/view/services/flogging/logging_test.go
+++ b/platform/view/services/flogging/logging_test.go
@@ -32,17 +32,17 @@ func TestNew(t *testing.T) {
 }
 
 func TestNewWithEnvironment(t *testing.T) {
-	oldSpec, set := os.LookupEnv("FABRIC_LOGGING_SPEC")
+	oldSpec, set := os.LookupEnv("FSCNODE_LOGGING_SPEC")
 	if set {
-		defer os.Setenv("FABRIC_LOGGING_SPEC", oldSpec)
+		defer os.Setenv("FSCNODE_LOGGING_SPEC", oldSpec)
 	}
 
-	os.Setenv("FABRIC_LOGGING_SPEC", "fatal")
+	os.Setenv("FSCNODE_LOGGING_SPEC", "fatal")
 	logging, err := flogging.New(flogging.Config{})
 	assert.NoError(t, err)
 	assert.Equal(t, zapcore.FatalLevel, logging.DefaultLevel())
 
-	os.Unsetenv("FABRIC_LOGGING_SPEC")
+	os.Unsetenv("FSCNODE_LOGGING_SPEC")
 	logging, err = flogging.New(flogging.Config{})
 	assert.NoError(t, err)
 	assert.Equal(t, zapcore.InfoLevel, logging.DefaultLevel())


### PR DESCRIPTION
1. create a grpc section in core and move appropriate keys to be children
2. sort out tls for fabric-driver section
3. make web client configuration keys match intent

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>