### PR TITLE
Cache fix

### DIFF
--- a/platform/common/core/generic/vault/txidstore/cache.go
+++ b/platform/common/core/generic/vault/txidstore/cache.go
@@ -1,0 +1,96 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package txidstore
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/core"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/core/generic/vault"
+)
+
+type Logger interface {
+	Debugf(template string, args ...interface{})
+	Infof(template string, args ...interface{})
+	Errorf(template string, args ...interface{})
+}
+
+type Entry[V vault.ValidationCode] struct {
+	ValidationCode    V
+	ValidationMessage string
+}
+
+type cache[V vault.ValidationCode] interface {
+	Get(key string) (*Entry[V], bool)
+	Add(key string, value *Entry[V])
+	Delete(key string)
+}
+
+type txidStore[V vault.ValidationCode] interface {
+	Get(txID core.TxID) (V, string, error)
+	Set(txID core.TxID, code V, message string) error
+	Iterator(pos interface{}) (vault.TxIDIterator[V], error)
+}
+
+type CachedStore[V vault.ValidationCode] struct {
+	backed txidStore[V]
+	cache  cache[V]
+	logger Logger
+}
+
+type NotCachedStore[V vault.ValidationCode] struct {
+	txidStore[V]
+}
+
+func (s *NotCachedStore[V]) Invalidate(string) {}
+
+func NewNoCache[V vault.ValidationCode](backed txidStore[V]) *NotCachedStore[V] {
+	return &NotCachedStore[V]{txidStore: backed}
+}
+
+func NewCache[V vault.ValidationCode](backed txidStore[V], cache cache[V], logger Logger) *CachedStore[V] {
+	return &CachedStore[V]{backed: backed, cache: cache, logger: logger}
+}
+
+func (s *CachedStore[V]) Invalidate(txID core.TxID) {
+	s.logger.Debugf("Invalidating cache entry for [%s]", txID)
+	s.cache.Delete(txID)
+	if _, _, err := s.forceGet(txID); err != nil {
+		s.logger.Errorf("failed getting new value from backed: %v", err)
+	}
+}
+
+func (s *CachedStore[V]) Get(txID core.TxID) (V, string, error) {
+	// first cache
+	if entry, ok := s.cache.Get(txID); ok && entry != nil { // Deleted entries return ok
+		s.logger.Debugf("Found value for [%s] in cache: %v", txID, entry.ValidationCode)
+		return entry.ValidationCode, entry.ValidationMessage, nil
+	}
+	// then backed
+	return s.forceGet(txID)
+}
+
+func (s *CachedStore[V]) forceGet(txID core.TxID) (V, string, error) {
+	vc, msg, err := s.backed.Get(txID)
+	s.logger.Debugf("Got value [%v] from backed: %v", vc, err)
+	if err != nil {
+		return vc, "", err
+	}
+	s.cache.Add(txID, &Entry[V]{ValidationCode: vc, ValidationMessage: msg})
+	return vc, msg, nil
+}
+
+func (s *CachedStore[V]) Set(txID string, code V, message string) error {
+	s.logger.Debugf("Set value [%v] for [%s] into backed and cache", code, txID)
+	if err := s.backed.Set(txID, code, message); err != nil {
+		return err
+	}
+	s.cache.Add(txID, &Entry[V]{ValidationCode: code, ValidationMessage: message})
+	return nil
+}
+
+func (s *CachedStore[V]) Iterator(pos interface{}) (vault.TxIDIterator[V], error) {
+	return s.backed.Iterator(pos)
+}

--- a/platform/fabric/core/generic/vault.go
+++ b/platform/fabric/core/generic/vault.go
@@ -76,8 +76,11 @@ func NewVault(configService driver.ConfigService, channel string) (*vault.Vault,
 
 	if txIDStoreCacheSize > 0 {
 		logger.Debugf("creating txID store second cache with size [%d]", txIDStoreCacheSize)
-		txidStore = txidstore.NewCache(txidStore, secondcache.NewTyped[*txidstore.Entry](txIDStoreCacheSize))
+		c := txidstore.NewCache(txidStore, secondcache.NewTyped[*txidstore.Entry](txIDStoreCacheSize), logger)
+		return vault.New(persistence, c), c, nil
+	} else {
+		logger.Debugf("txID store without cache selected")
+		c := txidstore.NewNoCache(txidStore)
+		return vault.New(persistence, c), c, nil
 	}
-
-	return vault.New(persistence, txidStore), txidStore, nil
 }

--- a/platform/orion/core/generic/vault.go
+++ b/platform/orion/core/generic/vault.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package generic
 
 import (
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/core/generic/vault/txidstore"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/orion/core/generic/config"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/orion/core/generic/vault"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/orion/driver"
@@ -42,7 +43,7 @@ func NewVault(config *config.Config, network Network, channel string) (*Vault, e
 	}
 
 	return &Vault{
-		Vault:           vault.New(persistence, txIDStore),
+		Vault:           vault.New(persistence, txidstore.NewNoCache[driver.ValidationCode](txIDStore)),
 		SimpleTXIDStore: txIDStore,
 		network:         network,
 	}, nil

--- a/platform/view/services/db/driver/driver.go
+++ b/platform/view/services/db/driver/driver.go
@@ -48,6 +48,8 @@ type SQLError = error
 var (
 	// UniqueKeyViolation happens when we try to insert a record with a conflicting unique key (e.g. replicas)
 	UniqueKeyViolation = errors.New("unique key violation")
+	// DeadlockDetected happens when two transactions are taking place at the same time and interact with the same rows
+	DeadlockDetected = errors.New("deadlock detected")
 )
 
 // SQLErrorWrapper transforms the different errors returned by various SQL implementations into an SQLError that is common


### PR DESCRIPTION
This PR addresses two issues detected by the integration tests of Token SDK:
* When two nodes try to set the state at the same time, one gets a duplicate error and doesn't update the vault. Then we don't fail, because we know that another process has updated it, but the txidstore cache remains with the same previous value. Now we invalidate the cache and fetch the new value.
* When multiple replicas are trying to commit the same TX and rewrite the same keys, we get a deadlock error from the DB. Now we retry every time we get a deadlock error until the operation is successful. This means that either the other writes have failed so we can write the new values, or the other writes were successful so we update the state (using the same values).