### PR TITLE
Lock func

### DIFF
--- a/platform/common/utils/hash.go
+++ b/platform/common/utils/hash.go
@@ -1,0 +1,52 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package utils
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+
+	"github.com/pkg/errors"
+)
+
+func HashUInt64(raw []byte) (uint64, error) {
+	digest, err := SHA256(raw)
+	if err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint64(digest[:8]), nil
+}
+
+func HashInt64(raw []byte) (int64, error) {
+	digest, err := HashUInt64(raw)
+	if err != nil {
+		return 0, err
+	}
+	return int64(digest >> 1), nil
+}
+
+func HashUInt32(raw []byte) (uint32, error) {
+	digest, err := SHA256(raw)
+	if err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint32(digest[:4]), nil
+}
+
+func SHA256(raw []byte) ([]byte, error) {
+	hash := sha256.New()
+	n, err := hash.Write(raw)
+	if n != len(raw) {
+		return nil, errors.Errorf("hash failure")
+	}
+	if err != nil {
+		return nil, err
+	}
+	digest := hash.Sum(nil)
+
+	return digest, nil
+}

--- a/platform/common/utils/hash_test.go
+++ b/platform/common/utils/hash_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHashUInt64(t *testing.T) {
+	digest, err := HashUInt64([]byte("any_string?!"))
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(12901064304492776662), digest)
+}
+
+func TestHashInt64(t *testing.T) {
+	digest, err := HashInt64([]byte("any_string?!"))
+	assert.NoError(t, err)
+	assert.Equal(t, int64(6450532152246388331), digest)
+}
+
+func TestHashUInt32(t *testing.T) {
+	digest, err := HashUInt32([]byte("any_string?!"))
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(3003763105), digest)
+}

--- a/platform/common/utils/nulls.go
+++ b/platform/common/utils/nulls.go
@@ -11,6 +11,13 @@ func Zero[A any]() A {
 	return a
 }
 
+func MustGet[V any](v V, err error) V {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
 func Must(err error) {
 	if err != nil {
 		panic(err)

--- a/platform/fabric/core/generic/msp/x509/ecdsa.go
+++ b/platform/fabric/core/generic/msp/x509/ecdsa.go
@@ -18,6 +18,7 @@ import (
 	"math/big"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	utils2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger/fabric-protos-go/msp"
@@ -73,15 +74,10 @@ func (d *edsaVerifier) Verify(message, sigma []byte) error {
 		return err
 	}
 
-	hash := sha256.New()
-	n, err := hash.Write(message)
-	if n != len(message) {
-		return errors.Errorf("hash failure")
-	}
+	digest, err := utils2.SHA256(message)
 	if err != nil {
 		return err
 	}
-	digest := hash.Sum(nil)
 
 	lowS, err := IsLowS(d.pk, signature.S)
 	if err != nil {

--- a/platform/view/core/id/x509/ecdsa.go
+++ b/platform/view/core/id/x509/ecdsa.go
@@ -9,12 +9,12 @@ package x509
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	"crypto/sha256"
 	"crypto/x509"
 	"encoding/asn1"
 	"encoding/pem"
 	"math/big"
 
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
 	"github.com/pkg/errors"
 )
 
@@ -50,15 +50,10 @@ func (d *EdsaVerifier) Verify(message, sigma []byte) error {
 		return err
 	}
 
-	hash := sha256.New()
-	n, err := hash.Write(message)
-	if n != len(message) {
-		return errors.Errorf("hash failure")
-	}
+	digest, err := utils.SHA256(message)
 	if err != nil {
 		return err
 	}
-	digest := hash.Sum(nil)
 
 	lowS, err := IsLowS(d.pk, signature.S)
 	if err != nil {

--- a/platform/view/services/hash/hash.go
+++ b/platform/view/services/hash/hash.go
@@ -7,35 +7,13 @@ SPDX-License-Identifier: Apache-2.0
 package hash
 
 import (
-	"crypto/sha256"
-
-	"github.com/pkg/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
 )
 
 func SHA256(raw []byte) ([]byte, error) {
-	hash := sha256.New()
-	n, err := hash.Write(raw)
-	if n != len(raw) {
-		return nil, errors.Errorf("hash failure")
-	}
-	if err != nil {
-		return nil, err
-	}
-	digest := hash.Sum(nil)
-
-	return digest, nil
+	return utils.SHA256(raw)
 }
 
 func SHA256OrPanic(raw []byte) []byte {
-	hash := sha256.New()
-	n, err := hash.Write(raw)
-	if n != len(raw) {
-		panic("hash failure")
-	}
-	if err != nil {
-		panic(err)
-	}
-	digest := hash.Sum(nil)
-
-	return digest
+	return utils.MustGet(utils.SHA256(raw))
 }

--- a/platform/view/services/hash/hashable.go
+++ b/platform/view/services/hash/hashable.go
@@ -7,8 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package hash
 
 import (
-	"crypto/sha256"
 	"encoding/base64"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
 )
 
 type Hashable []byte
@@ -17,15 +18,7 @@ func (id Hashable) Raw() []byte {
 	if len(id) == 0 {
 		return nil
 	}
-	hash := sha256.New()
-	n, err := hash.Write(id)
-	if n != len(id) {
-		panic("hash failure")
-	}
-	if err != nil {
-		panic(err)
-	}
-	return hash.Sum(nil)
+	return utils.MustGet(utils.SHA256(id))
 }
 
 func (id Hashable) String() string { return base64.StdEncoding.EncodeToString(id.Raw()) }

--- a/platform/view/view/identity.go
+++ b/platform/view/view/identity.go
@@ -8,8 +8,9 @@ package view
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"encoding/base64"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
 )
 
 // Identity wraps the byte representation of a lower level identity.
@@ -25,16 +26,7 @@ func (id Identity) UniqueID() string {
 	if len(id) == 0 {
 		return "<empty>"
 	}
-	hash := sha256.New()
-	n, err := hash.Write(id)
-	if n != len(id) {
-		panic("hash failure")
-	}
-	if err != nil {
-		panic(err)
-	}
-	digest := hash.Sum(nil)
-	return base64.StdEncoding.EncodeToString(digest)
+	return base64.StdEncoding.EncodeToString(utils.MustGet(utils.SHA256(id)))
 }
 
 // Hash returns the hash of this identity
@@ -42,16 +34,7 @@ func (id Identity) Hash() string {
 	if len(id) == 0 {
 		return "<empty>"
 	}
-	hash := sha256.New()
-	n, err := hash.Write(id)
-	if n != len(id) {
-		panic("hash failure")
-	}
-	if err != nil {
-		panic(err)
-	}
-	digest := hash.Sum(nil)
-	return string(digest)
+	return string(utils.MustGet(utils.SHA256(id)))
 }
 
 // String returns a string representation of this identity


### PR DESCRIPTION
When CREATE OR REPLACE FUNCTION is called from two different threads (replicas), we get the following error

```
pq: tuple concurrently updated
```

Now we use a lock to coordinate the creation of the function and the trigger.