### PR TITLE
Minor updates

### DIFF
--- a/integration/fsc/pingpong/testdata/fsc/crypto-config.yaml
+++ b/integration/fsc/pingpong/testdata/fsc/crypto-config.yaml
@@ -14,11 +14,13 @@ PeerOrgs:
   Specs:
   - Hostname: initiator
     SANS:
+    - 0.0.0.0
     - localhost
     - 127.0.0.1
     - ::1
   - Hostname: responder
     SANS:
+    - 0.0.0.0
     - localhost
     - 127.0.0.1
     - ::1

--- a/integration/nwo/fabric/topology/crypto_template.go
+++ b/integration/nwo/fabric/topology/crypto_template.go
@@ -20,6 +20,7 @@ OrdererOrgs:{{ range .OrdererOrgs }}
   Specs:{{ range $w.OrderersInOrg .Name }}
   - Hostname: {{ .Name }}
     SANS:
+    - 0.0.0.0
     - localhost
     - 127.0.0.1
     - host.docker.internal
@@ -36,6 +37,7 @@ PeerOrgs:{{ range .PeerOrgs }}
   CA:{{ if .CA.Hostname }}
     hostname: {{ .CA.Hostname }}
     SANS:
+    - 0.0.0.0
     - localhost
     - 127.0.0.1
     - ::1
@@ -53,6 +55,7 @@ PeerOrgs:{{ range .PeerOrgs }}
   Specs:{{ range $w.PeersInOrg .Name }}
   - Hostname: {{ .Name }}
     SANS:
+    - 0.0.0.0
     - localhost
     - 127.0.0.1
     - ::1

--- a/integration/nwo/fsc/node/crypto_template.go
+++ b/integration/nwo/fsc/node/crypto_template.go
@@ -16,6 +16,7 @@ PeerOrgs:{{ range .PeerOrgs }}
   CA:{{ if .CA.Hostname }}
     hostname: {{ .CA.Hostname }}
     SANS:
+    - 0.0.0.0
     - localhost
     - 127.0.0.1
     - ::1
@@ -32,6 +33,7 @@ PeerOrgs:{{ range .PeerOrgs }}
   Specs:{{ range $w.PeersInOrg .Name }}
   - Hostname: {{ .Name }}
     SANS:
+    - 0.0.0.0
     - localhost
     - 127.0.0.1
     - ::1

--- a/platform/fabric/core/generic/delivery/delivery.go
+++ b/platform/fabric/core/generic/delivery/delivery.go
@@ -100,7 +100,7 @@ func (d *delivery) Run() error {
 		default:
 			if df == nil {
 				if logger.IsEnabledFor(zapcore.DebugLevel) {
-					logger.Debugf("deliver service [%s:%s], connecting...", d.channel)
+					logger.Debugf("deliver service [%s], connecting...", d.channel)
 				}
 				df, err = d.connect()
 				if err != nil {


### PR DESCRIPTION
- correct a trace point that was incorrect
- update to include 0.0.0.0 in the x509 SAN fields, for the Ubuntu WSL2 distribution the standard x509 certificates fail validation.

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>