### PR TITLE
various enhancements 

### DIFF
--- a/integration/fabric/atsa/chaincode/topology.go
+++ b/integration/fabric/atsa/chaincode/topology.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
+	fabric2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk"
 )
 
 func Topology() []api.Topology {
@@ -64,7 +65,7 @@ func Topology() []api.Topology {
 	bob.RegisterViewFactory("Transfer", &views.TransferViewFactory{})
 
 	// Add Fabric SDK to FSC Nodes
-	fabricTopology.AddSDK(fscTopology)
+	fscTopology.AddSDK(&fabric2.SDK{})
 
 	// Done
 	return []api.Topology{fabricTopology, fscTopology}

--- a/integration/fabric/atsa/chaincode/topology.go
+++ b/integration/fabric/atsa/chaincode/topology.go
@@ -63,6 +63,9 @@ func Topology() []api.Topology {
 	bob.RegisterViewFactory("AgreeToBuy", &views.AgreeToBuyViewFactory{})
 	bob.RegisterViewFactory("Transfer", &views.TransferViewFactory{})
 
+	// Add Fabric SDK to FSC Nodes
+	fabricTopology.AddSDK(fscTopology)
+
 	// Done
 	return []api.Topology{fabricTopology, fscTopology}
 }

--- a/integration/fabric/atsa/fsc/topology.go
+++ b/integration/fabric/atsa/fsc/topology.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
+	fabric2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk"
 )
 
 func Topology() []api.Topology {
@@ -59,7 +60,7 @@ func Topology() []api.Topology {
 	bob.RegisterResponder(&views.TransferResponderView{}, &views.TransferView{})
 
 	// Add Fabric SDK to FSC Nodes
-	fabricTopology.AddSDK(fscTopology)
+	fscTopology.AddSDK(&fabric2.SDK{})
 
 	return []api.Topology{fabricTopology, fscTopology}
 }

--- a/integration/fabric/atsa/fsc/topology.go
+++ b/integration/fabric/atsa/fsc/topology.go
@@ -58,5 +58,8 @@ func Topology() []api.Topology {
 	bob.RegisterResponder(&views.AcceptAssetView{}, &views.IssueView{})
 	bob.RegisterResponder(&views.TransferResponderView{}, &views.TransferView{})
 
+	// Add Fabric SDK to FSC Nodes
+	fabricTopology.AddSDK(fscTopology)
+
 	return []api.Topology{fabricTopology, fscTopology}
 }

--- a/integration/fabric/events/chaincode/topology.go
+++ b/integration/fabric/events/chaincode/topology.go
@@ -49,6 +49,10 @@ func Topology() []api.Topology {
 	bob.AddOptions(fabric.WithOrganization("Org2"), fabric.WithClientRole())
 	// Register the factories of the initiator views for each business process
 	bob.RegisterViewFactory("EventsView", &views.EventsViewFactory{})
+
+	// Add Fabric SDK to FSC Nodes
+	fabricTopology.AddSDK(fscTopology)
+
 	// Done
 	return []api.Topology{fabricTopology, fscTopology}
 }

--- a/integration/fabric/events/chaincode/topology.go
+++ b/integration/fabric/events/chaincode/topology.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
+	fabric2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk"
 )
 
 func Topology() []api.Topology {
@@ -51,7 +52,7 @@ func Topology() []api.Topology {
 	bob.RegisterViewFactory("EventsView", &views.EventsViewFactory{})
 
 	// Add Fabric SDK to FSC Nodes
-	fabricTopology.AddSDK(fscTopology)
+	fscTopology.AddSDK(&fabric2.SDK{})
 
 	// Done
 	return []api.Topology{fabricTopology, fscTopology}

--- a/integration/fabric/fpc/echo/topology.go
+++ b/integration/fabric/fpc/echo/topology.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
+	fabric2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk"
 )
 
 func Topology() []api.Topology {
@@ -43,7 +44,7 @@ func Topology() []api.Topology {
 	bob.RegisterViewFactory("Echo", &views.EchoViewFactory{})
 
 	// Add Fabric SDK to FSC Nodes
-	fabricTopology.AddSDK(fscTopology)
+	fscTopology.AddSDK(&fabric2.SDK{})
 
 	return []api.Topology{fabricTopology, fscTopology}
 }

--- a/integration/fabric/fpc/echo/topology.go
+++ b/integration/fabric/fpc/echo/topology.go
@@ -42,5 +42,8 @@ func Topology() []api.Topology {
 	bob.RegisterViewFactory("ListProvisionedEnclaves", &views.ListProvisionedEnclavesViewFactory{})
 	bob.RegisterViewFactory("Echo", &views.EchoViewFactory{})
 
+	// Add Fabric SDK to FSC Nodes
+	fabricTopology.AddSDK(fscTopology)
+
 	return []api.Topology{fabricTopology, fscTopology}
 }

--- a/integration/fabric/iou/topology.go
+++ b/integration/fabric/iou/topology.go
@@ -64,5 +64,8 @@ func Topology() []api.Topology {
 	lender.RegisterResponder(&views.UpdateIOUResponderView{}, &views.UpdateIOUView{})
 	lender.RegisterViewFactory("query", &views.QueryViewFactory{})
 
+	// Add Fabric SDK to FSC Nodes
+	fabricTopology.AddSDK(fscTopology)
+
 	return []api.Topology{fabricTopology, fscTopology}
 }

--- a/integration/fabric/iou/topology.go
+++ b/integration/fabric/iou/topology.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
+	fabric2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk"
 )
 
 func Topology() []api.Topology {
@@ -65,7 +66,7 @@ func Topology() []api.Topology {
 	lender.RegisterViewFactory("query", &views.QueryViewFactory{})
 
 	// Add Fabric SDK to FSC Nodes
-	fabricTopology.AddSDK(fscTopology)
+	fscTopology.AddSDK(&fabric2.SDK{})
 
 	return []api.Topology{fabricTopology, fscTopology}
 }

--- a/integration/fabric/iouhsm/topology.go
+++ b/integration/fabric/iouhsm/topology.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
+	fabric2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk"
 )
 
 func Topology() []api.Topology {
@@ -59,7 +60,7 @@ func Topology() []api.Topology {
 	lender.RegisterViewFactory("query", &views.QueryViewFactory{})
 
 	// Add Fabric SDK to FSC Nodes
-	fabricTopology.AddSDK(fscTopology)
+	fscTopology.AddSDK(&fabric2.SDK{})
 
 	return []api.Topology{fabricTopology, fscTopology}
 }

--- a/integration/fabric/iouhsm/topology.go
+++ b/integration/fabric/iouhsm/topology.go
@@ -58,5 +58,8 @@ func Topology() []api.Topology {
 	lender.RegisterResponder(&views.UpdateIOUResponderView{}, &views.UpdateIOUView{})
 	lender.RegisterViewFactory("query", &views.QueryViewFactory{})
 
+	// Add Fabric SDK to FSC Nodes
+	fabricTopology.AddSDK(fscTopology)
+
 	return []api.Topology{fabricTopology, fscTopology}
 }

--- a/integration/fabric/iouorionbe/topology.go
+++ b/integration/fabric/iouorionbe/topology.go
@@ -59,5 +59,8 @@ func Topology() []api.Topology {
 	lender.RegisterResponder(&views.UpdateIOUResponderView{}, &views.UpdateIOUView{})
 	lender.RegisterViewFactory("query", &views.QueryViewFactory{})
 
+	// Add Fabric SDK to FSC Nodes
+	fabricTopology.AddSDK(fscTopology)
+
 	return []api.Topology{borrowerTopology, fabricTopology, fscTopology}
 }

--- a/integration/fabric/iouorionbe/topology.go
+++ b/integration/fabric/iouorionbe/topology.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/orion"
+	fabric2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk"
 )
 
 func Topology() []api.Topology {
@@ -60,7 +61,7 @@ func Topology() []api.Topology {
 	lender.RegisterViewFactory("query", &views.QueryViewFactory{})
 
 	// Add Fabric SDK to FSC Nodes
-	fabricTopology.AddSDK(fscTopology)
+	fscTopology.AddSDK(&fabric2.SDK{})
 
 	return []api.Topology{borrowerTopology, fabricTopology, fscTopology}
 }

--- a/integration/fabric/stoprestart/topology.go
+++ b/integration/fabric/stoprestart/topology.go
@@ -28,5 +28,9 @@ func Topology() []api.Topology {
 	).RegisterResponder(
 		&Responder{}, &Initiator{},
 	)
+
+	// Add Fabric SDK to FSC Nodes
+	fabricTopology.AddSDK(fscTopology)
+
 	return []api.Topology{fabricTopology, fscTopology}
 }

--- a/integration/fabric/stoprestart/topology.go
+++ b/integration/fabric/stoprestart/topology.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
+	fabric2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk"
 )
 
 func Topology() []api.Topology {
@@ -30,7 +31,7 @@ func Topology() []api.Topology {
 	)
 
 	// Add Fabric SDK to FSC Nodes
-	fabricTopology.AddSDK(fscTopology)
+	fscTopology.AddSDK(&fabric2.SDK{})
 
 	return []api.Topology{fabricTopology, fscTopology}
 }

--- a/integration/fabric/twonets/topology.go
+++ b/integration/fabric/twonets/topology.go
@@ -46,5 +46,8 @@ func Topology() []api.Topology {
 	)
 	bob.RegisterResponder(&views.Pong{}, &views.Ping{})
 
+	// Add Fabric SDK to FSC Nodes
+	f1Topology.AddSDK(fscTopology)
+
 	return []api.Topology{f1Topology, f2Topology, fscTopology}
 }

--- a/integration/fabric/twonets/topology.go
+++ b/integration/fabric/twonets/topology.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
+	fabric2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk"
 )
 
 func Topology() []api.Topology {
@@ -47,7 +48,7 @@ func Topology() []api.Topology {
 	bob.RegisterResponder(&views.Pong{}, &views.Ping{})
 
 	// Add Fabric SDK to FSC Nodes
-	f1Topology.AddSDK(fscTopology)
+	fscTopology.AddSDK(&fabric2.SDK{})
 
 	return []api.Topology{f1Topology, f2Topology, fscTopology}
 }

--- a/integration/fabric/weaver/relay/topology.go
+++ b/integration/fabric/weaver/relay/topology.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/weaver"
+	fabric2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk"
 )
 
 func Topology() []api.Topology {
@@ -56,7 +57,7 @@ func Topology() []api.Topology {
 	bob.RegisterResponder(&views.Responder{}, &views.InitiatorView{})
 
 	// Add Fabric SDK to FSC Nodes
-	f1Topology.AddSDK(fscTopology)
+	fscTopology.AddSDK(&fabric2.SDK{})
 
 	return []api.Topology{f1Topology, f2Topology, wTopology, fscTopology}
 }

--- a/integration/fabric/weaver/relay/topology.go
+++ b/integration/fabric/weaver/relay/topology.go
@@ -55,5 +55,8 @@ func Topology() []api.Topology {
 	)
 	bob.RegisterResponder(&views.Responder{}, &views.InitiatorView{})
 
+	// Add Fabric SDK to FSC Nodes
+	f1Topology.AddSDK(fscTopology)
+
 	return []api.Topology{f1Topology, f2Topology, wTopology, fscTopology}
 }

--- a/integration/nwo/cmd/cryptogen/ca/ca.go
+++ b/integration/nwo/cmd/cryptogen/ca/ca.go
@@ -134,6 +134,45 @@ func NewCA(
 	return ca, err
 }
 
