### PR TITLE
add functions to initiate a view context from an existing go context

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -39,6 +39,7 @@ type ViewManager interface {
 	InitiateView(view view.View, ctx context.Context) (interface{}, error)
 	InitiateContext(view view.View) (view.Context, error)
 	InitiateContextWithIdentity(view view.View, id view.Identity) (view.Context, error)
+	InitiateContextFrom(ctx context.Context, view view.View, id view.Identity, contextID string) (view.Context, error)
 	Context(contextID string) (view.Context, error)
 }
 
@@ -265,6 +266,17 @@ func (n *node) InitiateContext(view view.View) (view.Context, error) {
 	manager := s.(ViewManager)
 
 	return manager.InitiateContext(view)
+}
+
+// InitiateContextFrom creates a new view context, derived from the passed context.Context
+func (n *node) InitiateContextFrom(ctx context.Context, view view.View) (view.Context, error) {
+	s, err := n.GetService(reflect.TypeOf((*ViewManager)(nil)))
+	if err != nil {
+		return nil, err
+	}
+	manager := s.(ViewManager)
+
+	return manager.InitiateContextFrom(ctx, view, nil, "")
 }
 
 func (n *node) InitiateContextWithIdentity(view view.View, id view.Identity) (view.Context, error) {

--- a/platform/view/core/manager/manager.go
+++ b/platform/view/core/manager/manager.go
@@ -242,18 +242,35 @@ func (cm *manager) InitiateViewWithIdentity(view view.View, id view.Identity, c 
 }
 
 func (cm *manager) InitiateContext(view view.View) (view.Context, error) {
-	return cm.InitiateContextWithIdentity(view, cm.me())
-}
-
-func (cm *manager) InitiateContextWithIdentity(view view.View, id view.Identity) (view.Context, error) {
-	return cm.InitiateContextWithIdentityAndID(view, id, "")
-}
-
-func (cm *manager) InitiateContextWithIdentityAndID(view view.View, id view.Identity, contextID string) (view.Context, error) {
-	// Create the context
 	cm.contextsSync.Lock()
 	ctx := cm.ctx
 	cm.contextsSync.Unlock()
+
+	return cm.InitiateContextFrom(ctx, view, cm.me(), "")
+}
+
+func (cm *manager) InitiateContextWithIdentity(view view.View, id view.Identity) (view.Context, error) {
+	cm.contextsSync.Lock()
+	ctx := cm.ctx
+	cm.contextsSync.Unlock()
+
+	return cm.InitiateContextFrom(ctx, view, id, "")
+}
+
+func (cm *manager) InitiateContextWithIdentityAndID(view view.View, id view.Identity, contextID string) (view.Context, error) {
+	cm.contextsSync.Lock()
+	ctx := cm.ctx
+	cm.contextsSync.Unlock()
+
+	return cm.InitiateContextFrom(ctx, view, id, contextID)
+}
+
+func (cm *manager) InitiateContextFrom(ctx context.Context, view view.View, id view.Identity, contextID string) (view.Context, error) {
+	if ctx == nil {
+		cm.contextsSync.Lock()
+		ctx = cm.ctx
+		cm.contextsSync.Unlock()
+	}
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/platform/view/driver/flowmanager.go
+++ b/platform/view/driver/flowmanager.go
@@ -25,6 +25,8 @@ type ViewManager interface {
 	InitiateContext(view view.View) (view.Context, error)
 	// InitiateContextWithIdentityAndID initiates a new context
 	InitiateContextWithIdentityAndID(view view.View, id view.Identity, contextID string) (view.Context, error)
+	// InitiateContextFrom initiates a new context for the passed view, derived from the passed context
+	InitiateContextFrom(ctx context.Context, view view.View, id view.Identity, contextID string) (view.Context, error)
 }
 
 // GetViewManager returns an instance of the view manager.

--- a/platform/view/manager.go
+++ b/platform/view/manager.go
@@ -61,6 +61,15 @@ func (m *Manager) InitiateContextWithIdentityAndID(view View, id view.Identity, 
 	return context, nil
 }
 
+// InitiateContextFrom initiates a new context for the passed view, derived from the passed context
+func (m *Manager) InitiateContextFrom(ctx context.Context, view View, id view.Identity, contextID string) (*Context, error) {
+	context, err := m.m.InitiateContextFrom(ctx, view, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	return &Context{Context: context}, nil
+}
+
 // GetManager returns an instance of the view manager.
 // It panics, if no instance is found.
 func GetManager(sp ServiceProvider) *Manager {


### PR DESCRIPTION
for people who don't InitiateView directly but create the view.Context first, this PR creates the opportunity to pass a go context. This is useful for tracing a request through the process.