### PR TITLE
Replace deprecated logging param in nwo

### DIFF
--- a/cmd/fsccli/main.go
+++ b/cmd/fsccli/main.go
@@ -33,14 +33,6 @@ func main() {
 	replacer := strings.NewReplacer(".", "_")
 	viper.SetEnvKeyReplacer(replacer)
 
-	// Define command-line flags that are valid for all peer commands and
-	// subcommands.
-	mainFlags := mainCmd.PersistentFlags()
-
-	mainFlags.String("logging-level", "", "Legacy logging level flag")
-	viper.BindPFlag("logging_level", mainFlags.Lookup("logging-level"))
-	mainFlags.MarkHidden("logging-level")
-
 	mainCmd.AddCommand(artifactgen.NewCmd())
 	mainCmd.AddCommand(cryptogen.NewCmd())
 	mainCmd.AddCommand(view.NewCmd())

--- a/integration/nwo/cmd/main.go
+++ b/integration/nwo/cmd/main.go
@@ -44,14 +44,6 @@ func (m *Main) Execute() {
 	replacer := strings.NewReplacer(".", "_")
 	viper.SetEnvKeyReplacer(replacer)
 
-	// Define command-line flags that are valid for all peer commands and
-	// subcommands.
-	mainFlags := m.mainCmd.PersistentFlags()
-
-	mainFlags.String("logging-level", "", "Legacy logging level flag")
-	viper.BindPFlag("logging_level", mainFlags.Lookup("logging-level"))
-	mainFlags.MarkHidden("logging-level")
-
 	// On failure Cobra prints the usage message and error string, so we only
 	// need to exit with a non-0 status
 	if m.mainCmd.Execute() != nil {

--- a/integration/nwo/fabric/network/network_support.go
+++ b/integration/nwo/fabric/network/network_support.go
@@ -1047,7 +1047,7 @@ func (n *Network) peerCommand(command common.Command, tlsDir string, env ...stri
 		cmd.Args = append(cmd.Args, "--keyfile", keyfilePath)
 	}
 
-	cmd.Args = append(cmd.Args, "--logging-level", n.Logging.Spec)
+	cmd.Env = append(cmd.Env, fmt.Sprintf("FABRIC_LOGGING_SPEC=%s", n.Logging.Spec))
 
 	// In case we have a peer invoke with multiple certificates,
 	// we need to mimic the correct peer CLI usage,

--- a/integration/nwo/fsc/fsc.go
+++ b/integration/nwo/fsc/fsc.go
@@ -550,7 +550,7 @@ func (p *Platform) fscNodeCommand(node *node2.Replica, command common.Command, t
 		cmd.Args = append(cmd.Args, "--keyfile", keyfilePath)
 	}
 
-	cmd.Args = append(cmd.Args, "--logging-level", p.Topology.Logging.Spec)
+	cmd.Env = append(cmd.Env, fmt.Sprintf("FSCNODE_LOGGING_SPEC=%s", p.Topology.Logging.Spec))
 
 	return cmd
 }

--- a/node/node.go
+++ b/node/node.go
@@ -9,15 +9,13 @@ package node
 import (
 	"os"
 
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-
 	node2 "github.com/hyperledger-labs/fabric-smart-client/node/node"
 	"github.com/hyperledger-labs/fabric-smart-client/node/version"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/api"
 	node3 "github.com/hyperledger-labs/fabric-smart-client/pkg/node"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/spf13/cobra"
 )
 
 var logger = flogging.MustGetLogger("fsc")
@@ -61,14 +59,6 @@ func newFromFsc(fscNode FabricSmartClient) *node {
 		mainCmd:           mainCmd,
 		callbackChannel:   make(chan error, 1),
 	}
-
-	// Define command-line flags that are valid for all peer commands and
-	// subcommands.
-	mainFlags := mainCmd.PersistentFlags()
-
-	mainFlags.String("logging-level", "", "Legacy logging level flag")
-	viper.BindPFlag("logging_level", mainFlags.Lookup("logging-level"))
-	mainFlags.MarkHidden("logging-level")
 
 	mainCmd.AddCommand(version.Cmd())
 	mainCmd.AddCommand(node2.Cmd(node))

--- a/platform/fabric/core/provider.go
+++ b/platform/fabric/core/provider.go
@@ -126,17 +126,6 @@ func (p *FSNProvider) FabricNetworkService(network string) (driver.FabricNetwork
 // InitFabricLogging initializes the fabric logging system
 // using the FSC configuration.
 func (p *FSNProvider) InitFabricLogging() {
-	// read in the legacy logging level settings and, if set,
-	// notify users of the FSCNODE_LOGGING_SPEC env variable
-	var loggingLevel string
-	if p.configService.GetString("logging_level") != "" {
-		loggingLevel = p.configService.GetString("logging_level")
-	} else {
-		loggingLevel = p.configService.GetString("logging.level")
-	}
-	if loggingLevel != "" {
-		logger.Warning("CORE_LOGGING_LEVEL is no longer supported, please use the FSCNODE_LOGGING_SPEC environment variable")
-	}
 	loggingSpec := os.Getenv("FSCNODE_LOGGING_SPEC")
 	loggingFormat := os.Getenv("FSCNODE_LOGGING_FORMAT")
 	if len(loggingSpec) == 0 {

--- a/platform/view/core/config/provider.go
+++ b/platform/view/core/config/provider.go
@@ -27,10 +27,7 @@ const (
 
 const OfficialPath = "/etc/hyperledger-labs/fabric-smart-client-node"
 
-var (
-	logger    = flogging.MustGetLogger("view-sdk.config")
-	logOutput = os.Stderr
-)
+var logOutput = os.Stderr
 
 type provider struct {
 	confPath string
@@ -117,18 +114,6 @@ func (p *provider) load() error {
 		} else {
 			return errors.WithMessagef(err, "error when reading %s config file", CmdRoot)
 		}
-	}
-
-	// read in the legacy logging level settings and, if set,
-	// notify users of the FSCNODE_LOGGING_SPEC env variable
-	var loggingLevel string
-	if p.v.GetString("logging_level") != "" {
-		loggingLevel = p.v.GetString("logging_level")
-	} else {
-		loggingLevel = p.v.GetString("logging.level")
-	}
-	if loggingLevel != "" {
-		logger.Warning("CORE_LOGGING_LEVEL is no longer supported, please use the FSCNODE_LOGGING_SPEC environment variable")
 	}
 
 	loggingSpec := os.Getenv("FSCNODE_LOGGING_SPEC")


### PR DESCRIPTION
Currently, NWO uses the deprecated --logging-level param when invoking the peer cli. This commit replaces this param with FABRIC_LOGGING_SPEC env variable.