### PR TITLE
remove the txid from the committer list after the listeners have been called

### DIFF
--- a/platform/common/core/generic/committer/finality.go
+++ b/platform/common/core/generic/committer/finality.go
@@ -128,8 +128,9 @@ func (c *FinalityManager[V]) runStatusListener(ctx context.Context) {
 			}
 
 			newCtx, span := c.tracer.Start(context.Background(), "vault_status_check")
-			c.logger.Debugf("check vault status for [%d] transactions", len(txIDs))
-			if len(txIDs) > 500 {
+			if len(txIDs) < 500 {
+				c.logger.Debugf("check vault status for [%d] transactions", len(txIDs))
+			} else {
 				c.logger.Warnf("check vault status for %d transactions", len(txIDs))
 			}
 			statuses, err := c.vault.Statuses(txIDs...)

--- a/platform/common/core/generic/committer/finality_test.go
+++ b/platform/common/core/generic/committer/finality_test.go
@@ -115,6 +115,7 @@ func TestFinalityManager_RunStatusListener(t *testing.T) {
 	go manager.runEventQueue(ctx)
 	manager.runStatusListener(ctx)
 	listener.AssertExpectations(t)
+	assert.Equal(t, manager.txIDs.Length(), 0)
 
 	// Error case: Vault returns an error
 	vault.On("Statuses", []string{"txID"}).Return(nil, errors.New("some error"))
@@ -127,6 +128,7 @@ func TestFinalityManager_RunStatusListener(t *testing.T) {
 	defer cancel()
 	manager.runStatusListener(ctx)
 	listener.AssertNotCalled(t, "OnStatus", event.TxID, event.ValidationCode, event.ValidationMessage)
+	assert.Equal(t, manager.txIDs.Length(), 1)
 
 	vault.AssertExpectations(t)
 }

--- a/platform/fabric/core/generic/committer/committer.go
+++ b/platform/fabric/core/generic/committer/committer.go
@@ -9,7 +9,6 @@ package committer
 import (
 	"context"
 	"fmt"
-	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -171,6 +170,7 @@ func (c *Committer) runEventNotifiers(context context.Context) {
 	for {
 		select {
 		case <-context.Done():
+			c.logger.Debugf("context done: closing event notifiers")
 			return
 		case event := <-c.events:
 			c.metrics.EventQueueLength.Add(-1)
@@ -458,7 +458,7 @@ func (c *Committer) IsFinal(ctx context.Context, txID string) error {
 				time.Sleep(c.ChannelConfig.CommitterFinalityUnknownTXTimeout())
 			}
 
-			c.logger.Debugf("Tx [%s] is unknown with no deps, remote check [%d][%s]", txID, iter, debug.Stack())
+			c.logger.Debugf("Tx [%s] is unknown with no deps, remote check [%d]", txID, iter)
 			peerForFinality := c.ConfigService.PickPeer(driver.PeerForFinality).Address
 			err := c.FabricFinality.IsFinal(txID, peerForFinality)
 			if err == nil {


### PR DESCRIPTION
Otherwise the list keeps growing, which causes SQL failures after 1000 transactions and possibly other issues as well.