### PR TITLE
add closing state to prevent send on closed channel panic

### DIFF
--- a/integration/fabric/events/chaincode/client.go
+++ b/integration/fabric/events/chaincode/client.go
@@ -35,6 +35,15 @@ func (c *Client) EventsView(chaincodeFunction string, eventName string) (interfa
 	return event, err
 }
 
+func (c *Client) MultipleListenersView(chaincodeFunction string, eventName string, listenerCount uint8) (interface{}, error) {
+	event, err := c.c.CallView("MultipleListenersView", common.JSONMarshall(&views.MultipleListeners{
+		Function:      chaincodeFunction,
+		EventName:     eventName,
+		ListenerCount: listenerCount,
+	}))
+	return event, err
+}
+
 func (c *Client) MultipleEventsView(chaincodeFunctions []string, eventCount uint8) (interface{}, error) {
 	event, err := c.c.CallView("MultipleEventsView", common.JSONMarshall(&views.MultipleEvents{
 		Functions:  chaincodeFunctions,

--- a/integration/fabric/events/chaincode/topology.go
+++ b/integration/fabric/events/chaincode/topology.go
@@ -46,7 +46,8 @@ func Topology(sdk api2.SDK, commType fsc.P2PCommunicationType, replicationOpts *
 		AddOptions(replicationOpts.For("alice")...).
 		// Register the factories of the initiator views for each business process
 		RegisterViewFactory("EventsView", &views.EventsViewFactory{}).
-		RegisterViewFactory("MultipleEventsView", &views.MultipleEventsViewFactory{})
+		RegisterViewFactory("MultipleEventsView", &views.MultipleEventsViewFactory{}).
+		RegisterViewFactory("MultipleListenersView", &views.MultipleListenersViewFactory{})
 
 	// Define Bob's FSC node
 	fscTopology.AddNodeByName("bob").

--- a/integration/fabric/events/chaincode/views/multipleEvents.go
+++ b/integration/fabric/events/chaincode/views/multipleEvents.go
@@ -51,18 +51,12 @@ func (c *MultipleEventsView) Call(context view.Context) (interface{}, error) {
 	assert.NoError(err, "failed to listen to events")
 
 	for _, function := range c.Functions {
-
 		// Invoke the chaincode
-		_, err = context.RunView(
-			chaincode.NewInvokeView(
-				"events",
-				function,
-			),
-		)
-		assert.NoError(err, "Failed Running Invoke View ")
+		_, err = context.RunView(chaincode.NewInvokeView("events", function))
+		assert.NoError(err, "Failed Running Invoke View")
 	}
 
-	// wait for the event to arriver
+	// wait for the event to arrive
 	wg.Wait()
 
 	return &MultipleEventsReceived{

--- a/integration/fabric/events/chaincode/views/multipleListeners.go
+++ b/integration/fabric/events/chaincode/views/multipleListeners.go
@@ -1,0 +1,129 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package views
+
+import (
+	context2 "context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/chaincode"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
+
+type MultipleListenersView struct {
+	*MultipleListeners
+}
+
+type MultipleListeners struct {
+	Function      string
+	EventName     string
+	ListenerCount uint8
+}
+
+type MultipleListenersReceived struct {
+	Events []*chaincode.Event
+}
+
+func (c *MultipleListenersView) Call(context view.Context) (interface{}, error) {
+	wg := sync.WaitGroup{}
+	wg.Add(int(c.ListenerCount))
+
+	mtx := sync.Mutex{}
+	eventReceived := make([]*chaincode.Event, c.ListenerCount)
+	cancels := make([]context2.CancelFunc, c.ListenerCount)
+
+	rec := uint8(0)
+
+	for i := 0; i < int(c.ListenerCount); i++ {
+		go func(i int) {
+			callBack := func(event *chaincode.Event) (bool, error) {
+				// simulate processing, to test concurrency issues
+				time.Sleep(500 * time.Millisecond)
+				if event.Err != nil && strings.Contains(event.Err.Error(), "context done") {
+					logger.Infof(">>>> close %d", i)
+					return false, nil
+				}
+
+				logger.Debugf("Chaincode Event Received in callback %s", event.EventName)
+				mtx.Lock()
+				eventReceived[i] = event
+				// don't call done too often
+				if rec < c.ListenerCount {
+					wg.Done()
+				}
+				rec++
+				mtx.Unlock()
+
+				return false, nil
+			}
+
+			ctx, cancelFunc := context2.WithCancel(context.Context())
+			cancels[i] = cancelFunc
+			_, err := context.RunView(chaincode.NewListenToEventsViewWithContext(ctx, "events", callBack))
+			assert.NoError(err, "failed to listen to events")
+		}(i)
+	}
+
+	// Invoke the chaincode to trigger all the listeners once
+	_, err := context.RunView(chaincode.NewInvokeView("events", c.Function))
+	assert.NoError(err, "Failed Running Invoke View")
+	wg.Wait()
+
+	invokes := 50
+	continueAfter := 20
+
+	// create a steady load of 10 transactions per second
+	wg.Add(continueAfter)
+	for i := 0; i < invokes; i++ {
+		go func(j int) {
+			time.Sleep(100 * time.Millisecond)
+			_, err := context.RunView(
+				chaincode.NewInvokeView(
+					"events",
+					c.Function,
+				),
+			)
+			assert.NoError(err, "Failed Running Invoke View")
+			if j < continueAfter {
+				wg.Done()
+			}
+		}(i)
+	}
+
+	// wait for the first events to arrive
+	wg.Wait()
+
+	// cancel subscriptions while new transactions are still coming in
+	wg.Add(int(c.ListenerCount))
+	for _, cancel := range cancels {
+		go func(cn context2.CancelFunc) {
+			cn()
+			wg.Done()
+		}(cancel)
+	}
+	_, err = context.RunView(chaincode.NewInvokeView("events", c.Function))
+	assert.NoError(err, "Failed Running Invoke View")
+
+	wg.Wait()
+
+	return &MultipleEventsReceived{
+		Events: eventReceived,
+	}, nil
+}
+
+type MultipleListenersViewFactory struct{}
+
+func (c *MultipleListenersViewFactory) NewView(in []byte) (view.View, error) {
+	f := &MultipleListenersView{MultipleListeners: &MultipleListeners{}}
+	err := json.Unmarshal(in, f)
+	assert.NoError(err, "failed unmarshalling input")
+	return f, nil
+}

--- a/platform/fabric/events_test.go
+++ b/platform/fabric/events_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fabric
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/committer"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/events"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockSubscriber struct {
+	listener events.Listener
+	sync.RWMutex
+}
+
+func (m *mockSubscriber) Subscribe(chaincodeName string, listener events.Listener) {
+	m.listener = listener
+}
+
+func (m *mockSubscriber) Unsubscribe(chaincodeName string, listener events.Listener) {
+	m.listener = nil
+}
+
+func (m *mockSubscriber) Publish(chaincodeName string, event *committer.ChaincodeEvent) {
+	if m.listener != nil {
+		m.listener.OnReceive(event)
+	}
+}
+
+func TestEventListener(t *testing.T) {
+	subscriber := &mockSubscriber{}
+	listener := newEventListener(subscriber, "testChaincode")
+	eventChannel := listener.ChaincodeEvents()
+
+	var wg sync.WaitGroup
+
+	// Publish events
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			subscriber.Publish("testChaincode", &committer.ChaincodeEvent{Payload: []byte(fmt.Sprintf("event %d", i))})
+			time.Sleep(1 * time.Millisecond)
+		}
+	}()
+
+	wg.Add(1)
+	// Stop while the publisher is still publishing
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	go func() {
+		defer wg.Done()
+		stop := false
+		for {
+			select {
+			case event := <-eventChannel:
+				assert.NotNil(t, event)
+			case <-ctx.Done():
+				stop = true
+			}
+			if stop {
+				listener.CloseChaincodeEvents()
+				break
+			}
+		}
+	}()
+	wg.Wait()
+
+	// Ensure the channel is closed
+	select {
+	case _, ok := <-eventChannel:
+		if ok {
+			t.Fatal("expected channel to be closed")
+		}
+	default:
+		t.Fatal("expected to read from closed channel")
+	}
+}

--- a/platform/fabric/services/chaincode/events.go
+++ b/platform/fabric/services/chaincode/events.go
@@ -86,17 +86,10 @@ func (r *ListenToEventsView) RegisterChaincodeEvents(viewContext view.Context) e
 		return errors.Wrapf(err, "failed to get chaincode [%s:%s:%s]", r.Network, r.Channel, r.ChaincodeName)
 	}
 	logger.Debugf("getting chaincode events stream for [%s:%s:%s]", r.Network, r.Channel, r.ChaincodeName)
-	events, err := chaincode.EventListener.ChaincodeEvents()
-	if err != nil {
-		return errors.Wrapf(err, "failed to get chaincode event channel [%s:%s:%s]", r.Network, r.Channel, r.ChaincodeName)
-	}
+	events := chaincode.EventListener.ChaincodeEvents()
 
 	go func() {
-		defer func() {
-			if err := chaincode.EventListener.CloseChaincodeEvents(); err != nil {
-				logger.Errorf("Failed to close event channel [%s:%s:%s]: [%s]", r.Network, r.Channel, r.ChaincodeName, err)
-			}
-		}()
+		defer chaincode.EventListener.CloseChaincodeEvents()
 
 		ctx := r.Context
 		if ctx == nil {


### PR DESCRIPTION
With multiple subscribers and events, we encountered a race condition where the OnReceive would still try to send when CloseChaincodeEvents had already closed the channel (which causes a panic). This PR adds a unit- and integration test to reproduce it, and a `closing` boolean behind a mutex to prevent it.