### PR TITLE
Remove span termination from function that should not be responsible for ending it

### DIFF
--- a/platform/view/services/comm/host/rest/websocket/multiplexed_provider.go
+++ b/platform/view/services/comm/host/rest/websocket/multiplexed_provider.go
@@ -116,7 +116,6 @@ func (c *MultiplexedProvider) NewClientStream(info host2.StreamInfo, ctx context
 		if err != nil {
 			span.RecordError(err)
 		}
-		span.End()
 	}()
 	logger.Debugf("Creating new stream from [%s] to [%s@%s]...", src, info.RemotePeerID, info.RemotePeerAddress)
 	tlsEnabled := config != nil && (config.InsecureSkipVerify || config.RootCAs != nil)


### PR DESCRIPTION
Previously, this function was responsible for ending the Hitman span,
even though it was not the function that created it. This caused the
span to close unexpectedly and potentially break trace continuity.
Removed the span termination here so it is handled only by the correct
owner.