### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/cmd/fsccli/main_test.go
+++ b/cmd/fsccli/main_test.go
@@ -34,10 +34,7 @@ func TestArtifactsGen(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 	defer gexec.CleanupBuildArtifacts()
 
-	tmpDir, err := os.MkdirTemp("", t.Name())
-	Expect(err).NotTo(HaveOccurred())
-
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	topologyFolder := filepath.Join("testdata", "fabric_iou.yaml")
 	session, err := gexec.Start(exec.Command(cli, "artifactsgen", "gen", "-t", topologyFolder, "-o", tmpDir), GinkgoWriter, GinkgoWriter)

--- a/integration/nwo/cmd/cryptogen/csp/csp_test.go
+++ b/integration/nwo/cmd/cryptogen/csp/csp_test.go
@@ -26,11 +26,7 @@ import (
 )
 
 func TestLoadPrivateKey(t *testing.T) {
-	testDir, err := os.MkdirTemp("", "csp-test")
-	if err != nil {
-		t.Fatalf("Failed to create test directory: %s", err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 	priv, err := csp2.GeneratePrivateKey(testDir)
 	if err != nil {
 		t.Fatalf("Failed to generate private key: %s", err)
@@ -45,11 +41,7 @@ func TestLoadPrivateKey(t *testing.T) {
 }
 
 func TestLoadPrivateKey_BadPEM(t *testing.T) {
-	testDir, err := os.MkdirTemp("", "csp-test")
-	if err != nil {
-		t.Fatalf("Failed to create test directory: %s", err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	badPEMFile := filepath.Join(testDir, "badpem_sk")
 
@@ -108,11 +100,7 @@ func TestLoadPrivateKey_BadPEM(t *testing.T) {
 }
 
 func TestGeneratePrivateKey(t *testing.T) {
-	testDir, err := os.MkdirTemp("", "csp-test")
-	if err != nil {
-		t.Fatalf("Failed to create test directory: %s", err)
-	}
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	expectedFile := filepath.Join(testDir, "priv_sk")
 	priv, err := csp2.GeneratePrivateKey(testDir)


### PR DESCRIPTION
`TempDir()` is a method introduced in Go 1.15 for `testing.T`. It automatically creates a temporary directory and cleans it up after the test is complete, eliminating the hassle of manually handling errors and cleanup.  More detail about TempDir  https://pkg.go.dev/testing#B.TempDir