### PR TITLE
fix delivery service

### DIFF
--- a/platform/fabric/core/generic/delivery/delivery.go
+++ b/platform/fabric/core/generic/delivery/delivery.go
@@ -120,7 +120,7 @@ func New(
 		callback:   callback,
 		vault:      vault,
 		bufferSize: max(bufferSize, 1),
-		stop:       make(chan struct{}),
+		stop:       make(chan struct{}, 1),
 	}
 	return d, nil
 }

--- a/platform/fabric/core/generic/delivery/delivery.go
+++ b/platform/fabric/core/generic/delivery/delivery.go
@@ -133,6 +133,7 @@ func (d *Delivery) Start(ctx context.Context) {
 }
 
 func (d *Delivery) Stop() {
+	d.stop <- struct{}{}
 	close(d.stop)
 }
 
@@ -159,7 +160,7 @@ func (d *Delivery) readBlocks(ch <-chan blockResponse) {
 			}
 			if stop {
 				logger.Infof("Stopping delivery at block [%d]", b.block.Header.Number)
-				close(d.stop)
+				d.Stop()
 				return
 			}
 		case <-d.stop:

--- a/platform/fabric/core/generic/delivery/delivery.go
+++ b/platform/fabric/core/generic/delivery/delivery.go
@@ -140,13 +140,11 @@ func (d *Delivery) Stop(err error) {
 var ctr = atomic.Uint32{}
 
 func (d *Delivery) untilStop() error {
-	for {
-		select {
-		case err := <-d.stop:
-			logger.Infof("Stopping delivery service")
-			return err
-		}
+	for err := range d.stop {
+		logger.Infof("Stopping delivery service")
+		return err
 	}
+	return nil
 }
 
 func (d *Delivery) Run(ctx context.Context) error {

--- a/platform/fabric/core/generic/delivery/service.go
+++ b/platform/fabric/core/generic/delivery/service.go
@@ -100,7 +100,7 @@ func (c *Service) Start(ctx context.Context) error {
 }
 
 func (c *Service) Stop() {
-	c.deliveryService.Stop()
+	c.deliveryService.Stop(nil)
 }
 
 func (c *Service) scanBlock(ctx context.Context, vault Vault, callback driver.BlockCallback) error {
@@ -137,9 +137,9 @@ func (c *Service) Scan(ctx context.Context, txID string, callback driver.Deliver
 			for i, tx := range block.Data.Data {
 				validationCode := ValidationFlags(block.Metadata.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER])[i]
 
-				//if pb.TxValidationCode(validationCode) != pb.TxValidationCode_VALID {
+				// if pb.TxValidationCode(validationCode) != pb.TxValidationCode_VALID {
 				//	continue
-				//}
+				// }
 				_, _, channelHeader, err := fabricutils.UnmarshalTx(tx)
 				if err != nil {
 					logger.Errorf("[%s] unmarshal tx failed: %s", c.channel, err)


### PR DESCRIPTION
This PR does the following: It decouples the checking of the stop condition from the reading of the blocks from the delivery service that is a blocking operation. This avoids that the reading process gets stuck after the callback notifies to stop.