+func LoadCA(baseDir string) (*CA, error) {
+	var ca *CA
+
+	// check baseDir exist
+	_, err := os.Stat(baseDir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load private key
+	priv, err := csp2.LoadPrivateKey(baseDir)
+	if err != nil {
+		return nil, err
+	}
+
+	// load certificate
+	x509Cert, err := LoadCertificateECDSA(baseDir)
+	if err != nil {
+		return nil, err
+	}
+
+	// setup ca
+	ca = &CA{
+		Name: x509Cert.Subject.CommonName,
+		Signer: &csp2.ECDSASigner{
+			PrivateKey: priv,
+		},
+		SignCert:           x509Cert,
+		Country:            x509Cert.Subject.Country[0],
+		Province:           x509Cert.Subject.Province[0],
+		Locality:           x509Cert.Subject.Locality[0],
+		OrganizationalUnit: x509Cert.Subject.OrganizationalUnit[0],
+		StreetAddress:      x509Cert.Subject.StreetAddress[0],
+		PostalCode:         x509Cert.Subject.PostalCode[0],
+	}
+
+	return ca, err
+}
+
 // SignCertificate creates a signed certificate based on a built-in template
 // and saves it in baseDir/name
 func (ca *CA) SignCertificate(baseDir, name string, orgUnits, alternateNames []string, pub *ecdsa.PublicKey, ku x509.KeyUsage, eku []x509.ExtKeyUsage, nodeType int) (*x509.Certificate, error) {

--- a/integration/nwo/cmd/cryptogen/ca/ca.go
+++ b/integration/nwo/cmd/cryptogen/ca/ca.go
@@ -161,13 +161,25 @@ func LoadCA(baseDir string) (*CA, error) {
 		Signer: &csp2.ECDSASigner{
 			PrivateKey: priv,
 		},
-		SignCert:           x509Cert,
-		Country:            x509Cert.Subject.Country[0],
-		Province:           x509Cert.Subject.Province[0],
-		Locality:           x509Cert.Subject.Locality[0],
-		OrganizationalUnit: x509Cert.Subject.OrganizationalUnit[0],
-		StreetAddress:      x509Cert.Subject.StreetAddress[0],
-		PostalCode:         x509Cert.Subject.PostalCode[0],
+		SignCert: x509Cert,
+	}
+	if len(x509Cert.Subject.Country) > 0 {
+		ca.Country = x509Cert.Subject.Country[0]
+	}
+	if len(x509Cert.Subject.Province) > 0 {
+		ca.Province = x509Cert.Subject.Province[0]
+	}
+	if len(x509Cert.Subject.Locality) > 0 {
+		ca.Locality = x509Cert.Subject.Locality[0]
+	}
+	if len(x509Cert.Subject.OrganizationalUnit) > 0 {
+		ca.OrganizationalUnit = x509Cert.Subject.OrganizationalUnit[0]
+	}
+	if len(x509Cert.Subject.StreetAddress) > 0 {
+		ca.StreetAddress = x509Cert.Subject.StreetAddress[0]
+	}
+	if len(x509Cert.Subject.PostalCode) > 0 {
+		ca.PostalCode = x509Cert.Subject.PostalCode[0]
 	}
 
 	return ca, err

--- a/integration/nwo/cmd/cryptogen/cryptogen.go
+++ b/integration/nwo/cmd/cryptogen/cryptogen.go
@@ -480,7 +480,7 @@ func generateNodes(baseDir string, nodes []NodeSpec, signCA *ca2.CA, tlsCA *ca2.
 			if node.isAdmin && nodeOUs {
 				currentNodeType = msp2.ADMIN
 			}
-			err := msp2.GenerateLocalMSP(nodeDir, node.CommonName, node.SANS, signCA, tlsCA, currentNodeType, nodeOUs, node.HSM)
+			err := msp2.GenerateLocalMSP(nodeDir, node.CommonName, node.SANS, signCA, tlsCA, currentNodeType, nodeOUs, node.HSM, nil)
 			if err != nil {
 				fmt.Printf("Error generating local MSP for %v:\n%v\n", node, err)
 				os.Exit(1)

--- a/integration/nwo/cmd/cryptogen/msp/msp_test.go
+++ b/integration/nwo/cmd/cryptogen/msp/msp_test.go
@@ -36,7 +36,7 @@ var testDir = filepath.Join(os.TempDir(), "msp-test")
 func testGenerateLocalMSP(t *testing.T, nodeOUs bool) {
 	cleanup(testDir)
 
-	err := msp2.GenerateLocalMSP(testDir, testName, nil, &ca2.CA{}, &ca2.CA{}, msp2.PEER, nodeOUs, false)
+	err := msp2.GenerateLocalMSP(testDir, testName, nil, &ca2.CA{}, &ca2.CA{}, msp2.PEER, nodeOUs, false, nil)
 	assert.Error(t, err, "Empty CA should have failed")
 
 	caDir := filepath.Join(testDir, "ca")
@@ -65,7 +65,7 @@ func testGenerateLocalMSP(t *testing.T, nodeOUs bool) {
 	assert.Equal(t, testPostalCode, signCA.SignCert.Subject.PostalCode[0], "Failed to match postalCode")
 
 	// generate local MSP for nodeType=PEER
-	err = msp2.GenerateLocalMSP(testDir, testName, nil, signCA, tlsCA, msp2.PEER, nodeOUs, false)
+	err = msp2.GenerateLocalMSP(testDir, testName, nil, signCA, tlsCA, msp2.PEER, nodeOUs, false, nil)
 	assert.NoError(t, err, "Failed to generate local MSP")
 
 	// check to see that the right files were generated/saved
@@ -97,7 +97,7 @@ func testGenerateLocalMSP(t *testing.T, nodeOUs bool) {
 	}
 
 	// generate local MSP for nodeType=CLIENT
-	err = msp2.GenerateLocalMSP(testDir, testName, nil, signCA, tlsCA, msp2.CLIENT, nodeOUs, false)
+	err = msp2.GenerateLocalMSP(testDir, testName, nil, signCA, tlsCA, msp2.CLIENT, nodeOUs, false, nil)
 	assert.NoError(t, err, "Failed to generate local MSP")
 	// check all
 	for _, file := range mspFiles {
@@ -111,10 +111,10 @@ func testGenerateLocalMSP(t *testing.T, nodeOUs bool) {
 	}
 
 	tlsCA.Name = "test/fail"
-	err = msp2.GenerateLocalMSP(testDir, testName, nil, signCA, tlsCA, msp2.CLIENT, nodeOUs, false)
+	err = msp2.GenerateLocalMSP(testDir, testName, nil, signCA, tlsCA, msp2.CLIENT, nodeOUs, false, nil)
 	assert.Error(t, err, "Should have failed with CA name 'test/fail'")
 	signCA.Name = "test/fail"
-	err = msp2.GenerateLocalMSP(testDir, testName, nil, signCA, tlsCA, msp2.ORDERER, nodeOUs, false)
+	err = msp2.GenerateLocalMSP(testDir, testName, nil, signCA, tlsCA, msp2.ORDERER, nodeOUs, false, nil)
 	assert.Error(t, err, "Should have failed with CA name 'test/fail'")
 	t.Log(err)
 	cleanup(testDir)

--- a/integration/nwo/common/context/context.go
+++ b/integration/nwo/common/context/context.go
@@ -150,7 +150,11 @@ func (c *Context) AddIdentityAlias(id string, alias string) {
 }
 
 func (c *Context) PlatformByName(name string) api.Platform {
-	return c.PlatformsByName[name]
+	p, ok := c.PlatformsByName[name]
+	if !ok {
+		logger.Errorf("cannot find platform with name [%s], platforms available [%v]", c.PlatformsByName)
+	}
+	return p
 }
 
 func (c *Context) PlatformsByType(typ string) []api.Platform {
@@ -164,7 +168,7 @@ func (c *Context) PlatformsByType(typ string) []api.Platform {
 }
 
 func (c *Context) AddPlatform(platform api.Platform) {
-	logger.Infof("add platform [%s:%s]", platform.Type(), platform.Name())
+	logger.Infof("Add platform [%s:%s]", platform.Type(), platform.Name())
 	c.PlatformsByName[platform.Name()] = platform
 }
 

--- a/integration/nwo/common/context/context.go
+++ b/integration/nwo/common/context/context.go
@@ -9,9 +9,12 @@ package context
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api"
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/client/view"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
+
+var logger = flogging.MustGetLogger("fsc.integration")
 
 type Builder interface {
 	Build(path string) string
@@ -161,6 +164,7 @@ func (c *Context) PlatformsByType(typ string) []api.Platform {
 }
 
 func (c *Context) AddPlatform(platform api.Platform) {
+	logger.Infof("add platform [%s:%s]", platform.Type(), platform.Name())
 	c.PlatformsByName[platform.Name()] = platform
 }
 

--- a/integration/nwo/fabric/topology/topology.go
+++ b/integration/nwo/fabric/topology/topology.go
@@ -10,9 +10,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
-	fabric "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk"
 )
 
 // Topology holds the basic information needed to generate
@@ -352,8 +349,4 @@ func (t *Topology) EnableLogPeersToFile() {
 
 func (t *Topology) EnableLogOrderersToFile() {
 	t.LogOrderersToFile = true
-}
-
-func (t *Topology) AddSDK(topology *fsc.Topology) {
-	topology.AddSDK(&fabric.SDK{})
 }

--- a/integration/nwo/fabric/topology/topology.go
+++ b/integration/nwo/fabric/topology/topology.go
@@ -10,6 +10,9 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
+	fabric "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk"
 )
 
 // Topology holds the basic information needed to generate
@@ -349,4 +352,8 @@ func (t *Topology) EnableLogPeersToFile() {
 
 func (t *Topology) EnableLogOrderersToFile() {
 	t.LogOrderersToFile = true
+}
+
+func (t *Topology) AddSDK(topology *fsc.Topology) {
+	topology.AddSDK(&fabric.SDK{})
 }

--- a/integration/nwo/fsc/node/node_template.go
+++ b/integration/nwo/fsc/node/node_template.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	fscnode "github.com/hyperledger-labs/fabric-smart-client/node"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk"
 
 	{{ if InstallView }}viewregistry "github.com/hyperledger-labs/fabric-smart-client/platform/view"{{ end }}
 	{{- range .Imports }}
@@ -25,7 +24,6 @@ import (
 
 func main() {
 	n := fscnode.New()
-	n.InstallSDK(fabric.NewSDK(n))
 	{{- range .SDKs }}
 	n.InstallSDK({{ .Type }})
 	{{ end }}

--- a/integration/nwo/fsc/node/org.go
+++ b/integration/nwo/fsc/node/org.go
@@ -36,8 +36,7 @@ type PeerIdentity struct {
 	Org          string
 }
 
-// Peer defines a peer instance, it's owning organization, and the list of
-// channels that the peer should be joined to.
+// Peer defines an FSC node instance
 type Peer struct {
 	*Node
 	Name            string          `yaml:"name,omitempty"`

--- a/integration/nwo/fsc/testdata/main/main.go.output
+++ b/integration/nwo/fsc/testdata/main/main.go.output
@@ -8,7 +8,6 @@ package main
 
 import (
 	fscnode "github.com/hyperledger-labs/fabric-smart-client/node"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk"
 
 	viewregistry "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	fsc "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
@@ -19,7 +18,6 @@ import (
 
 func main() {
 	n := fscnode.New()
-	n.InstallSDK(fabric.NewSDK(n))
 	n.InstallSDK(fsc.NewDummySDK(n))
 	
 	n.Execute(func() error {

--- a/integration/nwo/fsc/topology.go
+++ b/integration/nwo/fsc/topology.go
@@ -6,7 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package fsc
 
-import "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc/node"
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc/node"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/api"
+)
 
 const (
 	TopologyName = "fsc"
@@ -121,6 +124,12 @@ func (t *Topology) EnableLogToFile() {
 
 func (t *Topology) EnablePrometheusMetrics() {
 	t.MetricsProvider = "prometheus"
+}
+
+func (t *Topology) AddSDK(sdk api.SDK) {
+	for _, n := range t.Nodes {
+		n.AddSDK(sdk)
+	}
 }
 
 func (t *Topology) addNode(node *node.Node) *node.Node {

--- a/platform/fabric/core/driver.go
+++ b/platform/fabric/core/driver.go
@@ -1,0 +1,46 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package core
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+)
+
+var (
+	driversMu sync.RWMutex
+	drivers   = make(map[string]driver.Driver)
+)
+
+// Register makes a kvs driver available by the provided name.
+// If Register is called twice with the same name or if driver is nil,
+// it panics.
+func Register(name string, driver driver.Driver) {
+	driversMu.Lock()
+	defer driversMu.Unlock()
+	if driver == nil {
+		panic("Register driver is nil")
+	}
+	if _, dup := drivers[name]; dup {
+		panic("Register called twice for driver " + name)
+	}
+	drivers[name] = driver
+}
+
+// Drivers returns a sorted list of the names of the registered drivers.
+func Drivers() []string {
+	driversMu.RLock()
+	defer driversMu.RUnlock()
+	list := make([]string, 0, len(drivers))
+	for name := range drivers {
+		list = append(list, name)
+	}
+	sort.Strings(list)
+	return list
+}

--- a/platform/fabric/core/generic/config/ds.go
+++ b/platform/fabric/core/generic/config/ds.go
@@ -46,12 +46,12 @@ type MSPOpts struct {
 }
 
 type MSP struct {
-	ID        string   `yaml:"id"`
-	MSPType   string   `yaml:"mspType"`
-	MSPID     string   `yaml:"mspID"`
-	Path      string   `yaml:"path"`
-	CacheSize int      `yaml:"cacheSize"`
-	Opts      *MSPOpts `yaml:"opts, omitempty"`
+	ID        string                      `yaml:"id"`
+	MSPType   string                      `yaml:"mspType"`
+	MSPID     string                      `yaml:"mspID"`
+	Path      string                      `yaml:"path"`
+	CacheSize int                         `yaml:"cacheSize"`
+	Opts      map[interface{}]interface{} `yaml:"opts, omitempty"`
 }
 
 type File struct {

--- a/platform/fabric/core/generic/driver.go
+++ b/platform/fabric/core/generic/driver.go
@@ -1,0 +1,85 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package generic
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/endpoint"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/id"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
+	"github.com/pkg/errors"
+)
+
+type Driver struct {
+}
+
+func (d *Driver) New(sp view.ServiceProvider, network string, defaultNetwork bool) (driver.FabricNetworkService, error) {
+	logger.Debugf("creating new fabric network service for network [%s]", network)
+	// bridge services
+	c, err := config.New(view.GetConfigService(sp), network, defaultNetwork)
+	if err != nil {
+		return nil, err
+	}
+	sigService := NewSigService(sp)
+
+	// Endpoint service
+	resolverService, err := endpoint.NewResolverService(
+		c,
+		view.GetEndpointService(sp),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed instantiating fabric endpoint resolver")
+	}
+	if err := resolverService.LoadResolvers(); err != nil {
+		return nil, errors.Wrap(err, "failed loading fabric endpoint resolvers")
+	}
+	endpointService, err := NewEndpointResolver(resolverService, view.GetEndpointService(sp))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed loading endpoint service")
+	}
+
+	// Local MSP Manager
+	mspService := msp.NewLocalMSPManager(
+		sp,
+		c,
+		sigService,
+		view.GetEndpointService(sp),
+		view.GetIdentityProvider(sp).DefaultIdentity(),
+		c.MSPCacheSize(),
+	)
+	if err := mspService.Load(); err != nil {
+		return nil, errors.Wrap(err, "failed loading local msp service")
+	}
+
+	// Identity Manager
+	idProvider, err := id.NewProvider(endpointService)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating id provider")
+	}
+
+	// New Network
+	net, err := NewNetwork(
+		sp,
+		network,
+		c,
+		idProvider,
+		mspService,
+		sigService,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed instantiating fabric service provider")
+	}
+
+	return net, nil
+}
+
+func init() {
+	core.Register("fabric", &Driver{})
+}

--- a/platform/fabric/core/generic/driver/driver.go
+++ b/platform/fabric/core/generic/driver/driver.go
@@ -4,21 +4,24 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package generic
+package driver
 
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/endpoint"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/id"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/pkg/errors"
 )
 
-type Driver struct {
-}
+var logger = flogging.MustGetLogger("fabric-sdk.core.generic.driver")
+
+type Driver struct{}
 
 func (d *Driver) New(sp view.ServiceProvider, network string, defaultNetwork bool) (driver.FabricNetworkService, error) {
 	logger.Debugf("creating new fabric network service for network [%s]", network)
@@ -27,7 +30,7 @@ func (d *Driver) New(sp view.ServiceProvider, network string, defaultNetwork boo
 	if err != nil {
 		return nil, err
 	}
-	sigService := NewSigService(sp)
+	sigService := generic.NewSigService(sp)
 
 	// Endpoint service
 	resolverService, err := endpoint.NewResolverService(
@@ -40,7 +43,7 @@ func (d *Driver) New(sp view.ServiceProvider, network string, defaultNetwork boo
 	if err := resolverService.LoadResolvers(); err != nil {
 		return nil, errors.Wrap(err, "failed loading fabric endpoint resolvers")
 	}
-	endpointService, err := NewEndpointResolver(resolverService, view.GetEndpointService(sp))
+	endpointService, err := generic.NewEndpointResolver(resolverService, view.GetEndpointService(sp))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed loading endpoint service")
 	}
@@ -65,7 +68,7 @@ func (d *Driver) New(sp view.ServiceProvider, network string, defaultNetwork boo
 	}
 
 	// New Network
-	net, err := NewNetwork(
+	net, err := generic.NewNetwork(
 		sp,
 		network,
 		c,

--- a/platform/fabric/core/generic/fabricutils/pr.go
+++ b/platform/fabric/core/generic/fabricutils/pr.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package ordering
+package fabricutils
 
 import (
 	pb "github.com/hyperledger/fabric-protos-go/peer"

--- a/platform/fabric/core/generic/fabricutils/utils.go
+++ b/platform/fabric/core/generic/fabricutils/utils.go
@@ -1,0 +1,184 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fabricutils
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
+	"github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/hyperledger/fabric/protoutil"
+	"github.com/pkg/errors"
+	"go.uber.org/zap/zapcore"
+)
+
+var logger = flogging.MustGetLogger("fabric-sdk.utils")
+
+type SerializableSigner interface {
+	Sign(message []byte) ([]byte, error)
+
+	Serialize() ([]byte, error)
+}
+
+// CreateSignedTx assembles an Envelope message from proposal, endorsements,
+// and a signer. This function should be called by a client when it has
+// collected enough endorsements for a proposal to create a transaction and
+// submit it to peers for ordering
+func CreateSignedTx(proposal driver.Proposal, signer SerializableSigner, resps ...driver.ProposalResponse) (*common.Envelope, error) {
+	if len(resps) == 0 {
+		return nil, errors.New("at least one proposal response is required")
+	}
+
+	// the original header
+	hdr, err := protoutil.UnmarshalHeader(proposal.Header())
+	if err != nil {
+		return nil, err
+	}
+
+	// the original payload
+	pPayl, err := protoutil.UnmarshalChaincodeProposalPayload(proposal.Payload())
+	if err != nil {
+		return nil, err
+	}
+
+	// check that the signer is the same that is referenced in the header
+	// TODO: maybe worth removing?
+	signerBytes, err := signer.Serialize()
+	if err != nil {
+		return nil, err
+	}
+
+	shdr, err := protoutil.UnmarshalSignatureHeader(hdr.SignatureHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	if !bytes.Equal(signerBytes, shdr.Creator) {
+		return nil, errors.New("signer must be the same as the one referenced in the header")
+	}
+
+	// ensure that all actions are bitwise equal and that they are successful
+	var a1 []byte
+	var first driver.ProposalResponse
+	for n, r := range resps {
+		if r.ResponseStatus() < 200 || r.ResponseStatus() >= 400 {
+			return nil, errors.Errorf("proposal response was not successful, error code %d, msg %s", r.ResponseStatus(), r.ResponseMessage())
+		}
+
+		if n == 0 {
+			a1 = r.Payload()
+			first = r
+			continue
+		}
+
+		if !bytes.Equal(a1, r.Payload()) {
+			upr1, err := UnpackProposalResponse(first.Payload())
+			if err != nil {
+				return nil, err
+			}
+			rwset1, err := json.MarshalIndent(upr1.TxRwSet, "", "  ")
+			if err != nil {
+				return nil, err
+			}
+
+			upr2, err := UnpackProposalResponse(r.Payload())
+			if err != nil {
+				return nil, err
+			}
+			rwset2, err := json.MarshalIndent(upr2.TxRwSet, "", "  ")
+			if err != nil {
+				return nil, err
+			}
+
+			if !bytes.Equal(rwset1, rwset2) {
+				if logger.IsEnabledFor(zapcore.DebugLevel) {
+					logger.Debugf("ProposalResponsePayloads do not match (%v) \n[%s]\n!=\n[%s]",
+						bytes.Equal(rwset1, rwset2), string(rwset1), string(rwset2),
+					)
+				}
+			} else {
+				pr1, err := json.MarshalIndent(first, "", "  ")
+				if err != nil {
+					return nil, err
+				}
+				pr2, err := json.MarshalIndent(r, "", "  ")
+				if err != nil {
+					return nil, err
+				}
+
+				if logger.IsEnabledFor(zapcore.DebugLevel) {
+					logger.Debugf("ProposalResponse do not match  \n[%s]\n!=\n[%s]",
+						bytes.Equal(pr1, pr2), string(pr1), string(pr2),
+					)
+				}
+			}
+
+			return nil, errors.Errorf(
+				"ProposalResponsePayloads do not match [%s]!=[%s]",
+				base64.StdEncoding.EncodeToString(a1),
+				base64.StdEncoding.EncodeToString(r.Payload()),
+			)
+		}
+	}
+
+	// fill endorsements
+	endorsements := make([]*peer.Endorsement, len(resps))
+	for n, r := range resps {
+		endorsements[n] = &peer.Endorsement{
+			Endorser:  r.Endorser(),
+			Signature: r.EndorserSignature(),
+		}
+	}
+
+	// create ChaincodeEndorsedAction
+	cea := &peer.ChaincodeEndorsedAction{ProposalResponsePayload: resps[0].Payload(), Endorsements: endorsements}
+
+	// obtain the bytes of the proposal payload that will go to the transaction
+	propPayloadBytes, err := protoutil.GetBytesProposalPayloadForTx(pPayl)
+	if err != nil {
+		return nil, err
+	}
+
+	// serialize the chaincode action payload
+	cap := &peer.ChaincodeActionPayload{ChaincodeProposalPayload: propPayloadBytes, Action: cea}
+	capBytes, err := protoutil.GetBytesChaincodeActionPayload(cap)
+	if err != nil {
+		return nil, err
+	}
+
+	// create a transaction
+	taa := &peer.TransactionAction{Header: hdr.SignatureHeader, Payload: capBytes}
+	taas := make([]*peer.TransactionAction, 1)
+	taas[0] = taa
+	tx := &peer.Transaction{Actions: taas}
+
+	// serialize the tx
+	txBytes, err := protoutil.GetBytesTransaction(tx)
+	if err != nil {
+		return nil, err
+	}
+
+	// create the payload
+	payl := &common.Payload{Header: hdr, Data: txBytes}
+	paylBytes, err := protoutil.GetBytesPayload(payl)
+	if err != nil {
+		return nil, err
+	}
+
+	// sign the payload
+	sig, err := signer.Sign(paylBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// here's the envelope
+	return &common.Envelope{Payload: paylBytes, Signature: sig}, nil
+}

--- a/platform/fabric/core/generic/msp/driver/driver.go
+++ b/platform/fabric/core/generic/msp/driver/driver.go
@@ -1,0 +1,77 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package driver
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
+	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/core/sig"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
+
+type MSP struct {
+	Name         string `yaml:"name,omitempty"`
+	Type         string `yaml:"type,omitempty"`
+	EnrollmentID string
+	GetIdentity  fdriver.GetIdentityFunc
+}
+
+type Config interface {
+	Name() string
+	DefaultMSP() string
+	MSPs() ([]config.MSP, error)
+	TranslatePath(path string) string
+}
+
+type SignerService interface {
+	RegisterSigner(identity view.Identity, signer fdriver.Signer, verifier fdriver.Verifier) error
+}
+
+type BinderService interface {
+	Bind(longTerm view.Identity, ephemeral view.Identity) error
+}
+
+type ConfigProvider interface {
+	driver.ConfigService
+}
+
+type DeserializerManager interface {
+	AddDeserializer(deserializer sig.Deserializer)
+}
+
+type Manager interface {
+	AddDeserializer(deserializer sig.Deserializer)
+	AddMSP(name string, mspType string, enrollmentID string, idGetter fdriver.GetIdentityFunc)
+	Config() Config
+	DefaultMSP() string
+	SignerService() SignerService
+	ServiceProvider() view2.ServiceProvider
+	CacheSize() int
+	SetDefaultIdentity(id string, defaultIdentity view.Identity, defaultSigningIdentity SigningIdentity)
+}
+
+type IdentityLoader interface {
+	Load(manager Manager, config config.MSP) error
+}
+
+// Identity refers to the creator of a tx;
+type Identity interface {
+	Serialize() ([]byte, error)
+
+	Verify(msg []byte, sig []byte) error
+}
+
+// SigningIdentity defines the functions necessary to sign an
+// array of bytes; it is needed to sign the commands transmitted to
+// the prover peer service.
+type SigningIdentity interface {
+	Identity //extends Identity
+
+	Sign(msg []byte) ([]byte, error)
+}

--- a/platform/fabric/core/generic/msp/idemix/cache.go
+++ b/platform/fabric/core/generic/msp/idemix/cache.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package msp
+package idemix
 
 import (
 	"runtime"

--- a/platform/fabric/core/generic/msp/idemix/cache.go
+++ b/platform/fabric/core/generic/msp/idemix/cache.go
@@ -11,13 +11,12 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/zap/zapcore"
-
-	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"go.uber.org/zap/zapcore"
 )
 
-type IdentityCacheBackendFunc func(opts *driver2.IdentityOptions) (view.Identity, []byte, error)
+type IdentityCacheBackendFunc func(opts *driver.IdentityOptions) (view.Identity, []byte, error)
 
 type identityCacheEntry struct {
 	Identity view.Identity
@@ -39,7 +38,7 @@ func NewIdentityCache(backed IdentityCacheBackendFunc, size int) *IdentityCache 
 	return ci
 }
 
-func (c *IdentityCache) Identity(opts *driver2.IdentityOptions) (view.Identity, []byte, error) {
+func (c *IdentityCache) Identity(opts *driver.IdentityOptions) (view.Identity, []byte, error) {
 	if opts != nil {
 		return c.fetchIdentityFromBackend(opts)
 	}
@@ -59,7 +58,7 @@ func (c *IdentityCache) Identity(opts *driver2.IdentityOptions) (view.Identity, 
 
 }
 
-func (c *IdentityCache) fetchIdentityFromCache(opts *driver2.IdentityOptions) (view.Identity, []byte, error) {
+func (c *IdentityCache) fetchIdentityFromCache(opts *driver.IdentityOptions) (view.Identity, []byte, error) {
 	var identity view.Identity
 	var audit []byte
 
@@ -98,7 +97,7 @@ func (c *IdentityCache) fetchIdentityFromCache(opts *driver2.IdentityOptions) (v
 	return identity, audit, nil
 }
 
-func (c *IdentityCache) fetchIdentityFromBackend(opts *driver2.IdentityOptions) (view.Identity, []byte, error) {
+func (c *IdentityCache) fetchIdentityFromBackend(opts *driver.IdentityOptions) (view.Identity, []byte, error) {
 	if logger.IsEnabledFor(zapcore.DebugLevel) {
 		logger.Debugf("fetching identity from backend")
 	}

--- a/platform/fabric/core/generic/msp/idemix/cache_test.go
+++ b/platform/fabric/core/generic/msp/idemix/cache_test.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package msp
+package idemix
 
 import (
 	"testing"

--- a/platform/fabric/core/generic/msp/idemix/loader.go
+++ b/platform/fabric/core/generic/msp/idemix/loader.go
@@ -1,0 +1,72 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package idemix
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/driver"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
+	msp2 "github.com/hyperledger/fabric/msp"
+	"github.com/pkg/errors"
+)
+
+const (
+	MSPType = "idemix"
+)
+
+type IdentityLoader struct{}
+
+func (i *IdentityLoader) Load(manager driver.Manager, c config.MSP) error {
+	conf, err := msp2.GetLocalMspConfigWithType(manager.Config().TranslatePath(c.Path), nil, c.MSPID, c.MSPType)
+	if err != nil {
+		return errors.Wrapf(err, "failed reading idemix msp configuration from [%s]", manager.Config().TranslatePath(c.Path))
+	}
+	provider, err := NewAnyProvider(conf, manager.ServiceProvider())
+	if err != nil {
+		return errors.Wrapf(err, "failed instantiating idemix msp provider from [%s]", manager.Config().TranslatePath(c.Path))
+	}
+	manager.AddDeserializer(provider)
+	cacheSize := manager.CacheSize()
+	if c.CacheSize > 0 {
+		cacheSize = c.CacheSize
+	}
+	manager.AddMSP(c.ID, c.MSPType, provider.EnrollmentID(), NewIdentityCache(provider.Identity, cacheSize).Identity)
+	logger.Debugf("added %s msp for id %s with cache of size %d", c.MSPType, c.ID+"@"+provider.EnrollmentID(), cacheSize)
+
+	return nil
+}
+
+type FolderIdentityLoader struct {
+	*IdentityLoader
+}
+
+func (f *FolderIdentityLoader) Load(manager driver.Manager, c config.MSP) error {
+	entries, err := ioutil.ReadDir(manager.Config().TranslatePath(c.Path))
+	if err != nil {
+		logger.Warnf("failed reading from [%s]: [%s]", manager.Config().TranslatePath(c.Path), err)
+		return errors.Wrapf(err, "failed reading from [%s]", manager.Config().TranslatePath(c.Path))
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		id := entry.Name()
+
+		if err := f.IdentityLoader.Load(manager, config.MSP{
+			ID:      id,
+			MSPType: MSPType,
+			MSPID:   id,
+			Path:    filepath.Join(manager.Config().TranslatePath(c.Path), id),
+		}); err != nil {
+			return errors.WithMessagef(err, "failed to load Idemix MSP configuration [%s]", id)
+		}
+	}
+	return nil
+}

--- a/platform/fabric/core/generic/msp/idemix/loader.go
+++ b/platform/fabric/core/generic/msp/idemix/loader.go
@@ -10,9 +10,8 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/driver"
-
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/driver"
 	msp2 "github.com/hyperledger/fabric/msp"
 	"github.com/pkg/errors"
 )

--- a/platform/fabric/core/generic/msp/mock/config_provider.go
+++ b/platform/fabric/core/generic/msp/mock/config_provider.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/driver"
 )
 
 type ConfigProvider struct {
@@ -768,4 +768,4 @@ func (fake *ConfigProvider) recordInvocation(key string, args []interface{}) {
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
 
-var _ msp.ConfigProvider = new(ConfigProvider)
+var _ driver.ConfigProvider = new(ConfigProvider)

--- a/platform/fabric/core/generic/msp/service.go
+++ b/platform/fabric/core/generic/msp/service.go
@@ -12,13 +12,11 @@ import (
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/driver"
-
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/core/sig"
-
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/idemix"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/x509"
 	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/core/sig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger/fabric/msp"

--- a/platform/fabric/core/generic/msp/service.go
+++ b/platform/fabric/core/generic/msp/service.go
@@ -380,7 +380,7 @@ func (s *service) loadLocalMSPs() error {
 			continue
 		}
 		if err := loader.Load(s, config); err != nil {
-			return errors.WithMessagef(err, "failed to load idemix msp [%s]", config.ID)
+			return errors.WithMessagef(err, "failed to load msp [%s:%s] at [%s]", config.ID, config.MSPType, config.Path)
 		}
 	}
 

--- a/platform/fabric/core/generic/msp/service.go
+++ b/platform/fabric/core/generic/msp/service.go
@@ -8,18 +8,17 @@ package msp
 
 import (
 	"fmt"
-	"io/ioutil"
-	"path/filepath"
 	"reflect"
 	"sync"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/driver"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/core/sig"
+
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/idemix"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/x509"
 	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/core/sig"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger/fabric/msp"
@@ -35,88 +34,89 @@ const (
 
 var logger = flogging.MustGetLogger("fabric-sdk.msp")
 
-type Config interface {
-	Name() string
-	DefaultMSP() string
-	MSPs() ([]config.MSP, error)
-	TranslatePath(path string) string
-}
-
-type SignerService interface {
-	RegisterSigner(identity view.Identity, signer fdriver.Signer, verifier fdriver.Verifier) error
-}
-
-type BinderService interface {
-	Bind(longTerm view.Identity, ephemeral view.Identity) error
-}
-
-type ConfigProvider interface {
-	driver.ConfigService
-}
-
-type DeserializerManager interface {
-	AddDeserializer(deserializer sig.Deserializer)
-}
-
-type Configuration struct {
-	ID      string `yaml:"id"`
-	MSPType string `yaml:"mspType"`
-	MSPID   string `yaml:"mspID"`
-	Path    string `yaml:"path"`
-}
-
-type MSP struct {
-	Name         string `yaml:"name,omitempty"`
-	Type         string `yaml:"type,omitempty"`
-	EnrollmentID string
-	GetIdentity  fdriver.GetIdentityFunc
-}
-
 type service struct {
 	sp                     view2.ServiceProvider
 	defaultIdentity        view.Identity
-	defaultSigningIdentity x509.SigningIdentity
-	signerService          SignerService
-	binderService          BinderService
+	defaultSigningIdentity driver.SigningIdentity
+	signerService          driver.SignerService
+	binderService          driver.BinderService
 	defaultViewIdentity    view.Identity
-	config                 Config
+	config                 driver.Config
 
 	mspsMutex           sync.RWMutex
-	msps                []*MSP
-	mspsByName          map[string]*MSP
-	mspsByEnrollmentID  map[string]*MSP
-	mspsByTypeAndName   map[string]*MSP
-	bccspMspsByIdentity map[string]*MSP
+	defaultMSP          string
+	identityLoaders     map[string]driver.IdentityLoader
+	msps                []*driver.MSP
+	mspsByName          map[string]*driver.MSP
+	mspsByEnrollmentID  map[string]*driver.MSP
+	mspsByTypeAndName   map[string]*driver.MSP
+	bccspMspsByIdentity map[string]*driver.MSP
 	cacheSize           int
 }
 
 func NewLocalMSPManager(
 	sp view2.ServiceProvider,
-	config Config,
-	signerService SignerService,
-	binderService BinderService,
+	config driver.Config,
+	signerService driver.SignerService,
+	binderService driver.BinderService,
 	defaultViewIdentity view.Identity,
 	cacheSize int,
 ) *service {
-	return &service{
+	s := &service{
 		sp:                  sp,
 		config:              config,
 		signerService:       signerService,
 		binderService:       binderService,
 		defaultViewIdentity: defaultViewIdentity,
-		mspsByTypeAndName:   map[string]*MSP{},
-		bccspMspsByIdentity: map[string]*MSP{},
-		mspsByEnrollmentID:  map[string]*MSP{},
-		mspsByName:          map[string]*MSP{},
+		mspsByTypeAndName:   map[string]*driver.MSP{},
+		bccspMspsByIdentity: map[string]*driver.MSP{},
+		mspsByEnrollmentID:  map[string]*driver.MSP{},
+		mspsByName:          map[string]*driver.MSP{},
 		cacheSize:           cacheSize,
+		identityLoaders:     map[string]driver.IdentityLoader{},
 	}
+	s.PutIdentityLoader(BccspMSP, &x509.IdentityLoader{})
+	s.PutIdentityLoader(BccspMSPFolder, &x509.FolderIdentityLoader{})
+	s.PutIdentityLoader(IdemixMSP, &idemix.IdentityLoader{})
+	s.PutIdentityLoader(IdemixMSPFolder, &idemix.FolderIdentityLoader{})
+	return s
 }
 
-func (s *service) Load() error {
-	if err := s.loadLocalMSPs(); err != nil {
-		return err
+func (s *service) AddDeserializer(deserializer sig.Deserializer) {
+	s.DeserializerManager().AddDeserializer(deserializer)
+}
+
+func (s *service) Config() driver.Config {
+	return s.config
+}
+
+func (s *service) DefaultMSP() string {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s *service) SignerService() driver.SignerService {
+	return s.signerService
+}
+
+func (s *service) ServiceProvider() view2.ServiceProvider {
+	return s.sp
+}
+
+func (s *service) CacheSize() int {
+	return s.cacheSize
+}
+
+func (s *service) SetDefaultIdentity(id string, defaultIdentity view.Identity, defaultSigningIdentity driver.SigningIdentity) {
+	if id == s.defaultMSP {
+		if s.defaultIdentity == nil {
+			logger.Infof("setting default identity to [%s]", id)
+		}
+
+		// set default
+		s.defaultIdentity = defaultIdentity
+		s.defaultSigningIdentity = defaultSigningIdentity
 	}
-	return nil
 }
 
 func (s *service) DefaultIdentity() view.Identity {
@@ -247,8 +247,8 @@ func (s *service) RegisterIdemixMSP(id string, path string, mspID string) error 
 		return errors.Wrapf(err, "failed instantiating idemix msp provider from [%s]", path)
 	}
 
-	s.deserializerManager().AddDeserializer(provider)
-	s.addMSP(id, IdemixMSP, provider.EnrollmentID(), NewIdentityCache(provider.Identity, s.cacheSize).Identity)
+	s.DeserializerManager().AddDeserializer(provider)
+	s.AddMSP(id, IdemixMSP, provider.EnrollmentID(), idemix.NewIdentityCache(provider.Identity, s.cacheSize).Identity)
 	logger.Debugf("added IdemixMSP msp for id %s with cache of size %d", id+"@"+provider.EnrollmentID(), s.cacheSize)
 	return nil
 }
@@ -262,8 +262,8 @@ func (s *service) RegisterX509MSP(id string, path string, mspID string) error {
 		return errors.Wrapf(err, "failed instantiating idemix msp provider from [%s]", path)
 	}
 
-	s.deserializerManager().AddDeserializer(provider)
-	s.addMSP(id, BccspMSP, provider.EnrollmentID(), provider.Identity)
+	s.DeserializerManager().AddDeserializer(provider)
+	s.AddMSP(id, BccspMSP, provider.EnrollmentID(), provider.Identity)
 
 	return nil
 }
@@ -274,13 +274,69 @@ func (s *service) Refresh() error {
 
 	// clean cashes
 	s.msps = nil
-	s.mspsByTypeAndName = map[string]*MSP{}
-	s.bccspMspsByIdentity = map[string]*MSP{}
-	s.mspsByEnrollmentID = map[string]*MSP{}
-	s.mspsByName = map[string]*MSP{}
+	s.mspsByTypeAndName = map[string]*driver.MSP{}
+	s.bccspMspsByIdentity = map[string]*driver.MSP{}
+	s.mspsByEnrollmentID = map[string]*driver.MSP{}
+	s.mspsByName = map[string]*driver.MSP{}
 
 	// reload
-	return s.Load()
+	if err := s.loadLocalMSPs(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *service) AddMSP(name string, mspType string, enrollmentID string, IdentityGetter fdriver.GetIdentityFunc) {
+	if mspType == BccspMSP && s.binderService != nil {
+		id, _, err := IdentityGetter(nil)
+		if err != nil {
+			panic(fmt.Sprintf("cannot get identity for [%s,%s,%s][%s]", name, mspType, enrollmentID, err))
+		}
+		if err := s.binderService.Bind(s.defaultViewIdentity, id); err != nil {
+			panic(fmt.Sprintf("cannot bind identity for [%s,%s,%s][%s]", name, mspType, enrollmentID, err))
+		}
+	}
+
+	msp := &driver.MSP{
+		Name:         name,
+		Type:         mspType,
+		EnrollmentID: enrollmentID,
+		GetIdentity:  IdentityGetter,
+	}
+	if mspType == BccspMSP {
+		id, _, err := IdentityGetter(nil)
+		if err != nil {
+			panic(fmt.Sprintf("cannot get identity for [%s,%s,%s][%s]", name, mspType, enrollmentID, err))
+		}
+		s.bccspMspsByIdentity[id.String()] = msp
+		logger.Debugf("add bccsp msp for id %s, identity [%s]", name+"@"+enrollmentID, id.String())
+	} else {
+		logger.Debugf("add idemix msp for id %s", name+"@"+enrollmentID)
+	}
+	s.mspsByTypeAndName[mspType+name] = msp
+	s.mspsByName[name] = msp
+	if len(enrollmentID) != 0 {
+		s.mspsByEnrollmentID[enrollmentID] = msp
+	}
+	s.msps = append(s.msps, msp)
+}
+
+func (s *service) PutIdentityLoader(idType string, loader driver.IdentityLoader) {
+	s.mspsMutex.Lock()
+	defer s.mspsMutex.Unlock()
+
+	s.identityLoaders[idType] = loader
+}
+
+func (s *service) Load() error {
+	s.mspsMutex.Lock()
+	defer s.mspsMutex.Unlock()
+
+	if err := s.loadLocalMSPs(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *service) Msps() []string {
@@ -294,47 +350,12 @@ func (s *service) Msps() []string {
 	return res
 }
 
-func (s *service) addMSP(Name string, Type string, EnrollmentID string, IdentityGetter fdriver.GetIdentityFunc) {
-	if Type == BccspMSP && s.binderService != nil {
-		id, _, err := IdentityGetter(nil)
-		if err != nil {
-			panic(fmt.Sprintf("cannot get identity for [%s,%s,%s][%s]", Name, Type, EnrollmentID, err))
-		}
-		if err := s.binderService.Bind(s.defaultViewIdentity, id); err != nil {
-			panic(fmt.Sprintf("cannot bind identity for [%s,%s,%s][%s]", Name, Type, EnrollmentID, err))
-		}
-	}
-
-	msp := &MSP{
-		Name:         Name,
-		Type:         Type,
-		EnrollmentID: EnrollmentID,
-		GetIdentity:  IdentityGetter,
-	}
-	if Type == BccspMSP {
-		id, _, err := IdentityGetter(nil)
-		if err != nil {
-			panic(fmt.Sprintf("cannot get identity for [%s,%s,%s][%s]", Name, Type, EnrollmentID, err))
-		}
-		s.bccspMspsByIdentity[id.String()] = msp
-		logger.Debugf("add bccsp msp for id %s, identity [%s]", Name+"@"+EnrollmentID, id.String())
-	} else {
-		logger.Debugf("add idemix msp for id %s", Name+"@"+EnrollmentID)
-	}
-	s.mspsByTypeAndName[Type+Name] = msp
-	s.mspsByName[Name] = msp
-	if len(EnrollmentID) != 0 {
-		s.mspsByEnrollmentID[EnrollmentID] = msp
-	}
-	s.msps = append(s.msps, msp)
-}
-
-func (s *service) deserializerManager() DeserializerManager {
-	dm, err := s.sp.GetService(reflect.TypeOf((*DeserializerManager)(nil)))
+func (s *service) DeserializerManager() driver.DeserializerManager {
+	dm, err := s.sp.GetService(reflect.TypeOf((*driver.DeserializerManager)(nil)))
 	if err != nil {
 		panic(fmt.Sprintf("failed looking up deserializer manager [%s]", err))
 	}
-	return dm.(DeserializerManager)
+	return dm.(driver.DeserializerManager)
 }
 
 func (s *service) loadLocalMSPs() error {
@@ -342,37 +363,24 @@ func (s *service) loadLocalMSPs() error {
 	if err != nil {
 		return errors.WithMessagef(err, "failed loading local MSP configs")
 	}
-	defaultMSP := s.config.DefaultMSP()
-	if len(defaultMSP) == 0 {
+	s.defaultMSP = s.config.DefaultMSP()
+	if len(s.defaultMSP) == 0 {
 		if len(configs) == 0 {
 			return errors.New("default MSP not configured and no MSPs set")
 		}
 		logger.Warnf("default MSP not configured, set it to [%s]", configs[0].ID)
-		defaultMSP = configs[0].ID
+		s.defaultMSP = configs[0].ID
 	}
 
-	logger.Debugf("Local Local [%d] MSPS using default [%s]", len(configs), defaultMSP)
+	logger.Debugf("Local Local [%d] MSPS using default [%s]", len(configs), s.defaultMSP)
 	for _, config := range configs {
-		switch config.MSPType {
-		case IdemixMSP:
-			if err := s.loadIdemixMSP(config); err != nil {
-				return errors.WithMessagef(err, "failed to load idemix msp [%s]", config.ID)
-			}
-		case IdemixMSPFolder:
-			if err := s.loadIdemixMSPFolder(config); err != nil {
-				return errors.WithMessagef(err, "failed to load idemix msp folder [%s]", config.ID)
-			}
-		case BccspMSP:
-			if err := s.loadBCCSPMSP(config.ID, config, defaultMSP); err != nil {
-				return errors.WithMessagef(err, "failed loading bccsp msp [%s]", config.ID)
-			}
-		case BccspMSPFolder:
-			if err := s.loadBCCSPMSPFolder(config, defaultMSP); err != nil {
-				return errors.WithMessagef(err, "failed loading bccsp msp folder [%s]", config.Path)
-			}
-		default:
+		loader, ok := s.identityLoaders[config.MSPType]
+		if !ok {
 			logger.Warnf("msp type [%s] not recognized, skipping", config.MSPType)
 			continue
+		}
+		if err := loader.Load(s, config); err != nil {
+			return errors.WithMessagef(err, "failed to load idemix msp [%s]", config.ID)
 		}
 	}
 
@@ -380,124 +388,5 @@ func (s *service) loadLocalMSPs() error {
 		return errors.Errorf("no default identity set for network [%s]", s.config.Name())
 	}
 
-	return nil
-}
-
-func (s *service) loadBCCSPMSP(id string, c config.MSP, defaultMSP string) error {
-	// Try without "msp"
-	var bccspOpts *config.BCCSP
-	if c.Opts != nil {
-		bccspOpts = c.Opts.BCCSP
-	}
-	provider, err := x509.NewProviderWithBCCSPConfig(
-		s.config.TranslatePath(c.Path),
-		c.MSPID,
-		s.signerService,
-		bccspOpts,
-	)
-	if err != nil {
-		logger.Warnf("failed reading bccsp msp configuration from [%s]: [%s]", filepath.Join(s.config.TranslatePath(c.Path), id), err)
-		// Try with "msp"
-		provider, err = x509.NewProviderWithBCCSPConfig(
-			filepath.Join(s.config.TranslatePath(c.Path), "msp"),
-			c.MSPID,
-			s.signerService,
-			bccspOpts,
-		)
-		if err != nil {
-			logger.Warnf("failed reading bccsp msp configuration from [%s and %s]: [%s]",
-				filepath.Join(s.config.TranslatePath(c.Path),
-					filepath.Join(s.config.TranslatePath(c.Path), "msp")), err,
-			)
-			return errors.WithMessagef(err, "failed to load BCCSP MSP configuration [%s]", id)
-		}
-	}
-
-	s.deserializerManager().AddDeserializer(provider)
-	s.addMSP(c.ID, c.MSPType, provider.EnrollmentID(), provider.Identity)
-	if id == defaultMSP {
-		if s.defaultIdentity == nil {
-			logger.Infof("setting default identity to [%s]", c.ID)
-		}
-
-		// set default
-		s.defaultIdentity, _, err = provider.Identity(nil)
-		if err != nil {
-			return errors.WithMessagef(err, "failed to get default identity for [%s]", c.MSPID)
-		}
-		s.defaultSigningIdentity, err = provider.SerializedIdentity()
-		if err != nil {
-			return errors.WithMessagef(err, "failed to get default signing identity for [%s]", c.MSPID)
-		}
-	}
-	return nil
-}
-
-func (s *service) loadIdemixMSP(config config.MSP) error {
-	conf, err := msp.GetLocalMspConfigWithType(s.config.TranslatePath(config.Path), nil, config.MSPID, config.MSPType)
-	if err != nil {
-		return errors.Wrapf(err, "failed reading idemix msp configuration from [%s]", s.config.TranslatePath(config.Path))
-	}
-	provider, err := idemix.NewAnyProvider(conf, s.sp)
-	if err != nil {
-		return errors.Wrapf(err, "failed instantiating idemix msp provider from [%s]", s.config.TranslatePath(config.Path))
-	}
-	s.deserializerManager().AddDeserializer(provider)
-	cacheSize := s.cacheSize
-	if config.CacheSize > 0 {
-		cacheSize = config.CacheSize
-	}
-	s.addMSP(config.ID, config.MSPType, provider.EnrollmentID(), NewIdentityCache(provider.Identity, cacheSize).Identity)
-	logger.Debugf("added %s msp for id %s with cache of size %d", config.MSPType, config.ID+"@"+provider.EnrollmentID(), cacheSize)
-
-	return nil
-}
-
-func (s *service) loadBCCSPMSPFolder(mspConfig config.MSP, defaultMSP string) error {
-	entries, err := ioutil.ReadDir(s.config.TranslatePath(mspConfig.Path))
-	if err != nil {
-		logger.Warnf("failed reading from [%s]: [%s]", s.config.TranslatePath(mspConfig.Path), err)
-		return errors.Wrapf(err, "failed reading from [%s]", s.config.TranslatePath(mspConfig.Path))
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		id := entry.Name()
-
-		if err := s.loadBCCSPMSP(id, config.MSP{
-			ID:      id,
-			MSPType: BccspMSP,
-			MSPID:   id,
-			Path:    filepath.Join(s.config.TranslatePath(mspConfig.Path), id),
-			Opts:    mspConfig.Opts,
-		}, defaultMSP); err != nil {
-			return errors.WithMessagef(err, "failed to load BCCSP MSP configuration [%s]", id)
-		}
-	}
-	return nil
-}
-
-func (s *service) loadIdemixMSPFolder(mspConfig config.MSP) error {
-	entries, err := ioutil.ReadDir(s.config.TranslatePath(mspConfig.Path))
-	if err != nil {
-		logger.Warnf("failed reading from [%s]: [%s]", s.config.TranslatePath(mspConfig.Path), err)
-		return errors.Wrapf(err, "failed reading from [%s]", s.config.TranslatePath(mspConfig.Path))
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		id := entry.Name()
-
-		if err := s.loadIdemixMSP(config.MSP{
-			ID:      id,
-			MSPType: IdemixMSP,
-			MSPID:   id,
-			Path:    filepath.Join(s.config.TranslatePath(mspConfig.Path), id),
-		}); err != nil {
-			return errors.WithMessagef(err, "failed to load Idemix MSP configuration [%s]", id)
-		}
-	}
 	return nil
 }

--- a/platform/fabric/core/generic/msp/x509/loader.go
+++ b/platform/fabric/core/generic/msp/x509/loader.go
@@ -28,10 +28,9 @@ var logger = flogging.MustGetLogger("fabric-sdk.msp.x509")
 type IdentityLoader struct{}
 
 func (i *IdentityLoader) Load(manager driver.Manager, c config.MSP) error {
-	// Try without "msp"
 	var bccspOpts *config.BCCSP
 	if c.Opts != nil {
-		logger.Infof("Options [%v]", c.Opts)
+		logger.Debugf("Options [%v]", c.Opts)
 		bccspOptsBoxed, ok := c.Opts[BCCSPOptField]
 		if ok {
 			var err error
@@ -39,9 +38,11 @@ func (i *IdentityLoader) Load(manager driver.Manager, c config.MSP) error {
 			if err != nil {
 				return errors.Wrapf(err, "failed to unmarshal BCCSP opts")
 			}
-			logger.Infof("Options unmarshalled [%v]", bccspOpts)
+			logger.Debugf("Options unmarshalled [%v]", bccspOpts)
 		}
 	}
+
+	// Try without "msp"
 	provider, err := NewProviderWithBCCSPConfig(
 		manager.Config().TranslatePath(c.Path),
 		c.MSPID,

--- a/platform/fabric/core/generic/msp/x509/loader.go
+++ b/platform/fabric/core/generic/msp/x509/loader.go
@@ -7,245 +7,95 @@ SPDX-License-Identifier: Apache-2.0
 package x509
 
 import (
-	x5092 "crypto/x509"
-	"encoding/hex"
-	"encoding/pem"
-	"os"
+	"io/ioutil"
 	"path/filepath"
 
-	pkcs112 "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common/pkcs11"
-	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
-	msp2 "github.com/hyperledger/fabric-protos-go/msp"
-	"github.com/hyperledger/fabric/bccsp"
-	"github.com/hyperledger/fabric/bccsp/pkcs11"
-	"github.com/hyperledger/fabric/bccsp/sw"
-	"github.com/hyperledger/fabric/msp"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/pkg/errors"
 )
 
 const (
-	BCCSPType = "bccsp"
-	SignCerts = "signcerts"
+	MSPType = "bccsp"
 )
 
-// Identity refers to the creator of a tx;
-type Identity interface {
-	Serialize() ([]byte, error)
+var logger = flogging.MustGetLogger("fabric-sdk.msp.x509")
 
-	Verify(msg []byte, sig []byte) error
-}
+type IdentityLoader struct{}
 
-// SigningIdentity defines the functions necessary to sign an
-// array of bytes; it is needed to sign the commands transmitted to
-// the prover peer service.
-type SigningIdentity interface {
-	Identity //extends Identity
-
-	Sign(msg []byte) ([]byte, error)
-}
-
-// GetSigningIdentity retrieves a signing identity from the passed arguments
-func GetSigningIdentity(mspConfigPath, mspID string, bccspConfig *config.BCCSP) (SigningIdentity, error) {
-	mspInstance, err := LoadLocalMSPAt(mspConfigPath, mspID, BCCSPType, bccspConfig)
+func (i *IdentityLoader) Load(manager driver.Manager, c config.MSP) error {
+	// Try without "msp"
+	var bccspOpts *config.BCCSP
+	if c.Opts != nil {
+		bccspOpts = c.Opts.BCCSP
+	}
+	provider, err := NewProviderWithBCCSPConfig(
+		manager.Config().TranslatePath(c.Path),
+		c.MSPID,
+		manager.SignerService(),
+		bccspOpts,
+	)
 	if err != nil {
-		return nil, err
-	}
-
-	signingIdentity, err := mspInstance.GetDefaultSigningIdentity()
-	if err != nil {
-		return nil, err
-	}
-
-	return signingIdentity, nil
-}
-
-// LoadLocalMSPAt loads an MSP whose configuration is stored at 'dir', and whose
-// id and type are the passed as arguments.
-func LoadLocalMSPAt(dir, id, mspType string, bccspConfig *config.BCCSP) (msp.MSP, error) {
-	if mspType != BCCSPType {
-		return nil, errors.Errorf("invalid msp type, expected 'bccsp', got %s", mspType)
-	}
-	conf, err := msp.GetLocalMspConfig(dir, nil, id)
-	if err != nil {
-		return nil, errors.WithMessagef(err, "could not get msp config from dir [%s]", dir)
-	}
-
-	cp, _, err := GetBCCSPFromConf(dir, bccspConfig)
-	if err != nil {
-		return nil, errors.WithMessagef(err, "failed to get bccsp from config [%v]", bccspConfig)
-	}
-
-	mspOpts := &msp.BCCSPNewOpts{
-		NewBaseOpts: msp.NewBaseOpts{
-			Version: msp.MSPv1_0,
-		},
-	}
-	thisMSP, err := msp.New(mspOpts, cp)
-	if err != nil {
-		return nil, errors.WithMessagef(err, "failed to create new BCCSPMSP instance at [%s]", dir)
-	}
-	err = thisMSP.Setup(conf)
-	if err != nil {
-		return nil, errors.WithMessagef(err, "failed to setup the new BCCSPMSP instance at [%s]", dir)
-	}
-	return thisMSP, nil
-}
-
-// LoadVerifyingMSPAt loads a verifying MSP whose configuration is stored at 'dir', and whose
-// id and type are the passed as arguments.
-func LoadVerifyingMSPAt(dir, id, mspType string) (msp.MSP, error) {
-	if mspType != BCCSPType {
-		return nil, errors.Errorf("invalid msp type, expected 'bccsp', got %s", mspType)
-	}
-	conf, err := msp.GetVerifyingMspConfig(dir, id, mspType)
-	if err != nil {
-		return nil, errors.WithMessagef(err, "could not get msp config from dir [%s]", dir)
-	}
-
-	cp, _, err := GetBCCSPFromConf(dir, nil)
-	if err != nil {
-		return nil, errors.WithMessagef(err, "failed to get bccsp")
-	}
-
-	mspOpts := &msp.BCCSPNewOpts{
-		NewBaseOpts: msp.NewBaseOpts{
-			Version: msp.MSPv1_0,
-		},
-	}
-	thisMSP, err := msp.New(mspOpts, cp)
-	if err != nil {
-		return nil, errors.WithMessagef(err, "failed to create new BCCSPMSP instance at [%s]", dir)
-	}
-	err = thisMSP.Setup(conf)
-	if err != nil {
-		return nil, errors.WithMessagef(err, "failed to setup the new BCCSPMSP instance at [%s]", dir)
-	}
-	return thisMSP, nil
-}
-
-func LoadLocalMSPSignerCert(dir string) ([]byte, error) {
-	signCertsPath := filepath.Join(dir, SignCerts)
-	signCerts, err := getPemMaterialFromDir(signCertsPath)
-	if err != nil || len(signCerts) == 0 {
-		return nil, errors.Wrapf(err, "could not load a valid signer certificate from directory %s", signCertsPath)
-	}
-	return signCerts[0], nil
-}
-
-// GetBCCSPFromConf returns a BCCSP instance and its relative key store from the passed configuration.
-// If no configuration is passed, the default one is used, namely the `SW` provider.
-func GetBCCSPFromConf(dir string, conf *config.BCCSP) (bccsp.BCCSP, bccsp.KeyStore, error) {
-	if conf == nil {
-		return GetSWBCCSP(dir)
-	}
-
-	switch conf.Default {
-	case "SW":
-		return GetSWBCCSP(dir)
-	case "PKCS11":
-		return GetPKCS11BCCSP(conf)
-	default:
-		return nil, nil, errors.Errorf("invalid config.BCCSP.Default.%s", conf.Default)
-	}
-}
-
-// GetPKCS11BCCSP returns a new instance of the HSM-based BCCSP
-func GetPKCS11BCCSP(conf *config.BCCSP) (bccsp.BCCSP, bccsp.KeyStore, error) {
-	if conf.PKCS11 == nil {
-		return nil, nil, errors.New("invalid config.BCCSP.PKCS11. missing configuration")
-	}
-
-	p11Opts := *conf.PKCS11
-	ks := sw.NewDummyKeyStore()
-	mapper := skiMapper(p11Opts)
-	csp, err := pkcs11.New(*pkcs112.ToPKCS11Opts(&p11Opts), ks, pkcs11.WithKeyMapper(mapper))
-	if err != nil {
-		return nil, nil, errors.WithMessagef(err, "Failed initializing PKCS11 library with config [%+v]", p11Opts)
-	}
-	return csp, ks, nil
-}
-
-func skiMapper(p11Opts config.PKCS11) func([]byte) []byte {
-	keyMap := map[string]string{}
-	for _, k := range p11Opts.KeyIDs {
-		keyMap[k.SKI] = k.ID
-	}
-
-	return func(ski []byte) []byte {
-		keyID := hex.EncodeToString(ski)
-		if id, ok := keyMap[keyID]; ok {
-			return []byte(id)
-		}
-		if p11Opts.AltID != "" {
-			return []byte(p11Opts.AltID)
-		}
-		return ski
-	}
-}
-
-// GetSWBCCSP returns a new instance of the software-based BCCSP
-func GetSWBCCSP(dir string) (bccsp.BCCSP, bccsp.KeyStore, error) {
-	ks, err := sw.NewFileBasedKeyStore(nil, filepath.Join(dir, "keystore"), true)
-	if err != nil {
-		return nil, nil, err
-	}
-	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(ks)
-	if err != nil {
-		return nil, nil, err
-	}
-	return cryptoProvider, ks, nil
-}
-
-func GetEnrollmentID(id []byte) (string, error) {
-	si := &msp2.SerializedIdentity{}
-	err := proto.Unmarshal(id, si)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to unmarshal to msp.SerializedIdentity{}")
-	}
-	block, _ := pem.Decode(si.IdBytes)
-	if block == nil {
-		return "", errors.New("bytes are not PEM encoded")
-	}
-	switch block.Type {
-	case "CERTIFICATE":
-		cert, err := x5092.ParseCertificate(block.Bytes)
+		logger.Warnf("failed reading bccsp msp configuration from [%s]: [%s]", filepath.Join(manager.Config().TranslatePath(c.Path), c.ID), err)
+		// Try with "msp"
+		provider, err = NewProviderWithBCCSPConfig(
+			filepath.Join(manager.Config().TranslatePath(c.Path), "msp"),
+			c.MSPID,
+			manager.SignerService(),
+			bccspOpts,
+		)
 		if err != nil {
-			return "", errors.WithMessage(err, "pem bytes are not cert encoded ")
+			logger.Warnf("failed reading bccsp msp configuration from [%s and %s]: [%s]",
+				filepath.Join(manager.Config().TranslatePath(c.Path),
+					filepath.Join(manager.Config().TranslatePath(c.Path), "msp")), err,
+			)
+			return errors.WithMessagef(err, "failed to load BCCSP MSP configuration [%s]", c.ID)
 		}
-		return cert.Subject.CommonName, nil
-	default:
-		return "", errors.Errorf("bad block type %s, expected CERTIFICATE", block.Type)
 	}
+
+	manager.AddDeserializer(provider)
+	manager.AddMSP(c.ID, c.MSPType, provider.EnrollmentID(), provider.Identity)
+
+	// set default
+	defaultIdentity, _, err := provider.Identity(nil)
+	if err != nil {
+		return errors.WithMessagef(err, "failed to get default identity for [%s]", c.MSPID)
+	}
+	defaultSigningIdentity, err := provider.SerializedIdentity()
+	if err != nil {
+		return errors.WithMessagef(err, "failed to get default signing identity for [%s]", c.MSPID)
+	}
+	manager.SetDefaultIdentity(c.ID, defaultIdentity, defaultSigningIdentity)
+
+	return nil
 }
 
-func getPemMaterialFromDir(dir string) ([][]byte, error) {
-	_, err := os.Stat(dir)
-	if os.IsNotExist(err) {
-		return nil, err
-	}
+type FolderIdentityLoader struct {
+	*IdentityLoader
+}
 
-	content := make([][]byte, 0)
-	files, err := os.ReadDir(dir)
+func (f *FolderIdentityLoader) Load(manager driver.Manager, c config.MSP) error {
+	entries, err := ioutil.ReadDir(manager.Config().TranslatePath(c.Path))
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not read directory %s", dir)
+		logger.Warnf("failed reading from [%s]: [%s]", manager.Config().TranslatePath(c.Path), err)
+		return errors.Wrapf(err, "failed reading from [%s]", manager.Config().TranslatePath(c.Path))
 	}
-
-	for _, f := range files {
-		fullName := filepath.Join(dir, f.Name())
-		f, err := os.Stat(fullName)
-		if err != nil {
+	for _, entry := range entries {
+		if !entry.IsDir() {
 			continue
 		}
-		if f.IsDir() {
-			continue
-		}
-		item, err := readPemFile(fullName)
-		if err != nil {
-			continue
-		}
-		content = append(content, item)
-	}
+		id := entry.Name()
 
-	return content, nil
+		if err := f.IdentityLoader.Load(manager, config.MSP{
+			ID:      id,
+			MSPType: MSPType,
+			MSPID:   id,
+			Path:    filepath.Join(manager.Config().TranslatePath(c.Path), id),
+			Opts:    c.Opts,
+		}); err != nil {
+			return errors.WithMessagef(err, "failed to load BCCSP MSP configuration [%s]", id)
+		}
+	}
+	return nil
 }

--- a/platform/fabric/core/generic/msp/x509/loader.go
+++ b/platform/fabric/core/generic/msp/x509/loader.go
@@ -43,25 +43,25 @@ func (i *IdentityLoader) Load(manager driver.Manager, c config.MSP) error {
 	}
 
 	// Try without "msp"
+	rootPath := filepath.Join(manager.Config().TranslatePath(c.Path))
 	provider, err := NewProviderWithBCCSPConfig(
-		manager.Config().TranslatePath(c.Path),
+		rootPath,
 		c.MSPID,
 		manager.SignerService(),
 		bccspOpts,
 	)
 	if err != nil {
-		logger.Warnf("failed reading bccsp msp configuration from [%s]: [%s]", filepath.Join(manager.Config().TranslatePath(c.Path), c.ID), err)
+		logger.Warnf("failed reading bccsp msp configuration from [%s]: [%s]", rootPath, err)
 		// Try with "msp"
 		provider, err = NewProviderWithBCCSPConfig(
-			filepath.Join(manager.Config().TranslatePath(c.Path), "msp"),
+			filepath.Join(rootPath, "msp"),
 			c.MSPID,
 			manager.SignerService(),
 			bccspOpts,
 		)
 		if err != nil {
 			logger.Warnf("failed reading bccsp msp configuration from [%s and %s]: [%s]",
-				filepath.Join(manager.Config().TranslatePath(c.Path),
-					filepath.Join(manager.Config().TranslatePath(c.Path), "msp")), err,
+				rootPath, filepath.Join(rootPath, "msp"), err,
 			)
 			return errors.WithMessagef(err, "failed to load BCCSP MSP configuration [%s]", c.ID)
 		}

--- a/platform/fabric/core/generic/msp/x509/provider.go
+++ b/platform/fabric/core/generic/msp/x509/provider.go
@@ -10,9 +10,11 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 
+	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/driver"
+
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
-	api2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger/fabric-protos-go/msp"
@@ -20,11 +22,11 @@ import (
 )
 
 type SignerService interface {
-	RegisterSigner(identity view.Identity, signer api2.Signer, verifier api2.Verifier) error
+	RegisterSigner(identity view.Identity, signer fdriver.Signer, verifier fdriver.Verifier) error
 }
 
 type provider struct {
-	sID          SigningIdentity
+	sID          driver2.SigningIdentity
 	id           []byte
 	enrollmentID string
 }
@@ -56,7 +58,7 @@ func NewProviderWithBCCSPConfig(mspConfigPath, mspID string, signerService Signe
 	return &provider{sID: sID, id: idRaw, enrollmentID: enrollmentID}, nil
 }
 
-func (p *provider) Identity(opts *api2.IdentityOptions) (view.Identity, []byte, error) {
+func (p *provider) Identity(opts *fdriver.IdentityOptions) (view.Identity, []byte, error) {
 	return p.id, []byte(p.enrollmentID), nil
 }
 
@@ -101,7 +103,7 @@ func (p *provider) Info(raw []byte, auditInfo []byte) (string, error) {
 	return fmt.Sprintf("MSP.x509: [%s][%s][%s]", view.Identity(raw).UniqueID(), si.Mspid, cert.Subject.CommonName), nil
 }
 
-func (p *provider) SerializedIdentity() (SigningIdentity, error) {
+func (p *provider) SerializedIdentity() (driver2.SigningIdentity, error) {
 	return p.sID, nil
 }
 

--- a/platform/fabric/core/generic/msp/x509/provider.go
+++ b/platform/fabric/core/generic/msp/x509/provider.go
@@ -10,10 +10,9 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 
-	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/driver"
-
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
+	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/driver"
 	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"

--- a/platform/fabric/core/generic/msp/x509/setup.go
+++ b/platform/fabric/core/generic/msp/x509/setup.go
@@ -1,0 +1,237 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package x509
+
+import (
+	x5092 "crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/driver"
+
+	pkcs112 "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common/pkcs11"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
+	msp2 "github.com/hyperledger/fabric-protos-go/msp"
+	"github.com/hyperledger/fabric/bccsp"
+	"github.com/hyperledger/fabric/bccsp/pkcs11"
+	"github.com/hyperledger/fabric/bccsp/sw"
+	"github.com/hyperledger/fabric/msp"
+	"github.com/pkg/errors"
+)
+
+const (
+	BCCSPType = "bccsp"
+	SignCerts = "signcerts"
+)
+
+// GetSigningIdentity retrieves a signing identity from the passed arguments
+func GetSigningIdentity(mspConfigPath, mspID string, bccspConfig *config.BCCSP) (driver.SigningIdentity, error) {
+	mspInstance, err := LoadLocalMSPAt(mspConfigPath, mspID, BCCSPType, bccspConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	signingIdentity, err := mspInstance.GetDefaultSigningIdentity()
+	if err != nil {
+		return nil, err
+	}
+
+	return signingIdentity, nil
+}
+
+// LoadLocalMSPAt loads an MSP whose configuration is stored at 'dir', and whose
+// id and type are the passed as arguments.
+func LoadLocalMSPAt(dir, id, mspType string, bccspConfig *config.BCCSP) (msp.MSP, error) {
+	if mspType != BCCSPType {
+		return nil, errors.Errorf("invalid msp type, expected 'bccsp', got %s", mspType)
+	}
+	conf, err := msp.GetLocalMspConfig(dir, nil, id)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "could not get msp config from dir [%s]", dir)
+	}
+
+	cp, _, err := GetBCCSPFromConf(dir, bccspConfig)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to get bccsp from config [%v]", bccspConfig)
+	}
+
+	mspOpts := &msp.BCCSPNewOpts{
+		NewBaseOpts: msp.NewBaseOpts{
+			Version: msp.MSPv1_0,
+		},
+	}
+	thisMSP, err := msp.New(mspOpts, cp)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to create new BCCSPMSP instance at [%s]", dir)
+	}
+	err = thisMSP.Setup(conf)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to setup the new BCCSPMSP instance at [%s]", dir)
+	}
+	return thisMSP, nil
+}
+
+// LoadVerifyingMSPAt loads a verifying MSP whose configuration is stored at 'dir', and whose
+// id and type are the passed as arguments.
+func LoadVerifyingMSPAt(dir, id, mspType string) (msp.MSP, error) {
+	if mspType != BCCSPType {
+		return nil, errors.Errorf("invalid msp type, expected 'bccsp', got %s", mspType)
+	}
+	conf, err := msp.GetVerifyingMspConfig(dir, id, mspType)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "could not get msp config from dir [%s]", dir)
+	}
+
+	cp, _, err := GetBCCSPFromConf(dir, nil)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to get bccsp")
+	}
+
+	mspOpts := &msp.BCCSPNewOpts{
+		NewBaseOpts: msp.NewBaseOpts{
+			Version: msp.MSPv1_0,
+		},
+	}
+	thisMSP, err := msp.New(mspOpts, cp)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to create new BCCSPMSP instance at [%s]", dir)
+	}
+	err = thisMSP.Setup(conf)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to setup the new BCCSPMSP instance at [%s]", dir)
+	}
+	return thisMSP, nil
+}
+
+func LoadLocalMSPSignerCert(dir string) ([]byte, error) {
+	signCertsPath := filepath.Join(dir, SignCerts)
+	signCerts, err := getPemMaterialFromDir(signCertsPath)
+	if err != nil || len(signCerts) == 0 {
+		return nil, errors.Wrapf(err, "could not load a valid signer certificate from directory %s", signCertsPath)
+	}
+	return signCerts[0], nil
+}
+
+// GetBCCSPFromConf returns a BCCSP instance and its relative key store from the passed configuration.
+// If no configuration is passed, the default one is used, namely the `SW` provider.
+func GetBCCSPFromConf(dir string, conf *config.BCCSP) (bccsp.BCCSP, bccsp.KeyStore, error) {
+	if conf == nil {
+		return GetSWBCCSP(dir)
+	}
+
+	switch conf.Default {
+	case "SW":
+		return GetSWBCCSP(dir)
+	case "PKCS11":
+		return GetPKCS11BCCSP(conf)
+	default:
+		return nil, nil, errors.Errorf("invalid config.BCCSP.Default.%s", conf.Default)
+	}
+}
+
+// GetPKCS11BCCSP returns a new instance of the HSM-based BCCSP
+func GetPKCS11BCCSP(conf *config.BCCSP) (bccsp.BCCSP, bccsp.KeyStore, error) {
+	if conf.PKCS11 == nil {
+		return nil, nil, errors.New("invalid config.BCCSP.PKCS11. missing configuration")
+	}
+
+	p11Opts := *conf.PKCS11
+	ks := sw.NewDummyKeyStore()
+	mapper := skiMapper(p11Opts)
+	csp, err := pkcs11.New(*pkcs112.ToPKCS11Opts(&p11Opts), ks, pkcs11.WithKeyMapper(mapper))
+	if err != nil {
+		return nil, nil, errors.WithMessagef(err, "Failed initializing PKCS11 library with config [%+v]", p11Opts)
+	}
+	return csp, ks, nil
+}
+
+func skiMapper(p11Opts config.PKCS11) func([]byte) []byte {
+	keyMap := map[string]string{}
+	for _, k := range p11Opts.KeyIDs {
+		keyMap[k.SKI] = k.ID
+	}
+
+	return func(ski []byte) []byte {
+		keyID := hex.EncodeToString(ski)
+		if id, ok := keyMap[keyID]; ok {
+			return []byte(id)
+		}
+		if p11Opts.AltID != "" {
+			return []byte(p11Opts.AltID)
+		}
+		return ski
+	}
+}
+
+// GetSWBCCSP returns a new instance of the software-based BCCSP
+func GetSWBCCSP(dir string) (bccsp.BCCSP, bccsp.KeyStore, error) {
+	ks, err := sw.NewFileBasedKeyStore(nil, filepath.Join(dir, "keystore"), true)
+	if err != nil {
+		return nil, nil, err
+	}
+	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(ks)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cryptoProvider, ks, nil
+}
+
+func GetEnrollmentID(id []byte) (string, error) {
+	si := &msp2.SerializedIdentity{}
+	err := proto.Unmarshal(id, si)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to unmarshal to msp.SerializedIdentity{}")
+	}
+	block, _ := pem.Decode(si.IdBytes)
+	if block == nil {
+		return "", errors.New("bytes are not PEM encoded")
+	}
+	switch block.Type {
+	case "CERTIFICATE":
+		cert, err := x5092.ParseCertificate(block.Bytes)
+		if err != nil {
+			return "", errors.WithMessage(err, "pem bytes are not cert encoded ")
+		}
+		return cert.Subject.CommonName, nil
+	default:
+		return "", errors.Errorf("bad block type %s, expected CERTIFICATE", block.Type)
+	}
+}
+
+func getPemMaterialFromDir(dir string) ([][]byte, error) {
+	_, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		return nil, err
+	}
+
+	content := make([][]byte, 0)
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not read directory %s", dir)
+	}
+
+	for _, f := range files {
+		fullName := filepath.Join(dir, f.Name())
+		f, err := os.Stat(fullName)
+		if err != nil {
+			continue
+		}
+		if f.IsDir() {
+			continue
+		}
+		item, err := readPemFile(fullName)
+		if err != nil {
+			continue
+		}
+		content = append(content, item)
+	}
+
+	return content, nil
+}

--- a/platform/fabric/core/generic/msp/x509/setup.go
+++ b/platform/fabric/core/generic/msp/x509/setup.go
@@ -13,11 +13,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/driver"
-
 	pkcs112 "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common/pkcs11"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/driver"
 	msp2 "github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric/bccsp"
 	"github.com/hyperledger/fabric/bccsp/pkcs11"

--- a/platform/fabric/core/generic/ordering/ordering.go
+++ b/platform/fabric/core/generic/ordering/ordering.go
@@ -7,12 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package ordering
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"sync"
 	"time"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/fabricutils"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/transaction"
@@ -23,8 +22,6 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	common2 "github.com/hyperledger/fabric-protos-go/common"
 	ab "github.com/hyperledger/fabric-protos-go/orderer"
-	"github.com/hyperledger/fabric-protos-go/peer"
-	"github.com/hyperledger/fabric/protoutil"
 	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
 )
@@ -34,12 +31,6 @@ var logger = flogging.MustGetLogger("fabric-sdk.ordering")
 type Signer interface {
 	// Sign the message
 	Sign(msg []byte) ([]byte, error)
-}
-
-type SerializableSigner interface {
-	Sign(message []byte) ([]byte, error)
-
-	Serialize() ([]byte, error)
 }
 
 type ViewManager interface {
@@ -133,7 +124,7 @@ func (o *service) createFabricEndorseTransactionEnvelope(tx Transaction) (*commo
 		logger.Errorf("signer not found for %s while creating tx envelope for ordering [%s]", signerID.UniqueID(), err)
 		return nil, errors.Wrapf(err, "signer not found for %s while creating tx envelope for ordering", signerID.UniqueID())
 	}
-	env, err := createSignedTx(
+	env, err := fabricutils.CreateSignedTx(
 		tx.Proposal(),
 		&signerWrapper{signerID, signer},
 		tx.ProposalResponses()...,
@@ -255,161 +246,6 @@ func (o *service) broadcastEnvelope(env *common2.Envelope) error {
 		return nil
 	}
 	return errors.Wrap(err, "failed to send transaction to orderer")
-}
-
-// createSignedTx assembles an Envelope message from proposal, endorsements,
-// and a signer. This function should be called by a client when it has
-// collected enough endorsements for a proposal to create a transaction and
-// submit it to peers for ordering
-func createSignedTx(proposal driver.Proposal, signer SerializableSigner, resps ...driver.ProposalResponse) (*common2.Envelope, error) {
-	if len(resps) == 0 {
-		return nil, errors.New("at least one proposal response is required")
-	}
-
-	// the original header
-	hdr, err := protoutil.UnmarshalHeader(proposal.Header())
-	if err != nil {
-		return nil, err
-	}
-
-	// the original payload
-	pPayl, err := protoutil.UnmarshalChaincodeProposalPayload(proposal.Payload())
-	if err != nil {
-		return nil, err
-	}
-
-	// check that the signer is the same that is referenced in the header
-	// TODO: maybe worth removing?
-	signerBytes, err := signer.Serialize()
-	if err != nil {
-		return nil, err
-	}
-
-	shdr, err := protoutil.UnmarshalSignatureHeader(hdr.SignatureHeader)
-	if err != nil {
-		return nil, err
-	}
-
-	if !bytes.Equal(signerBytes, shdr.Creator) {
-		return nil, errors.New("signer must be the same as the one referenced in the header")
-	}
-
-	// ensure that all actions are bitwise equal and that they are successful
-	var a1 []byte
-	var first driver.ProposalResponse
-	for n, r := range resps {
-		if r.ResponseStatus() < 200 || r.ResponseStatus() >= 400 {
-			return nil, errors.Errorf("proposal response was not successful, error code %d, msg %s", r.ResponseStatus(), r.ResponseMessage())
-		}
-
-		if n == 0 {
-			a1 = r.Payload()
-			first = r
-			continue
-		}
-
-		if !bytes.Equal(a1, r.Payload()) {
-			upr1, err := UnpackProposalResponse(first.Payload())
-			if err != nil {
-				return nil, err
-			}
-			rwset1, err := json.MarshalIndent(upr1.TxRwSet, "", "  ")
-			if err != nil {
-				return nil, err
-			}
-
-			upr2, err := UnpackProposalResponse(r.Payload())
-			if err != nil {
-				return nil, err
-			}
-			rwset2, err := json.MarshalIndent(upr2.TxRwSet, "", "  ")
-			if err != nil {
-				return nil, err
-			}
-
-			if !bytes.Equal(rwset1, rwset2) {
-				if logger.IsEnabledFor(zapcore.DebugLevel) {
-					logger.Debugf("ProposalResponsePayloads do not match (%v) \n[%s]\n!=\n[%s]",
-						bytes.Equal(rwset1, rwset2), string(rwset1), string(rwset2),
-					)
-				}
-			} else {
-				pr1, err := json.MarshalIndent(first, "", "  ")
-				if err != nil {
-					return nil, err
-				}
-				pr2, err := json.MarshalIndent(r, "", "  ")
-				if err != nil {
-					return nil, err
-				}
-
-				if logger.IsEnabledFor(zapcore.DebugLevel) {
-					logger.Debugf("ProposalResponse do not match  \n[%s]\n!=\n[%s]",
-						bytes.Equal(pr1, pr2), string(pr1), string(pr2),
-					)
-				}
-			}
-
-			return nil, errors.Errorf(
-				"ProposalResponsePayloads do not match [%s]!=[%s]",
-				base64.StdEncoding.EncodeToString(a1),
-				base64.StdEncoding.EncodeToString(r.Payload()),
-			)
-		}
-	}
-
-	// fill endorsements
-	endorsements := make([]*peer.Endorsement, len(resps))
-	for n, r := range resps {
-		endorsements[n] = &peer.Endorsement{
-			Endorser:  r.Endorser(),
-			Signature: r.EndorserSignature(),
-		}
-	}
-
-	// create ChaincodeEndorsedAction
-	cea := &peer.ChaincodeEndorsedAction{ProposalResponsePayload: resps[0].Payload(), Endorsements: endorsements}
-
-	// obtain the bytes of the proposal payload that will go to the transaction
-	propPayloadBytes, err := protoutil.GetBytesProposalPayloadForTx(pPayl)
-	if err != nil {
-		return nil, err
-	}
-
-	// serialize the chaincode action payload
-	cap := &peer.ChaincodeActionPayload{ChaincodeProposalPayload: propPayloadBytes, Action: cea}
-	capBytes, err := protoutil.GetBytesChaincodeActionPayload(cap)
-	if err != nil {
-		return nil, err
-	}
-
-	// create a transaction
-	taa := &peer.TransactionAction{Header: hdr.SignatureHeader, Payload: capBytes}
-	taas := make([]*peer.TransactionAction, 1)
-	taas[0] = taa
-	tx := &peer.Transaction{Actions: taas}
-
-	// serialize the tx
-	txBytes, err := protoutil.GetBytesTransaction(tx)
-	if err != nil {
-		return nil, err
-	}
-
-	// create the payload
-	payl := &common2.Payload{Header: hdr, Data: txBytes}
-	paylBytes, err := protoutil.GetBytesPayload(payl)
-	if err != nil {
-		return nil, err
-	}
-
-	// sign the payload
-	sig, err := signer.Sign(paylBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	// here's the envelope
-	return &common2.Envelope{Payload: paylBytes, Signature: sig}, nil
 }
 
 type signerWrapper struct {

--- a/platform/fabric/core/generic/transaction/pr.go
+++ b/platform/fabric/core/generic/transaction/pr.go
@@ -75,3 +75,11 @@ func (p *ProposalResponse) ResponseStatus() int32 {
 func (p *ProposalResponse) ResponseMessage() string {
 	return p.pr.Response.Message
 }
+
+func (p *ProposalResponse) Bytes() ([]byte, error) {
+	raw, err := proto.Marshal(p.pr)
+	if err != nil {
+		return nil, err
+	}
+	return raw, nil
+}

--- a/platform/fabric/core/generic/transaction/transasction.go
+++ b/platform/fabric/core/generic/transaction/transasction.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package transaction
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 
@@ -622,8 +623,14 @@ func (t *Transaction) generateProposal(signer SerializableSigner) error {
 }
 
 func (t *Transaction) appendProposalResponse(response *pb.ProposalResponse) error {
-	t.TProposalResponses = append(t.TProposalResponses, response)
+	for _, r := range t.TProposalResponses {
+		if bytes.Equal(r.Endorsement.Endorser, response.Endorsement.Endorser) {
+			logger.Debugf("an endorsement from [%s] found, skip it", view.Identity(r.Endorsement.Endorser))
+			return nil
+		}
+	}
 
+	t.TProposalResponses = append(t.TProposalResponses, response)
 	return nil
 }
 

--- a/platform/fabric/driver/driver.go
+++ b/platform/fabric/driver/driver.go
@@ -1,0 +1,15 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package driver
+
+import "github.com/hyperledger-labs/fabric-smart-client/platform/view"
+
+// Driver models the network driver factory
+type Driver interface {
+	// New returns a new network instance for the passed network and channel (if applicable)
+	New(sp view.ServiceProvider, network string, defaultNetwork bool) (FabricNetworkService, error)
+}

--- a/platform/fabric/driver/transaction.go
+++ b/platform/fabric/driver/transaction.go
@@ -27,6 +27,7 @@ type ProposalResponse interface {
 	Results() []byte
 	ResponseStatus() int32
 	ResponseMessage() string
+	Bytes() ([]byte, error)
 }
 
 type Proposal interface {

--- a/platform/fabric/driver/transaction.go
+++ b/platform/fabric/driver/transaction.go
@@ -114,6 +114,7 @@ type Transaction interface {
 	ProposalResponses() []ProposalResponse
 	ProposalResponse() ([]byte, error)
 	BytesNoTransient() ([]byte, error)
+	Envelope() (Envelope, error)
 }
 
 type SignedProposal interface {

--- a/platform/fabric/sdk/sdk.go
+++ b/platform/fabric/sdk/sdk.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core"
-	_ "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic"
+	_ "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/crypto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/state"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/state/vault"
@@ -36,16 +36,16 @@ type Startable interface {
 	Stop() error
 }
 
-type p struct {
+type SDK struct {
 	registry    Registry
 	fnsProvider Startable
 }
 
-func NewSDK(registry Registry) *p {
-	return &p{registry: registry}
+func NewSDK(registry Registry) *SDK {
+	return &SDK{registry: registry}
 }
 
-func (p *p) Install() error {
+func (p *SDK) Install() error {
 	if !view.GetConfigService(p.registry).GetBool("fabric.enabled") {
 		logger.Infof("Fabric platform not enabled, skipping")
 		return nil
@@ -91,11 +91,11 @@ func (p *p) Install() error {
 	return nil
 }
 
-func (p *p) Start(ctx context.Context) error {
+func (p *SDK) Start(ctx context.Context) error {
 	return nil
 }
 
-func (p *p) PostStart(ctx context.Context) error {
+func (p *SDK) PostStart(ctx context.Context) error {
 	if !view.GetConfigService(p.registry).GetBool("fabric.enabled") {
 		logger.Infof("Fabric platform not enabled, skipping start")
 		return nil

--- a/platform/fabric/sdk/sdk.go
+++ b/platform/fabric/sdk/sdk.go
@@ -9,18 +9,18 @@ package fabric
 import (
 	"context"
 
-	"github.com/pkg/errors"
-
-	fabric2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core"
+	_ "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/crypto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/state"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/state/vault"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/weaver"
-	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/tracker"
+	"github.com/pkg/errors"
 )
 
 var logger = flogging.MustGetLogger("fabric-sdk")
@@ -46,7 +46,7 @@ func NewSDK(registry Registry) *p {
 }
 
 func (p *p) Install() error {
-	if !view2.GetConfigService(p.registry).GetBool("fabric.enabled") {
+	if !view.GetConfigService(p.registry).GetBool("fabric.enabled") {
 		logger.Infof("Fabric platform not enabled, skipping")
 		return nil
 	}
@@ -56,29 +56,29 @@ func (p *p) Install() error {
 	assert.NoError(p.registry.RegisterService(cryptoProvider))
 
 	logger.Infof("Set Fabric Network Service Provider")
-	fnsConfig, err := core.NewConfig(view2.GetConfigService(p.registry))
+	fnsConfig, err := core.NewConfig(view.GetConfigService(p.registry))
 	assert.NoError(err, "failed parsing configuration")
 	p.fnsProvider, err = core.NewFabricNetworkServiceProvider(p.registry, fnsConfig)
 	assert.NoError(err, "failed instantiating fabric network service provider")
 	assert.NoError(p.registry.RegisterService(p.fnsProvider))
-	assert.NoError(p.registry.RegisterService(fabric2.NewNetworkServiceProvider(p.registry)))
+	assert.NoError(p.registry.RegisterService(fabric.NewNetworkServiceProvider(p.registry)))
 
 	// Register processors
-	names := fabric2.GetFabricNetworkNames(p.registry)
+	names := fabric.GetFabricNetworkNames(p.registry)
 	if len(names) == 0 {
 		return errors.New("no fabric network names found")
 	}
 	for _, name := range names {
-		fns := fabric2.GetFabricNetworkService(p.registry, name)
+		fns := fabric.GetFabricNetworkService(p.registry, name)
 		if fns == nil {
 			return errors.Errorf("no fabric network service found for [%s]", name)
 		}
 		assert.NoError(fns.ProcessorManager().SetDefaultProcessor(
-			state.NewRWSetProcessor(fabric2.GetDefaultFNS(p.registry)),
+			state.NewRWSetProcessor(fabric.GetDefaultFNS(p.registry)),
 		), "failed setting state processor for fabric network [%s]", name)
 	}
 
-	assert.NotNil(fabric2.GetDefaultFNS(p.registry), "default fabric network service not found")
+	assert.NotNil(fabric.GetDefaultFNS(p.registry), "default fabric network service not found")
 
 	// TODO: remove this
 	assert.NoError(p.registry.RegisterService(tracker.NewTracker()))
@@ -96,13 +96,13 @@ func (p *p) Start(ctx context.Context) error {
 }
 
 func (p *p) PostStart(ctx context.Context) error {
-	if !view2.GetConfigService(p.registry).GetBool("fabric.enabled") {
+	if !view.GetConfigService(p.registry).GetBool("fabric.enabled") {
 		logger.Infof("Fabric platform not enabled, skipping start")
 		return nil
 	}
 
 	// start the delivery pipeline on all configured networks
-	fnsConfig, err := core.NewConfig(view2.GetConfigService(p.registry))
+	fnsConfig, err := core.NewConfig(view.GetConfigService(p.registry))
 	assert.NoError(err, "failed parsing configuration")
 
 	fnsConfig.Names()

--- a/platform/fabric/services/endorser/builder.go
+++ b/platform/fabric/services/endorser/builder.go
@@ -37,12 +37,19 @@ func NewBuilderWithServiceProvider(sp view2.ServiceProvider) *Builder {
 	return &Builder{sp: sp}
 }
 
-func (t *Builder) NewTransaction() (*Transaction, error) {
-	return t.NewTransactionForChannel("")
-}
-
-func (t *Builder) NewTransactionForChannel(channel string) (*Transaction, error) {
-	return t.newTransaction(nil, "", channel, nil, nil, false)
+func (t *Builder) NewTransaction(opts ...fabric.TransactionOption) (*Transaction, error) {
+	fabricOptions, err := fabric.CompileTransactionOptions(opts...)
+	if err != nil {
+		return nil, errors.WithMessage(err, "failed to compile options")
+	}
+	return t.newTransaction(
+		fabricOptions.Creator,
+		"",
+		fabricOptions.Channel,
+		fabricOptions.Nonce,
+		nil,
+		false,
+	)
 }
 
 func (t *Builder) NewTransactionFromBytes(bytes []byte) (*Transaction, error) {
@@ -112,9 +119,9 @@ func (t *Builder) newTransaction(creator []byte, network, channel string, nonce,
 	return tx, nil
 }
 
-func NewTransaction(context view.Context) (*Builder, *Transaction, error) {
+func NewTransaction(context view.Context, opts ...fabric.TransactionOption) (*Builder, *Transaction, error) {
 	txBuilder := NewBuilder(context)
-	tx, err := txBuilder.NewTransaction()
+	tx, err := txBuilder.NewTransaction(opts...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/platform/fabric/services/endorser/endorsement_proposal.go
+++ b/platform/fabric/services/endorser/endorsement_proposal.go
@@ -52,6 +52,8 @@ func (c *parallelCollectEndorsementsOnProposalView) Call(context view.Context) (
 			return nil, errors.Wrapf(a.err, "got failure [%s] from [%s]", a.party.String(), a.err)
 		}
 
+		logger.Debugf("answer from [%s] contains [%d] responses, adding them", a.party, len(a.prs))
+
 		for _, pr := range a.prs {
 			proposalResponse, err := tm.NewProposalResponseFromBytes(pr)
 			if err != nil {
@@ -114,6 +116,7 @@ func (s *endorsementsOnProposalResponderView) Call(context view.Context) (interf
 	}
 
 	for _, id := range s.identities {
+		logger.Debugf("endorse proposal response with [%s]", id)
 		err := s.tx.EndorseProposalResponseWithIdentity(id)
 		if err != nil {
 			return nil, err
@@ -124,6 +127,7 @@ func (s *endorsementsOnProposalResponderView) Call(context view.Context) (interf
 	if err != nil {
 		return nil, err
 	}
+	logger.Debugf("number of endorse proposal response produced [%d], send them back", len(prs))
 
 	session := session2.JSON(context)
 	if err != nil {

--- a/platform/fabric/services/endorser/endorsement_proposal.go
+++ b/platform/fabric/services/endorser/endorsement_proposal.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package endorser
 
 import (
+	session2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/session"
 	"github.com/pkg/errors"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
@@ -18,10 +19,14 @@ type parallelCollectEndorsementsOnProposalView struct {
 	parties []view.Identity
 }
 
+type response struct {
+	prs [][]byte
+}
+
 type answer struct {
-	payload []byte
-	err     error
-	party   view.Identity
+	prs   [][]byte
+	err   error
+	party view.Identity
 }
 
 func (c *parallelCollectEndorsementsOnProposalView) Call(context view.Context) (interface{}, error) {
@@ -42,21 +47,23 @@ func (c *parallelCollectEndorsementsOnProposalView) Call(context view.Context) (
 	tm := fns.TransactionManager()
 	for i := 0; i < len(c.parties); i++ {
 		// TODO: put a timeout
-		answer := <-answerChannel
-		if answer.err != nil {
-			return nil, errors.Wrapf(answer.err, "got failure [%s] from [%s]", answer.party.String(), answer.err)
+		a := <-answerChannel
+		if a.err != nil {
+			return nil, errors.Wrapf(a.err, "got failure [%s] from [%s]", a.party.String(), a.err)
 		}
 
-		proposalResponse, err := tm.NewProposalResponseFromBytes(answer.payload)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed unmarshalling received proposal response")
-		}
+		for _, pr := range a.prs {
+			proposalResponse, err := tm.NewProposalResponseFromBytes(pr)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed unmarshalling received proposal response")
+			}
 
-		// TODO: check the validity of the response
+			// TODO: check the validity of the response
 
-		err = c.tx.AppendProposalResponse(proposalResponse)
-		if err != nil {
-			return nil, errors.Wrapf(answer.err, "failed appending response from [%s]", answer.party.String())
+			err = c.tx.AppendProposalResponse(proposalResponse)
+			if err != nil {
+				return nil, errors.Wrapf(a.err, "failed appending response from [%s]", a.party.String())
+			}
 		}
 	}
 	return c.tx, nil
@@ -67,28 +74,25 @@ func (c *parallelCollectEndorsementsOnProposalView) callView(
 	party view.Identity,
 	raw []byte,
 	answerChan chan *answer) {
-	session, err := context.GetSession(context.Initiator(), party)
+
+	session, err := session2.NewJSON(context, context.Initiator(), party)
 	if err != nil {
 		answerChan <- &answer{err: err}
 		return
 	}
 
 	// Wait to receive a Transaction back
-	ch := session.Receive()
-
-	err = session.Send(raw)
+	err = session.SendRaw(raw)
 	if err != nil {
 		answerChan <- &answer{err: err}
 		return
 	}
-	msg := <-ch
-
-	if msg.Status == view.ERROR {
-		answerChan <- &answer{err: errors.New(string(msg.Payload))}
+	r := &response{}
+	if err := session.Receive(r); err != nil {
+		answerChan <- &answer{err: err}
 		return
 	}
-
-	answerChan <- &answer{payload: msg.Payload, party: party}
+	answerChan <- &answer{prs: r.prs, party: party}
 }
 
 func NewParallelCollectEndorsementsOnProposalView(tx *Transaction, parties ...view.Identity) *parallelCollectEndorsementsOnProposalView {
@@ -96,38 +100,44 @@ func NewParallelCollectEndorsementsOnProposalView(tx *Transaction, parties ...vi
 }
 
 type endorsementsOnProposalResponderView struct {
-	tx *Transaction
+	tx         *Transaction
+	identities []view.Identity
 }
 
 func (s *endorsementsOnProposalResponderView) Call(context view.Context) (interface{}, error) {
-	fns := fabric.GetFabricNetworkService(context, s.tx.Network())
-	if fns == nil {
-		return nil, errors.Errorf("fabric network service [%s] not found", s.tx.Network())
+	if len(s.identities) == 0 {
+		fns := fabric.GetFabricNetworkService(context, s.tx.Network())
+		if fns == nil {
+			return nil, errors.Errorf("fabric network service [%s] not found", s.tx.Network())
+		}
+		s.identities = []view.Identity{fns.IdentityProvider().DefaultIdentity()}
 	}
-	err := s.tx.EndorseProposalResponseWithIdentity(fns.IdentityProvider().DefaultIdentity())
+
+	for _, id := range s.identities {
+		err := s.tx.EndorseProposalResponseWithIdentity(id)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	prs, err := s.tx.ProposalResponses()
 	if err != nil {
 		return nil, err
 	}
 
-	pr, err := s.tx.ProposalResponse()
+	session := session2.JSON(context)
 	if err != nil {
 		return nil, err
 	}
 
-	session := context.Session()
+	// Send the proposal responses back
+	err = session.Send(&response{prs: prs})
 	if err != nil {
 		return nil, err
 	}
-
-	// Send the proposal response back
-	err = session.Send(pr)
-	if err != nil {
-		return nil, err
-	}
-
 	return s.tx, nil
 }
 
-func NewEndorsementOnProposalResponderView(tx *Transaction) *endorsementsOnProposalResponderView {
-	return &endorsementsOnProposalResponderView{tx: tx}
+func NewEndorsementOnProposalResponderView(tx *Transaction, identities ...view.Identity) *endorsementsOnProposalResponderView {
+	return &endorsementsOnProposalResponderView{tx: tx, identities: identities}
 }

--- a/platform/fabric/services/endorser/transaction.go
+++ b/platform/fabric/services/endorser/transaction.go
@@ -226,3 +226,16 @@ func (t *Transaction) AppendVerifierProvider(vp VerifierProvider) {
 func (t *Transaction) Envelope() (*fabric.Envelope, error) {
 	return t.Transaction.Envelope()
 }
+
+func (t *Transaction) ProposalResponses() ([][]byte, error) {
+	prs := t.Transaction.ProposalResponses()
+	res := [][]byte{}
+	for _, pr := range prs {
+		prRaw, err := pr.Bytes()
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, prRaw)
+	}
+	return res, nil
+}

--- a/platform/fabric/services/endorser/transaction.go
+++ b/platform/fabric/services/endorser/transaction.go
@@ -222,3 +222,7 @@ func (t *Transaction) FabricNetworkService() *fabric.NetworkService {
 func (t *Transaction) AppendVerifierProvider(vp VerifierProvider) {
 	t.verifierProviders = append(t.verifierProviders, vp)
 }
+
+func (t *Transaction) Envelope() (*fabric.Envelope, error) {
+	return t.Transaction.Envelope()
+}

--- a/platform/fabric/transaction.go
+++ b/platform/fabric/transaction.go
@@ -98,6 +98,10 @@ func (r *ProposalResponse) Results() []byte {
 	return r.pr.Results()
 }
 
+func (r *ProposalResponse) Bytes() ([]byte, error) {
+	return r.pr.Bytes()
+}
+
 type Proposal struct {
 	p driver.Proposal
 }

--- a/platform/fabric/transaction.go
+++ b/platform/fabric/transaction.go
@@ -23,7 +23,7 @@ type TransactionOptions struct {
 
 type TransactionOption func(*TransactionOptions) error
 
-func compileTransactionOptions(opts ...TransactionOption) (*TransactionOptions, error) {
+func CompileTransactionOptions(opts ...TransactionOption) (*TransactionOptions, error) {
 	txOptions := &TransactionOptions{}
 	for _, opt := range opts {
 		if err := opt(txOptions); err != nil {
@@ -344,7 +344,7 @@ func (t *TransactionManager) NewProposalResponseFromBytes(raw []byte) (*Proposal
 }
 
 func (t *TransactionManager) NewTransaction(opts ...TransactionOption) (*Transaction, error) {
-	options, err := compileTransactionOptions(opts...)
+	options, err := CompileTransactionOptions(opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -365,7 +365,7 @@ func (t *TransactionManager) NewTransaction(opts ...TransactionOption) (*Transac
 }
 
 func (t *TransactionManager) NewTransactionFromBytes(raw []byte, opts ...TransactionOption) (*Transaction, error) {
-	options, err := compileTransactionOptions(opts...)
+	options, err := CompileTransactionOptions(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/fabric/transaction.go
+++ b/platform/fabric/transaction.go
@@ -315,6 +315,14 @@ func (t *Transaction) FabricNetworkService() *NetworkService {
 	return t.fns
 }
 
+func (t *Transaction) Envelope() (*Envelope, error) {
+	env, err := t.tx.Envelope()
+	if err != nil {
+		return nil, err
+	}
+	return &Envelope{e: env}, nil
+}
+
 type TransactionManager struct {
 	fns *NetworkService
 }

--- a/platform/view/core/manager/context.go
+++ b/platform/view/core/manager/context.go
@@ -11,13 +11,12 @@ import (
 	"runtime/debug"
 	"sync"
 
-	"github.com/pkg/errors"
-	"go.uber.org/zap/zapcore"
-
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/registry"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/pkg/errors"
+	"go.uber.org/zap/zapcore"
 )
 
 type ctx struct {
@@ -37,8 +36,11 @@ type ctx struct {
 	errorCallbackFuncs []func()
 }
 
-func NewContextForInitiator(context context.Context, sp driver.ServiceProvider, sessionFactory SessionFactory, resolver driver.EndpointService, party view.Identity, initiator view.View) (*ctx, error) {
-	ctx, err := NewContext(context, sp, GenerateUUID(), sessionFactory, resolver, party, nil, nil)
+func NewContextForInitiator(contextID string, context context.Context, sp driver.ServiceProvider, sessionFactory SessionFactory, resolver driver.EndpointService, party view.Identity, initiator view.View) (*ctx, error) {
+	if len(contextID) == 0 {
+		contextID = GenerateUUID()
+	}
+	ctx, err := NewContext(context, sp, contextID, sessionFactory, resolver, party, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/view/core/manager/manager.go
+++ b/platform/view/core/manager/manager.go
@@ -218,6 +218,9 @@ func (cm *manager) InitiateContextWithIdentityAndID(view view.View, id view.Iden
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if id.IsNone() {
+		id = cm.me()
+	}
 	viewContext, err := NewContextForInitiator(contextID, ctx, cm.sp, GetCommLayer(cm.sp), driver.GetEndpointService(cm.sp), id, view)
 	if err != nil {
 		return nil, err

--- a/platform/view/core/manager/manager.go
+++ b/platform/view/core/manager/manager.go
@@ -177,7 +177,7 @@ func (cm *manager) InitiateViewWithIdentity(view view.View, id view.Identity) (i
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	viewContext, err := NewContextForInitiator(ctx, cm.sp, GetCommLayer(cm.sp), driver.GetEndpointService(cm.sp), id, view)
+	viewContext, err := NewContextForInitiator("", ctx, cm.sp, GetCommLayer(cm.sp), driver.GetEndpointService(cm.sp), id, view)
 	if err != nil {
 		return nil, err
 	}
@@ -207,6 +207,10 @@ func (cm *manager) InitiateContext(view view.View) (view.Context, error) {
 }
 
 func (cm *manager) InitiateContextWithIdentity(view view.View, id view.Identity) (view.Context, error) {
+	return cm.InitiateContextWithIdentityAndID(view, id, "")
+}
+
+func (cm *manager) InitiateContextWithIdentityAndID(view view.View, id view.Identity, contextID string) (view.Context, error) {
 	// Create the context
 	cm.contextsSync.Lock()
 	ctx := cm.ctx
@@ -214,7 +218,7 @@ func (cm *manager) InitiateContextWithIdentity(view view.View, id view.Identity)
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	viewContext, err := NewContextForInitiator(ctx, cm.sp, GetCommLayer(cm.sp), driver.GetEndpointService(cm.sp), id, view)
+	viewContext, err := NewContextForInitiator(contextID, ctx, cm.sp, GetCommLayer(cm.sp), driver.GetEndpointService(cm.sp), id, view)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/view/driver/flowmanager.go
+++ b/platform/view/driver/flowmanager.go
@@ -22,6 +22,8 @@ type ViewManager interface {
 	InitiateView(view view.View) (interface{}, error)
 	// InitiateContext initiates a new context for the passed view
 	InitiateContext(view view.View) (view.Context, error)
+	// InitiateContextWithIdentityAndID initiates a new context
+	InitiateContextWithIdentityAndID(view view.View, id view.Identity, contextID string) (view.Context, error)
 }
 
 // GetViewManager returns an instance of the view manager.

--- a/platform/view/manager.go
+++ b/platform/view/manager.go
@@ -26,6 +26,10 @@ func (c *Context) ID() string {
 	return c.c.ID()
 }
 
+func (c *Context) GetSessionByID(id string, party view.Identity) (view.Session, error) {
+	return c.c.GetSessionByID(id, party)
+}
+
 // Manager manages the lifecycle of views and contexts
 type Manager struct {
 	m driver.ViewManager
@@ -58,6 +62,15 @@ func (m *Manager) InitiateContext(view View) (*Context, error) {
 		return nil, err
 	}
 	return &Context{c: context}, nil
+}
+
+// InitiateContextWithIdentityAndID initiates
+func (m *Manager) InitiateContextWithIdentityAndID(view View, id view.Identity, contextID string) (view.Context, error) {
+	context, err := m.m.InitiateContextWithIdentityAndID(view, id, contextID)
+	if err != nil {
+		return nil, err
+	}
+	return context, nil
 }
 
 // GetManager returns an instance of the view manager.

--- a/platform/view/sdk/sdk.go
+++ b/platform/view/sdk/sdk.go
@@ -67,6 +67,8 @@ type p struct {
 
 	context          context.Context
 	operationsSystem *operations.System
+
+	commService *comm2.Service
 }
 
 func NewSDK(confPath string, registry Registry) *p {
@@ -149,6 +151,8 @@ func (p *p) Install() error {
 	}
 
 	finality.InstallHandler(p.registry, p.viewService)
+
+	p.initCommLayer()
 
 	return nil
 }
@@ -234,7 +238,7 @@ func (p *p) initGRPCServer() error {
 	return nil
 }
 
-func (p *p) startCommLayer() error {
+func (p *p) initCommLayer() {
 	configProvider := view.GetConfigService(p.registry)
 
 	k, err := identity.NewCryptoPrivKeyFromMSP(configProvider.GetPath("fsc.identity.key.file"))
@@ -248,7 +252,11 @@ func (p *p) startCommLayer() error {
 	)
 	assert.NoError(err, "failed instantiating the communication service")
 	assert.NoError(p.registry.RegisterService(commService), "failed registering communication service")
-	commService.Start(p.context)
+	p.commService = commService
+}
+
+func (p *p) startCommLayer() error {
+	p.commService.Start(p.context)
 
 	return nil
 }

--- a/platform/view/services/session/json.go
+++ b/platform/view/services/session/json.go
@@ -92,6 +92,11 @@ func (j *jsonSession) Send(state interface{}) error {
 	return j.s.Send(v)
 }
 
+func (j *jsonSession) SendRaw(raw []byte) error {
+	logger.Debugf("json session, send raw message [%s]", hash.Hashable(raw).String())
+	return j.s.Send(raw)
+}
+
 func (j *jsonSession) SendError(err string) error {
 	logger.Debugf("json session, send error [%s]", err)
 	return j.s.SendError([]byte(err))

--- a/samples/fabric/iou/topology/topology.go
+++ b/samples/fabric/iou/topology/topology.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
+	fabric2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk"
 	"github.com/hyperledger-labs/fabric-smart-client/samples/fabric/iou/views"
 )
 
@@ -61,7 +62,7 @@ func Topology() []api.Topology {
 	//monitoringTopology.EnablePrometheusGrafana()
 
 	// Add Fabric SDK to FSC Nodes
-	fabricTopology.AddSDK(fscTopology)
+	fscTopology.AddSDK(&fabric2.SDK{})
 
 	return []api.Topology{
 		fabricTopology,

--- a/samples/fabric/iou/topology/topology.go
+++ b/samples/fabric/iou/topology/topology.go
@@ -60,6 +60,9 @@ func Topology() []api.Topology {
 	//monitoringTopology.EnableHyperledgerExplorer()
 	//monitoringTopology.EnablePrometheusGrafana()
 
+	// Add Fabric SDK to FSC Nodes
+	fabricTopology.AddSDK(fscTopology)
+
 	return []api.Topology{
 		fabricTopology,
 		fscTopology,

--- a/samples/fabric/weaver/relay/topology/topology.go
+++ b/samples/fabric/weaver/relay/topology/topology.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/weaver"
+	fabric2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk"
 	"github.com/hyperledger-labs/fabric-smart-client/samples/fabric/weaver/relay/views"
 )
 
@@ -60,7 +61,7 @@ func Topology() []api.Topology {
 	bob.RegisterViewFactory("remoteGet", &views.RemoteGetViewFactory{})
 
 	// Add Fabric SDK to FSC Nodes
-	f1Topology.AddSDK(fscTopology)
+	fscTopology.AddSDK(&fabric2.SDK{})
 
 	return []api.Topology{f1Topology, f2Topology, wTopology, fscTopology}
 }

--- a/samples/fabric/weaver/relay/topology/topology.go
+++ b/samples/fabric/weaver/relay/topology/topology.go
@@ -59,5 +59,8 @@ func Topology() []api.Topology {
 	bob.RegisterViewFactory("get", &views.LocalGetViewFactory{})
 	bob.RegisterViewFactory("remoteGet", &views.RemoteGetViewFactory{})
 
+	// Add Fabric SDK to FSC Nodes
+	f1Topology.AddSDK(fscTopology)
+
 	return []api.Topology{f1Topology, f2Topology, wTopology, fscTopology}
 }


### PR DESCRIPTION
This PR brings the following:

### View SDK
- Ability to create a view context with a given ID
- Initialise the communication layer at view SDK installation time to let other components open sessions immediately

### Fabric SDK
- Ability to get the Envelope from a Transaction
- Endorser Transaction: Improved ParallelCollectEndorsementsOnProposalView.
- Ability to specify a different implementation of the Fabric API
- MSP: Ability to add third party identity loaders

### NWO
- Fabric SDK must be added explicitly to the topology. This is to offer the ability to specify a different Fabric SDK.
- Cryptogen: Ability to generate a new identity or certify an existing pk starting from an existing CA
