### PR TITLE
Integrate otelzap to combine logging with span events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,9 +99,12 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/sykesm/zap-logfmt v0.0.4 // indirect
 	github.com/uptrace/opentelemetry-go-extra/otelsql v0.3.2 // indirect
+	github.com/uptrace/opentelemetry-go-extra/otelutil v0.3.2 // indirect
+	github.com/uptrace/opentelemetry-go-extra/otelzap v0.3.2 // indirect
 	github.com/wlynxg/anet v0.0.5 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.29.0 // indirect
+	go.opentelemetry.io/otel/log v0.6.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.29.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1718,6 +1718,10 @@ github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65E
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/uptrace/opentelemetry-go-extra/otelsql v0.3.2 h1:ZjUj9BLYf9PEqBn8W/OapxhPjVRdC6CsXTdULHsyk5c=
 github.com/uptrace/opentelemetry-go-extra/otelsql v0.3.2/go.mod h1:O8bHQfyinKwTXKkiKNGmLQS7vRsqRxIQTFZpYpHK3IQ=
+github.com/uptrace/opentelemetry-go-extra/otelutil v0.3.2 h1:3/aHKUq7qaFMWxyQV0W2ryNgg8x8rVeKVA20KJUkfS0=
+github.com/uptrace/opentelemetry-go-extra/otelutil v0.3.2/go.mod h1:Zit4b8AQXaXvA68+nzmbyDzqiyFRISyw1JiD5JqUBjw=
+github.com/uptrace/opentelemetry-go-extra/otelzap v0.3.2 h1:cj/Z6FKTTYBnstI0Lni9PA+k2foounKIPUmj1LBwNiQ=
+github.com/uptrace/opentelemetry-go-extra/otelzap v0.3.2/go.mod h1:LDaXk90gKEC2nC7JH3Lpnhfu+2V7o/TsqomJJmqA39o=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
@@ -1801,6 +1805,8 @@ go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.29.0 h1:WDdP9acbMYjbKI
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.29.0/go.mod h1:BLbf7zbNIONBLPwvFnwNHGj4zge8uTCM/UPIVW1Mq2I=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.28.0 h1:EVSnY9JbEEW92bEkIYOVMw4q1WJxIAGoFTrtYOzWuRQ=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.28.0/go.mod h1:Ea1N1QQryNXpCD0I1fdLibBAIpQuBkznMmkdKrapk1Y=
+go.opentelemetry.io/otel/log v0.6.0 h1:nH66tr+dmEgW5y+F9LanGJUBYPrRgP4g2EkmPE3LeK8=
+go.opentelemetry.io/otel/log v0.6.0/go.mod h1:KdySypjQHhP069JX0z/t26VHwa8vSwzgaKmXtIB3fJM=
 go.opentelemetry.io/otel/metric v0.20.0/go.mod h1:598I5tYlH1vzBjn+BTuhzTCSb/9debfNp6R3s7Pr1eU=
 go.opentelemetry.io/otel/metric v1.29.0 h1:vPf/HFWTNkPu1aYeIsc98l4ktOQaL6LeSoeV2g+8YLc=
 go.opentelemetry.io/otel/metric v1.29.0/go.mod h1:auu/QWieFVWx+DmQOUMgj0F8LHWdgalxXqvp7BII/W8=

