### PR TITLE
Fix flaky cache timeout tests

### DIFF
--- a/platform/common/utils/cache/timeout.go
+++ b/platform/common/utils/cache/timeout.go
@@ -50,7 +50,15 @@ func NewTimeoutEviction[K comparable](timeout time.Duration, evict func([]K)) *t
 
 func (e *timeoutEviction[K]) cleanup(timeout time.Duration) {
 	logger.Debugf("Launch cleanup function with eviction timeout [%v]", timeout)
-	for range time.Tick(1 * time.Second) {
+
+	// TODO: the cleanup should be revisited
+	// when the cleanup is started we loop forever using the ticker; even if there are no items in the cache anymore.
+	// this might also prevent the GC from removing the cache if not needed anymore
+
+	// let's use the eviction timeout as our check interval
+	checkInterval := timeout
+
+	for range time.Tick(checkInterval) {
 		expiry := time.Now().Add(-timeout)
 		logger.Debugf("Cleanup invoked: evicting everything created after [%v]", expiry)
 		e.mu.RLock()

--- a/platform/common/utils/cache/timeout_test.go
+++ b/platform/common/utils/cache/timeout_test.go
@@ -15,62 +15,77 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/cache"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	evictionTimeout = 10 * time.Millisecond
+	timeout         = 10 * evictionTimeout
+	tick            = evictionTimeout / 4
 )
 
 func TestTimeoutSimple(t *testing.T) {
-	mu := sync.RWMutex{}
+	var mu sync.RWMutex
 	allEvicted := make(map[int]string)
-	done := make(chan struct{})
 
-	c := cache.NewTimeoutCache(2*time.Second, func(evicted map[int]string) {
+	input := map[int]string{1: "a", 2: "b", 3: "c", 4: "d", 5: "e"}
+
+	c := cache.NewTimeoutCache(evictionTimeout, func(evicted map[int]string) {
 		mu.Lock()
 		collections.CopyMap(allEvicted, evicted)
 		mu.Unlock()
-		done <- struct{}{}
 	})
 
-	c.Put(1, "a")
-	c.Put(2, "b")
-	c.Put(3, "c")
-	c.Put(4, "d")
-	c.Put(5, "e")
+	for k, v := range input {
+		c.Put(k, v)
+	}
 
 	mu.RLock()
-	assert.Equal(0, len(allEvicted))
-	assert.Equal(5, c.Len())
-	v, _ := c.Get(1)
-	assert.Equal("a", v)
+	assert.Equal(t, 0, len(allEvicted))
+	assert.Equal(t, 5, c.Len())
+	for k, expected := range input {
+		actual, _ := c.Get(k)
+		assert.Equal(t, expected, actual)
+	}
 	mu.RUnlock()
-	<-done
+
+	assert.EventuallyWithT(t, func(a *assert.CollectT) {
+		// eventually our cache is empty again due to eviction
+		assert.Equal(a, 0, c.Len())
+	}, timeout, tick)
 
 	mu.RLock()
-	time.Sleep(3 * time.Second)
-	assert.Equal(map[int]string{1: "a", 2: "b", 3: "c", 4: "d", 5: "e"}, allEvicted)
-	assert.Equal(0, c.Len())
+	assert.Equal(t, input, allEvicted)
+	mu.RUnlock()
+
 	_, ok := c.Get(1)
-	assert.False(ok)
-	mu.RUnlock()
+	assert.False(t, ok)
 }
 
 func TestTimeoutParallel(t *testing.T) {
-	evictedCount := atomic.Int32{}
-	c := cache.NewTimeoutCache(2*time.Second, func(evicted map[int]string) { evictedCount.Add(int32(len(evicted))) })
+	numItem := 100
+
+	var evictedCount atomic.Int32
+	c := cache.NewTimeoutCache(evictionTimeout, func(evicted map[int]string) { evictedCount.Add(int32(len(evicted))) })
 
 	var wg sync.WaitGroup
-	wg.Add(100)
-	for i := 0; i < 100; i++ {
+	wg.Add(numItem)
+	for i := 0; i < numItem; i++ {
 		go func(i int) {
 			c.Put(i, fmt.Sprintf("item-%d", i))
 			wg.Done()
 		}(i)
 	}
 	wg.Wait()
-	assert.Equal(100, c.Len())
-	assert.Equal(0, int(evictedCount.Load()))
+	// cache full and nothing evicted yet
+	assert.Equal(t, numItem, c.Len())
+	assert.Equal(t, 0, int(evictedCount.Load()))
 
-	time.Sleep(3 * time.Second)
+	assert.EventuallyWithT(t, func(a *assert.CollectT) {
+		// eventually our cache is empty again due to eviction
+		assert.Equal(a, 0, c.Len())
+	}, timeout, tick)
 
-	assert.Equal(0, c.Len())
-	assert.Equal(100, int(evictedCount.Load()))
+	// once empty evictedCount should match the number of items we cached before
+	assert.Equal(t, numItem, int(evictedCount.Load()))
 }


### PR DESCRIPTION
Before
```bash
❯ time go test -count=10 -failfast -race ./platform/common/utils/cache/
--- FAIL: TestTimeoutParallel (3.00s)
        Error Trace:    timeout_test.go:74
        Error:          Not equal: 0 (expected)
                        != 97 (actual)
 [recovered]
        Error Trace:    timeout_test.go:74
        Error:          Not equal: 0 (expected)
                        != 97 (actual)


goroutine 138 [running]:
testing.tRunner.func1.2({0x1011d4540, 0xc000104f90})
        /opt/homebrew/Cellar/go/1.23.6/libexec/src/testing/testing.go:1632 +0x2c4
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.23.6/libexec/src/testing/testing.go:1635 +0x47c
panic({0x1011d4540?, 0xc000104f90?})
        /opt/homebrew/Cellar/go/1.23.6/libexec/src/runtime/panic.go:785 +0x124
github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert.(*panickier).Errorf(0xc0001f7188, {0x10113bb20, 0x21}, {0xc0001f4180, 0x3, 0x3})
        /Users/bur/Developer/gocode/src/github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert/assert.go:26 +0xd8
github.com/test-go/testify/assert.Fail({0x1012355c0, 0xc0001f7188}, {0xc000106660, 0x2e}, {0x0, 0x0, 0x0})
        /Users/bur/Developer/gocode/pkg/mod/github.com/test-go/testify@v1.1.4/assert/assertions.go:237 +0x3a4
github.com/test-go/testify/assert.Equal({0x1012355c0, 0xc0001f7188}, {0x1011d4780, 0x1011a86b8}, {0x1011d4780, 0x1013d1e28}, {0x0, 0x0, 0x0})
        /Users/bur/Developer/gocode/pkg/mod/github.com/test-go/testify@v1.1.4/assert/assertions.go:282 +0x1b4
github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert.Equal({0x1011d4780, 0x1011a86b8}, {0x1011d4780, 0x1013d1e28}, {0x0, 0x0, 0xc00028be88?})
        /Users/bur/Developer/gocode/src/github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert/assert.go:63 +0x2f8
github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/cache_test.TestTimeoutParallel(0xc000123380?)
        /Users/bur/Developer/gocode/src/github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/cache/timeout_test.go:74 +0x2d8
testing.tRunner(0xc000123380, 0x1012326e8)
        /opt/homebrew/Cellar/go/1.23.6/libexec/src/testing/testing.go:1690 +0x188
created by testing.(*T).Run in goroutine 1
        /opt/homebrew/Cellar/go/1.23.6/libexec/src/testing/testing.go:1743 +0x5e4
FAIL    github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/cache     24.335s
FAIL
go test -count=10 -failfast -race ./platform/common/utils/cache/  0.41s user 0.59s system 4% cpu 24.729 total

```

Now
```bash
❯ time go test -count=100 -failfast -race ./platform/common/utils/cache/
ok      github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/cache     4.707s
go test -count=100 -failfast -race ./platform/common/utils/cache/  1.41s user 0.96s system 46% cpu 5.084 total
```