### PR TITLE
remove default resolver, register the node id itself so we don't need…

### DIFF
--- a/platform/view/core/endpoint/resolver.go
+++ b/platform/view/core/endpoint/resolver.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package endpoint
 
 import (
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
 	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
 
@@ -71,57 +70,49 @@ func NewResolverService(config ConfigService, backend Backend, is IdentityServic
 }
 
 func (r *ResolverService) LoadResolvers() error {
-	// add default
-	_, err := r.backend.AddResolver(
-		r.config.GetString("fsc.id"),
-		"",
-		map[string]string{
-			string(driver.ViewPort): r.config.GetString("fsc.grpc.address"),
-		},
-		nil,
-		r.is.DefaultIdentity(),
-	)
-	if err != nil {
-		logger.Errorf("failed adding default resolver [%s]", err)
-		return errors.Wrapf(err, "failed adding default resolver")
+	if !r.config.IsSet("fsc.endpoint.resolvers") {
+		logger.Infof("no resolvers in configuration")
+		return nil
 	}
 
-	// Load entry
-	if r.config.IsSet("fsc.endpoint.resolvers") {
-		logger.Infof("loading resolvers")
-		var resolvers []*entry
-		err := r.config.UnmarshalKey("fsc.endpoint.resolvers", &resolvers)
+	logger.Infof("loading resolvers")
+	var resolvers []*entry
+	err := r.config.UnmarshalKey("fsc.endpoint.resolvers", &resolvers)
+	if err != nil {
+		logger.Errorf("failed loading resolvers [%s]", err)
+		return errors.Wrapf(err, "failed loading resolvers")
+	}
+	logger.Infof("loaded resolvers successfully, number of entries found %d", len(resolvers))
+
+	for _, resolver := range resolvers {
+		// Load identity
+		raw, err := id.LoadIdentity(r.config.TranslatePath(resolver.Identity.Path))
 		if err != nil {
-			logger.Errorf("failed loading resolvers [%s]", err)
-			return errors.Wrapf(err, "failed loading resolvers")
+			return err
 		}
-		logger.Infof("loaded resolvers successfully, number of entries found %d", len(resolvers))
+		resolver.Id = raw
+		logger.Infof("resolver [%s,%s][%s] %s",
+			resolver.Name, resolver.Domain, resolver.Addresses,
+			view.Identity(resolver.Id).UniqueID(),
+		)
 
-		for _, resolver := range resolvers {
-			// Load identity
-			raw, err := id.LoadIdentity(r.config.TranslatePath(resolver.Identity.Path))
-			if err != nil {
-				return err
+		// Add entry
+		if _, err := r.backend.AddResolver(resolver.Name, resolver.Domain, resolver.Addresses, resolver.Aliases, resolver.Id); err != nil {
+			return errors.Wrapf(err, "failed adding resolver")
+		}
+
+		// Bind the identity to itself
+		if err := r.backend.Bind(resolver.Id, resolver.Id); err != nil {
+			return errors.WithMessagef(err, "failed binding identity [%s] to itself", resolver.Name)
+		}
+
+		// Bind Aliases
+		for _, alias := range resolver.Aliases {
+			if logger.IsEnabledFor(zapcore.DebugLevel) {
+				logger.Debugf("binding [%s] to [%s]", resolver.Name, alias)
 			}
-			resolver.Id = raw
-			logger.Infof("resolver [%s,%s][%s] %s",
-				resolver.Name, resolver.Domain, resolver.Addresses,
-				view.Identity(resolver.Id).UniqueID(),
-			)
-
-			// Add entry
-			if _, err := r.backend.AddResolver(resolver.Name, resolver.Domain, resolver.Addresses, resolver.Aliases, resolver.Id); err != nil {
-				return errors.Wrapf(err, "failed adding resolver")
-			}
-
-			// Bind Aliases
-			for _, alias := range resolver.Aliases {
-				if logger.IsEnabledFor(zapcore.DebugLevel) {
-					logger.Debugf("binding [%s] to [%s]", resolver.Name, alias)
-				}
-				if err := r.backend.Bind(resolver.Id, []byte(alias)); err != nil {
-					return errors.WithMessagef(err, "failed binding identity [%s] to alias [%s]", resolver.Name, alias)
-				}
+			if err := r.backend.Bind(resolver.Id, []byte(alias)); err != nil {
+				return errors.WithMessagef(err, "failed binding identity [%s] to alias [%s]", resolver.Name, alias)
 			}
 		}
 	}


### PR DESCRIPTION
… the alias.

This PR attempts to solve two things:

1. The default resolver, which was registered with the node id and the grpc address, was causing unpredictable behaviour with the new websockets communication method (the default resolver is selected instead of the correct one - even though the grpc address is empty).
2. It was necessary to list the resolver id as 'alias' in the configuration, even though it's not really an alias if it's the same id. The code in this PR binds the node id to itself, so it's not necessary anymore to do that.

For the first one, I'm not sure if this code was still in use in some way. For the second, binding the id to itself looks a bit odd, and there might be cleaner solutions available that I'm not aware of. Would like to get some feedback before 'undrafting' it.