### PR TITLE
introduce query policy

### DIFF
--- a/integration/fabric/atsa/chaincode/views/assets.go
+++ b/integration/fabric/atsa/chaincode/views/assets.go
@@ -60,9 +60,13 @@ type ReadAssetView struct {
 
 func (r *ReadAssetView) Call(context view.Context) (interface{}, error) {
 	res, err := context.RunView(
-		chaincode.NewQueryView(
-			"asset_transfer", "ReadAsset", r.ID,
-		).WithEndorsersFromMyOrg().WithNumRetries(2).WithRetrySleep(2 * time.Second).WithMatchEndorsementPolicy())
+		chaincode.NewQueryView("asset_transfer", "ReadAsset", r.ID).
+			WithEndorsersFromMyOrg().
+			WithNumRetries(2).
+			WithRetrySleep(2 * time.Second).
+			WithMatchEndorsementPolicy().
+			WithQueryPolicy(chaincode.QueryOne),
+	)
 	assert.NoError(err, "failed reading asset")
 	return res, nil
 }

--- a/platform/fabric/chaincode.go
+++ b/platform/fabric/chaincode.go
@@ -15,6 +15,18 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
+// QueryPolicy defines the policy to use to decide if a query is successful
+type QueryPolicy int
+
+const (
+	// QueryAll requires an answer from all selected peers
+	QueryAll QueryPolicy = iota
+	// QueryMajority requires an answer from the majority of the selected peers
+	QueryMajority
+	// QueryOne requires an answer from at least one of the selected peers
+	QueryOne
+)
+
 type Envelope struct {
 	e driver.Envelope
 }
@@ -246,6 +258,12 @@ func (i *ChaincodeQuery) WithNumRetries(numRetries uint) *ChaincodeQuery {
 // WithRetrySleep sets the time interval between each retry
 func (i *ChaincodeQuery) WithRetrySleep(duration time.Duration) *ChaincodeQuery {
 	i.ChaincodeInvocation.WithRetrySleep(duration)
+	return i
+}
+
+// WithQueryPolicy sets the query policy to use
+func (i *ChaincodeQuery) WithQueryPolicy(policy QueryPolicy) *ChaincodeQuery {
+	i.ChaincodeInvocation.WithQueryPolicy(driver.QueryPolicy(policy))
 	return i
 }
 

--- a/platform/fabric/chaincode.go
+++ b/platform/fabric/chaincode.go
@@ -146,6 +146,11 @@ func (i *ChaincodeDiscover) WithFilterByMSPIDs(mspIDs ...string) *ChaincodeDisco
 	return i
 }
 
+func (i *ChaincodeDiscover) WithContext(context context.Context) *ChaincodeDiscover {
+	i.ChaincodeDiscover.WithContext(context)
+	return i
+}
+
 type ChaincodeInvocation struct {
 	driver.ChaincodeInvocation
 }

