### PR TITLE
Replace ttlcache with our own cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/hyperledger/fabric-protos-go v0.3.3
 	github.com/jackc/pgx/v5 v5.7.1
 	github.com/jackc/pgxlisten v0.0.0-20241106001234-1d6f6656415c
-	github.com/jellydator/ttlcache/v2 v2.11.1
 	github.com/libp2p/go-libp2p v0.37.2
 	github.com/libp2p/go-libp2p-kad-dht v0.25.2
 	github.com/miekg/pkcs11 v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1216,8 +1216,6 @@ github.com/jbenet/go-temp-err-catcher v0.1.0/go.mod h1:0kJRvmDZXNMIiJirNPEYfhpPw
 github.com/jbenet/goprocess v0.1.4 h1:DRGOFReOMqqDNXwW70QkacFW0YN9QnwLV0Vqk+3oU0o=
 github.com/jbenet/goprocess v0.1.4/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZlqdZVfqY4=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
-github.com/jellydator/ttlcache/v2 v2.11.1 h1:AZGME43Eh2Vv3giG6GeqeLeFXxwxn1/qHItqWZl6U64=
-github.com/jellydator/ttlcache/v2 v2.11.1/go.mod h1:RtE5Snf0/57e+2cLWFYWCCsLas2Hy3c5Z4n14XmSvTI=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
@@ -2296,7 +2294,6 @@ golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.0.0-20210112230658-8b4aab62c064/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=

--- a/platform/fabric/core/generic/chaincode/chaincode.go
+++ b/platform/fabric/core/generic/chaincode/chaincode.go
@@ -8,14 +8,12 @@ package chaincode
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/services"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
-	"github.com/jellydator/ttlcache/v2"
 )
 
 var logger = logging.MustGetLogger("fabric-sdk.core.generic.chaincode")
@@ -52,9 +50,6 @@ type Chaincode struct {
 	Broadcaster     Broadcaster
 	Finality        driver.Finality
 	MSPProvider     MSPProvider
-
-	discoveryResultsCacheLock sync.RWMutex
-	discoveryResultsCache     ttlcache.SimpleCache
 }
 
 func NewChaincode(
@@ -69,21 +64,19 @@ func NewChaincode(
 	MSPProvider MSPProvider,
 ) *Chaincode {
 	return &Chaincode{
-		name:                      name,
-		NetworkID:                 networkConfig.NetworkName(),
-		ChannelID:                 channelConfig.ID(),
-		ConfigService:             networkConfig,
-		ChannelConfig:             channelConfig,
-		NumRetries:                channelConfig.GetNumRetries(),
-		RetrySleep:                channelConfig.GetRetrySleep(),
-		LocalMembership:           localMembership,
-		Services:                  peerManager,
-		SignerService:             signerService,
-		Broadcaster:               broadcaster,
-		Finality:                  finality,
-		MSPProvider:               MSPProvider,
-		discoveryResultsCacheLock: sync.RWMutex{},
-		discoveryResultsCache:     ttlcache.NewCache(),
+		name:            name,
+		NetworkID:       networkConfig.NetworkName(),
+		ChannelID:       channelConfig.ID(),
+		ConfigService:   networkConfig,
+		ChannelConfig:   channelConfig,
+		NumRetries:      channelConfig.GetNumRetries(),
+		RetrySleep:      channelConfig.GetRetrySleep(),
+		LocalMembership: localMembership,
+		Services:        peerManager,
+		SignerService:   signerService,
+		Broadcaster:     broadcaster,
+		Finality:        finality,
+		MSPProvider:     MSPProvider,
 	}
 }
 


### PR DESCRIPTION
This PR replaced the third-party cache implementation within the discovery component with our own. This is part of #827 