### PR TITLE
Remove race conditions and simplify endpoint service constructor

### DIFF
--- a/platform/view/core/endpoint/endpoint.go
+++ b/platform/view/core/endpoint/endpoint.go
@@ -13,14 +13,13 @@ import (
 	"strings"
 	"sync"
 
-	"golang.org/x/exp/slices"
-
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/kvs"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
+	"golang.org/x/exp/slices"
 )
 
 var logger = flogging.MustGetLogger("view-sdk.endpoint")
@@ -237,12 +236,14 @@ func (r *Service) SetPublicKeyIDSynthesizer(publicKeyIDSynthesizer driver.Public
 }
 
 func (r *Service) pkiResolve(resolver *Resolver) []byte {
-	resolver.PKILock.Lock()
-	defer resolver.PKILock.Unlock()
+	resolver.PKILock.RLock()
 	if len(resolver.PKI) != 0 {
 		return resolver.PKI
 	}
+	resolver.PKILock.RUnlock()
 
+	resolver.PKILock.Lock()
+	defer resolver.PKILock.Unlock()
 	resolver.PKI = r.ExtractPKI(resolver.Id)
 	return resolver.PKI
 }

--- a/platform/view/core/endpoint/endpoint.go
+++ b/platform/view/core/endpoint/endpoint.go
@@ -238,13 +238,16 @@ func (r *Service) SetPublicKeyIDSynthesizer(publicKeyIDSynthesizer driver.Public
 func (r *Service) pkiResolve(resolver *Resolver) []byte {
 	resolver.PKILock.RLock()
 	if len(resolver.PKI) != 0 {
+		resolver.PKILock.RUnlock()
 		return resolver.PKI
 	}
 	resolver.PKILock.RUnlock()
 
 	resolver.PKILock.Lock()
 	defer resolver.PKILock.Unlock()
-	resolver.PKI = r.ExtractPKI(resolver.Id)
+	if len(resolver.PKI) == 0 {
+		resolver.PKI = r.ExtractPKI(resolver.Id)
+	}
 	return resolver.PKI
 }
 

--- a/platform/view/core/endpoint/endpoint.go
+++ b/platform/view/core/endpoint/endpoint.go
@@ -15,7 +15,6 @@ import (
 
 	"golang.org/x/exp/slices"
 
-	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/kvs"
@@ -64,10 +63,8 @@ type KVS interface {
 }
 
 type Service struct {
-	sp             view2.ServiceProvider
 	resolvers      []*Resolver
 	resolversMutex sync.RWMutex
-	discovery      Discovery
 	kvs            KVS
 
 	pkiExtractorsLock      sync.RWMutex
@@ -76,10 +73,8 @@ type Service struct {
 }
 
 // NewService returns a new instance of the view-sdk endpoint service
-func NewService(sp view2.ServiceProvider, discovery Discovery, kvs KVS) (*Service, error) {
+func NewService(kvs KVS) (*Service, error) {
 	er := &Service{
-		sp:                     sp,
-		discovery:              discovery,
 		kvs:                    kvs,
 		publicKeyExtractors:    []driver.PublicKeyExtractor{},
 		publicKeyIDSynthesizer: DefaultPublicKeyIDSynthesizer{},

--- a/platform/view/core/endpoint/endpoint_test.go
+++ b/platform/view/core/endpoint/endpoint_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package endpoint
 
 import (

--- a/platform/view/core/endpoint/endpoint_test.go
+++ b/platform/view/core/endpoint/endpoint_test.go
@@ -43,8 +43,8 @@ func TestPKIResolveConcurrency(t *testing.T) {
 	assert.NoError(err)
 
 	var wg sync.WaitGroup
-	wg.Add(10)
-	for i := 0; i < 10; i++ {
+	wg.Add(100)
+	for i := 0; i < 100; i++ {
 		go func() {
 			defer wg.Done()
 			svc.pkiResolve(resolver)

--- a/platform/view/core/endpoint/endpoint_test.go
+++ b/platform/view/core/endpoint/endpoint_test.go
@@ -1,0 +1,68 @@
+package endpoint
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
+
+type mockKVS struct{}
+
+func (k mockKVS) Exists(id string) bool {
+	return true
+}
+func (k mockKVS) Put(id string, state interface{}) error {
+	return nil
+}
+func (k mockKVS) Get(id string, state interface{}) error {
+	return nil
+}
+
+type mockExtractor struct{}
+
+func (m mockExtractor) ExtractPublicKey(id view.Identity) (any, error) {
+	return []byte("id"), nil
+}
+
+func TestPKIResolveConcurrency(t *testing.T) {
+	svc, err := NewService(nil, nil, mockKVS{})
+	assert.NoError(err)
+
+	ext := mockExtractor{}
+	resolver := &Resolver{}
+
+	err = svc.AddPublicKeyExtractor(ext)
+	assert.NoError(err)
+
+	var wg sync.WaitGroup
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			defer wg.Done()
+			svc.pkiResolve(resolver)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestGetIdentity(t *testing.T) {
+	svc, err := NewService(nil, nil, mockKVS{})
+	assert.NoError(err)
+
+	ext := mockExtractor{}
+	_, err = svc.AddResolver("getbyname", "", map[string]string{}, []string{}, []byte("id"))
+	assert.NoError(err)
+
+	err = svc.AddPublicKeyExtractor(ext)
+	assert.NoError(err)
+
+	resultID, err := svc.GetIdentity("getbyname", []byte{})
+	assert.NoError(err)
+	assert.Equal([]byte("id"), []byte(resultID))
+
+	resultID, err = svc.GetIdentity("notfound", []byte("no"))
+	assert.Error(err, "identity not found")
+	assert.Equal([]byte(nil), []byte(resultID))
+}

--- a/platform/view/core/endpoint/endpoint_test.go
+++ b/platform/view/core/endpoint/endpoint_test.go
@@ -27,7 +27,7 @@ func (m mockExtractor) ExtractPublicKey(id view.Identity) (any, error) {
 }
 
 func TestPKIResolveConcurrency(t *testing.T) {
-	svc, err := NewService(nil, nil, mockKVS{})
+	svc, err := NewService(mockKVS{})
 	assert.NoError(err)
 
 	ext := mockExtractor{}
@@ -48,7 +48,7 @@ func TestPKIResolveConcurrency(t *testing.T) {
 }
 
 func TestGetIdentity(t *testing.T) {
-	svc, err := NewService(nil, nil, mockKVS{})
+	svc, err := NewService(mockKVS{})
 	assert.NoError(err)
 
 	ext := mockExtractor{}

--- a/platform/view/sdk/dig/sdk.go
+++ b/platform/view/sdk/dig/sdk.go
@@ -105,7 +105,7 @@ func (p *SDK) Install() error {
 		p.C.Provide(sig.NewSignService, dig.As(new(id.SigService), new(driver.SigService), new(driver.SigRegistry), new(driver.AuditRegistry))),
 		p.C.Provide(view.NewSigService, dig.As(new(view3.VerifierProvider), new(view3.SignerProvider))),
 		p.C.Provide(digutils.Identity[*kvs.KVS](), dig.As(new(sig.KVS))),
-		p.C.Provide(func(defaultKVS *kvs.KVS) (*endpoint.Service, error) { return endpoint.NewService(nil, nil, defaultKVS) }),
+		p.C.Provide(func(defaultKVS *kvs.KVS) (*endpoint.Service, error) { return endpoint.NewService(defaultKVS) }),
 		p.C.Provide(digutils.Identity[*endpoint.Service](), dig.As(new(driver.EndpointService))),
 		p.C.Provide(view.NewEndpointService),
 		p.C.Provide(digutils.Identity[*view.EndpointService](), dig.As(new(comm.EndpointService), new(id.EndpointService), new(endpoint.Backend))),


### PR DESCRIPTION
This PR removes a few race conditions and simplifies the constructor for the endpoint service.