### PR TITLE
fix bug web service

### DIFF
--- a/integration/fsc/pingpong/topology.go
+++ b/integration/fsc/pingpong/topology.go
@@ -15,6 +15,7 @@ import (
 func Topology(commType fsc.P2PCommunicationType, replicationOpts *integration.ReplicationOptions) []api.Topology {
 	// Create an empty FSC topology
 	topology := fsc.NewTopology()
+	topology.WebEnabled = true
 	topology.P2PCommunicationType = commType
 
 	// Add the initiator fsc node

--- a/integration/nwo/fsc/fsc.go
+++ b/integration/nwo/fsc/fsc.go
@@ -476,6 +476,7 @@ func (p *Platform) GenerateCoreConfig(peer *node2.Replica) {
 		"NodeKVSPersistenceType": func() string { return GetPersistenceType(peer.Peer) },
 		"NodeKVSSQLDataSource":   func() string { return GetPersistenceDataSource(peer.Peer) },
 		"Resolvers":              func() []*Resolver { return resolvers },
+		"WebEnabled":             func() bool { return p.Topology.WebEnabled },
 	}).Parse(p.Topology.Templates.CoreTemplate())
 	Expect(err).NotTo(HaveOccurred())
 	Expect(t.Execute(io.MultiWriter(core), p)).NotTo(HaveOccurred())

--- a/integration/nwo/fsc/node/core_template.go
+++ b/integration/nwo/fsc/node/core_template.go
@@ -102,7 +102,7 @@ fsc:
         size: 200
   # HTML Server configuration for REST calls
   web:
-    enabled: true
+    enabled: {{ WebEnabled }}
     # HTTPS server listener address
     address: 0.0.0.0:{{ .NodePort Replica "Web" }}
     tls:

--- a/integration/nwo/fsc/topology.go
+++ b/integration/nwo/fsc/topology.go
@@ -37,7 +37,8 @@ type Topology struct {
 	Templates            Templates            `yaml:"templates,omitempty"`
 	Monitoring           Monitoring           `yaml:"monitoring,omitempty"`
 	P2PCommunicationType P2PCommunicationType `yaml:"p2p_communication_type,omitempty"`
-	WebEnabled           bool                 `yaml:"web_enabled,omitempty"`
+	// WebEnabled is used to activate the FSC web server
+	WebEnabled bool `yaml:"web_enabled,omitempty"`
 }
 
 type Monitoring struct {
@@ -150,10 +151,6 @@ func (t *Topology) AddSDK(sdk api.SDK) {
 	for _, n := range t.Nodes {
 		n.AddSDK(sdk)
 	}
-}
-
-func (t *Topology) EnableWeb() {
-	t.WebEnabled = true
 }
 
 func (t *Topology) addNode(node *node.Node) *node.Node {

--- a/integration/nwo/fsc/topology.go
+++ b/integration/nwo/fsc/topology.go
@@ -37,6 +37,7 @@ type Topology struct {
 	Templates            Templates            `yaml:"templates,omitempty"`
 	Monitoring           Monitoring           `yaml:"monitoring,omitempty"`
 	P2PCommunicationType P2PCommunicationType `yaml:"p2p_communication_type,omitempty"`
+	WebEnabled           bool                 `yaml:"web_enabled,omitempty"`
 }
 
 type Monitoring struct {
@@ -149,6 +150,10 @@ func (t *Topology) AddSDK(sdk api.SDK) {
 	for _, n := range t.Nodes {
 		n.AddSDK(sdk)
 	}
+}
+
+func (t *Topology) EnableWeb() {
+	t.WebEnabled = true
 }
 
 func (t *Topology) addNode(node *node.Node) *node.Node {


### PR DESCRIPTION
This PR does the following: It fixes the bug reported in #568 .
The integration tests by default have the web server disabled. Only the `pingpong` test uses it.
The web server can be enabled by setting `WebEnabled` to `true` on the fsc topology.