### PR TITLE
Tame ignore error logging

### DIFF
--- a/integration/nwo/common/runner/runner.go
+++ b/integration/nwo/common/runner/runner.go
@@ -132,8 +132,8 @@ func (r *Runner) Run(sigChan <-chan os.Signal, ready chan<- struct{}) error {
 			startCheckTimeout = nil
 			detectStartCheck = nil
 			// close our buffer that is used to detect ready state
-			utils.IgnoreError(allOutput.Close())
 			utils.IgnoreError(allOutput.Clear())
+			utils.IgnoreError(allOutput.Close())
 			close(ready)
 
 		case <-startCheckTimeout:

--- a/platform/common/utils/closer.go
+++ b/platform/common/utils/closer.go
@@ -21,8 +21,9 @@ func CloseMute(closer Closer) {
 }
 
 func IgnoreError(err error) {
-	// ignore the error
-	fmt.Printf("IgnoreError: %v\n", err)
+	if err != nil {
+		fmt.Printf("IgnoreError: %v\n", err)
+	}
 }
 
 func IgnoreErrorFunc(f func() error) {


### PR DESCRIPTION
This PR addresses the following verbose logging.
```
IgnoreError: <nil>
IgnoreError: attempt to clear closed buffer 
```

This PR is part of #981