--- a/platform/fabric/core/generic/chaincode/chaincode.go
+++ b/platform/fabric/core/generic/chaincode/chaincode.go
@@ -88,7 +88,9 @@ func NewChaincode(
 }
 
 func (c *Chaincode) NewInvocation(function string, args ...interface{}) driver.ChaincodeInvocation {
-	return NewInvoke(c, function, args...)
+	return NewInvoke(c, func(chaincode *Chaincode) driver.ChaincodeDiscover {
+		return NewDiscovery(chaincode)
+	}, function, args...)
 }
 
 func (c *Chaincode) NewDiscover() driver.ChaincodeDiscover {

--- a/platform/fabric/core/generic/chaincode/discovery.go
+++ b/platform/fabric/core/generic/chaincode/discovery.go
@@ -29,6 +29,7 @@ type Discovery struct {
 	QueryForPeers       bool
 
 	DefaultTTL time.Duration
+	Context    context.Context
 }
 
 func NewDiscovery(chaincode *Chaincode) *Discovery {
@@ -36,6 +37,7 @@ func NewDiscovery(chaincode *Chaincode) *Discovery {
 	return &Discovery{
 		chaincode:  chaincode,
 		DefaultTTL: chaincode.ChannelConfig.DiscoveryDefaultTTLS(),
+		Context:    context.Background(),
 	}
 }
 
@@ -230,7 +232,7 @@ func (d *Discovery) query(req *discovery.Request) (discovery.Response, error) {
 		ClientIdentity:    signerRaw,
 		ClientTlsCertHash: ClientTLSCertHash,
 	}
-	timeout, cancel := context.WithTimeout(context.Background(), d.chaincode.ChannelConfig.DiscoveryTimeout())
+	timeout, cancel := context.WithTimeout(d.Context, d.chaincode.ChannelConfig.DiscoveryTimeout())
 	defer cancel()
 	cl, err := pc.DiscoveryClient()
 	if err != nil {
@@ -316,6 +318,10 @@ func (d *Discovery) ChaincodeVersion() (string, error) {
 		}
 	}
 	return "", errors.Errorf("chaincode [%s] not found", d.chaincode.name)
+}
+
+func (d *Discovery) WithContext(context context.Context) {
+	d.Context = context
 }
 
 func ccCall(ccNames ...string) []*peer.ChaincodeCall {

--- a/platform/fabric/driver/chaincode.go
+++ b/platform/fabric/driver/chaincode.go
@@ -19,6 +19,18 @@ type TxID struct {
 	Creator []byte
 }
 
+// QueryPolicy defines the policy to use to decide if a query is successful
+type QueryPolicy int
+
+const (
+	// QueryAll requires an answer from all selected peers
+	QueryAll QueryPolicy = iota
+	// QueryMajority requires an answer from the majority of the selected peers
+	QueryMajority
+	// QueryOne requires an answer from at least one of the selected peers
+	QueryOne
+)
+
 // ChaincodeInvocation models a client-side chaincode invocation
 type ChaincodeInvocation interface {
 	Endorse() (Envelope, error)
@@ -56,6 +68,8 @@ type ChaincodeInvocation interface {
 	WithRetrySleep(duration time.Duration) ChaincodeInvocation
 
 	WithContext(context context.Context) ChaincodeInvocation
+
+	WithQueryPolicy(policy QueryPolicy) ChaincodeInvocation
 }
 
 // DiscoveredPeer contains the information of a discovered peer
@@ -76,6 +90,8 @@ type ChaincodeDiscover interface {
 	Call() ([]DiscoveredPeer, error)
 	WithFilterByMSPIDs(mspIDs ...string) ChaincodeDiscover
 	WithImplicitCollections(mspIDs ...string) ChaincodeDiscover
+	WithForQuery() ChaincodeDiscover
+	ChaincodeVersion() (string, error)
 }
 
 // Chaincode exposes chaincode-related functions

--- a/platform/fabric/driver/chaincode.go
+++ b/platform/fabric/driver/chaincode.go
@@ -92,6 +92,7 @@ type ChaincodeDiscover interface {
 	WithImplicitCollections(mspIDs ...string) ChaincodeDiscover
 	WithForQuery() ChaincodeDiscover
 	ChaincodeVersion() (string, error)
+	WithContext(ctx context.Context)
 }
 
 // Chaincode exposes chaincode-related functions

--- a/platform/fabric/services/chaincode/chaincode.go
+++ b/platform/fabric/services/chaincode/chaincode.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
@@ -33,6 +34,7 @@ type Query interface {
 	Call() ([]byte, error)
 	WithNumRetries(retries uint)
 	WithRetrySleep(sleep time.Duration)
+	WithQueryPolicy(policy driver.QueryPolicy) Query
 }
 
 type Chaincode interface {
@@ -114,6 +116,11 @@ func (s *stdQuery) WithNumRetries(numRetries uint) {
 
 func (s *stdQuery) WithRetrySleep(duration time.Duration) {
 	s.chq.WithRetrySleep(duration)
+}
+
+func (s *stdQuery) WithQueryPolicy(policy driver.QueryPolicy) Query {
+	s.chq.WithQueryPolicy(fabric.QueryPolicy(policy))
+	return s
 }
 
 type stdChaincode struct {


### PR DESCRIPTION
This PR allows the developer to choose a policy to decide how many responses are needed to accept the result of a query. The PR also allows the developer to make use of an external context to track the progress. 