### PR TITLE
when reading channel config, skip orderer endpoints which are empty

### DIFF
--- a/docs/core-fabric.md
+++ b/docs/core-fabric.md
@@ -297,10 +297,10 @@ fabric:
 
     ordering:
       # number of retries to attempt to send a transaction to an orderer
-      # If not specified or set to 0, it will default to 3 retries
+      # If not specified or set to 0, it will default to 3 retries. The orderer is picked randomly for every attempt.
       numRetries: 3
-      # retryInternal specifies the amount of time to wait before retrying a connection to the ordering service, it has no default and must be specified
-      retryInterval: 3s
+      # retryInternal specifies the amount of time to wait before retrying a connection to the ordering service, it defaults to 500ms
+      retryInterval: 500ms
       # here is possible to disable tls just for the ordering service.
       # if this key is not specified, then the `tls` section is used.
       tlsEnabled: true

--- a/platform/fabric/core/generic/config/service.go
+++ b/platform/fabric/core/generic/config/service.go
@@ -23,6 +23,7 @@ import (
 const (
 	defaultMSPCacheSize               = 3
 	defaultBroadcastNumRetries        = 3
+	defaultBroadcastRetryInterval     = 500 * time.Millisecond
 	vaultPersistenceOptsKey           = "vault.persistence.opts"
 	defaultOrderingConnectionPoolSize = 10
 	defaultNumRetries                 = 3
@@ -313,7 +314,10 @@ func (s *Service) BroadcastNumRetries() int {
 }
 
 func (s *Service) BroadcastRetryInterval() time.Duration {
-	return s.GetDuration("ordering.retryInterval")
+	if s.IsSet("ordering.retryInterval") {
+		return s.GetDuration("ordering.retryInterval")
+	}
+	return defaultBroadcastRetryInterval
 }
 
 func (s *Service) OrdererConnectionPoolSize() int {

--- a/platform/fabric/core/generic/delivery/delivery.go
+++ b/platform/fabric/core/generic/delivery/delivery.go
@@ -148,7 +148,7 @@ func (d *Delivery) Run(ctx context.Context) error {
 				span.AddEvent("connect")
 				df, err = d.connect(ctx)
 				if err != nil {
-					logger.Errorf("failed connecting to delivery service [%s:%s] [%s]. Wait 10 sec before reconnecting", d.NetworkName, d.channel, err)
+					logger.Errorf("failed connecting to delivery service [%s:%s] [%s]. Wait %.1fs before reconnecting", d.NetworkName, d.channel, err, waitTime.Seconds())
 					time.Sleep(waitTime)
 					if logger.IsEnabledFor(zapcore.DebugLevel) {
 						logger.Debugf("reconnecting to delivery service [%s:%s]", d.NetworkName, d.channel)

--- a/platform/fabric/core/generic/ordering/cft.go
+++ b/platform/fabric/core/generic/ordering/cft.go
@@ -123,7 +123,7 @@ func (o *CFTBroadcaster) getConnection(ctx context.Context) (*Connection, error)
 			oClient, err := client.OrdererClient()
 			if err != nil {
 				rpcStatus, _ := status.FromError(err)
-				return nil, errors.Wrapf(err, "failed to new a broadcast, rpcStatus=%+v", rpcStatus)
+				return nil, errors.Wrapf(err, "failed to new a broadcast for %s, rpcStatus=%+v", to.Address, rpcStatus)
 			}
 
 			stream, err := oClient.Broadcast(ctx)

--- a/platform/view/services/grpc/client.go
+++ b/platform/view/services/grpc/client.go
@@ -297,6 +297,9 @@ func (client *Client) SetServerRootCAs(serverRoots [][]byte) error {
 // overrides the server name used to verify the hostname on the
 // certificate returned by a server when using TLS
 func (client *Client) NewConnection(address string, tlsOptions ...TLSOption) (*grpc.ClientConn, error) {
+	if len(address) == 0 {
+		return nil, errors.New("address is empty")
+	}
 
 	var dialOpts []grpc.DialOption
 	dialOpts = append(dialOpts, client.dialOpts...)


### PR DESCRIPTION
And set a default for the orderer retryInterval. Before, it defaulted to immediate.