### PR TITLE
enhancement pack

### DIFF
--- a/integration/nwo/fabric/network/network_support.go
+++ b/integration/nwo/fabric/network/network_support.go
@@ -1602,6 +1602,15 @@ func (n *Network) PeerByName(name string) *topology.Peer {
 	return nil
 }
 
+func (n *Network) FSCPeerByName(name string) *topology.Peer {
+	for _, p := range n.Peers {
+		if p.Name == name && p.Type == topology.FSCPeer {
+			return p
+		}
+	}
+	return nil
+}
+
 func (n *Network) Chaincodes(channel string) []*topology.ChannelChaincode {
 	var res []*topology.ChannelChaincode
 	for _, chaincode := range n.topology.Chaincodes {

--- a/integration/nwo/fabric/platform.go
+++ b/integration/nwo/fabric/platform.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	"runtime"
 
@@ -185,6 +186,13 @@ func (p *Platform) Cleanup() {
 
 func (p *Platform) DeployChaincode(chaincode *topology.ChannelChaincode) {
 	p.Network.DeployChaincode(chaincode)
+}
+
+func (p *Platform) DeleteVault(id string) {
+	fscPeer := p.Network.FSCPeerByName(id)
+	Expect(fscPeer).ToNot(BeNil())
+	p.Network.FSCNodeVaultDir(fscPeer)
+	Expect(os.RemoveAll(p.Network.FSCNodeVaultDir(fscPeer))).ToNot(HaveOccurred())
 }
 
 func (p *Platform) DefaultIdemixOrgMSPDir() string {

--- a/integration/nwo/fabric/topology.go
+++ b/integration/nwo/fabric/topology.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package fabric
 
 import (
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common/context"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/opts"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/topology"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc/node"
@@ -185,4 +186,18 @@ func WithOrionVaultPersistence(network, db, creator string) node.Option {
 		o.Put("fabric.vault.persistence.orion.creator", creator)
 		return nil
 	}
+}
+
+// Network returns the fabric network from the passed context bound to the passed id.
+// It returns nil, if nothing is found
+func Network(ctx *context.Context, id string) *Platform {
+	p := ctx.PlatformByName(id)
+	if p == nil {
+		return nil
+	}
+	fp, ok := p.(*Platform)
+	if ok {
+		return fp
+	}
+	return nil
 }

--- a/integration/nwo/fsc/topology.go
+++ b/integration/nwo/fsc/topology.go
@@ -94,6 +94,22 @@ func (t *Topology) SetBootstrapNode(n *node.Node) {
 	n.Bootstrap = true
 }
 
+func (t *Topology) ListNodes(ids ...string) []*node.Node {
+	if len(ids) == 0 {
+		return t.Nodes
+	}
+	var res []*node.Node
+	for _, n := range t.Nodes {
+		for _, id := range ids {
+			if n.Name == id {
+				res = append(res, n)
+				break
+			}
+		}
+	}
+	return res
+}
+
 func (t *Topology) EnableUDPTracing() {
 	t.TracingProvider = "udp"
 	t.TraceAggregator = "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc/tracing/server"

--- a/integration/nwo/fsc/topology.go
+++ b/integration/nwo/fsc/topology.go
@@ -87,6 +87,13 @@ func (t *Topology) NewTemplate(name string) *node.Node {
 	return n
 }
 
+func (t *Topology) SetBootstrapNode(n *node.Node) {
+	for _, n2 := range t.Nodes {
+		n2.Bootstrap = false
+	}
+	n.Bootstrap = true
+}
+
 func (t *Topology) EnableUDPTracing() {
 	t.TracingProvider = "udp"
 	t.TraceAggregator = "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc/tracing/server"

--- a/integration/nwo/orion/platform.go
+++ b/integration/nwo/orion/platform.go
@@ -212,11 +212,11 @@ func (p *Platform) Cleanup() {
 func (p *Platform) DeleteVault(id string) {
 	fscTopology := p.Context.TopologyByName("fsc").(*fsc.Topology)
 	for _, node := range fscTopology.Nodes {
-		if node.Name == id {
+		if strings.Contains(node.Name, id) {
 			Expect(os.RemoveAll(p.FSCNodeVaultDir(node))).ToNot(HaveOccurred())
 		}
 	}
-	Expect(false).To(BeTrue(), "cannot find node [%d]", id)
+	Expect(false).To(BeTrue(), "cannot find node [%s]", id)
 }
 
 func (p *Platform) replaceForDocker(origin string) string {

--- a/integration/nwo/orion/platform.go
+++ b/integration/nwo/orion/platform.go
@@ -211,12 +211,14 @@ func (p *Platform) Cleanup() {
 
 func (p *Platform) DeleteVault(id string) {
 	fscTopology := p.Context.TopologyByName("fsc").(*fsc.Topology)
+	found := false
 	for _, node := range fscTopology.Nodes {
 		if strings.Contains(node.Name, id) {
 			Expect(os.RemoveAll(p.FSCNodeVaultDir(node))).ToNot(HaveOccurred())
+			found = true
 		}
 	}
-	Expect(false).To(BeTrue(), "cannot find node [%s]", id)
+	Expect(found).To(BeTrue(), "cannot find node [%s]", id)
 }
 
 func (p *Platform) replaceForDocker(origin string) string {

--- a/integration/nwo/orion/platform.go
+++ b/integration/nwo/orion/platform.go
@@ -209,6 +209,16 @@ func (p *Platform) Cleanup() {
 	Expect(err).NotTo(HaveOccurred())
 }
 
+func (p *Platform) DeleteVault(id string) {
+	fscTopology := p.Context.TopologyByName("fsc").(*fsc.Topology)
+	for _, node := range fscTopology.Nodes {
+		if node.Name == id {
+			Expect(os.RemoveAll(p.FSCNodeVaultDir(node))).ToNot(HaveOccurred())
+		}
+	}
+	Expect(false).To(BeTrue(), "cannot find node [%d]", id)
+}
+
 func (p *Platform) replaceForDocker(origin string) string {
 	return strings.Replace(origin, p.rootDir(), "/etc/orion-server", 1)
 }

--- a/integration/nwo/orion/topology.go
+++ b/integration/nwo/orion/topology.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package orion
 
 import (
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common/context"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc/node"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/orion/opts"
@@ -84,4 +85,18 @@ func (t *Topology) AddDB(name string, roles ...string) {
 		Name:  name,
 		Roles: roles,
 	})
+}
+
+// Network returns the orion network from the passed context bound to the passed id.
+// It returns nil, if nothing is found
+func Network(ctx *context.Context, id string) *Platform {
+	p := ctx.PlatformByName(id)
+	if p == nil {
+		return nil
+	}
+	fp, ok := p.(*Platform)
+	if ok {
+		return fp
+	}
+	return nil
 }

--- a/platform/fabric/core/generic/chaincode/chaincode.go
+++ b/platform/fabric/core/generic/chaincode/chaincode.go
@@ -12,8 +12,6 @@ import (
 	"github.com/ReneKroon/ttlcache/v2"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
-	discovery2 "github.com/hyperledger/fabric-protos-go/discovery"
-	"github.com/pkg/errors"
 )
 
 type Chaincode struct {
@@ -74,39 +72,5 @@ func (c *Chaincode) IsPrivate() bool {
 // Version returns the version of this chaincode.
 // It uses discovery to extract this information from the endorsers
 func (c *Chaincode) Version() (string, error) {
-	response, err := NewDiscovery(c).Response()
-	if err != nil {
-		return "", errors.Wrapf(err, "unable to discover channel information for chaincode [%s] on channel [%s]", c.name, c.channel.Name())
-	}
-	endorsers, err := response.ForChannel(c.channel.Name()).Endorsers([]*discovery2.ChaincodeCall{{
-		Name: c.name,
-	}}, &noFilter{})
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to get endorsers for chaincode [%s] on channel [%s]", c.name, c.channel.Name())
-	}
-	if len(endorsers) == 0 {
-		return "", errors.Errorf("no endorsers found for chaincode [%s] on channel [%s]", c.name, c.channel.Name())
-	}
-	stateInfoMessage := endorsers[0].StateInfoMessage
-	if stateInfoMessage == nil {
-		return "", errors.Errorf("no state info message found for chaincode [%s] on channel [%s]", c.name, c.channel.Name())
-	}
-	stateInfo := stateInfoMessage.GetStateInfo()
-	if stateInfo == nil {
-		return "", errors.Errorf("no state info found for chaincode [%s] on channel [%s]", c.name, c.channel.Name())
-	}
-	properties := stateInfo.GetProperties()
-	if properties == nil {
-		return "", errors.Errorf("no properties found for chaincode [%s] on channel [%s]", c.name, c.channel.Name())
-	}
-	chaincodes := properties.Chaincodes
-	if len(chaincodes) == 0 {
-		return "", errors.Errorf("no chaincode info found for chaincode [%s] on channel [%s]", c.name, c.channel.Name())
-	}
-	for _, chaincode := range chaincodes {
-		if chaincode.Name == c.name {
-			return chaincode.Version, nil
-		}
-	}
-	return "", errors.Errorf("chaincode [%s] not found", c.name)
+	return NewDiscovery(c).ChaincodeVersion()
 }

--- a/platform/fabric/core/generic/chaincode/discovery.go
+++ b/platform/fabric/core/generic/chaincode/discovery.go
@@ -87,6 +87,9 @@ func (d *Discovery) GetEndorsers() ([]driver.DiscoveredPeer, error) {
 
 func (d *Discovery) GetPeers() ([]driver.DiscoveredPeer, error) {
 	response, err := d.Response()
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to get discovery response")
+	}
 
 	// extract peers
 	cr := response.ForChannel(d.chaincode.channel.Name())

--- a/platform/fabric/core/generic/channel.go
+++ b/platform/fabric/core/generic/channel.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package generic
 
 import (
+	"context"
 	"io/ioutil"
 	"sync"
 	"time"
@@ -48,6 +49,11 @@ const (
 	GetBlockByTxID     string = "GetBlockByTxID"
 )
 
+type Delivery interface {
+	Start(ctx context.Context)
+	Stop()
+}
+
 type channel struct {
 	sp                 view2.ServiceProvider
 	config             *config2.Config
@@ -62,6 +68,7 @@ type channel struct {
 	metadataService    driver.MetadataService
 	eventsSubscriber   events.Subscriber
 	eventsPublisher    events.Publisher
+	deliveryService    Delivery
 	driver.TXIDStore
 
 	// applyLock is used to serialize calls to CommitConfig and bundle update processing.
@@ -116,20 +123,12 @@ func newChannel(network *network, name string, quiet bool) (*channel, error) {
 	}
 
 	// Delivery
-	deliveryService, err := delivery2.New(
-		network.ctx,
-		name,
-		sp,
-		network,
-		func(block *common.Block) (bool, error) {
-			if err := committerInst.Commit(block); err != nil {
-				return true, err
-			}
-			return false, nil
-		},
-		txIDStore,
-		waitForEventTimeout,
-	)
+	deliveryService, err := delivery2.New(name, sp, network, func(block *common.Block) (bool, error) {
+		if err := committerInst.Commit(block); err != nil {
+			return true, err
+		}
+		return false, nil
+	}, txIDStore, waitForEventTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -156,6 +155,7 @@ func newChannel(network *network, name string, quiet bool) (*channel, error) {
 		vault:              v,
 		sp:                 sp,
 		finality:           fs,
+		deliveryService:    deliveryService,
 		externalCommitter:  externalCommitter,
 		TXIDStore:          txIDStore,
 		envelopeService:    transaction.NewEnvelopeService(sp, network.Name(), name),
@@ -169,8 +169,6 @@ func newChannel(network *network, name string, quiet bool) (*channel, error) {
 	if err := c.init(); err != nil {
 		return nil, errors.WithMessagef(err, "failed initializing channel [%s]", name)
 	}
-
-	deliveryService.Start()
 
 	return c, nil
 }
@@ -278,6 +276,7 @@ func (c *channel) GetBlockNumberByTxID(txID string) (uint64, error) {
 }
 
 func (c *channel) Close() error {
+	c.deliveryService.Stop()
 	return c.vault.Close()
 }
 

--- a/platform/fabric/core/generic/delivery.go
+++ b/platform/fabric/core/generic/delivery.go
@@ -9,77 +9,73 @@ package generic
 import (
 	"context"
 
+	delivery2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/delivery"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger/fabric-protos-go/common"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/hyperledger/fabric/protoutil"
-
-	delivery2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/delivery"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 )
 
 type ValidationFlags []uint8
 
+func (c *channel) StartDelivery(ctx context.Context) error {
+	c.deliveryService.Start(ctx)
+	return nil
+}
+
 func (c *channel) Scan(ctx context.Context, txID string, callback driver.DeliveryCallback) error {
 	vault := &fakeVault{txID: txID}
-	deliveryService, err := delivery2.New(
-		ctx,
-		c.name,
-		c.sp,
-		c.network,
-		func(block *common.Block) (bool, error) {
-			for i, tx := range block.Data.Data {
-				validationCode := ValidationFlags(block.Metadata.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER])[i]
+	deliveryService, err := delivery2.New(c.name, c.sp, c.network, func(block *common.Block) (bool, error) {
+		for i, tx := range block.Data.Data {
+			validationCode := ValidationFlags(block.Metadata.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER])[i]
 
-				if pb.TxValidationCode(validationCode) != pb.TxValidationCode_VALID {
-					continue
-				}
-
-				env, err := protoutil.UnmarshalEnvelope(tx)
-				if err != nil {
-					logger.Errorf("Error getting tx from block: %s", err)
-					return false, err
-				}
-				payl, err := protoutil.UnmarshalPayload(env.Payload)
-				if err != nil {
-					logger.Errorf("[%s] unmarshal payload failed: %s", c.name, err)
-					return false, err
-				}
-				chdr, err := protoutil.UnmarshalChannelHeader(payl.Header.ChannelHeader)
-				if err != nil {
-					logger.Errorf("[%s] unmarshal channel header failed: %s", c.name, err)
-					return false, err
-				}
-
-				if common.HeaderType(chdr.Type) != common.HeaderType_ENDORSER_TRANSACTION {
-					continue
-				}
-
-				ptx, err := newProcessedTransactionFromEnvelopeRaw(tx)
-				if err != nil {
-					return false, err
-				}
-
-				stop, err := callback(ptx)
-				if err != nil {
-					// if an error occurred, stop processing
-					return false, err
-				}
-				if stop {
-					return true, nil
-				}
-				vault.txID = chdr.TxId
-				logger.Debugf("commit transaction [%s] in block [%d]", chdr.TxId, block.Header.Number)
+			if pb.TxValidationCode(validationCode) != pb.TxValidationCode_VALID {
+				continue
 			}
-			return false, nil
-		},
-		vault,
-		waitForEventTimeout,
-	)
+
+			env, err := protoutil.UnmarshalEnvelope(tx)
+			if err != nil {
+				logger.Errorf("Error getting tx from block: %s", err)
+				return false, err
+			}
+			payload, err := protoutil.UnmarshalPayload(env.Payload)
+			if err != nil {
+				logger.Errorf("[%s] unmarshal payload failed: %s", c.name, err)
+				return false, err
+			}
+			channelHeader, err := protoutil.UnmarshalChannelHeader(payload.Header.ChannelHeader)
+			if err != nil {
+				logger.Errorf("[%s] unmarshal channel header failed: %s", c.name, err)
+				return false, err
+			}
+
+			if common.HeaderType(channelHeader.Type) != common.HeaderType_ENDORSER_TRANSACTION {
+				continue
+			}
+
+			ptx, err := newProcessedTransactionFromEnvelopeRaw(tx)
+			if err != nil {
+				return false, err
+			}
+
+			stop, err := callback(ptx)
+			if err != nil {
+				// if an error occurred, stop processing
+				return false, err
+			}
+			if stop {
+				return true, nil
+			}
+			vault.txID = channelHeader.TxId
+			logger.Debugf("commit transaction [%s] in block [%d]", channelHeader.TxId, block.Header.Number)
+		}
+		return false, nil
+	}, vault, waitForEventTimeout)
 	if err != nil {
 		return err
 	}
 
-	return deliveryService.Run()
+	return deliveryService.Run(ctx)
 }
 
 type fakeVault struct {

--- a/platform/fabric/core/generic/delivery/delivery.go
+++ b/platform/fabric/core/generic/delivery/delivery.go
@@ -100,7 +100,7 @@ func (d *delivery) Run() error {
 		default:
 			if df == nil {
 				if logger.IsEnabledFor(zapcore.DebugLevel) {
-					logger.Debugf("deliver service [%s], connecting...", d.channel)
+					logger.Debugf("deliver service [%s], connecting...", d.network, d.channel)
 				}
 				df, err = d.connect()
 				if err != nil {

--- a/platform/fabric/core/generic/delivery/delivery.go
+++ b/platform/fabric/core/generic/delivery/delivery.go
@@ -91,8 +91,8 @@ func (d *Delivery) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-d.stop:
-			// Time to cancel
-			return errors.New("stop")
+			// Time to stop
+			return nil
 		case <-ctx.Done():
 			// Time to cancel
 			return errors.New("context done")

--- a/platform/fabric/core/generic/delivery/delivery.go
+++ b/platform/fabric/core/generic/delivery/delivery.go
@@ -45,8 +45,7 @@ type Network interface {
 	LocalMembership() driver.LocalMembership
 }
 
-type delivery struct {
-	ctx                 context.Context
+type Delivery struct {
 	channel             string
 	sp                  view2.ServiceProvider
 	network             Network
@@ -55,46 +54,46 @@ type delivery struct {
 	vault               Vault
 	client              peer.Client
 	lastBlockReceived   uint64
+	stop                chan bool
 }
 
-func New(
-	ctx context.Context,
-	channel string,
-	sp view2.ServiceProvider,
-	network Network,
-	callback Callback,
-	vault Vault,
-	waitForEventTimeout time.Duration,
-) (*delivery, error) {
+func New(channel string, sp view2.ServiceProvider, network Network, callback Callback, vault Vault, waitForEventTimeout time.Duration) (*Delivery, error) {
 	if len(channel) == 0 {
 		panic("expected a channel, got empty string")
 	}
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	d := &delivery{
-		ctx:                 ctx,
+	d := &Delivery{
 		channel:             channel,
 		sp:                  sp,
 		network:             network,
 		waitForEventTimeout: waitForEventTimeout,
 		callback:            callback,
 		vault:               vault,
+		stop:                make(chan bool),
 	}
 	return d, nil
 }
 
 // Start runs the delivery service in a goroutine
-func (d *delivery) Start() {
-	go d.Run()
+func (d *Delivery) Start(ctx context.Context) {
+	go d.Run(ctx)
 }
 
-func (d *delivery) Run() error {
+func (d *Delivery) Stop() {
+	d.stop <- true
+}
+
+func (d *Delivery) Run(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	var df DeliverStream
 	var err error
 	for {
 		select {
-		case <-d.ctx.Done():
+		case <-d.stop:
+			// Time to cancel
+			return errors.New("stop")
+		case <-ctx.Done():
 			// Time to cancel
 			return errors.New("context done")
 		default:
@@ -102,7 +101,7 @@ func (d *delivery) Run() error {
 				if logger.IsEnabledFor(zapcore.DebugLevel) {
 					logger.Debugf("deliver service [%s], connecting...", d.network, d.channel)
 				}
-				df, err = d.connect()
+				df, err = d.connect(ctx)
 				if err != nil {
 					logger.Errorf("failed connecting to delivery service [%s:%s] [%s]. Wait 10 sec before reconnecting", d.channel, err)
 					time.Sleep(10 * time.Second)
@@ -170,7 +169,7 @@ func (d *delivery) Run() error {
 	}
 }
 
-func (d *delivery) connect() (DeliverStream, error) {
+func (d *Delivery) connect(ctx context.Context) (DeliverStream, error) {
 	// first cleanup everything
 	d.cleanup()
 
@@ -192,7 +191,7 @@ func (d *delivery) connect() (DeliverStream, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get deliver client")
 	}
-	stream, err := deliverClient.NewDeliver(d.ctx)
+	stream, err := deliverClient.NewDeliver(ctx)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get delivery stream")
 	}
@@ -263,7 +262,7 @@ func (d *delivery) connect() (DeliverStream, error) {
 	return stream, nil
 }
 
-func (d *delivery) cleanup() {
+func (d *Delivery) cleanup() {
 	if d.client != nil {
 		d.client.Close()
 	}

--- a/platform/fabric/core/generic/network.go
+++ b/platform/fabric/core/generic/network.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package generic
 
 import (
-	"context"
 	"math/rand"
 	"sync"
 
@@ -25,8 +24,7 @@ import (
 var logger = flogging.MustGetLogger("fabric-sdk.core")
 
 type network struct {
-	sp  view2.ServiceProvider
-	ctx context.Context
+	sp view2.ServiceProvider
 
 	config *config2.Config
 
@@ -49,7 +47,6 @@ type network struct {
 }
 
 func NewNetwork(
-	ctx context.Context,
 	sp view2.ServiceProvider,
 	name string,
 	config *config2.Config,
@@ -59,7 +56,6 @@ func NewNetwork(
 ) (*network, error) {
 	// Load configuration
 	fsp := &network{
-		ctx:             ctx,
 		sp:              sp,
 		name:            name,
 		config:          config,
@@ -143,11 +139,11 @@ func (f *network) Channel(name string) (driver.Channel, error) {
 	if !ok {
 		logger.Debugf("Channel [%s] not found, allocate resources", name)
 		var err error
-		c, err := newChannel(f, name, chanQuiet)
+		ch, err = newChannel(f, name, chanQuiet)
 		if err != nil {
 			return nil, err
 		}
-		f.channels[name] = c
+		f.channels[name] = ch
 		logger.Debugf("Channel [%s] not found, created", name)
 	}
 

--- a/platform/fabric/driver/committer.go
+++ b/platform/fabric/driver/committer.go
@@ -48,6 +48,8 @@ type Committer interface {
 	// ProcessNamespace registers namespaces that will be committed even if the rwset is not known
 	ProcessNamespace(nss ...string) error
 
+	ProcessPredicates(predicate func(set RWSet) (bool, error)) error
+
 	// AddProcessor(ns string, processor Processor) error
 
 	// Status returns a validation code this committer bind to the passed transaction id, plus

--- a/platform/fabric/driver/committer.go
+++ b/platform/fabric/driver/committer.go
@@ -48,8 +48,6 @@ type Committer interface {
 	// ProcessNamespace registers namespaces that will be committed even if the rwset is not known
 	ProcessNamespace(nss ...string) error
 
-	ProcessPredicates(predicate func(set RWSet) (bool, error)) error
-
 	// AddProcessor(ns string, processor Processor) error
 
 	// Status returns a validation code this committer bind to the passed transaction id, plus

--- a/platform/fabric/driver/delivery.go
+++ b/platform/fabric/driver/delivery.go
@@ -14,6 +14,9 @@ type DeliveryCallback func(tx ProcessedTransaction) (bool, error)
 
 // Delivery gives access to Fabric channel delivery
 type Delivery interface {
+	// StartDelivery starts the delivery process
+	StartDelivery(ctx context.Context) error
+
 	// Scan iterates over all transactions in block starting from the block containing the passed transaction id.
 	// If txID is empty, the iterations starts from the first block.
 	// On each transaction, the callback function is invoked.

--- a/platform/fabric/sdk/sdk.go
+++ b/platform/fabric/sdk/sdk.go
@@ -56,9 +56,9 @@ func (p *p) Install() error {
 	assert.NoError(p.registry.RegisterService(cryptoProvider))
 
 	logger.Infof("Set Fabric Network Service Provider")
-	fnspConfig, err := core.NewConfig(view2.GetConfigService(p.registry))
+	fnsConfig, err := core.NewConfig(view2.GetConfigService(p.registry))
 	assert.NoError(err, "failed parsing configuration")
-	p.fnsProvider, err = core.NewFabricNetworkServiceProvider(p.registry, fnspConfig)
+	p.fnsProvider, err = core.NewFabricNetworkServiceProvider(p.registry, fnsConfig)
 	assert.NoError(err, "failed instantiating fabric network service provider")
 	assert.NoError(p.registry.RegisterService(p.fnsProvider))
 	assert.NoError(p.registry.RegisterService(fabric2.NewNetworkServiceProvider(p.registry)))
@@ -92,11 +92,20 @@ func (p *p) Install() error {
 }
 
 func (p *p) Start(ctx context.Context) error {
+	return nil
+}
+
+func (p *p) PostStart(ctx context.Context) error {
 	if !view2.GetConfigService(p.registry).GetBool("fabric.enabled") {
 		logger.Infof("Fabric platform not enabled, skipping start")
 		return nil
 	}
 
+	// start the delivery pipeline on all configured networks
+	fnsConfig, err := core.NewConfig(view2.GetConfigService(p.registry))
+	assert.NoError(err, "failed parsing configuration")
+
+	fnsConfig.Names()
 	if err := p.fnsProvider.Start(ctx); err != nil {
 		return errors.WithMessagef(err, "failed starting fabric network service provider")
 	}

--- a/platform/orion/core/generic/committer/committer.go
+++ b/platform/orion/core/generic/committer/committer.go
@@ -178,8 +178,6 @@ func (c *committer) DiscardTX(txID string, blockNum uint64, validationCode types
 		logger.Warnf("transaction [%s] in block [%d] is marked as valid but for orion is invalid", txID, blockNum)
 	case driver.Invalid:
 		logger.Debugf("transaction [%s] in block [%d] is marked as invalid, skipping", txID, blockNum)
-	case driver.Unknown:
-		logger.Debugf("transaction [%s] in block [%d] is marked as unknown, skipping", txID, blockNum)
 	default:
 		event.Err = errors.Errorf("transaction [%s] status is not valid: %d", txID, validationCode)
 		// rollback

--- a/platform/orion/core/generic/delivery/delivery.go
+++ b/platform/orion/core/generic/delivery/delivery.go
@@ -52,7 +52,6 @@ type DeliverStream interface {
 }
 
 type delivery struct {
-	ctx                 context.Context
 	sp                  view2.ServiceProvider
 	network             Network
 	waitForEventTimeout time.Duration
@@ -60,21 +59,17 @@ type delivery struct {
 	vault               Vault
 	me                  string
 	networkName         string
+	stop                chan bool
 }
 
 func New(
-	ctx context.Context,
 	sp view2.ServiceProvider,
 	network Network,
 	callback Callback,
 	vault Vault,
 	waitForEventTimeout time.Duration,
 ) (*delivery, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	d := &delivery{
-		ctx:                 ctx,
 		sp:                  sp,
 		network:             network,
 		waitForEventTimeout: waitForEventTimeout,
@@ -82,21 +77,29 @@ func New(
 		vault:               vault,
 		me:                  network.IdentityManager().Me(),
 		networkName:         network.Name(),
+		stop:                make(chan bool),
 	}
 	return d, nil
 }
 
-// Start runs the delivery service in a goroutine
-func (d *delivery) Start() {
-	go d.Run()
+// StartDelivery runs the delivery service in a goroutine
+func (d *delivery) StartDelivery(ctx context.Context) error {
+	go d.Run(ctx)
+	return nil
 }
 
-func (d *delivery) Run() error {
+func (d *delivery) Run(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	var df DeliverStream
 	var err error
 	for {
 		select {
-		case <-d.ctx.Done():
+		case <-d.stop:
+			// Time to cancel
+			return errors.New("stop")
+		case <-ctx.Done():
 			// Time to cancel
 			return errors.New("context done")
 		default:
@@ -158,6 +161,10 @@ func (d *delivery) Run() error {
 			}
 		}
 	}
+}
+
+func (d *delivery) Stop() {
+	d.stop <- true
 }
 
 func (d *delivery) connect() (DeliverStream, error) {

--- a/platform/orion/core/generic/delivery/delivery.go
+++ b/platform/orion/core/generic/delivery/delivery.go
@@ -97,8 +97,8 @@ func (d *delivery) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-d.stop:
-			// Time to cancel
-			return errors.New("stop")
+			// Time to stop
+			return nil
 		case <-ctx.Done():
 			// Time to cancel
 			return errors.New("context done")

--- a/platform/orion/core/generic/network.go
+++ b/platform/orion/core/generic/network.go
@@ -46,6 +46,7 @@ type network struct {
 	transactionService driver.TransactionService
 	finality           driver.Finality
 	committer          driver.Committer
+	deliveryService    driver.DeliveryService
 }
 
 func NewDB(ctx context.Context, sp view2.ServiceProvider, config *config2.Config, name string) (*network, error) {
@@ -156,7 +157,6 @@ func NewNetwork(ctx context.Context, sp view2.ServiceProvider, config *config2.C
 	n.finality = finality
 
 	deliveryService, err := delivery2.New(
-		n.ctx,
 		sp,
 		n,
 		func(block *types.AugmentedBlockHeader) (bool, error) {
@@ -171,7 +171,7 @@ func NewNetwork(ctx context.Context, sp view2.ServiceProvider, config *config2.C
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to create delivery service")
 	}
-	deliveryService.Start()
+	n.deliveryService = deliveryService
 
 	return n, nil
 }
@@ -218,4 +218,8 @@ func (f *network) Committer() driver.Committer {
 
 func (f *network) Finality() driver.Finality {
 	return f.finality
+}
+
+func (f *network) DeliveryService() driver.DeliveryService {
+	return f.deliveryService
 }

--- a/platform/orion/core/generic/network.go
+++ b/platform/orion/core/generic/network.go
@@ -117,7 +117,7 @@ func NewNetwork(ctx context.Context, sp view2.ServiceProvider, config *config2.C
 	n.envelopeService = transaction.NewEnvelopeService(sp, name)
 	n.transactionManager = transaction.NewManager(sp, n.sessionManager)
 	n.transactionService = transaction.NewEndorseTransactionService(sp, name)
-	n.vault, err = NewVault(sp, n.config, name)
+	n.vault, err = NewVault(sp, n.config, n.envelopeService, name)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to create vault")
 	}

--- a/platform/orion/core/generic/network.go
+++ b/platform/orion/core/generic/network.go
@@ -117,7 +117,7 @@ func NewNetwork(ctx context.Context, sp view2.ServiceProvider, config *config2.C
 	n.envelopeService = transaction.NewEnvelopeService(sp, name)
 	n.transactionManager = transaction.NewManager(sp, n.sessionManager)
 	n.transactionService = transaction.NewEndorseTransactionService(sp, name)
-	n.vault, err = NewVault(sp, n.config, n.envelopeService, name)
+	n.vault, err = NewVault(sp, n.config, n, name)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to create vault")
 	}

--- a/platform/orion/core/generic/vault.go
+++ b/platform/orion/core/generic/vault.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/orion/core/generic/config"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/orion/core/generic/vault"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/orion/driver"
-	odriver "github.com/hyperledger-labs/fabric-smart-client/platform/orion/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db"
 	"github.com/pkg/errors"
@@ -54,30 +53,30 @@ func (v *Vault) GetLastTxID() (string, error) {
 	return v.SimpleTXIDStore.GetLastTxID()
 }
 
-func (v *Vault) NewQueryExecutor() (odriver.QueryExecutor, error) {
+func (v *Vault) NewQueryExecutor() (driver.QueryExecutor, error) {
 	return v.Vault.NewQueryExecutor()
 }
 
-func (v *Vault) NewRWSet(txID string) (odriver.RWSet, error) {
+func (v *Vault) NewRWSet(txID string) (driver.RWSet, error) {
 	return v.Vault.NewRWSet(txID)
 }
 
-func (v *Vault) GetRWSet(id string, results []byte) (odriver.RWSet, error) {
+func (v *Vault) GetRWSet(id string, results []byte) (driver.RWSet, error) {
 	return v.Vault.GetRWSet(id, results)
 }
 
-func (v *Vault) Status(txID string) (odriver.ValidationCode, error) {
+func (v *Vault) Status(txID string) (driver.ValidationCode, error) {
 	vc, err := v.Vault.Status(txID)
 	if err != nil {
-		return odriver.Unknown, err
+		return driver.Unknown, err
 	}
-	if vc == odriver.Unknown {
+	if vc == driver.Unknown {
 		// give it a second chance
 		if v.network.EnvelopeService().Exists(txID) {
 			if err := v.extractStoredEnvelopeToVault(txID); err != nil {
-				return odriver.Unknown, errors.WithMessagef(err, "failed to extract stored enveloper for [%s]", txID)
+				return driver.Unknown, errors.WithMessagef(err, "failed to extract stored enveloper for [%s]", txID)
 			}
-			vc = odriver.Busy
+			vc = driver.Busy
 		}
 	}
 	return vc, nil
@@ -88,7 +87,7 @@ func (v *Vault) DiscardTx(txID string) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed getting tx's status in state db [%s]", txID)
 	}
-	if vc == odriver.Unknown {
+	if vc == driver.Unknown {
 		return nil
 	}
 

--- a/platform/orion/core/generic/vault.go
+++ b/platform/orion/core/generic/vault.go
@@ -74,12 +74,14 @@ func (v *Vault) Status(txID string) (odriver.ValidationCode, error) {
 	if err != nil {
 		return odriver.Unknown, err
 	}
-	// give it a second chance
-	if v.envelopeService.Exists(txID) {
-		if err := v.extractStoredEnvelopeToVault(txID); err != nil {
-			return odriver.Unknown, errors.WithMessagef(err, "failed to extract stored enveloper for [%s]", txID)
+	if vc == odriver.Unknown {
+		// give it a second chance
+		if v.envelopeService.Exists(txID) {
+			if err := v.extractStoredEnvelopeToVault(txID); err != nil {
+				return odriver.Unknown, errors.WithMessagef(err, "failed to extract stored enveloper for [%s]", txID)
+			}
+			vc = odriver.Busy
 		}
-		vc = odriver.Busy
 	}
 	return vc, nil
 }

--- a/platform/orion/driver/delivery.go
+++ b/platform/orion/driver/delivery.go
@@ -1,0 +1,17 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package driver
+
+import "context"
+
+// DeliveryService models the delivery service
+type DeliveryService interface {
+	// StartDelivery starts the delivery
+	StartDelivery(context.Context) error
+	// Stop stops delivery
+	Stop()
+}

--- a/platform/orion/driver/ons.go
+++ b/platform/orion/driver/ons.go
@@ -25,6 +25,7 @@ type OrionNetworkService interface {
 	ProcessorManager() ProcessorManager
 	Finality() Finality
 	Committer() Committer
+	DeliveryService() DeliveryService
 }
 
 type OrionNetworkServiceProvider interface {

--- a/platform/orion/finality.go
+++ b/platform/orion/finality.go
@@ -9,7 +9,7 @@ package orion
 import (
 	"context"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/orion/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 

--- a/platform/orion/sdk/sdk.go
+++ b/platform/orion/sdk/sdk.go
@@ -59,7 +59,11 @@ func (p *SDK) Install() error {
 	return nil
 }
 
-func (p *SDK) Start(ctx context.Context) error {
+func (p *SDK) Start(context.Context) error {
+	return nil
+}
+
+func (p *SDK) PostStart(ctx context.Context) error {
 	if !view2.GetConfigService(p.registry).GetBool("orion.enabled") {
 		logger.Infof("Orion platform not enabled, skipping start")
 		return nil
@@ -75,6 +79,5 @@ func (p *SDK) Start(ctx context.Context) error {
 			logger.Errorf("failed stopping orion network service provider [%s]", err)
 		}
 	}()
-
 	return nil
 }


### PR DESCRIPTION
- NWO fabric and orion: ability to remove the vault of FSC nodes
- Introduce the `PostStart` interface. PostStart allows a platform to start services after all the other platforms have been started. This feature has been introduce to allow platforms to add hookups in the fabric and orion commit pipelines before the pipelines start. Fabric and Orion commit pipelines are now activated in post-start.
- fabric chaincode: when querying a chiancode, discovery performs now a `peer query` and not an `endorser query`.
- Fabric and Orion Committer: if the status of a transaction is requested, if this transaction does not exist in the vault but its envelope exists, then the envelope is loaded into the vaul.

The changes to the commit pipelines and `PostStart` allow a node to rebuild its vault if the KVS has not been compromised.

Used by: https://github.com/hyperledger-labs/fabric-token-sdk/pull/406