### PR TITLE
allow a second registration of the same fabric driver

### DIFF
--- a/platform/fabric/core/driver.go
+++ b/platform/fabric/core/driver.go
@@ -28,7 +28,7 @@ func Register(name string, driver driver.Driver) {
 		panic("Register driver is nil")
 	}
 	if _, dup := drivers[name]; dup {
-		panic("Register called twice for driver " + name)
+		logger.Warnf("programming error - register called twice for driver %s", name)
 	}
 	drivers[name] = driver
 }


### PR DESCRIPTION
In our project, we have  integration tests that create two FSC nodes in a single process. It's a nice and quick way to start them. Since the new dig dependency injection, our test panics because the Fabric SDK is registered twice. This PR fixes that by just warning instead of panicking. But is this the way to go?

(Also, I'd be interested to know whether the driver registration + dig might be doing the same thing in two different ways? Do we need both?)