### PR TITLE
transaction filter

### DIFF
--- a/integration/fabric/iou/views/utils.go
+++ b/integration/fabric/iou/views/utils.go
@@ -9,6 +9,7 @@ package views
 import (
 	"sync"
 
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/core"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 )
 
@@ -21,8 +22,9 @@ func NewFinalityListener(expectedTxID string, WG *sync.WaitGroup) *FinalityListe
 	return &FinalityListener{ExpectedTxID: expectedTxID, WaitGroup: WG}
 }
 
-func (t *FinalityListener) OnStatus(txID string, _ driver.ValidationCode, _ string) {
+func (t *FinalityListener) OnStatusChange(txID core.TxID, _ driver.ValidationCode, _ string) error {
 	if txID == t.ExpectedTxID {
 		t.WaitGroup.Done()
 	}
+	return nil
 }

--- a/platform/common/core/generic/committer/finality.go
+++ b/platform/common/core/generic/committer/finality.go
@@ -40,8 +40,8 @@ type FinalityEvent[V comparable] struct {
 
 // FinalityListener is the interface that must be implemented to receive transaction status notifications
 type FinalityListener[V comparable] interface {
-	// OnStatus is called when the status of a transaction changes, or it is valid or invalid
-	OnStatus(txID core.TxID, status V, statusMessage string)
+	// OnStatusChange is called when the status of a transaction changes, or it is valid or invalid
+	OnStatusChange(txID core.TxID, status V, statusMessage string) error
 }
 
 type Vault[V comparable] interface {
@@ -114,7 +114,7 @@ func (c *FinalityManager[V]) invokeListener(l FinalityListener[V], txID core.TxI
 			logger.Errorf("caught panic while running dispatching event [%s:%d:%s]: [%s][%s]", txID, status, statusMessage, r, debug.Stack())
 		}
 	}()
-	l.OnStatus(txID, status, statusMessage)
+	l.OnStatusChange(txID, status, statusMessage)
 }
 
 func (c *FinalityManager[V]) runEventQueue(context context.Context) {

--- a/platform/common/core/generic/vault/vault.go
+++ b/platform/common/core/generic/vault/vault.go
@@ -443,3 +443,21 @@ func (db *Vault[V]) GetExistingRWSet(txID core.TxID) (TxInterceptor, error) {
 
 	return interceptor, nil
 }
+
+func (db *Vault[V]) SetStatus(txID core.TxID, code V) error {
+	err := db.store.BeginUpdate()
+	if err != nil {
+		return errors.WithMessagef(err, "begin update for txid '%s' failed", txID)
+	}
+	err = db.txIDStore.Set(txID, code, "")
+	if err != nil {
+		db.store.Discard()
+		return err
+	}
+	err = db.store.Commit()
+	if err != nil {
+		db.store.Discard()
+		return errors.WithMessagef(err, "committing tx for txid '%s' failed", txID)
+	}
+	return nil
+}

--- a/platform/common/driver/committer.go
+++ b/platform/common/driver/committer.go
@@ -1,0 +1,31 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package driver
+
+import "github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
+
+type AggregatedTransactionFilter struct {
+	filters []driver.TransactionFilter
+}
+
+func NewAggregatedTransactionFilter() *AggregatedTransactionFilter {
+	return &AggregatedTransactionFilter{filters: []driver.TransactionFilter{}}
+}
+
+func (f *AggregatedTransactionFilter) Add(filter driver.TransactionFilter) {
+	f.filters = append(f.filters, filter)
+}
+
+func (f *AggregatedTransactionFilter) Accept(txID string, env []byte) (bool, error) {
+	for _, filter := range f.filters {
+		ok, err := filter.Accept(txID, env)
+		if err != nil || ok {
+			return ok, err
+		}
+	}
+	return false, nil
+}

--- a/platform/fabric/channel.go
+++ b/platform/fabric/channel.go
@@ -15,7 +15,7 @@ type Channel struct {
 	sp        view2.ServiceProvider
 	fns       driver.FabricNetworkService
 	ch        driver.Channel
-	committer *Committer
+	committer Committer
 }
 
 func NewChannel(sp view2.ServiceProvider, fns driver.FabricNetworkService, ch driver.Channel) *Channel {
@@ -38,7 +38,7 @@ func (c *Channel) MSPManager() *MSPManager {
 	return &MSPManager{ch: c.ch.ChannelMembership()}
 }
 
-func (c *Channel) Committer() *Committer {
+func (c *Channel) Committer() Committer {
 	return c.committer
 }
 

--- a/platform/fabric/committer.go
+++ b/platform/fabric/committer.go
@@ -8,50 +8,25 @@ package fabric
 
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/events"
 )
 
-// FinalityListener is the interface that must be implemented to receive transaction status notifications
-type FinalityListener interface {
-	// OnStatus is called when the status of a transaction changes
-	OnStatus(txID string, status driver.ValidationCode, statusMessage string)
+type Committer interface {
+	// ProcessNamespace registers namespaces that will be committed even if the rwset is not known
+	ProcessNamespace(nss ...string) error
+	// Status returns a validation code this committer bind to the passed transaction id, plus
+	// a list of dependant transaction ids if they exist.
+	Status(txID string) (driver.ValidationCode, string, error)
+	AddTransactionFilter(sr driver.TransactionFilter) error
+	// AddFinalityListener registers a listener for transaction status for the passed transaction id.
+	// If the status is already valid or invalid, the listener is called immediately.
+	// When the listener is invoked, then it is also removed.
+	// If the transaction id is empty, the listener will be called on status changes of any transaction.
+	// In this case, the listener is not removed
+	AddFinalityListener(txID string, listener driver.FinalityListener) error
+	// RemoveFinalityListener unregisters the passed listener.
+	RemoveFinalityListener(txID string, listener driver.FinalityListener) error
 }
 
-type Committer struct {
-	committer   driver.Committer
-	subscribers *events.Subscribers
-}
-
-func NewCommitter(ch driver.Channel) *Committer {
-	return &Committer{committer: ch.Committer(), subscribers: events.NewSubscribers()}
-}
-
-// ProcessNamespace registers namespaces that will be committed even if the rwset is not known
-func (c *Committer) ProcessNamespace(nss ...string) error {
-	return c.committer.ProcessNamespace(nss...)
-}
-
-// Status returns a validation code this committer bind to the passed transaction id, plus
-// a list of dependant transaction ids if they exist.
-func (c *Committer) Status(txID string) (ValidationCode, string, error) {
-	vc, message, err := c.committer.Status(txID)
-	return ValidationCode(vc), message, err
-}
-
-func (c *Committer) AddStatusReporter(sr driver.StatusReporter) error {
-	return c.committer.AddStatusReporter(sr)
-}
-
-// AddFinalityListener registers a listener for transaction status for the passed transaction id.
-// If the status is already valid or invalid, the listener is called immediately.
-// When the listener is invoked, then it is also removed.
-// If the transaction id is empty, the listener will be called on status changes of any transaction.
-// In this case, the listener is not removed
-func (c *Committer) AddFinalityListener(txID string, listener FinalityListener) error {
-	return c.committer.AddFinalityListener(txID, listener)
-}
-
-// RemoveFinalityListener unregisters the passed listener.
-func (c *Committer) RemoveFinalityListener(txID string, listener FinalityListener) error {
-	return c.committer.RemoveFinalityListener(txID, listener)
+func NewCommitter(ch driver.Channel) Committer {
+	return ch.Committer()
 }

--- a/platform/fabric/core/generic/committer/config.go
+++ b/platform/fabric/core/generic/committer/config.go
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func (c *Service) HandleConfig(block *common.Block, i int, event *FinalityEvent, env *common.Envelope, chHdr *common.ChannelHeader) error {
+func (c *Service) HandleConfig(block *common.Block, i int, event *FinalityEvent, envRaw []byte, env *common.Envelope, chHdr *common.ChannelHeader) error {
 	if logger.IsEnabledFor(zapcore.DebugLevel) {
 		logger.Debugf("[%s] Config transaction received: %s", c.ChannelConfig.ID(), chHdr.TxId)
 	}

--- a/platform/fabric/core/generic/committer/endorsertx.go
+++ b/platform/fabric/core/generic/committer/endorsertx.go
@@ -17,7 +17,7 @@ import (
 
 type ValidationFlags []uint8
 
-func (c *Service) HandleEndorserTransaction(block *common.Block, i int, event *FinalityEvent, env *common.Envelope, chHdr *common.ChannelHeader) error {
+func (c *Service) HandleEndorserTransaction(block *common.Block, i int, event *FinalityEvent, envRaw []byte, env *common.Envelope, chHdr *common.ChannelHeader) error {
 	if logger.IsEnabledFor(zapcore.DebugLevel) {
 		logger.Debugf("[%s] Endorser transaction received: %s", c.ChannelConfig.ID(), chHdr.TxId)
 	}
@@ -50,7 +50,7 @@ func (c *Service) HandleEndorserTransaction(block *common.Block, i int, event *F
 		return nil
 	}
 
-	if err := c.DiscardEndorserTransaction(txID, block, event); err != nil {
+	if err := c.DiscardEndorserTransaction(txID, block, envRaw, event); err != nil {
 		return errors.Wrapf(err, "failed discarding transaction [%s]", txID)
 	}
 	return nil
@@ -115,7 +115,7 @@ func (c *Service) CommitEndorserTransaction(txID string, block *common.Block, in
 }
 
 // DiscardEndorserTransaction discards the transaction from the vault
-func (c *Service) DiscardEndorserTransaction(txID string, block *common.Block, event *FinalityEvent) error {
+func (c *Service) DiscardEndorserTransaction(txID string, block *common.Block, envRaw []byte, event *FinalityEvent) error {
 	blockNum := block.Header.Number
 	if logger.IsEnabledFor(zapcore.DebugLevel) {
 		logger.Debugf("transaction [%s] in block [%d] is not valid for fabric [%s], discard!", txID, blockNum, event.ValidationCode)
@@ -129,18 +129,35 @@ func (c *Service) DiscardEndorserTransaction(txID string, block *common.Block, e
 	case driver.Valid:
 		// TODO: this might be due the fact that there are transactions with the same tx-id, the first is valid, the others are all invalid
 		logger.Warnf("transaction [%s] in block [%d] is marked as valid but for fabric is invalid", txID, blockNum)
+		return nil
 	case driver.Invalid:
 		if logger.IsEnabledFor(zapcore.DebugLevel) {
 			logger.Debugf("transaction [%s] in block [%d] is marked as invalid, skipping", txID, blockNum)
 		}
 		// Nothing to commit
-	default:
-		event.Err = errors.Errorf("transaction [%s] status is not valid [%d], message [%s]", txID, event.ValidationCode, event.ValidationMessage)
-		err = c.DiscardTx(event.TxID, event.ValidationMessage)
+		return nil
+	case driver.Unknown:
+		ok, err := c.filterUnknownEnvelope(txID, envRaw)
 		if err != nil {
-			logger.Errorf("failed discarding tx in state db with err [%s]", err)
+			return err
+		}
+		if ok {
+			// so, we must remember that this transaction was discarded
+			if err := c.EnvelopeService.StoreEnvelope(txID, envRaw); err != nil {
+				return errors.WithMessagef(err, "failed to store unknown envelope for [%s]", txID)
+			}
+			rws, _, err := c.RWSetLoaderService.GetRWSetFromEvn(txID)
+			if err != nil {
+				return errors.WithMessagef(err, "failed to get rws from envelope [%s]", txID)
+			}
+			rws.Done()
 		}
 	}
 
+	event.Err = errors.Errorf("transaction [%s] status is not valid [%d], message [%s]", txID, event.ValidationCode, event.ValidationMessage)
+	err = c.DiscardTx(event.TxID, event.ValidationMessage)
+	if err != nil {
+		logger.Errorf("failed discarding tx in state db with err [%s]", err)
+	}
 	return nil
 }

--- a/platform/orion/committer.go
+++ b/platform/orion/committer.go
@@ -8,32 +8,23 @@ package orion
 
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/orion/driver"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/events"
 )
 
-// FinalityListener is the interface that must be implemented to receive transaction status change notifications
-type FinalityListener = driver.FinalityListener
-
 // Committer models the committer service
-type Committer struct {
-	c           driver.Committer
-	subscribers *events.Subscribers
+type Committer interface {
+	// AddFinalityListener registers a listener for transaction status for the passed transaction id.
+	// If the status is already valid or invalid, the listener is called immediately.
+	// When the listener is invoked, then it is also removed.
+	// If the transaction id is empty, the listener will be called on status changes of any transaction.
+	// In this case, the listener is not removed
+	AddFinalityListener(txID string, listener driver.FinalityListener) error
+
+	// RemoveFinalityListener unregisters the passed listener.
+	RemoveFinalityListener(txID string, listener driver.FinalityListener) error
+
+	AddTransactionFilter(filter driver.TransactionFilter) error
 }
 
-func NewCommitter(c driver.Committer) *Committer {
-	return &Committer{c: c, subscribers: events.NewSubscribers()}
-}
-
-// AddFinalityListener registers a listener for transaction status for the passed transaction id.
-// If the status is already valid or invalid, the listener is called immediately.
-// When the listener is invoked, then it is also removed.
-// If the transaction id is empty, the listener will be called on status changes of any transaction.
-// In this case, the listener is not removed
-func (c *Committer) AddFinalityListener(txID string, listener FinalityListener) error {
-	return c.c.AddFinalityListener(txID, listener)
-}
-
-// RemoveFinalityListener unregisters the passed listener.
-func (c *Committer) RemoveFinalityListener(txID string, listener FinalityListener) error {
-	return c.c.RemoveFinalityListener(txID, listener)
+func NewCommitter(c driver.Committer) Committer {
+	return c
 }

--- a/platform/orion/core/generic/vault.go
+++ b/platform/orion/core/generic/vault.go
@@ -24,8 +24,6 @@ type Vault struct {
 	*vault.Vault
 	*vault.SimpleTXIDStore
 	network Network
-
-	StatusReporters []driver.StatusReporter
 }
 
 func NewVault(sp view.ServiceProvider, config *config.Config, network Network, channel string) (*Vault, error) {
@@ -76,13 +74,6 @@ func (v *Vault) Status(txID string) (driver.ValidationCode, string, error) {
 		return driver.Busy, message, nil
 	}
 
-	// check status reporter, if any
-	for _, reporter := range v.StatusReporters {
-		if externalStatus, externalMessage, _, err := reporter.Status(txID); err == nil && externalStatus != driver.Unknown {
-			return externalStatus, externalMessage, nil
-		}
-	}
-
 	return driver.Unknown, message, nil
 }
 
@@ -108,23 +99,11 @@ func (v *Vault) DiscardTx(txID string, message string) error {
 		return errors.Wrapf(err, "failed getting tx's status in state db [%s]", txID)
 	}
 	if vc != driver.Unknown {
+		logger.Debugf("discarding transaction [%s], tx is known", txID)
 		return v.Vault.DiscardTx(txID, message)
 	}
-
-	// check status reporter, if any
-	for _, reporter := range v.StatusReporters {
-		if externalStatus, _, _, err := reporter.Status(txID); err == nil && externalStatus != driver.Unknown {
-			return v.Vault.DiscardTx(txID, message)
-		}
-	}
-
-	logger.Debugf("Discarding transaction [%s] skipped, tx is unknown", txID)
-	return nil
-}
-
-func (v *Vault) AddStatusReporter(sr driver.StatusReporter) error {
-	v.StatusReporters = append(v.StatusReporters, sr)
-	return nil
+	logger.Debugf("discarding transaction [%s], tx is unknown, set status to invalid", txID)
+	return v.Vault.SetStatus(txID, driver.Invalid)
 }
 
 func (v *Vault) extractStoredEnvelopeToVault(txID string) error {

--- a/platform/orion/driver/committer.go
+++ b/platform/orion/driver/committer.go
@@ -6,6 +6,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package driver
 
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/core/generic/committer"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
+)
+
 type StatusReporter interface {
 	Status(txID string) (ValidationCode, string, []string, error)
 }
@@ -28,14 +33,17 @@ func (t *TransactionStatusChanged) Message() interface{} {
 	return t
 }
 
-// FinalityListener is the interface that must be implemented to receive transaction status notifications
-type FinalityListener interface {
-	// OnStatus is called when the status of a transaction changes, or it is valid or invalid
-	OnStatus(txID string, status ValidationCode, statusMessage string)
-}
+type TransactionFilter = driver.TransactionFilter
+
+// FinalityListener is the interface that must be implemented to receive transaction status change notifications
+type FinalityListener = committer.FinalityListener[ValidationCode]
 
 // Committer models the committer service
 type Committer interface {
+	// AddTransactionFilter adds a new transaction filter to this commit pipeline.
+	// The transaction filter is used to check if an unknown transaction needs to be processed anyway
+	AddTransactionFilter(tf TransactionFilter) error
+
 	// AddFinalityListener registers a listener for transaction status for the passed transaction id.
 	// If the status is already valid or invalid, the listener is called immediately.
 	// When the listener is invoked, then it is also removed.

--- a/platform/orion/driver/vault.go
+++ b/platform/orion/driver/vault.go
@@ -15,6 +15,5 @@ type TxValidationStatus = driver2.TxValidationStatus[ValidationCode]
 // Vault models a key value store that can be updated by committing rwsets
 type Vault interface {
 	driver2.Vault[ValidationCode]
-	AddStatusReporter(sr StatusReporter) error
 	GetLastTxID() (string, error)
 }

--- a/platform/orion/ons.go
+++ b/platform/orion/ons.go
@@ -27,7 +27,7 @@ type NetworkService struct {
 	SP        view2.ServiceProvider
 	ons       driver.OrionNetworkService
 	name      string
-	committer *Committer
+	committer Committer
 }
 
 func NewNetworkService(SP view2.ServiceProvider, ons driver.OrionNetworkService, name string) *NetworkService {
@@ -65,7 +65,7 @@ func (n *NetworkService) Vault() Vault {
 }
 
 // Committer returns the committer service
-func (n *NetworkService) Committer() *Committer {
+func (n *NetworkService) Committer() Committer {
 	return n.committer
 }
 

--- a/platform/orion/vault.go
+++ b/platform/orion/vault.go
@@ -39,7 +39,6 @@ type Vault interface {
 	NewRWSet(txid string) (*RWSet, error)
 	GetRWSet(id string, results []byte) (*RWSet, error)
 	CommitTX(txid string, block uint64, indexInBloc int) error
-	AddStatusReporter(sr driver.StatusReporter) error
 }
 
 // vault models a key-value store that can be updated by committing rwsets

--- a/platform/view/driver/committer.go
+++ b/platform/view/driver/committer.go
@@ -1,0 +1,11 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package driver
+
+type TransactionFilter interface {
+	Accept(txID string, env []byte) (bool, error)
+}


### PR DESCRIPTION
This PR does the following: It allows both orion and fabric commit pipeline to process transactions that are unknown but are accepted by the custom filters.