### PR TITLE
scope sessions by calling view

### DIFF
--- a/platform/common/utils/lazy/iterator.go
+++ b/platform/common/utils/lazy/iterator.go
@@ -1,0 +1,34 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lazy
+
+import (
+	"io"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
+)
+
+func NewIterator[T any](fs ...func() (T, error)) *Iterator[T] {
+	return &Iterator[T]{fs: fs}
+}
+
+type Iterator[T any] struct {
+	fs []func() (T, error)
+}
+
+func (it *Iterator[T]) Next() (T, error) {
+	if len(it.fs) == 0 {
+		return utils.Zero[T](), io.EOF
+	}
+	result, err := it.fs[0]()
+	it.fs = it.fs[1:]
+	return result, err
+}
+
+func (it *Iterator[T]) Close() {
+	it.fs = nil
+}

--- a/platform/fabric/services/state/transaction.go
+++ b/platform/fabric/services/state/transaction.go
@@ -133,11 +133,7 @@ func (f *receiveTransactionView) Call(context view.Context) (interface{}, error)
 	if f.party.IsNone() {
 		ch = context.Session().Receive()
 	} else {
-		// In this case we expect context.Initiator() to be populated
-		if context.Initiator() == nil {
-			return nil, errors.Errorf("expect context.Initiator() to be populated, party set to [%s]", f.party)
-		}
-		s, err := context.GetSession(context.Initiator(), f.party)
+		s, err := context.GetSession(f, f.party, context.Initiator())
 		if err != nil {
 			return nil, err
 		}

--- a/platform/fabric/services/state/transaction.go
+++ b/platform/fabric/services/state/transaction.go
@@ -133,7 +133,11 @@ func (f *receiveTransactionView) Call(context view.Context) (interface{}, error)
 	if f.party.IsNone() {
 		ch = context.Session().Receive()
 	} else {
-		s, err := context.GetSession(f, f.party)
+		// In this case we expect context.Initiator() to be populated
+		if context.Initiator() == nil {
+			return nil, errors.Errorf("expect context.Initiator() to be populated, party set to [%s]", f.party)
+		}
+		s, err := context.GetSession(context.Initiator(), f.party)
 		if err != nil {
 			return nil, err
 		}

--- a/platform/fabric/services/state/transaction.go
+++ b/platform/fabric/services/state/transaction.go
@@ -133,7 +133,7 @@ func (f *receiveTransactionView) Call(context view.Context) (interface{}, error)
 	if f.party.IsNone() {
 		ch = context.Session().Receive()
 	} else {
-		s, err := context.GetSession(f, f.party, context.Initiator())
+		s, err := context.GetSession(context.Initiator(), f.party, f)
 		if err != nil {
 			return nil, err
 		}

--- a/platform/view/core/manager/context.go
+++ b/platform/view/core/manager/context.go
@@ -237,6 +237,9 @@ func (ctx *ctx) GetSession(caller view.View, party view.Identity, aliases ...vie
 	if logger.IsEnabledFor(zapcore.DebugLevel) {
 		logger.Debugf("[%s] Creating new session [%s:%s]", ctx.me, getViewIdentifier(caller), party)
 	}
+
+	logger.Infof("create session [%s][%s], [%s:%s]", ctx.me, ctx.id, getViewIdentifier(caller), party)
+
 	s, err = ctx.newSession(caller, ctx.id, party)
 	if err != nil {
 		return nil, err

--- a/platform/view/core/manager/context.go
+++ b/platform/view/core/manager/context.go
@@ -216,8 +216,8 @@ func (ctx *ctx) GetSession(f view.View, party view.Identity) (view.Session, erro
 		}
 
 		id, _, _, err = view2.GetEndpointService(ctx).Resolve(party)
-		contextSessionIdentifier = getViewIdentifier(f) + id.UniqueID()
 		if err == nil {
+			contextSessionIdentifier = getViewIdentifier(f) + id.UniqueID()
 			s, ok = ctx.sessions[contextSessionIdentifier]
 			if logger.IsEnabledFor(zapcore.DebugLevel) {
 				logger.Debugf("session resolved for [%s] exists? [%v]", contextSessionIdentifier, ok)
@@ -227,8 +227,8 @@ func (ctx *ctx) GetSession(f view.View, party view.Identity) (view.Session, erro
 			partyIdentity := view2.GetIdentityProvider(ctx).Identity(string(party))
 			if !partyIdentity.IsNone() {
 				id, _, _, err = view2.GetEndpointService(ctx).Resolve(partyIdentity)
-				contextSessionIdentifier = getViewIdentifier(f) + id.UniqueID()
 				if err == nil {
+					contextSessionIdentifier = getViewIdentifier(f) + id.UniqueID()
 					s, ok = ctx.sessions[contextSessionIdentifier]
 					if logger.IsEnabledFor(zapcore.DebugLevel) {
 						logger.Debugf("session resolved for [%s] exists? [%v]", contextSessionIdentifier, ok)

--- a/platform/view/core/manager/context.go
+++ b/platform/view/core/manager/context.go
@@ -126,7 +126,7 @@ func (ctx *ctx) Caller() view.Identity {
 	return ctx.caller
 }
 
-func (ctx *ctx) GetSession(caller view.View, party view.Identity, aliases ...view.View) (view.Session, error) {
+func (ctx *ctx) GetSession(caller view.View, party view.Identity, boundToViews ...view.View) (view.Session, error) {
 	viewId := getViewIdentifier(caller)
 	// TODO: we need a mechanism to close all the sessions opened in this ctx,
 	// when the ctx goes out of scope
@@ -152,7 +152,7 @@ func (ctx *ctx) GetSession(caller view.View, party view.Identity, aliases ...vie
 		return nil, errors.Errorf("a session should already exist, passed nil view")
 	}
 
-	return ctx.createSession(caller, targetIdentity, aliases...)
+	return ctx.createSession(caller, targetIdentity, boundToViews...)
 }
 
 func (ctx *ctx) GetSessionByID(id string, party view.Identity) (view.Session, error) {

--- a/platform/view/core/manager/context.go
+++ b/platform/view/core/manager/context.go
@@ -247,6 +247,9 @@ func (ctx *ctx) GetSession(caller view.View, party view.Identity, aliases ...vie
 
 	// add aliases as well
 	for _, alias := range aliases {
+		if alias == nil {
+			continue
+		}
 		aliasContextSessionIdentifier := getViewIdentifier(alias) + partyUniqueID
 		ctx.sessions[aliasContextSessionIdentifier] = s
 	}

--- a/platform/view/core/manager/context_test.go
+++ b/platform/view/core/manager/context_test.go
@@ -10,16 +10,16 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"go.opentelemetry.io/otel/trace/noop"
-	"golang.org/x/net/context"
-
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/core/endpoint"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/core/manager"
 	mock2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/core/manager/mock"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver/mock"
 	registry2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/registry"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/trace/noop"
+	"golang.org/x/net/context"
 )
 
 var emptyTracer = noop.NewTracerProvider().Tracer("empty")
@@ -71,6 +71,7 @@ func TestContextRace(t *testing.T) {
 	assert.NoError(t, registry.RegisterService(idProvider))
 	assert.NoError(t, registry.RegisterService(&mock2.CommLayer{}))
 	resolver := &mock.EndpointService{}
+	resolver.ResolveReturns(&endpoint.Resolver{Id: []byte("alice")}, nil, nil)
 	resolver.GetIdentityReturns([]byte("bob"), nil)
 	assert.NoError(t, registry.RegisterService(resolver))
 	assert.NoError(t, registry.RegisterService(&mock2.SessionFactory{}))

--- a/platform/view/core/manager/context_test.go
+++ b/platform/view/core/manager/context_test.go
@@ -40,7 +40,7 @@ func TestContext(t *testing.T) {
 	assert.NoError(t, registry.RegisterService(resolver))
 	assert.NoError(t, registry.RegisterService(&mock2.SessionFactory{}))
 	session := &mock.Session{}
-	ctx, err := manager.NewContext(context.TODO(), registry, "pineapple", nil, driver.GetEndpointService(registry), []byte("charlie"), session, []byte("caller"), emptyTracer)
+	ctx, err := manager.NewContext(context.TODO(), registry, "pineapple", nil, resolver, idProvider, []byte("charlie"), session, []byte("caller"), emptyTracer)
 	assert.NoError(t, err)
 
 	// Session
@@ -88,7 +88,7 @@ func TestContextRace(t *testing.T) {
 	sessionFactory := &mock2.SessionFactory{}
 	sessionFactory.NewSessionReturns(session, nil)
 
-	ctx, err := manager.NewContext(context.TODO(), registry, "pineapple", sessionFactory, resolver, []byte("charlie"), defaultSession, []byte("caller"), emptyTracer)
+	ctx, err := manager.NewContext(context.TODO(), registry, "pineapple", sessionFactory, resolver, idProvider, []byte("charlie"), defaultSession, []byte("caller"), emptyTracer)
 	assert.NoError(t, err)
 
 	wg := &sync.WaitGroup{}

--- a/platform/view/core/manager/context_test.go
+++ b/platform/view/core/manager/context_test.go
@@ -25,7 +25,7 @@ import (
 var emptyTracer = noop.NewTracerProvider().Tracer("empty")
 
 type Context interface {
-	GetSession(f view.View, party view.Identity) (view.Session, error)
+	GetSession(f view.View, party view.Identity, aliases ...view.View) (view.Session, error)
 	GetSessionByID(id string, party view.Identity) (view.Session, error)
 }
 

--- a/platform/view/core/manager/manager.go
+++ b/platform/view/core/manager/manager.go
@@ -116,7 +116,7 @@ func (cm *manager) InitiateViewWithIdentity(view view.View, id view.Identity, c 
 	}
 	ctx = trace.ContextWithSpanContext(ctx, trace.SpanContextFromContext(c))
 
-	viewContext, err := NewContextForInitiator("", ctx, cm.sp, cm.commLayer, cm.endpointService, id, view, cm.viewTracer)
+	viewContext, err := NewContextForInitiator("", ctx, cm.sp, cm.commLayer, cm.endpointService, cm.identityProvider, id, view, cm.viewTracer)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func (cm *manager) InitiateContextFrom(ctx context.Context, view view.View, id v
 	if id.IsNone() {
 		id = cm.me()
 	}
-	viewContext, err := NewContextForInitiator(contextID, ctx, cm.sp, cm.commLayer, cm.endpointService, id, view, cm.viewTracer)
+	viewContext, err := NewContextForInitiator(contextID, ctx, cm.sp, cm.commLayer, cm.endpointService, cm.identityProvider, id, view, cm.viewTracer)
 	if err != nil {
 		return nil, err
 	}
@@ -316,7 +316,7 @@ func (cm *manager) newContext(id view.Identity, msg *view.Message) (view.Context
 		return nil, false, err
 	}
 	ctx := trace.ContextWithSpanContext(cm.ctx, trace.SpanContextFromContext(msg.Ctx))
-	newCtx, err := NewContext(ctx, cm.sp, contextID, cm.commLayer, cm.endpointService, id, backend, caller, cm.viewTracer)
+	newCtx, err := NewContext(ctx, cm.sp, contextID, cm.commLayer, cm.endpointService, cm.identityProvider, id, backend, caller, cm.viewTracer)
 	if err != nil {
 		return nil, false, err
 	}

--- a/platform/view/core/manager/sessions.go
+++ b/platform/view/core/manager/sessions.go
@@ -1,0 +1,88 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package manager
+
+import (
+	"io"
+	"sync"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/pkg/errors"
+)
+
+type Sessions struct {
+	s  map[string]view.Session
+	mu sync.RWMutex
+}
+
+func newSessions() *Sessions {
+	return &Sessions{s: map[string]view.Session{}}
+}
+
+func (s *Sessions) Lock() {
+	s.mu.Lock()
+}
+
+func (s *Sessions) Unlock() {
+	s.mu.Unlock()
+}
+
+func (s *Sessions) PutDefault(party view.Identity, session view.Session) {
+	s.s[party.UniqueID()] = session
+}
+
+func (s *Sessions) Get(viewId string, party view.Identity) view.Session {
+	return s.s[lookupKey(viewId, party)]
+}
+
+func (s *Sessions) GetFirstOpen(viewId string, parties collections.Iterator[view.Identity]) (view.Session, view.Identity) {
+	defer parties.Close()
+	var targetId view.Identity
+	for party, err := parties.Next(); !errors.Is(err, io.EOF); party, err = parties.Next() {
+		if err != nil {
+			continue
+		}
+
+		session := s.Get(viewId, party)
+		if session != nil && session.Info().Closed {
+			logger.Debugf("removing session [%s:%s], it is closed", viewId, party)
+			s.Delete(viewId, party)
+			return nil, party
+		}
+		if session != nil {
+			logger.Debugf("session for [%s] found with identifier [%s]", party, viewId)
+			return session, party
+		}
+		targetId = party
+	}
+	return nil, targetId
+}
+
+func (s *Sessions) Put(viewId string, party view.Identity, session view.Session) {
+	s.s[lookupKey(viewId, party)] = session
+}
+
+func (s *Sessions) Delete(viewId string, party view.Identity) {
+	delete(s.s, lookupKey(viewId, party))
+}
+
+func (s *Sessions) Reset() {
+	s.s = map[string]view.Session{}
+}
+
+func (s *Sessions) GetSessionIDs() []string {
+	ids := make([]string, 0, len(s.s))
+	for _, session := range s.s {
+		ids = append(ids, session.Info().ID)
+	}
+	return ids
+}
+
+func lookupKey(viewId string, party view.Identity) string {
+	return viewId + party.UniqueID()
+}

--- a/platform/view/core/manager/wrapper.go
+++ b/platform/view/core/manager/wrapper.go
@@ -55,8 +55,8 @@ func (w *childContext) IsMe(id view.Identity) bool {
 	return w.ParentContext.IsMe(id)
 }
 
-func (w *childContext) GetSession(caller view.View, party view.Identity) (view.Session, error) {
-	return w.ParentContext.GetSession(caller, party)
+func (w *childContext) GetSession(caller view.View, party view.Identity, aliases ...view.View) (view.Session, error) {
+	return w.ParentContext.GetSession(caller, party, aliases...)
 }
 
 func (w *childContext) GetSessionByID(id string, party view.Identity) (view.Session, error) {

--- a/platform/view/core/manager/wrapper.go
+++ b/platform/view/core/manager/wrapper.go
@@ -103,6 +103,10 @@ func (w *childContext) Dispose() {
 	}
 }
 
+func (w *childContext) PutSession(caller view.View, party view.Identity, session view.Session) error {
+	return w.ParentContext.PutSession(caller, party, session)
+}
+
 func (w *childContext) cleanup() {
 	logger.Debugf("cleaning up child context [%s][%d]", w.ID(), len(w.errorCallbackFuncs))
 	for _, callbackFunc := range w.errorCallbackFuncs {

--- a/platform/view/core/manager/wrapper.go
+++ b/platform/view/core/manager/wrapper.go
@@ -55,8 +55,8 @@ func (w *childContext) IsMe(id view.Identity) bool {
 	return w.ParentContext.IsMe(id)
 }
 
-func (w *childContext) GetSession(caller view.View, party view.Identity, aliases ...view.View) (view.Session, error) {
-	return w.ParentContext.GetSession(caller, party, aliases...)
+func (w *childContext) GetSession(caller view.View, party view.Identity, boundToViews ...view.View) (view.Session, error) {
+	return w.ParentContext.GetSession(caller, party, boundToViews...)
 }
 
 func (w *childContext) GetSessionByID(id string, party view.Identity) (view.Session, error) {

--- a/platform/view/services/session/json.go
+++ b/platform/view/services/session/json.go
@@ -71,7 +71,7 @@ func (j *jsonSession) ReceiveWithTimeout(state interface{}, d time.Duration) err
 	}
 	err = json.Unmarshal(raw, state)
 	if err != nil {
-		return errors.Wrapf(err, "failed unmarshalling state [%s]", string(raw))
+		return errors.Wrapf(err, "failed unmarshalling state, len [%d]", len(raw))
 	}
 	return nil
 }

--- a/platform/view/services/session/json.go
+++ b/platform/view/services/session/json.go
@@ -88,6 +88,9 @@ func (j *jsonSession) ReceiveRawWithTimeout(d time.Duration) ([]byte, error) {
 	select {
 	case msg := <-ch:
 		span.AddEvent("Received message")
+		if msg == nil {
+			return nil, errors.New("received message is nil")
+		}
 		if msg.Status == view.ERROR {
 			return nil, errors.Errorf("received error from remote [%s]", string(msg.Payload))
 		}

--- a/platform/view/services/session/json.go
+++ b/platform/view/services/session/json.go
@@ -73,6 +73,7 @@ func (j *jsonSession) ReceiveWithTimeout(state interface{}, d time.Duration) err
 	if err != nil {
 		return errors.Wrapf(err, "failed unmarshalling state [%s]", string(raw))
 	}
+	return nil
 }
 
 func (j *jsonSession) ReceiveRaw() ([]byte, error) {

--- a/platform/view/services/session/json.go
+++ b/platform/view/services/session/json.go
@@ -69,7 +69,10 @@ func (j *jsonSession) ReceiveWithTimeout(state interface{}, d time.Duration) err
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(raw, state)
+	err = json.Unmarshal(raw, state)
+	if err != nil {
+		return errors.Wrapf(err, "failed unmarshalling state [%s]", string(raw))
+	}
 }
 
 func (j *jsonSession) ReceiveRaw() ([]byte, error) {

--- a/platform/view/services/view/context.go
+++ b/platform/view/services/view/context.go
@@ -87,7 +87,7 @@ func (c *MockContext) OnError(callback func()) {
 	c.Ctx.OnError(callback)
 }
 
-func (c *MockContext) GetSession(caller view.View, party view.Identity) (view.Session, error) {
+func (c *MockContext) GetSession(caller view.View, party view.Identity, aliases ...view.View) (view.Session, error) {
 	for _, responder := range c.responders {
 		if responder.InitiatorView == caller && responder.ResponderID.Equal(party) {
 			responder.Lock.RLock()

--- a/platform/view/services/view/context.go
+++ b/platform/view/services/view/context.go
@@ -70,11 +70,6 @@ func (c *MockContext) GetSessionByID(id string, party view.Identity) (view.Sessi
 	return c.Ctx.GetSessionByID(id, party)
 }
 
-func (c *MockContext) ResetSessions() error {
-	// TODO: clean responder channels
-	return c.Ctx.ResetSessions()
-}
-
 func (c *MockContext) Session() view.Session {
 	return c.Ctx.Session()
 }
@@ -87,7 +82,7 @@ func (c *MockContext) OnError(callback func()) {
 	c.Ctx.OnError(callback)
 }
 
-func (c *MockContext) GetSession(caller view.View, party view.Identity, aliases ...view.View) (view.Session, error) {
+func (c *MockContext) GetSession(caller view.View, party view.Identity, boundToViews ...view.View) (view.Session, error) {
 	for _, responder := range c.responders {
 		if responder.InitiatorView == caller && responder.ResponderID.Equal(party) {
 			responder.Lock.RLock()

--- a/platform/view/view/context.go
+++ b/platform/view/view/context.go
@@ -106,7 +106,7 @@ type Context interface {
 	// GetSession returns a session to the passed remote
 	// party for the given view caller.
 	// Cashing may be be used.
-	GetSession(caller View, party Identity) (Session, error)
+	GetSession(caller View, party Identity, aliases ...View) (Session, error)
 
 	// GetSessionByID returns a session to the passed remote party and id.
 	// Cashing may be used.

--- a/platform/view/view/context.go
+++ b/platform/view/view/context.go
@@ -103,16 +103,14 @@ type Context interface {
 	// Initiator returns the View that initiate a call
 	Initiator() View
 
-	// GetSession returns a session to the passed remote
-	// party for the given view caller.
-	// Cashing may be be used.
-	GetSession(caller View, party Identity, aliases ...View) (Session, error)
+	// GetSession returns a session to the passed remote party for the given view caller.
+	// Sessions are scoped by the caller view and cached.
+	// The session can be bound to other caller views by passing them as additional parameters.
+	GetSession(caller View, party Identity, boundToViews ...View) (Session, error)
 
 	// GetSessionByID returns a session to the passed remote party and id.
 	// Cashing may be used.
 	GetSessionByID(id string, party Identity) (Session, error)
-
-	ResetSessions() error
 
 	// Session returns the session created to respond to a
 	// remote party, nil if the context was created


### PR DESCRIPTION
When calling `GetSession` we pass the calling view and the party to reach. If the session is opened for the first time, the party is informed about the calling view as well. In a given context, `GetSession` can be called with different calling view, therefore it should be possible to scope the sessions by calling view as well. This allows the developer to open more than one  session to the same party but starting from different calling views.

This behaviour was not currently supported, this PR introduces this behaviour. 
