### PR TITLE
pass the network driver to the constructor

### DIFF
--- a/platform/fabric/core/generic/committer/committer.go
+++ b/platform/fabric/core/generic/committer/committer.go
@@ -75,7 +75,7 @@ type CommitTx struct {
 type TransactionHandler = func(ctx context.Context, block *common.BlockMetadata, tx CommitTx) (*FinalityEvent, error)
 
 type OrderingService interface {
-	SetConfigOrderers(o channelconfig.Orderer, orderers []*grpc.ConnectionConfig) error
+	Configure(consensusType string, orderers []*grpc.ConnectionConfig) error
 }
 
 type Committer struct {
@@ -904,7 +904,7 @@ func (c *Committer) applyBundle(bundle *channelconfig.Bundle) error {
 	}
 	if len(newOrderers) != 0 {
 		c.logger.Debugf("[Channel: %s] Updating the list of orderers: (%d) found", c.ChannelConfig.ID(), len(newOrderers))
-		return c.OrderingService.SetConfigOrderers(ordererConfig, newOrderers)
+		return c.OrderingService.Configure(ordererConfig.ConsensusType(), newOrderers)
 	}
 	c.logger.Infof("[Channel: %s] No orderers found in Channel config", c.ChannelConfig.ID())
 

--- a/platform/fabric/core/generic/delivery/delivery.go
+++ b/platform/fabric/core/generic/delivery/delivery.go
@@ -127,8 +127,6 @@ func (d *Delivery) Stop() {
 }
 
 func (d *Delivery) Run(ctx context.Context) error {
-	defer d.cleanup()
-
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/platform/fabric/core/generic/driver/identity/msp.go
+++ b/platform/fabric/core/generic/driver/identity/msp.go
@@ -9,7 +9,6 @@ package identity
 import (
 	"fmt"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/sig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/driver/config"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/driver"
@@ -30,7 +29,7 @@ type MSPManagerProvider interface {
 type localMSPManagerProvider struct {
 	configProvider      config.Provider
 	endpointService     driver.BinderService
-	sigService          *sig.Service
+	sigService          driver.SignerService
 	identityLoaders     []NamedIdentityLoader
 	deserializerManager driver.DeserializerManager
 	idProvider          vdriver.IdentityProvider
@@ -40,7 +39,7 @@ type localMSPManagerProvider struct {
 func NewMSPManagerProvider(
 	configProvider config.Provider,
 	endpointService EndpointService,
-	sigService *sig.Service,
+	sigService driver.SignerService,
 	identityLoaders []NamedIdentityLoader,
 	deserializerManager driver.DeserializerManager,
 	idProvider vdriver.IdentityProvider,

--- a/platform/fabric/core/generic/network.go
+++ b/platform/fabric/core/generic/network.go
@@ -17,8 +17,6 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/transaction"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
-	"github.com/hyperledger/fabric/common/channelconfig"
-	"github.com/pkg/errors"
 )
 
 var logger = logging.MustGetLogger("fabric-sdk.core")
@@ -179,16 +177,6 @@ func (f *Network) Init() error {
 		f.Metrics,
 		services.NewClientFactory(f.configService, f.LocalMembership().DefaultSigningIdentity()),
 	)
-	return nil
-}
-
-func (f *Network) SetConfigOrderers(o channelconfig.Orderer, orderers []*grpc.ConnectionConfig) error {
-	if err := f.Ordering.SetConsensusType(o.ConsensusType()); err != nil {
-		return errors.WithMessagef(err, "failed to set consensus type from channel config")
-	}
-	if err := f.ConfigService().SetConfigOrderers(orderers); err != nil {
-		return errors.WithMessagef(err, "failed to set ordererss")
-	}
 	return nil
 }
 

--- a/platform/fabric/core/generic/ordering/ordering.go
+++ b/platform/fabric/core/generic/ordering/ordering.go
@@ -14,11 +14,9 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/metrics"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	common2 "github.com/hyperledger/fabric-protos-go/common"
-	"github.com/hyperledger/fabric/common/channelconfig"
 	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
 	context2 "golang.org/x/net/context"
@@ -138,8 +136,8 @@ func (o *Service) SetConsensusType(consensusType ConsensusType) error {
 	return nil
 }
 
-func (f *Service) SetConfigOrderers(o channelconfig.Orderer, orderers []*grpc.ConnectionConfig) error {
-	if err := f.SetConsensusType(o.ConsensusType()); err != nil {
+func (f *Service) Configure(consensusType string, orderers []*grpc.ConnectionConfig) error {
+	if err := f.SetConsensusType(consensusType); err != nil {
 		return errors.WithMessagef(err, "failed to set consensus type from channel config")
 	}
 	if err := f.ConfigService.SetConfigOrderers(orderers); err != nil {


### PR DESCRIPTION
This PR simplify the constructors used to create a new channel. It also replaces certain dependencies with interfaces and not structs.

This PR is tested against FTS in https://github.com/hyperledger-labs/fabric-token-sdk/pull/804 