### PR TITLE
Add GH Action to block merging fixup commits

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,12 @@
+name: Git Checks
+
+on: [pull_request]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Block Fixup Commit Merge
+        uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
Fixup commits are great!!! In particular for development and PR review, however, it may happen that the fixup commits are not squashed before a PR is merged that results in a "bad" git history on the main branch.

Bad example:
<img width="1202" alt="Screenshot 2024-09-20 at 12 01 08" src="https://github.com/user-attachments/assets/0df62a9c-3132-4c76-9d41-48b0a87178dc">


This PR adds a GH action to check the existence of fixup commits and signals a test fail.