### PR TITLE
Bugfix: prefix trimming on configuration keys

### DIFF
--- a/platform/view/services/config/provider.go
+++ b/platform/view/services/config/provider.go
@@ -201,7 +201,7 @@ func (p *Provider) substituteEnv() error {
 		}
 		key, val := env[0], strings.Join(env[1:], "=")
 
-		noprefix := strings.TrimLeft(key, strings.ToUpper(CmdRoot)+"_")
+		noprefix := strings.TrimPrefix(key, strings.ToUpper(CmdRoot)+"_")
 		key = strings.ToLower(strings.ReplaceAll(noprefix, "_", "."))
 
 		// nested key

--- a/platform/view/services/config/provider_test.go
+++ b/platform/view/services/config/provider_test.go
@@ -42,12 +42,12 @@ func TestEnvSubstitution(t *testing.T) {
 	_ = os.Setenv("CORE_PATH_ABSOLUTE", "") // empty env vars are disregarded
 	_ = os.Setenv("CORE_NON_EXISTENT_KEY", "new")
 	_ = os.Setenv("CORE_NESTED_KEYS", "should not be able to replace for string")
+	_ = os.Setenv("CORE_CORE_ISFINE", "yes")
 
 	p, err := NewProvider("./testdata")
 	assert.NoError(t, err)
 
 	path, _ := filepath.Abs("testdata/newfile.name")
-
 	assert.Equal(t, "new=string=with=characters.\\AND.CAPS", p.GetString("str"))
 	assert.Equal(t, 10, p.GetInt("number"))
 	assert.Equal(t, 10*time.Second, p.GetDuration("duration"))
@@ -73,6 +73,7 @@ func TestEnvSubstitution(t *testing.T) {
 
 	assert.Equal(t, "new", p.GetString("non.existent.key"))
 	assert.Equal(t, 1, p.GetInt("nested.keys.one"))
+	assert.Equal(t, "yes", p.GetString("core.isFine"))
 }
 
 func testMerge(t *testing.T, p *Provider) {

--- a/platform/view/services/config/testdata/core.yaml
+++ b/platform/view/services/config/testdata/core.yaml
@@ -1,7 +1,6 @@
-
 number: 5
 duration: 5s
-str: a string         # with trailing spaces
+str: a string # with trailing spaces
 path:
   relative: file.name
   absolute: /absolute/path/file.name
@@ -22,3 +21,5 @@ nested:
     one: 1
     two: 2
 CAPITALS: true
+core:
+  isFine: "no"


### PR DESCRIPTION
This PR fixes a bug in config substitution via environment variables.

TrimLeft trims a set of characters, so if the configuration key starts with C, O, R or E, that character will be stripped as well. We now use TrimPrefix which only trims a match on the full string.
