### PR TITLE
NWO: Bring back nwo race detector

### DIFF
--- a/integration/fabric/atsa/chaincode/atsa_test.go
+++ b/integration/fabric/atsa/chaincode/atsa_test.go
@@ -41,7 +41,7 @@ type TestSuite struct {
 
 func NewTestSuite(commType fsc.P2PCommunicationType, nodeOpts *integration.ReplicationOptions) *TestSuite {
 	return &TestSuite{integration.NewTestSuite(func() (*integration.Infrastructure, error) {
-		return integration.Generate(StartPort(), true, chaincode.Topology(&fabricsdk.SDK{}, commType, nodeOpts)...)
+		return integration.Generate(StartPort(), integration.WithRaceDetection, chaincode.Topology(&fabricsdk.SDK{}, commType, nodeOpts)...)
 	})}
 }
 

--- a/integration/fabric/atsa/fsc/atsa_test.go
+++ b/integration/fabric/atsa/fsc/atsa_test.go
@@ -67,7 +67,7 @@ type TestSuite struct {
 
 func NewTestSuite(commType fsc2.P2PCommunicationType, nodeOpts *integration.ReplicationOptions) *TestSuite {
 	return &TestSuite{integration.NewTestSuite(func() (*integration.Infrastructure, error) {
-		return integration.Generate(StartPort(), true, fsc.Topology(&fsc.SDK{}, commType, nodeOpts)...)
+		return integration.Generate(StartPort(), integration.WithRaceDetection, fsc.Topology(&fsc.SDK{}, commType, nodeOpts)...)
 	})}
 }
 

--- a/integration/fabric/events/chaincode/events_test.go
+++ b/integration/fabric/events/chaincode/events_test.go
@@ -37,7 +37,7 @@ type TestSuite struct {
 
 func NewTestSuite(commType fsc.P2PCommunicationType, nodeOpts *integration.ReplicationOptions) *TestSuite {
 	return &TestSuite{integration.NewTestSuite(func() (*integration.Infrastructure, error) {
-		return integration.Generate(StartPort(), true, chaincode.Topology(&fabricsdk.SDK{}, commType, nodeOpts)...)
+		return integration.Generate(StartPort(), integration.WithRaceDetection, chaincode.Topology(&fabricsdk.SDK{}, commType, nodeOpts)...)
 	})}
 }
 

--- a/integration/fabric/iou/iou_test.go
+++ b/integration/fabric/iou/iou_test.go
@@ -64,7 +64,7 @@ type TestSuite struct {
 
 func NewTestSuite(commType fsc.P2PCommunicationType, nodeOpts *integration.ReplicationOptions, tlsEnabled bool) *TestSuite {
 	return &TestSuite{TestSuite: integration.NewTestSuite(func() (*integration.Infrastructure, error) {
-		return integration.Generate(StartPort(), true, iou.Topology(&iou.Opts{
+		return integration.Generate(StartPort(), integration.WithRaceDetection, iou.Topology(&iou.Opts{
 			SDK:             &iou.SDK{},
 			CommType:        commType,
 			ReplicationOpts: nodeOpts,

--- a/integration/fabric/iouhsm/iou_test.go
+++ b/integration/fabric/iouhsm/iou_test.go
@@ -53,7 +53,7 @@ type TestSuite struct {
 
 func NewTestSuite(commType fsc.P2PCommunicationType, nodeOpts *integration.ReplicationOptions) *TestSuite {
 	return &TestSuite{integration.NewTestSuite(func() (*integration.Infrastructure, error) {
-		return integration.Generate(StartPort(), true, iouhsm.Topology(&iou.SDK{}, commType, nodeOpts)...)
+		return integration.Generate(StartPort(), integration.WithRaceDetection, iouhsm.Topology(&iou.SDK{}, commType, nodeOpts)...)
 	})}
 }
 

--- a/integration/fabric/stoprestart/stoprestart_test.go
+++ b/integration/fabric/stoprestart/stoprestart_test.go
@@ -65,7 +65,7 @@ type TestSuite struct {
 
 func NewTestSuite(commType fsc.P2PCommunicationType, nodeOpts *integration.ReplicationOptions) *TestSuite {
 	return &TestSuite{integration.NewTestSuite(func() (*integration.Infrastructure, error) {
-		return integration.Generate(StartPort(), true, stoprestart.Topology(&fabricsdk.SDK{}, commType, nodeOpts)...)
+		return integration.Generate(StartPort(), integration.WithRaceDetection, stoprestart.Topology(&fabricsdk.SDK{}, commType, nodeOpts)...)
 	})}
 }
 

--- a/integration/fsc/pingpong/pingpong_test.go
+++ b/integration/fsc/pingpong/pingpong_test.go
@@ -213,9 +213,9 @@ func NewTestSuite(commType fsc.P2PCommunicationType, alwaysGenerate bool, nodeOp
 		TestSuite: integration.NewTestSuite(func() (ii *integration.Infrastructure, err error) {
 			topologies := pingpong.Topology(commType, nodeOpts)
 			if alwaysGenerate || init.CompareAndSwap(false, true) {
-				ii, err = integration.Generate(StartPortWithGeneration(), true, topologies...)
+				ii, err = integration.Generate(StartPortWithGeneration(), integration.WithRaceDetection, topologies...)
 			} else {
-				ii, err = integration.Load(0, testdataDir, true, topologies...)
+				ii, err = integration.Load(0, testdataDir, integration.WithRaceDetection, topologies...)
 			}
 			ii.DeleteOnStop = false
 			return

--- a/integration/fsc/stoprestart/stoprestart_test.go
+++ b/integration/fsc/stoprestart/stoprestart_test.go
@@ -64,7 +64,7 @@ type TestSuite struct {
 
 func NewTestSuite(commType fsc.P2PCommunicationType, nodeOpts *integration.ReplicationOptions) *TestSuite {
 	return &TestSuite{integration.NewTestSuite(func() (*integration.Infrastructure, error) {
-		return integration.Generate(StartPort(), true, stoprestart.Topology(commType, nodeOpts)...)
+		return integration.Generate(StartPort(), integration.WithRaceDetection, stoprestart.Topology(commType, nodeOpts)...)
 	})}
 }
 

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -45,6 +45,8 @@ type Configuration struct {
 	StartPort int
 }
 
+const WithRaceDetection = true
+
 type Infrastructure struct {
 	TestDir           string
 	StartPort         int

--- a/integration/nwo/common/builder.go
+++ b/integration/nwo/common/builder.go
@@ -119,8 +119,7 @@ func (a *artifact) build(args ...string) error {
 
 func (a *artifact) gBuild(input string, args ...string) (string, error) {
 	if a.raceDetectorEnabled && !strings.HasPrefix(input, "github.com/hyperledger/fabric/") {
-		logger.Infof("building [%s,%s] with race detection ", input, args)
-		return gexec.Build(input, args...)
+		args = append(args, "-race")
 	}
 
 	logger.Infof("building [%s,%s] ", input, args)


### PR DESCRIPTION
Somehow the race flag in the nwo builder got lost. 
As a result the race issue reported in #969 was not found.

This PR brings it back.