### PR TITLE
Fix flaky test

### DIFF
--- a/integration/fabric/events/chaincode/client.go
+++ b/integration/fabric/events/chaincode/client.go
@@ -33,7 +33,7 @@ func (c *Client) EventsView(chaincodeFunction string, eventName string) (interfa
 	return event, err
 }
 
-func (c *Client) MultipleListenersView(chaincodeFunction string, eventName string, listenerCount uint8) (interface{}, error) {
+func (c *Client) MultipleListenersView(chaincodeFunction string, eventName string, listenerCount int) (interface{}, error) {
 	event, err := c.c.CallView("MultipleListenersView", common.JSONMarshall(&views.MultipleListeners{
 		Function:      chaincodeFunction,
 		EventName:     eventName,

--- a/integration/fabric/events/chaincode/events_test.go
+++ b/integration/fabric/events/chaincode/events_test.go
@@ -20,16 +20,6 @@ import (
 )
 
 var _ = Describe("EndToEnd", func() {
-	Describe("Events (With Chaincode) With LibP2P", func() {
-		s := NewTestSuite(fsc.LibP2P, integration.NoReplication)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("clients listening to single chaincode events", s.TestSingleChaincodeEvents)
-		It("client listening to multiple chaincode events", s.TestMultipleChaincodeEvents)
-		It("multiple clients unsubscribing", s.TestMultipleListenersAndUnsubscribe)
-		It("Upgrade Chaincode", s.TestUpgradeChaincode)
-	})
-
 	Describe("Events (With Chaincode) With Websockets", func() {
 		s := NewTestSuite(fsc.WebSocket, integration.NoReplication)
 		BeforeEach(s.Setup)
@@ -92,7 +82,7 @@ func (s *TestSuite) TestMultipleChaincodeEvents() {
 }
 
 func (s *TestSuite) TestMultipleListenersAndUnsubscribe() {
-	n := uint8(20)
+	n := 20
 	alice := chaincode.NewClient(s.II.Client("alice"), s.II.Identity("alice"))
 
 	// - Operate from Alice (Org1)
@@ -103,7 +93,7 @@ func (s *TestSuite) TestMultipleListenersAndUnsubscribe() {
 	err = json.Unmarshal(events.([]byte), eventsReceived)
 	Expect(err).ToNot(HaveOccurred())
 
-	Expect(len(eventsReceived.Events)).To(Equal(int(n)))
+	Expect(len(eventsReceived.Events)).To(Equal(n))
 	for _, event := range eventsReceived.Events {
 		Expect(event).To(Not(BeNil()))
 		Expect(string(event.Payload)).To(Equal("Invoked Create Asset Successfully"))


### PR DESCRIPTION
This PR fixes a flaky test in `integration-tests-chaincode-events` where it may throw the following error:

```bash
 [e][fsc.alice.0] 2025-05-30 08:28:57.525 UTC 009d INFO [fsc.view.services.db.driver.sql.common] queryStatus -> SELECT tx_id, code, message FROM fsc_default__testchannel_vstatus WHERE tx_id = $1%!(EXTRA []interface {}=[4a5605c10d2a1e01fb68fbdc1b2e9f3b2c2f7a3e515ca26ea4d39b16c4169260])
  [e][fsc.alice.0] 2025-05-30 08:28:57.525 UTC 009e INFO [fsc.view.services.db.driver.sql.common] queryStatus -> SELECT tx_id, code, message FROM fsc_default__testchannel_vstatus WHERE tx_id = $1%!(EXTRA []interface {}=[4a5605c10d2a1e01fb68fbdc1b2e9f3b2c2f7a3e515ca26ea4d39b16c4169260])
  [e][fsc.alice.0] panic: sync: negative WaitGroup counter
  [e][fsc.alice.0] 
  [e][fsc.alice.0] goroutine 172 [running]:
  [e][fsc.alice.0] sync.(*WaitGroup).Add(0xc0006a9b30?, 0x28ed12c?)
  [e][fsc.alice.0] 	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.3.linux-amd64/src/sync/waitgroup.go:64 +0xcd
  [e][fsc.alice.0] sync.(*WaitGroup).Done(...)
  [e][fsc.alice.0] 	/home/runner/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.3.linux-amd64/src/sync/waitgroup.go:89
  [e][fsc.alice.0] github.com/hyperledger-labs/fabric-smart-client/integration/fabric/events/chaincode/views.(*MultipleListenersView).Call.func1.1(0xc001735da0)
  [e][fsc.alice.0] 	/home/runner/work/fabric-smart-client/fabric-smart-client/integration/fabric/events/chaincode/views/multipleListeners.go:60 +0x23f
  [e][fsc.alice.0] github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/chaincode.(*ListenToEventsView).RegisterChaincodeEvents.func1()
  [e][fsc.alice.0] 	/home/runner/work/fabric-smart-client/fabric-smart-client/platform/fabric/services/chaincode/events.go:103 +0x5ad
  [e][fsc.alice.0] created by github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/chaincode.(*ListenToEventsView).RegisterChaincodeEvents in goroutine 163
  [e][fsc.alice.0] 	/home/runner/work/fabric-smart-client/fabric-smart-client/platform/fabric/services/chaincode/events.go:91 +0x34c
  [e][fabric.default-OrdererOrg.orderer] 2025-05-30 08:28:58.022 UTC 0125 INFO [grpc] Infof -> [transport] [server-transport 0xc0004501a0] Closing: EOF
  ```

I've noticed this failing test here: https://github.com/hyperledger-labs/fabric-smart-client/actions/runs/15342233369/job/43170845044?pr=941

As the test case does not exercise node-to-node communication, I removed the libp2p setting which reduces the runtime of this test.