### PR TITLE
fix: send on closed channel in delivery #970

### DIFF
--- a/platform/fabric/core/generic/delivery/delivery.go
+++ b/platform/fabric/core/generic/delivery/delivery.go
@@ -136,8 +136,10 @@ func (d *Delivery) Start(ctx context.Context) {
 }
 
 func (d *Delivery) Stop(err error) {
-	logger.Debugf("stop delivery with error [%s]", err)
-	d.stop <- err
+	logger.Debugf("stop delivery with error [%v]", err)
+	if err != nil {
+		d.stop <- err
+	}
 	close(d.stop)
 }
 


### PR DESCRIPTION
fixing an issue when sending nil values in channel in `delivery.go`