### PR TITLE
F fix format

### DIFF
--- a/platform/view/services/db/driver/sql/common/auditinfo.go
+++ b/platform/view/services/db/driver/sql/common/auditinfo.go
@@ -41,7 +41,7 @@ func (db *AuditInfoStore) GetAuditInfo(ctx context.Context, id view.Identity) ([
 	query, params := q.Select().FieldsByName("audit_info").
 		From(q.Table(db.table)).
 		Where(cond.Eq("id", id.UniqueID())).
-		Format(db.ci, nil)
+		Format(db.ci)
 	logger.Debug(query, params)
 
 	return QueryUnique[[]byte](db.readDB, query, params...)

--- a/platform/view/services/db/driver/sql/common/binding.go
+++ b/platform/view/services/db/driver/sql/common/binding.go
@@ -42,7 +42,7 @@ func (db *BindingStore) GetLongTerm(ctx context.Context, ephemeral view.Identity
 	query, params := q.Select().FieldsByName("long_term_id").
 		From(q.Table(db.table)).
 		Where(cond.Eq("ephemeral_hash", ephemeral.UniqueID())).
-		Format(db.ci, nil)
+		Format(db.ci)
 
 	logger.Debug(query, params)
 	result, err := QueryUnique[view.Identity](db.readDB, query, params...)
@@ -57,7 +57,7 @@ func (db *BindingStore) HaveSameBinding(ctx context.Context, this, that view.Ide
 	query, params := q.Select().FieldsByName("long_term_id").
 		From(q.Table(db.table)).
 		Where(cond.In("ephemeral_hash", this.UniqueID(), that.UniqueID())).
-		Format(db.ci, nil)
+		Format(db.ci)
 
 	logger.Debug(query, params)
 	rows, err := db.readDB.QueryContext(ctx, query, params...)

--- a/platform/view/services/db/driver/sql/common/signerinfo.go
+++ b/platform/view/services/db/driver/sql/common/signerinfo.go
@@ -49,7 +49,7 @@ func (db *SignerInfoStore) FilterExistingSigners(ids ...view.Identity) ([]view.I
 	query, params := q.Select().FieldsByName("id").
 		From(q.Table(db.table)).
 		Where(cond.In("id", idHashes...)).
-		Format(db.ci, nil)
+		Format(db.ci)
 	logger.Debug(query, params)
 
 	rows, err := db.readDB.Query(query, params...)

--- a/platform/view/services/db/driver/sql/common/simplekeydata.go
+++ b/platform/view/services/db/driver/sql/common/simplekeydata.go
@@ -39,7 +39,7 @@ func (db *simpleKeyDataStore) GetData(key string) ([]byte, error) {
 	query, params := q.Select().FieldsByName("data").
 		From(q.Table(db.table)).
 		Where(cond.Eq("key", key)).
-		Format(db.ci, nil)
+		Format(db.ci)
 	logger.Debug(query, params)
 
 	return QueryUnique[[]byte](db.readDB, query, params...)

--- a/platform/view/services/db/driver/sql/common/unversioned.go
+++ b/platform/view/services/db/driver/sql/common/unversioned.go
@@ -55,7 +55,7 @@ func (db *KeyValueStore) GetStateRangeScanIterator(ns driver2.Namespace, startKe
 		From(q.Table(db.table)).
 		Where(cond.And(cond.Eq("ns", ns), cond.BetweenStrings("pkey", startKey, endKey))).
 		OrderBy(q.Asc(common2.FieldName("pkey"))).
-		Format(db.ci, nil)
+		Format(db.ci)
 
 	logger.Debug(query, params)
 
@@ -71,7 +71,7 @@ func (db *KeyValueStore) GetState(namespace driver2.Namespace, key driver2.PKey)
 	query, params := q.Select().FieldsByName("val").
 		From(q.Table(db.table)).
 		Where(HasKeys(namespace, key)).
-		Format(db.ci, nil)
+		Format(db.ci)
 	logger.Debug(query, params)
 
 	return QueryUnique[driver.UnversionedValue](db.readDB, query, params...)
@@ -84,7 +84,7 @@ func (db *KeyValueStore) GetStateSetIterator(ns driver2.Namespace, keys ...drive
 	query, params := q.Select().FieldsByName("pkey", "val").
 		From(q.Table(db.table)).
 		Where(HasKeys(ns, keys...)).
-		Format(db.ci, nil)
+		Format(db.ci)
 
 	logger.Debug(query[:30] + "...")
 

--- a/platform/view/services/db/driver/sql/common/vault.go
+++ b/platform/view/services/db/driver/sql/common/vault.go
@@ -388,7 +388,7 @@ func (db *vaultReader) queryState(where cond.Condition) (driver.TxStateIterator,
 	query, params := q.Select().FieldsByName("pkey", "kversion", "val").
 		From(q.Table(db.tables.StateTable)).
 		Where(where).
-		Format(db.ci, db.pi)
+		Format(db.ci)
 	params, err := db.sanitizer.EncodeAll(params)
 	if err != nil {
 		return nil, err
@@ -423,7 +423,7 @@ func (db *vaultReader) GetStateMetadata(ctx context.Context, namespace driver.Na
 	query, params := q.Select().FieldsByName("metadata", "kversion").
 		From(q.Table(db.tables.StateTable)).
 		Where(cond.And(cond.Eq("ns", namespace), cond.Eq("pkey", key))).
-		Format(db.ci, db.pi)
+		Format(db.ci)
 	logger.Debug(query, params)
 
 	row := db.readDB.QueryRowContext(ctx, query, params...)
@@ -508,7 +508,7 @@ func (db *vaultReader) queryStatus(where cond.Condition, pagination driver.Pagin
 		From(q.Table(db.tables.StatusTable)).
 		Where(where).
 		Paginated(pagination).
-		Format(db.ci, db.pi)
+		FormatPaginated(db.ci, db.pi)
 	logger.Infof(query, params)
 
 	rows, err := db.readDB.Query(query, params...)

--- a/platform/view/services/db/driver/sql/query/select/query.go
+++ b/platform/view/services/db/driver/sql/query/select/query.go
@@ -75,11 +75,19 @@ func (q *query) Paginated(p driver.Pagination) paginatedQuery {
 	return q
 }
 
-func (q *query) Format(ci common.CondInterpreter, pi common.PagInterpreter) (string, []any) {
-	return q.FormatWithOffset(ci, pi, common2.CopyPtr(1))
+func (q *query) Format(ci common.CondInterpreter) (string, []any) {
+	return q.FormatPaginated(ci, nil)
 }
 
-func (q *query) FormatWithOffset(ci common.CondInterpreter, pi common.PagInterpreter, pc *int) (string, []any) {
+func (q *query) FormatWithOffset(ci common.CondInterpreter, pc *int) (string, []any) {
+	return q.FormatPaginatedWithOffset(ci, nil, pc)
+}
+
+func (q *query) FormatPaginated(ci common.CondInterpreter, pi common.PagInterpreter) (string, []any) {
+	return q.FormatPaginatedWithOffset(ci, pi, common2.CopyPtr(1))
+}
+
+func (q *query) FormatPaginatedWithOffset(ci common.CondInterpreter, pi common.PagInterpreter, pc *int) (string, []any) {
 	sb := common.NewBuilderWithOffset(pc).WriteString("SELECT ")
 
 	if q.distinct {

--- a/platform/view/services/db/driver/sql/query/select/query_test.go
+++ b/platform/view/services/db/driver/sql/query/select/query_test.go
@@ -13,7 +13,6 @@ import (
 	q "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/sql/query"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/sql/query/common"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/sql/query/cond"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/sql/query/pagination"
 	. "github.com/onsi/gomega"
 )
 
@@ -27,7 +26,7 @@ func TestSelectSimple(t *testing.T) {
 		OrderBy(q.Asc(common.FieldName("id"))).
 		Limit(2).
 		Offset(1).
-		Format(postgres.NewConditionInterpreter(), pagination.NewDefaultInterpreter())
+		Format(postgres.NewConditionInterpreter())
 
 	Expect(query).To(Equal("SELECT id, name " +
 		"FROM my_table AS my_table " +
@@ -50,7 +49,7 @@ func TestSelectJoin(t *testing.T) {
 		OrderBy(q.Desc(yourTable.Field("date"))).
 		Limit(2).
 		Offset(1).
-		Format(postgres.NewConditionInterpreter(), pagination.NewDefaultInterpreter())
+		Format(postgres.NewConditionInterpreter())
 
 	Expect(query).To(Equal("SELECT my_table.name, your_table.id " +
 		"FROM my_table AS my_table " +

--- a/platform/view/services/db/driver/sql/query/select/types.go
+++ b/platform/view/services/db/driver/sql/query/select/types.go
@@ -39,17 +39,19 @@ type fromQuery interface {
 
 // whereQuery is the query state after WHERE
 type whereQuery interface {
-	paginatedQuery
+	orderByQuery
+
+	// OrderBy specifies the order by clause
+	OrderBy(...OrderBy) orderByQuery
 
 	// Paginated specifies the pagination details
 	Paginated(driver.Pagination) paginatedQuery
 }
 
 type paginatedQuery interface {
-	orderByQuery
+	FormatPaginated(common.CondInterpreter, common.PagInterpreter) (string, []common.Param)
 
-	// OrderBy specifies the order by clause
-	OrderBy(...OrderBy) orderByQuery
+	FormatPaginatedWithOffset(ci common.CondInterpreter, pi common.PagInterpreter, pc *int) (string, []any)
 }
 
 // orderByQuery is the query state after ORDER BY
@@ -71,8 +73,8 @@ type limitQuery interface {
 // offsetQuery is the query state after OFFSET
 type offsetQuery interface {
 	// Format composes the query and the params to pass to the DB
-	Format(common.CondInterpreter, common.PagInterpreter) (string, []common.Param)
+	Format(common.CondInterpreter) (string, []common.Param)
 
 	// FormatWithOffset composes the query and the params to pass to the DB with an offset for the numbered params
-	FormatWithOffset(common.CondInterpreter, common.PagInterpreter, *int) (string, []common.Param)
+	FormatWithOffset(common.CondInterpreter, *int) (string, []common.Param)
 }


### PR DESCRIPTION
Removed interpreter parameter from Format method when it is not needed. We need a pagination interpreter only when we have pagination in the query.