--- a/platform/common/services/logging/mock.go
+++ b/platform/common/services/logging/mock.go
@@ -1,0 +1,139 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package logging
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// Ensure MockLogger satisfies the Logger interface
+var _ Logger = (*MockLogger)(nil)
+
+type MockLogger struct{}
+
+func (m *MockLogger) Named(name string) Logger {
+	fmt.Println("Named:", name)
+	return m
+}
+
+func (m *MockLogger) Debug(args ...interface{}) {
+	fmt.Println("DEBUG:", fmt.Sprint(args...))
+}
+
+func (m *MockLogger) Debugf(format string, args ...interface{}) {
+	fmt.Printf("DEBUG: "+format+"\n", args...)
+}
+
+func (m *MockLogger) Error(args ...interface{}) {
+	fmt.Println("ERROR:", fmt.Sprint(args...))
+}
+
+func (m *MockLogger) Errorf(format string, args ...interface{}) {
+	fmt.Printf("ERROR: "+format+"\n", args...)
+}
+
+func (m *MockLogger) Fatal(args ...interface{}) {
+	fmt.Println("FATAL:", fmt.Sprint(args...))
+}
+
+func (m *MockLogger) Fatalf(format string, args ...interface{}) {
+	fmt.Printf("FATAL: "+format+"\n", args...)
+}
+
+func (m *MockLogger) Info(args ...interface{}) {
+	fmt.Println("INFO:", fmt.Sprint(args...))
+}
+
+func (m *MockLogger) Infof(format string, args ...interface{}) {
+	fmt.Printf("INFO: "+format+"\n", args...)
+}
+
+func (m *MockLogger) Panic(args ...interface{}) {
+	fmt.Println("PANIC:", fmt.Sprint(args...))
+}
+
+func (m *MockLogger) Panicf(format string, args ...interface{}) {
+	fmt.Printf("PANIC: "+format+"\n", args...)
+}
+
+func (m *MockLogger) Warn(args ...interface{}) {
+	fmt.Println("WARN:", fmt.Sprint(args...))
+}
+
+func (m *MockLogger) Warnf(format string, args ...interface{}) {
+	fmt.Printf("WARN: "+format+"\n", args...)
+}
+
+func (m *MockLogger) IsEnabledFor(level zapcore.Level) bool {
+	// Implement logic to check if the given log level is enabled
+	return true
+}
+
+func (m *MockLogger) Warnw(format string, args ...interface{}) {
+	fmt.Printf("WARN: "+format+"\n", args...)
+}
+
+func (m *MockLogger) Warningf(format string, args ...interface{}) {
+	fmt.Printf("WARNING: "+format+"\n", args...)
+}
+
+func (m *MockLogger) Errorw(format string, args ...interface{}) {
+	fmt.Printf("ERROR: "+format+"\n", args...)
+}
+
+func (m *MockLogger) With(args ...interface{}) Logger {
+	fmt.Println("With:", fmt.Sprint(args...))
+	return m
+}
+
+func (m *MockLogger) DebugfContext(_ context.Context, template string, args ...interface{}) {
+	m.Debugf(template, args...)
+}
+
+func (m *MockLogger) DebugwContext(_ context.Context, template string, args ...interface{}) {
+	m.Debugf(template, args...)
+}
+
+func (m *MockLogger) InfofContext(_ context.Context, template string, args ...interface{}) {
+	m.Infof(template, args...)
+}
+
+func (m *MockLogger) InfowContext(_ context.Context, template string, args ...interface{}) {
+	m.Infof(template, args...)
+}
+
+func (m *MockLogger) WarnwContext(_ context.Context, template string, args ...interface{}) {
+	m.Warnf(template, args...)
+}
+
+func (m *MockLogger) WarnfContext(_ context.Context, template string, args ...interface{}) {
+	m.Warnf(template, args...)
+}
+
+func (m *MockLogger) ErrorfContext(_ context.Context, template string, args ...interface{}) {
+	m.Errorf(template, args...)
+}
+
+func (m *MockLogger) ErrorwContext(_ context.Context, template string, args ...interface{}) {
+	m.Errorf(template, args...)
+}
+
+func (m *MockLogger) PanicfContext(_ context.Context, template string, args ...interface{}) {
+	m.Panicf(template, args...)
+}
+
+func (m *MockLogger) PanicwContext(_ context.Context, template string, args ...interface{}) {
+	m.Panicf(template, args...)
+}
+
+func (m *MockLogger) Zap() *zap.Logger {
+	return nil
+}

