### PR TITLE
hide pkcs11 behind a build tag so that fsc is pure go by default

### DIFF
--- a/docs/core-fabric.md
+++ b/docs/core-fabric.md
@@ -245,7 +245,8 @@ fabric:
               Hash: SHA2
               Security: 256
             # Definition of PKCS11 configuration parameters when using a Hardware HSM
-            # Only needs to be defined if the BCCSP Default is set to PKCS11
+            # Only needs to be defined if the BCCSP Default is set to PKCS11.
+            # NOTE: in order to use pkcs11, you have to build the application with "go build -tags pkcs11"
             PKCS11:
               # PKCS11 library
               Library: /path/to/pkcs11_library.so
@@ -391,6 +392,11 @@ fabric:
           path: /path/to/fscnodeB/msp
           addresses:
 ```
+
+## HSM Support
+
+In order to use a hardware HSM for x.509 identities, you have to build the application with
+`CGO_ENABLED=1 go build -tags pkcs11` and configure the PKCS11 settings as describe above.
 
 ## Persistence: sql
 

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -76,7 +76,7 @@ func New(startPort int, path string, topologies ...api.Topology) (*Infrastructur
 		}
 	}
 
-	buildServer := common.NewBuildServer()
+	buildServer := common.NewBuildServer("-tags", "pkcs11")
 	buildServer.Serve()
 	builder := buildServer.Client()
 

--- a/platform/fabric/core/generic/msp/x509/config.go
+++ b/platform/fabric/core/generic/msp/x509/config.go
@@ -1,0 +1,32 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package x509
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/x509/pkcs11"
+)
+
+func ToPKCS11OptsOpts(o *config.PKCS11) *pkcs11.PKCS11Opts {
+	res := &pkcs11.PKCS11Opts{
+		Security:       o.Security,
+		Hash:           o.Hash,
+		Library:        o.Library,
+		Label:          o.Label,
+		Pin:            o.Pin,
+		SoftwareVerify: o.SoftwareVerify,
+		Immutable:      o.Immutable,
+		AltID:          o.AltID,
+	}
+	for _, d := range o.KeyIDs {
+		res.KeyIDs = append(res.KeyIDs, pkcs11.KeyIDMapping{
+			SKI: d.SKI,
+			ID:  d.ID,
+		})
+	}
+	return res
+}

--- a/platform/fabric/core/generic/msp/x509/pkcs11/disabled.go
+++ b/platform/fabric/core/generic/msp/x509/pkcs11/disabled.go
@@ -1,0 +1,41 @@
+//go:build !pkcs11
+
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pkcs11
+
+import (
+	"github.com/hyperledger/fabric/bccsp"
+)
+
+type KeyIDMapping struct {
+	SKI string `yaml:"SKI,omitempty"`
+	ID  string `yaml:"ID,omitempty"`
+}
+
+type PKCS11Opts struct {
+	// Default algorithms when not specified (Deprecated?)
+	Security int    `yaml:"Security"`
+	Hash     string `yaml:"Hash"`
+
+	// PKCS11 options
+	Library        string         `yaml:"Library"`
+	Label          string         `yaml:"Label"`
+	Pin            string         `yaml:"Pin"`
+	SoftwareVerify bool           `yaml:"SoftwareVerify,omitempty"`
+	Immutable      bool           `yaml:"Immutable,omitempty"`
+	AltID          string         `yaml:"AltId,omitempty"`
+	KeyIDs         []KeyIDMapping `yaml:"KeyIds,omitempty" mapstructure:"KeyIds"`
+}
+
+func NewProvider(opts any, ks bccsp.KeyStore, mapper func(ski []byte) []byte) (bccsp.BCCSP, error) {
+	panic("pkcs11 not included in build. Use: go build -tags pkcs11")
+}
+
+func ToPKCS11OptsOpts(o any) *PKCS11Opts {
+	panic("pkcs11 not included in build. Use: go build -tags pkcs11")
+}

--- a/platform/fabric/core/generic/msp/x509/pkcs11/pkcs11.go
+++ b/platform/fabric/core/generic/msp/x509/pkcs11/pkcs11.go
@@ -1,0 +1,49 @@
+//go:build pkcs11
+
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pkcs11
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
+	"github.com/hyperledger/fabric/bccsp"
+	"github.com/hyperledger/fabric/bccsp/pkcs11"
+	"github.com/pkg/errors"
+)
+
+type (
+	PKCS11Opts   = pkcs11.PKCS11Opts
+	KeyIDMapping = pkcs11.KeyIDMapping
+)
+
+func NewProvider(opts pkcs11.PKCS11Opts, ks bccsp.KeyStore, mapper func(ski []byte) []byte) (*pkcs11.Provider, error) {
+	csp, err := pkcs11.New(opts, ks, pkcs11.WithKeyMapper(mapper))
+	if err != nil {
+		return nil, errors.WithMessagef(err, "Failed initializing PKCS11 library with config [%+v]", opts)
+	}
+	return csp, nil
+}
+
+func ToPKCS11OptsOpts(o *config.PKCS11) *pkcs11.PKCS11Opts {
+	res := &pkcs11.PKCS11Opts{
+		Security:       o.Security,
+		Hash:           o.Hash,
+		Library:        o.Library,
+		Label:          o.Label,
+		Pin:            o.Pin,
+		SoftwareVerify: o.SoftwareVerify,
+		Immutable:      o.Immutable,
+		AltID:          o.AltID,
+	}
+	for _, d := range o.KeyIDs {
+		res.KeyIDs = append(res.KeyIDs, pkcs11.KeyIDMapping{
+			SKI: d.SKI,
+			ID:  d.ID,
+		})
+	}
+	return res
+}


### PR DESCRIPTION
The `github.com/hyperledger/fabric/bccsp/pkcs11` dependency is the only reason we need CGO_ENABLED=1 when building an application that imports FSC. It makes things like cross-architecture builds unnecessarily difficult.

This PR makes it so that if you want to use pkcs11, you have to build the binary with `go build -tags pkcs11`. It includes a default implementation that panics if the user configures HSM in a binary that's not built with `pkcs11` as a build tag.