### PR TITLE
Set Otel log level based on parent logger

### DIFF
--- a/platform/common/services/logging/logger.go
+++ b/platform/common/services/logging/logger.go
@@ -63,7 +63,7 @@ type logger struct {
 func newLogger(zapLogger *zap.Logger) *logger {
 	return &logger{
 		fabricLogger: flogging.NewFabricLogger(zapLogger),
-		otelLogger:   NewOtelLogger(zapLogger),
+		otelLogger:   NewOtelLogger(zapLogger.WithOptions(zap.AddCallerSkip(1))),
 	}
 }
 

--- a/platform/common/services/logging/otel.go
+++ b/platform/common/services/logging/otel.go
@@ -15,7 +15,6 @@ import (
 	"go.opentelemetry.io/otel/log/noop"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -38,8 +37,7 @@ type otelLogger interface {
 func NewOtelLogger(zapLogger *zap.Logger) otelLogger {
 	return otelzap.New(zapLogger,
 		otelzap.WithLoggerProvider(newLoggerProvider(zapLogger.Name(), OtelSanitize())),
-		// otelzap.WithMinLevel(zapLogger.Level()),
-		otelzap.WithMinLevel(zapcore.DebugLevel),
+		otelzap.WithMinLevel(zapLogger.Level()),
 	).Sugar()
 }
 

--- a/platform/fabric/core/generic/committer/committer.go
+++ b/platform/fabric/core/generic/committer/committer.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -391,8 +392,9 @@ func (c *Committer) IsFinal(ctx context.Context, txID string) error {
 				c.logger.Debugf("Tx [%s] is unknown with no deps, wait a bit and retry [%d]", txID, iter)
 				time.Sleep(c.ChannelConfig.CommitterFinalityUnknownTXTimeout())
 			}
-
-			c.logger.Debugf("Tx [%s] is unknown with no deps, remote check [%d][%s]", txID, iter, debug.Stack())
+			if logger.IsEnabledFor(zapcore.DebugLevel) {
+				c.logger.Debugf("Tx [%s] is unknown with no deps, remote check [%d][%s]", txID, iter, debug.Stack())
+			}
 			peerForFinality := c.ConfigService.PickPeer(driver.PeerForFinality).Address
 			err := c.FabricFinality.IsFinal(txID, peerForFinality)
 			if err == nil {

--- a/platform/view/services/comm/p2p.go
+++ b/platform/view/services/comm/p2p.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/tracing"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -272,7 +273,9 @@ func (s *streamHandler) handleIncoming() {
 			}
 
 			streamHash := s.stream.Hash()
-			logger.Debugf("error reading message from stream [%s]: [%s][%s]", streamHash, err, debug.Stack())
+			if logger.IsEnabledFor(zapcore.DebugLevel) {
+				logger.Debugf("error reading message from stream [%s]: [%s][%s]", streamHash, err, debug.Stack())
+			}
 
 			// remove stream handler
 			s.node.streamsMutex.Lock()

--- a/platform/view/services/comm/session.go
+++ b/platform/view/services/comm/session.go
@@ -8,12 +8,10 @@ package comm
 
 import (
 	"context"
-	"runtime/debug"
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/comm/host"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
-	"go.uber.org/zap/zapcore"
 )
 
 // NetworkStreamSession implements view.Session
@@ -122,28 +120,12 @@ func (n *NetworkStreamSession) sendWithStatus(ctx context.Context, payload []byt
 	n.mutex.RUnlock()
 
 	err := n.node.sendTo(ctx, info, packet)
-	if logger.IsEnabledFor(zapcore.DebugLevel) {
-		n.mutex.RLock()
-		logger.Debugf(
-			"sent message [len:%d] to [%s:%s] from [%s] with err [%s]",
-			len(payload),
-			string(n.endpointID),
-			n.endpointAddress,
-			n.callerViewID,
-			err,
-		)
-		if len(n.callerViewID) == 0 {
-			logger.Debugf(
-				"sent message [len:%d] to [%s:%s] from [%s] with err [%s][%s]",
-				len(payload),
-				string(n.endpointID),
-				n.endpointAddress,
-				n.callerViewID,
-				err,
-				debug.Stack(),
-			)
-		}
-		n.mutex.RUnlock()
-	}
+	logger.Debugf("sent message [len:%d] to [%s:%s] from [%s] with err [%v]",
+		len(payload),
+		info.RemotePeerID,
+		info.RemotePeerAddress,
+		packet.Caller,
+		err,
+	)
 	return err
 }


### PR DESCRIPTION
This PR addresses the issue reported in #1010 

- fix hardcoded debug log level
- add log level check for expensive logging parms, such as, debug.Stack or ~base64 encoding~
- fix incorrect log caller for context based loggers