### PR TITLE
key validation removal

### DIFF
--- a/platform/fabric/core/generic/vault/rwset.go
+++ b/platform/fabric/core/generic/vault/rwset.go
@@ -180,10 +180,6 @@ func (w *metaWriteSet) add(ns, key string, meta map[string][]byte) error {
 		return err
 	}
 
-	if err := keys.ValidateKey(key); err != nil {
-		return err
-	}
-
 	nsMap, in := w.metawrites[ns]
 	if !in {
 		nsMap = keyedMetaWrites{}
@@ -278,10 +274,6 @@ type writeSet struct {
 
 func (w *writeSet) add(ns, key string, value []byte) error {
 	if err := keys.ValidateNs(ns); err != nil {
-		return err
-	}
-
-	if err := keys.ValidateKey(key); err != nil {
 		return err
 	}
 

--- a/platform/fabric/services/weaver/relay/fabric/rwset.go
+++ b/platform/fabric/services/weaver/relay/fabric/rwset.go
@@ -129,10 +129,6 @@ func (w *metaWriteSet) add(ns, key string, meta map[string][]byte) error {
 		return err
 	}
 
-	if err := keys.ValidateKey(key); err != nil {
-		return err
-	}
-
 	nsMap, in := w.metawrites[ns]
 	if !in {
 		nsMap = keyedMetaWrites{}
@@ -182,10 +178,6 @@ type writeSet struct {
 
 func (w *writeSet) add(ns, key string, value []byte) error {
 	if err := keys.ValidateNs(ns); err != nil {
-		return err
-	}
-
-	if err := keys.ValidateKey(key); err != nil {
 		return err
 	}
 

--- a/platform/orion/core/generic/vault/rwset.go
+++ b/platform/orion/core/generic/vault/rwset.go
@@ -168,10 +168,6 @@ func (w *metaWriteSet) add(ns, key string, meta map[string][]byte) error {
 		return err
 	}
 
-	if err := keys.ValidateKey(key); err != nil {
-		return err
-	}
-
 	nsMap, in := w.metawrites[ns]
 	if !in {
 		nsMap = keyedMetaWrites{}
@@ -261,10 +257,6 @@ type writeSet struct {
 
 func (w *writeSet) add(ns, key string, value []byte) error {
 	if err := keys.ValidateNs(ns); err != nil {
-		return err
-	}
-
-	if err := keys.ValidateKey(key); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Currently, FSC Vault is more restrictive when parsing RW sets imposing rules that Fabric does not actually impose.
This results in panic when transactions with a RW sets containing keys that do not pass the FSC check are committed to Fabric.

This PR fixes this issue by removing the extra checks.

Signed-off-by: Norhan Ali Araba <Norhan.Ali.Araba-CICNetherlands@ibm.com>