### PR TITLE
chore: update Go version to 1.24 in all modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,6 @@ require (
 	github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78 // indirect
 	github.com/envoyproxy/go-control-plane v0.13.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.1.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/libp2p/go-libp2p-routing-helpers v0.7.4 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect


### PR DESCRIPTION
There were 3 go.mod files where the Go version was updated
./go.mod
./tools/go.mod
./platform/fabric/services/state/cc/query/go.mod

Let me know

Thanks
