### PR TITLE
NWO: disable profiling by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ FABRIC_VERSION=2.5.0 make download-fabric
 
 If you want to provide your own versions of the fabric binaries then just set `FAB_BINS` to the directory where all the fabric binaries are stored.
 
+#### Profiling
+
+FSC comes with built-in profiling support. See more details in [profile.go](https://github.com/hyperledger-labs/fabric-smart-client/blob/main/node/start/profile/profile.go).  
+You can enable it using the `FSCNODE_PROFILER` environment variable.
+
+Example:
+```bash
+FSCNODE_PROFILER=true make integration-tests-iou
+```
+
 ## Getting Help
 
 Found a bug? Need help to fix an issue? You have a great idea for a new feature? Talk to us! You can reach us on

--- a/integration/nwo/fsc/fsc.go
+++ b/integration/nwo/fsc/fsc.go
@@ -8,6 +8,7 @@ package fsc
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
 	"io"
 	"net"
@@ -595,14 +596,19 @@ func (p *Platform) FSCNodeGroupRunner() ifrit.Runner {
 }
 
 func (p *Platform) FSCNodeRunner(node *node2.Replica, env ...string) *runner2.Runner {
+	// set config path
+	env = append(env, fmt.Sprintf("FSCNODE_CFG_PATH=%s", p.NodeDir(node)))
+
+	// enable/disable profiler
+	profilerEnv := cmp.Or(os.Getenv("FSCNODE_PROFILER"), "FSCNODE_PROFILER=false")
+	env = append(env, profilerEnv)
+
 	cmd := p.fscNodeCommand(
 		node,
 		commands.NodeStart{NodeID: node.ID()},
 		"",
-		fmt.Sprintf("FSCNODE_CFG_PATH=%s", p.NodeDir(node)),
-		"FSCNODE_PROFILER=true",
+		env...,
 	)
-	cmd.Env = append(cmd.Env, env...)
 
 	config := runner2.Config{
 		AnsiColorCode:     common.NextColor(),


### PR DESCRIPTION
This PR addresses #338. NWO currently enforces profiling for every test. This PR let the user decided when to run with profiling enabled via the `FSCNODE_PROFILE=true` env var.

The profiling section in the readme explains how to do that.