### PR TITLE
add defaults, make tls root cert path relative

### DIFF
--- a/platform/fabric/core/config.go
+++ b/platform/fabric/core/config.go
@@ -49,22 +49,24 @@ func NewConfig(configProvider ConfigProvider) (*Config, error) {
 			logger.Debugf("found fabric network [%s], driver [%s]", name, fsnConfig.Driver)
 
 			// is this default?
-			if fsnConfig.Default {
+			if fsnConfig.Default || name == "default" {
 				if len(defaultName) != 0 {
-					logger.Warnf("only one network should be set as default, ignoring [%s], default is set to [%s]", name, fsnConfig.Default)
+					logger.Warnf("only one network should be set as default, ignoring [%s], default is set to [%s]", name, defaultName)
 					continue
 				}
 				defaultName = name
 			}
 		}
 	}
+	if len(names) == 0 {
+		return nil, errors.New("no fabric network configured")
+	}
+
 	if len(defaultName) == 0 {
-		if len(names) != 0 {
-			defaultName = names[0]
-		} else {
-			defaultName = "default"
+		defaultName = names[0]
+		if len(names) > 1 {
+			logger.Warnf("no default network configured, set it to [%s]", defaultName)
 		}
-		logger.Warnf("no default network configured, set it to [%s]", defaultName)
 	}
 
 	return &Config{

--- a/platform/fabric/core/generic/config/ds.go
+++ b/platform/fabric/core/generic/config/ds.go
@@ -77,14 +77,7 @@ type TLS struct {
 	RootCertFile       string `yaml:"rootCertFile"`
 }
 
-type ConnectionConfig struct {
-	Address            string        `yaml:"address,omitempty"`
-	ConnectionTimeout  time.Duration `yaml:"connectionTimeout,omitempty"`
-	TLSEnabled         bool          `yaml:"tlsEnabled,omitempty"`
-	TLSRootCertFile    string        `yaml:"tlsRootCertFile,omitempty"`
-	TLSRootCertBytes   [][]byte      `yaml:"tlsRootCertBytes,omitempty"`
-	ServerNameOverride string        `yaml:"serverNameOverride,omitempty"`
-}
+type ConnectionConfig = grpc.ConnectionConfig
 
 type Chaincode struct {
 	Name    string `yaml:"Name,omitempty"`
@@ -250,13 +243,13 @@ func (c *Channel) GetRetrySleep() time.Duration {
 }
 
 type Network struct {
-	Default    bool                     `yaml:"default,omitempty"`
-	DefaultMSP string                   `yaml:"defaultMSP"`
-	MSPs       []*MSP                   `yaml:"msps"`
-	TLS        TLS                      `yaml:"tls"`
-	Orderers   []*grpc.ConnectionConfig `yaml:"orderers"`
-	Peers      []*grpc.ConnectionConfig `yaml:"peers"`
-	Channels   []*Channel               `yaml:"channels"`
-	Vault      Vault                    `yaml:"vault"`
-	Endpoint   *Endpoint                `yaml:"endpoint,omitempty"`
+	Default    bool                `yaml:"default,omitempty"`
+	DefaultMSP string              `yaml:"defaultMSP"`
+	MSPs       []*MSP              `yaml:"msps"`
+	TLS        TLS                 `yaml:"tls"`
+	Orderers   []*ConnectionConfig `yaml:"orderers"`
+	Peers      []*ConnectionConfig `yaml:"peers"`
+	Channels   []*Channel          `yaml:"channels"`
+	Vault      Vault               `yaml:"vault"`
+	Endpoint   *Endpoint           `yaml:"endpoint,omitempty"`
 }


### PR DESCRIPTION
Part of https://github.com/hyperledger-labs/fabric-smart-client/issues/908.

- Adds defaults for keepalive (if not specified used to lead to "keep your calm" warnings in the peers)
- Only warns for no default fabric network if there are more than one
- Uses TranslatePath for relative paths for the root tls certificate for peers.