--- a/platform/common/services/logging/otel.go
+++ b/platform/common/services/logging/otel.go
@@ -1,0 +1,74 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package logging
+
+import (
+	"context"
+
+	"github.com/uptrace/opentelemetry-go-extra/otelzap"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/log"
+	"go.opentelemetry.io/otel/log/noop"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+const loggerNameKey = "logger.name"
+
+type otelLogger interface {
+	DebugfContext(ctx context.Context, template string, args ...interface{})
+	DebugwContext(ctx context.Context, template string, args ...interface{})
+	InfofContext(ctx context.Context, template string, args ...interface{})
+	InfowContext(ctx context.Context, template string, args ...interface{})
+	WarnfContext(ctx context.Context, template string, args ...interface{})
+	WarnwContext(ctx context.Context, template string, args ...interface{})
+	ErrorfContext(ctx context.Context, template string, args ...interface{})
+	ErrorwContext(ctx context.Context, template string, args ...interface{})
+	PanicfContext(ctx context.Context, template string, args ...interface{})
+	PanicwContext(ctx context.Context, template string, args ...interface{})
+}
+
+func NewOtelLogger(zapLogger *zap.Logger) otelLogger {
+	return otelzap.New(zapLogger,
+		otelzap.WithLoggerProvider(newLoggerProvider(zapLogger.Name())),
+		//otelzap.WithMinLevel(zapLogger.Level()),
+		otelzap.WithMinLevel(zapcore.DebugLevel),
+	).Sugar()
+}
+
+func newLoggerProvider(name string) *spanLoggerProvider {
+	return &spanLoggerProvider{
+		LoggerProvider: noop.NewLoggerProvider(),
+		loggerName:     name,
+	}
+}
+
+type spanLoggerProvider struct {
+	log.LoggerProvider
+
+	loggerName string
+}
+
+func (p *spanLoggerProvider) Logger(name string, options ...log.LoggerOption) log.Logger {
+	return &spanLogger{
+		Logger:     p.LoggerProvider.Logger(name, options...),
+		loggerName: p.loggerName,
+	}
+}
+
+type spanLogger struct {
+	log.Logger
+
+	loggerName string
+}
+
+func (l *spanLogger) Emit(ctx context.Context, record log.Record) {
+	trace.SpanFromContext(ctx).AddEvent(record.Body().AsString(), trace.WithAttributes(attribute.String(loggerNameKey, l.loggerName)))
+}
+
+func (l *spanLogger) Enabled(context.Context, log.Record) bool { return true }

--- a/platform/common/services/logging/types.go
+++ b/platform/common/services/logging/types.go
@@ -1,0 +1,37 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package logging
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections"
+)
+
+// Keys logs lazily the keys of a map
+func Keys[K comparable, V any](m map[K]V) fmt.Stringer {
+	return keys[K, V](m)
+}
+
+type keys[K comparable, V any] map[K]V
+
+func (k keys[K, V]) String() string {
+	return fmt.Sprintf(strings.Join(collections.Repeat("%v", len(k)), ", "), collections.Keys(k))
+}
+
+// Base64 logs lazily a byte array in base64 format
+func Base64(b []byte) base64Enc {
+	return b
+}
+
+type base64Enc []byte
+
+func (b base64Enc) String() string {
+	return base64.StdEncoding.EncodeToString(b)
+}

--- a/platform/view/services/db/driver/sql/postgres/conditions.go
+++ b/platform/view/services/db/driver/sql/postgres/conditions.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package postgres
 
 import (
+	"time"
+
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/sql/query/common"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/sql/query/cond"
 )
@@ -16,6 +18,22 @@ func NewConditionInterpreter() *interpreter {
 }
 
 type interpreter struct{}
