### PR TITLE
Changes in core template

### DIFF
--- a/integration/nwo/fabric/topology/core_template.go
+++ b/integration/nwo/fabric/topology/core_template.go
@@ -17,7 +17,7 @@ peer:
   address: {{ .PeerAddress Peer "Listen" }}
   addressAutoDetect: true
   listenAddress: 0.0.0.0:{{ .PeerPort Peer "Listen" }}
-  chaincodeListenAddress: {{ .PeerAddress Peer "Chaincode" }}
+  chaincodeListenAddress: {{ if gt (.PeerPort Peer "Chaincode") 0 }}{{ .PeerAddress Peer "Chaincode" }}{{ end }}
   keepalive:
     minInterval: 60s
     interval: 300s


### PR DESCRIPTION
Not including chaincode address if port is 0. Otherwise, chaincode tries to connect to the peer as a service.