### PR TITLE
add configurable maxIdleConns and maxIdleTime for sql databases

### DIFF
--- a/docs/core-fabric.md
+++ b/docs/core-fabric.md
@@ -480,8 +480,10 @@ persistence:
     dataSource: file:/some/path/fsc.sqlite&_txlock=immediate
     tablePrefix: fsc  # optional
     skipCreateTable: true # tells FSC _not_ to create a table when starting up (because it already exists).
-    skipPragmas: true # if this is false, the pragmas we set in the datasource will be overridden with the defaults.
-    maxOpenConns: 50  # optional: max open read connections to the database. Defaults to unlimited.
+    skipPragmas: true # if this is false, the pragmas we set in the datasource will be overridden with the defaults (sqlite specific).
+    maxOpenConns: 20  # optional: max open read connections to the database. Defaults to unlimited. See https://go.dev/doc/database/manage-connections.
+    maxIdleConns: 20  # optional: max idle read connections to the database. Defaults to 2.
+    maxIdleTime: 30s  # optional: max duration a connection can be idle before it is closed. Defaults to 1 minute.
 ```
 
 By default we set the following pragmas (unless you do `skipPragmas: true`. Make sure you always have `_pragma=journal_mode(WAL`):
@@ -510,4 +512,11 @@ persistence:
   opts:
     driver: postgres
     dataSource: host=localhost port=5432 user=postgres password=example dbname=tokendb sslmode=disable
+    maxOpenConns: 25  # optional: max open read connections to the database. Defaults to unlimited. 
+    maxIdleConns: 25  # optional: max idle read connections to the database. Defaults to 2.
+    maxIdleTime: 30s  # optional: max duration a connection can be idle before it is closed. Defaults to 1 minute.
 ```
+
+For more info about managing connections, see https://go.dev/doc/database/manage-connections. Keep in mind that Fabric Smart Client
+maintains two independent database instances: one for KVS and one for the Vault. The combined maxOpenConns should not exceed the
+configured max_connections in the postgres server (100 by default).

--- a/platform/common/core/generic/vault/db/helpers.go
+++ b/platform/common/core/generic/vault/db/helpers.go
@@ -52,7 +52,7 @@ func openBadger[V any](tempDir, dir string, open opener[V]) (V, error) {
 
 type dbConfig common.Opts
 
-func (c *dbConfig) IsSet(string) bool { panic("not supported") }
+func (c *dbConfig) IsSet(string) bool { return false }
 func (c *dbConfig) UnmarshalKey(key string, rawVal interface{}) error {
 	if len(key) > 0 {
 		return errors.New("invalid key")

--- a/platform/view/services/db/driver/badger/badger.go
+++ b/platform/view/services/db/driver/badger/badger.go
@@ -248,6 +248,10 @@ func (db *DB) NewWriteTransaction() (driver.WriteTransaction, error) {
 	}, nil
 }
 
+func (db *DB) Stats() any {
+	return db.db.BlockCacheMetrics()
+}
+
 type txMgr interface {
 	Commit() error
 	Discard() error

--- a/platform/view/services/db/driver/driver.go
+++ b/platform/view/services/db/driver/driver.go
@@ -73,6 +73,8 @@ type BasePersistence[V any, R any] interface {
 	Commit() error
 	// Discard discards the changes since BeginUpdate
 	Discard() error
+	// Stats returns driver specific statistics of the datastore
+	Stats() any
 }
 
 // UnversionedPersistence models a key-value storage place

--- a/platform/view/services/db/driver/notifier/persistence.go
+++ b/platform/view/services/db/driver/notifier/persistence.go
@@ -108,6 +108,10 @@ func (db *UnversionedPersistenceNotifier[P]) Close() error { return db.Persisten
 
 func (db *UnversionedPersistenceNotifier[P]) BeginUpdate() error { return db.Persistence.BeginUpdate() }
 
+func (db *UnversionedPersistenceNotifier[P]) Stats() any {
+	return db.Persistence.Stats()
+}
+
 func (db *UnversionedPersistenceNotifier[P]) Subscribe(callback driver.TriggerCallback) error {
 	return db.Notifier.Subscribe(callback)
 }
@@ -208,6 +212,10 @@ func (db *VersionedPersistenceNotifier[P]) GetStateRangeScanIterator(namespace d
 
 func (db *VersionedPersistenceNotifier[P]) GetStateSetIterator(ns driver2.Namespace, keys ...driver2.PKey) (driver.VersionedResultsIterator, error) {
 	return db.Persistence.GetStateSetIterator(ns, keys...)
+}
+
+func (db *VersionedPersistenceNotifier[P]) Stats() any {
+	return db.Persistence.Stats()
 }
 
 func (db *VersionedPersistenceNotifier[P]) Close() error { return db.Persistence.Close() }

--- a/platform/view/services/db/driver/sql/common/utils.go
+++ b/platform/view/services/db/driver/sql/common/utils.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	errors2 "github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver"
@@ -91,6 +92,13 @@ func GetOpts(config driver.Config, optsKey string) (*Opts, error) {
 	if opts.DataSource == "" {
 		return nil, notSetError(optsKey + ".dataSource")
 	}
+	if !config.IsSet(optsKey + ".maxIdleConns") {
+		opts.MaxIdleConns = 2 // go default
+	}
+	if !config.IsSet(optsKey + ".maxIdleTime") {
+		opts.MaxIdleTime = time.Minute
+	}
+
 	return &opts, nil
 }
 

--- a/platform/view/services/db/driver/sql/common/versioned.go
+++ b/platform/view/services/db/driver/sql/common/versioned.go
@@ -100,7 +100,7 @@ func NewVersionedPersistence(base basePersistence[driver.VersionedValue, driver.
 }
 
 func NewVersioned(readDB *sql.DB, writeDB *sql.DB, table string, errorWrapper driver.SQLErrorWrapper, ci Interpreter) *VersionedPersistence {
-	base := NewBasePersistence[driver.VersionedValue, driver.VersionedRead](writeDB, readDB, table, &versionedReadScanner{}, &versionedValueScanner{}, errorWrapper, ci, writeDB.Begin)
+	base := NewBasePersistence(writeDB, readDB, table, &versionedReadScanner{}, &versionedValueScanner{}, errorWrapper, ci, writeDB.Begin)
 	return NewVersionedPersistence(base, base.table, base.errorWrapper, base.readDB, base.writeDB)
 }
 
@@ -174,6 +174,10 @@ func (db *VersionedPersistence) NewWriteTransaction() (driver.WriteTransaction, 
 	}
 
 	return NewWriteTransaction(txn, db), nil
+}
+
+func (db *VersionedPersistence) Stats() any {
+	return db.basePersistence.Stats()
 }
 
 type versionedPersistence interface {

--- a/platform/view/services/db/driver/sql/postgres/persistence.go
+++ b/platform/view/services/db/driver/sql/postgres/persistence.go
@@ -9,6 +9,7 @@ package postgres
 import (
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -18,13 +19,17 @@ var logger = flogging.MustGetLogger("view-sdk.db.postgres")
 
 const driverName = "pgx"
 
-func OpenDB(dataSourceName string, maxOpenConns int) (*sql.DB, error) {
+func OpenDB(dataSourceName string, maxOpenConns, maxIdleConns int, maxIdleTime time.Duration) (*sql.DB, error) {
 	db, err := sql.Open(driverName, dataSourceName)
 	if err != nil {
 		logger.Error(err)
 		return nil, fmt.Errorf("can't open %s database: %w", driverName, err)
 	}
+
 	db.SetMaxOpenConns(maxOpenConns)
+	db.SetMaxIdleConns(maxIdleConns)
+	db.SetConnMaxIdleTime(maxIdleTime)
+
 	if err = db.Ping(); err != nil {
 		return nil, err
 	}

--- a/platform/view/services/db/driver/sql/postgres/sql_test.go
+++ b/platform/view/services/db/driver/sql/postgres/sql_test.go
@@ -9,6 +9,7 @@ package postgres
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver"
 	common2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/sql/common"
@@ -31,13 +32,13 @@ func TestPostgres(t *testing.T) {
 	t.Log("postgres ready")
 
 	common2.TestCases(t, func(name string) (driver.TransactionalVersionedPersistence, error) {
-		return initPersistence(NewVersioned, pgConnStr, name, 50)
+		return initPersistence(NewVersioned, pgConnStr, name, 50, 2, time.Minute)
 	}, func(name string) (driver.UnversionedPersistence, error) {
-		return initPersistence(NewUnversioned, pgConnStr, name, 0)
+		return initPersistence(NewUnversioned, pgConnStr, name, 0, 2, time.Minute)
 	}, func(name string) (driver.UnversionedNotifier, error) {
-		return initPersistence(NewUnversionedNotifier, pgConnStr, name, 0)
+		return initPersistence(NewUnversionedNotifier, pgConnStr, name, 0, 2, time.Minute)
 	}, func(name string) (driver.VersionedNotifier, error) {
-		return initPersistence(NewVersionedNotifier, pgConnStr, name, 50)
+		return initPersistence(NewVersionedNotifier, pgConnStr, name, 50, 2, time.Minute)
 	}, func(p driver.UnversionedPersistence) *common2.BasePersistence[driver.UnversionedValue, driver.UnversionedRead] {
 		return p.(*UnversionedPersistence).BasePersistence.(*BasePersistence[driver.UnversionedValue, driver.UnversionedRead]).BasePersistence
 	})

--- a/platform/view/services/db/driver/sql/postgres/test_utils.go
+++ b/platform/view/services/db/driver/sql/postgres/test_utils.go
@@ -256,8 +256,8 @@ type dbObject interface {
 
 type persistenceConstructor[V dbObject] func(common2.Opts, string) (V, error)
 
-func initPersistence[V dbObject](constructor persistenceConstructor[V], pgConnStr, name string, maxOpenConns int) (V, error) {
-	p, err := constructor(common2.Opts{DataSource: pgConnStr, MaxOpenConns: maxOpenConns}, name)
+func initPersistence[V dbObject](constructor persistenceConstructor[V], pgConnStr, name string, maxOpenConns, maxIdleConns int, maxIdleTime time.Duration) (V, error) {
+	p, err := constructor(common2.Opts{DataSource: pgConnStr, MaxOpenConns: maxOpenConns, MaxIdleConns: maxIdleConns, MaxIdleTime: maxIdleTime}, name)
 	if err != nil {
 		return utils.Zero[V](), err
 	}
@@ -273,19 +273,19 @@ type TestDriver struct {
 }
 
 func (t *TestDriver) NewTransactionalVersioned(dataSourceName string, config driver.Config) (driver.TransactionalVersionedPersistence, error) {
-	return initPersistence(NewVersioned, t.ConnStr, t.Name, 50)
+	return initPersistence(NewVersioned, t.ConnStr, t.Name, 50, 10, time.Minute)
 }
 
 func (t *TestDriver) NewVersioned(dataSourceName string, config driver.Config) (driver.VersionedPersistence, error) {
-	return initPersistence(NewVersioned, t.ConnStr, t.Name, 50)
+	return initPersistence(NewVersioned, t.ConnStr, t.Name, 50, 10, time.Minute)
 }
 
 func (t *TestDriver) NewUnversioned(dataSourceName string, config driver.Config) (driver.UnversionedPersistence, error) {
-	return initPersistence(NewUnversioned, t.ConnStr, t.Name, 50)
+	return initPersistence(NewUnversioned, t.ConnStr, t.Name, 50, 10, time.Minute)
 }
 
 func (t *TestDriver) NewTransactionalUnversioned(dataSourceName string, config driver.Config) (driver.TransactionalUnversionedPersistence, error) {
-	p, err := initPersistence(NewVersioned, t.ConnStr, t.Name, 50)
+	p, err := initPersistence(NewVersioned, t.ConnStr, t.Name, 50, 10, time.Minute)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/view/services/db/driver/sql/postgres/unversioned.go
+++ b/platform/view/services/db/driver/sql/postgres/unversioned.go
@@ -49,7 +49,7 @@ func (p *UnversionedPersistence) GetStateSetIterator(ns driver2.Namespace, keys 
 }
 
 func NewUnversioned(opts common.Opts, table string) (*UnversionedPersistence, error) {
-	readWriteDB, err := OpenDB(opts.DataSource, opts.MaxOpenConns)
+	readWriteDB, err := OpenDB(opts.DataSource, opts.MaxOpenConns, opts.MaxIdleConns, opts.MaxIdleTime)
 	if err != nil {
 		return nil, fmt.Errorf("error opening db: %w", err)
 	}
@@ -69,7 +69,7 @@ func (db *unversionedPersistenceNotifier) CreateSchema() error {
 }
 
 func NewUnversionedNotifier(opts common.Opts, table string) (*unversionedPersistenceNotifier, error) {
-	readWriteDB, err := OpenDB(opts.DataSource, opts.MaxOpenConns)
+	readWriteDB, err := OpenDB(opts.DataSource, opts.MaxOpenConns, opts.MaxIdleConns, opts.MaxIdleTime)
 	if err != nil {
 		return nil, fmt.Errorf("error opening db: %w", err)
 	}

--- a/platform/view/services/db/driver/sql/sqlite/unversioned.go
+++ b/platform/view/services/db/driver/sql/sqlite/unversioned.go
@@ -20,7 +20,7 @@ type UnversionedPersistence struct {
 }
 
 func NewUnversioned(opts common.Opts, table string) (*UnversionedPersistence, error) {
-	readDB, writeDB, err := openDB(opts.DataSource, opts.MaxOpenConns, opts.SkipPragmas)
+	readDB, writeDB, err := openDB(opts.DataSource, opts.MaxOpenConns, opts.MaxIdleConns, opts.MaxIdleTime, opts.SkipPragmas)
 	if err != nil {
 		return nil, fmt.Errorf("error opening db: %w", err)
 	}
@@ -28,7 +28,7 @@ func NewUnversioned(opts common.Opts, table string) (*UnversionedPersistence, er
 }
 
 func NewUnversionedNotifier(opts common.Opts, table string) (*notifier.UnversionedPersistenceNotifier[*UnversionedPersistence], error) {
-	readDB, writeDB, err := openDB(opts.DataSource, opts.MaxOpenConns, opts.SkipPragmas)
+	readDB, writeDB, err := openDB(opts.DataSource, opts.MaxOpenConns, opts.MaxIdleConns, opts.MaxIdleTime, opts.SkipPragmas)
 	if err != nil {
 		return nil, fmt.Errorf("error opening db: %w", err)
 	}

--- a/platform/view/services/db/driver/sql/sqlite/versioned.go
+++ b/platform/view/services/db/driver/sql/sqlite/versioned.go
@@ -20,7 +20,7 @@ type VersionedPersistence struct {
 }
 
 func NewVersioned(opts common.Opts, table string) (*VersionedPersistence, error) {
-	readDB, writeDB, err := openDB(opts.DataSource, opts.MaxOpenConns, opts.SkipPragmas)
+	readDB, writeDB, err := openDB(opts.DataSource, opts.MaxOpenConns, opts.MaxIdleConns, opts.MaxIdleTime, opts.SkipPragmas)
 	if err != nil {
 		return nil, fmt.Errorf("error opening db: %w", err)
 	}
@@ -28,7 +28,7 @@ func NewVersioned(opts common.Opts, table string) (*VersionedPersistence, error)
 }
 
 func NewVersionedNotifier(opts common.Opts, table string) (*notifier.VersionedPersistenceNotifier[*VersionedPersistence], error) {
-	readDB, writeDB, err := openDB(opts.DataSource, opts.MaxOpenConns, opts.SkipPragmas)
+	readDB, writeDB, err := openDB(opts.DataSource, opts.MaxOpenConns, opts.MaxIdleConns, opts.MaxIdleTime, opts.SkipPragmas)
 	if err != nil {
 		return nil, fmt.Errorf("error opening db: %w", err)
 	}

--- a/platform/view/services/db/driver/unversioned/unversioned.go
+++ b/platform/view/services/db/driver/unversioned/unversioned.go
@@ -99,6 +99,10 @@ func (db *Unversioned) Discard() error {
 	return db.Versioned.Discard()
 }
 
+func (db *Unversioned) Stats() any {
+	return db.Versioned.Stats()
+}
+
 type Transactional struct {
 	TransactionalVersioned driver.TransactionalVersionedPersistence
 }
@@ -169,6 +173,10 @@ func (t *Transactional) NewWriteTransaction() (driver.UnversionedWriteTransactio
 		return nil, errors.WithMessage(err, "failed to create new transaction")
 	}
 	return &WriteTransaction{WriteTransaction: tx}, nil
+}
+
+func (t *Transactional) Stats() any {
+	return t.TransactionalVersioned.Stats()
 }
 
 type WriteTransaction struct {


### PR DESCRIPTION
Allows for use case specific tuning of database parameters.
 
```
    maxOpenConns: 20  # optional: max open read connections to the database. Defaults to unlimited. See https://go.dev/doc/database/manage-connections.
    maxIdleConns: 20  # optional: max idle read connections to the database. Defaults to 2.
    maxIdleTime: 30s  # optional: max duration a connection can be idle before it is closed. Defaults to 1 minute.
```

It also exposes a function `Stats(): any` to the database driver. This can be used for debugging or observability in general. In the case of SQL databases, this provides details about the connection pool (see [go docs](https://pkg.go.dev/database/sql#DBStats). For Badger, it returns the metrics for the underlying block cache.