+
+func (i *interpreter) TimeOffset(duration time.Duration, sb common.Builder) {
+	sb.WriteString("NOW()")
+	if duration == 0 {
+		return
+	}
+	if duration < 0 {
+		duration *= -1
+		sb.WriteString(" -")
+	} else {
+		sb.WriteString(" +")
+	}
+	sb.WriteString(" INTERVAL '").
+		WriteParam(int(duration.Seconds())).
+		WriteString(" seconds'")
+}
 
 func (i *interpreter) InTuple(fields []common.Serializable, vals []common.Tuple, sb common.Builder) {
 	if len(vals) == 0 || len(fields) == 0 {

--- a/platform/view/services/db/driver/sql/query/common/types.go
+++ b/platform/view/services/db/driver/sql/query/common/types.go
@@ -6,7 +6,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package common
 
-import "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+import (
+	"time"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+)
 
 // FieldName is the name of the DB column
 type FieldName string
@@ -20,6 +24,8 @@ type Param = any
 // CondInterpreter is the condition interpreter for the WHERE clauses
 // It specifies the behaviors that differ among different DBs
 type CondInterpreter interface {
+	// TimeOffset appends NOW() - '10 seconds'
+	TimeOffset(duration time.Duration, sb Builder)
 	// InTuple creates the condition (field1, field2, ...) IN ((val1, val2, ...), (val3, val4, ...))
 	InTuple(fields []Serializable, vals []Tuple, sb Builder)
 }

--- a/platform/view/services/db/driver/sql/query/cond/condition_test.go
+++ b/platform/view/services/db/driver/sql/query/cond/condition_test.go
@@ -8,6 +8,7 @@ package cond_test
 
 import (
 	"testing"
+	"time"
 
 	common2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/common"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/sql/postgres"
@@ -60,6 +61,21 @@ var testMatrix = []testCase{
 		condition:      cond.InTuple([]common.Serializable{common.NewAliasedTable("tab").Field("id"), common.NewAliasedTable("tab").Field("id2")}, []cond.Tuple{{10, "a"}, {20, "b"}, {30, "c"}}),
 		expectedQuery:  "((tab.id = $0) AND (tab.id2 = $1)) OR ((tab.id = $2) AND (tab.id2 = $3)) OR ((tab.id = $4) AND (tab.id2 = $5))",
 		expectedParams: []common.Param{10, "a", 20, "b", 30, "c"},
+	},
+	{
+		condition:      cond.OlderThan(common.FieldName("field"), 5*time.Minute),
+		expectedQuery:  "field < NOW() - INTERVAL '$0 seconds'",
+		expectedParams: []common.Param{300},
+	},
+	{
+		condition:      cond.AfterNext(common.FieldName("field"), 10*time.Minute),
+		expectedQuery:  "field > NOW() + INTERVAL '$0 seconds'",
+		expectedParams: []common.Param{600},
+	},
+	{
+		condition:      cond.InPast(common.FieldName("field")),
+		expectedQuery:  "field < NOW()",
+		expectedParams: []common.Param{},
 	},
 }
 

--- a/platform/view/services/db/driver/sql/query/cond/time.go
+++ b/platform/view/services/db/driver/sql/query/cond/time.go
@@ -1,0 +1,48 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cond
+
+import (
+	"time"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/sql/query/common"
+)
+
+type cmpDuration struct {
+	field    common.Serializable
+	operator string
+	duration time.Duration
+}
+
+func InPast(field common.Serializable) Condition {
+	return &cmpDuration{field: field, operator: " < ", duration: 0}
+}
+
+func InFuture(field common.Serializable) Condition {
+	return &cmpDuration{field: field, operator: " > ", duration: 0}
+}
+
+func OlderThan(field common.Serializable, duration time.Duration) Condition {
+	return &cmpDuration{field: field, operator: " < ", duration: -duration}
+}
+
+func NewerThan(field common.Serializable, duration time.Duration) Condition {
+	return &cmpDuration{field: field, operator: " > ", duration: -duration}
+}
+
+func BeforeNext(field common.Serializable, duration time.Duration) Condition {
+	return &cmpDuration{field: field, operator: " < ", duration: duration}
+}
+
+func AfterNext(field common.Serializable, duration time.Duration) Condition {
+	return &cmpDuration{field: field, operator: " > ", duration: duration}
+}
+
+func (c *cmpDuration) WriteString(in common.CondInterpreter, sb common.Builder) {
+	sb.WriteSerializables(c.field).WriteString(c.operator)
+	in.TimeOffset(c.duration, sb)
+}

--- a/platform/view/services/db/driver/sql/sqlite/conditions.go
+++ b/platform/view/services/db/driver/sql/sqlite/conditions.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package sqlite
 
 import (
+	"time"
+
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/sql/query/common"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/sql/query/cond"
 )
@@ -16,6 +18,23 @@ func NewConditionInterpreter() common.CondInterpreter {
 }
 
 type interpreter struct{}
+
+func (i *interpreter) TimeOffset(duration time.Duration, sb common.Builder) {
+	sb.WriteString("datetime('now'")
+	if duration == 0 {
+		sb.WriteRune(')')
+		return
+	}
+	sb.WriteString(", '")
+	if duration < 0 {
+		duration *= -1
+		sb.WriteRune('-')
+	} else {
+		sb.WriteRune('+')
+	}
+	sb.WriteParam(int(duration.Seconds())).
+		WriteString(" seconds')")
+}
 
 func (i *interpreter) InTuple(fields []common.Serializable, vals []common.Tuple, sb common.Builder) {
 	if len(vals) == 0 || len(fields) == 0 {


### PR DESCRIPTION
Instead of using
```
trace.SpanFromContext(ctx).AddEvent(...)
```
we can use the existing loggers to both log and add an event.
```
logger.InfofContext(ctx, ...)
logger.InfowContext(ctx, ...)
```