### PR TITLE
fabric: call discard for unknown tx

### DIFF
--- a/platform/fabric/core/generic/committer/endorsertx.go
+++ b/platform/fabric/core/generic/committer/endorsertx.go
@@ -126,11 +126,6 @@ func (c *committer) DiscardEndorserTransaction(txID string, block *common.Block,
 			logger.Debugf("transaction [%s] in block [%d] is marked as invalid, skipping", txID, blockNum)
 		}
 		// Nothing to commit
-	case driver.Unknown:
-		if logger.IsEnabledFor(zapcore.DebugLevel) {
-			logger.Debugf("transaction [%s] in block [%d] is marked as unknown, skipping", txID, blockNum)
-		}
-		// Nothing to commit
 	default:
 		event.Err = errors.Errorf("transaction [%s] status is not valid: %d", txID, validationCode)
 		err = committer.DiscardTx(event.Txid)


### PR DESCRIPTION
Currently, when a transaction is marked is invalid by Fabric and it is unknown to the vault, no event is fired.
The point is that the node can still be aware of the transaction because it stores the corresponding envelope.

This PR, discard all transactions.

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>