### PR TITLE
NWO minor improvements

### DIFF
--- a/integration/nwo/cmd/network/cmd.go
+++ b/integration/nwo/cmd/network/cmd.go
@@ -173,7 +173,6 @@ func Start(topologies Topologies) error {
 	if err != nil {
 		return errors.WithMessage(err, "failed to create new infrastructure")
 	}
-	ii.EnableRaceDetector()
 	if StartCMDPostNew != nil {
 		err = StartCMDPostNew(ii)
 		if err != nil {

--- a/integration/nwo/fabric/docker.go
+++ b/integration/nwo/fabric/docker.go
@@ -66,7 +66,7 @@ func (d *Docker) Cleanup() error {
 }
 
 func WaitUntilReady(ctx context.Context, grpcEndpoint string) error {
-	logger.Infof("Wait until read")
+	logger.Infof("Wait until ready %v", grpcEndpoint)
 
 	startWaitingAt := time.Now()
 
@@ -113,6 +113,6 @@ func WaitUntilReady(ctx context.Context, grpcEndpoint string) error {
 		return fmt.Errorf("invalid status .... %s", res)
 	}
 
-	logger.Infof("Ready! (t=%s)", time.Since(startWaitingAt))
+	logger.Infof("Ready! (t=%v)", time.Since(startWaitingAt))
 	return nil
 }

--- a/integration/nwo/monitoring/monitoring/docker.go
+++ b/integration/nwo/monitoring/monitoring/docker.go
@@ -78,6 +78,11 @@ func (n *Extension) startPrometheus() {
 		ExposedPorts: nat.PortSet{
 			nat.Port(port + "/tcp"): struct{}{},
 		},
+		Cmd: []string{
+			"--config.file=/etc/prometheus/prometheus.yml",
+			"--storage.tsdb.path=/prometheus",
+			"--enable-feature=native-histograms",
+		},
 	}, &container.HostConfig{
 		ExtraHosts:    []string{fmt.Sprintf("fabric:%s", localIP)},
 		RestartPolicy: container.RestartPolicy{Name: "always"},


### PR DESCRIPTION
This PR is part of the Performance EPIC #787 and introduces minor tweaks on NWO to enhance testing/benchmarking.

- This PR enables prometheus native histograms when started with NWO
- Improves monitoring startup time 
- Typos
- Disables default usage of race detector when using NWO network CMD. The user can enable the race detector when needed via `StartCMDPostNew` injection. For example:
  ```go
	m := cmd.NewMain("Perf network", "0.1")
	mainCmd := m.Cmd()
	network.StartCMDPostNew = func(infrastructure *integration.Infrastructure) error {
		infrastructure.EnableRaceDetector()
		return nil
	}
  ```