### PR TITLE
Fix comm stack resource consumption

### DIFF
--- a/platform/view/services/comm/host/rest/host.go
+++ b/platform/view/services/comm/host/rest/host.go
@@ -9,8 +9,8 @@ package rest
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
@@ -86,5 +86,13 @@ func (h *host) Close() error {
 func (h *host) Wait() {}
 
 func StreamHash(info host2.StreamInfo) host2.StreamHash {
-	return fmt.Sprintf("%s.%s.%s.%s", info.RemotePeerID, info.RemotePeerAddress, info.SessionID, info.ContextID)
+	var sb strings.Builder
+	sb.WriteString(info.RemotePeerID)
+	sb.WriteRune('.')
+	sb.WriteString(info.RemotePeerAddress)
+	sb.WriteRune('.')
+	sb.WriteString(info.SessionID)
+	sb.WriteRune('.')
+	sb.WriteString(info.ContextID)
+	return sb.String()
 }

--- a/platform/view/services/comm/host/rest/websocket/stream.go
+++ b/platform/view/services/comm/host/rest/websocket/stream.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
 	host2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/comm/host"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/comm/host/rest"
+	"go.uber.org/zap/zapcore"
 )
 
 type connection interface {
@@ -70,7 +71,9 @@ func (s *stream) readMessages(ctx context.Context) {
 				_ = s.Close()
 				return
 			}
-			logger.Debugf("Read message of length [%d] on [%s]", len(msg), s.Hash())
+			if logger.IsEnabledFor(zapcore.DebugLevel) {
+				logger.Debugf("Read message of length [%d] on [%s]", len(msg), s.Hash())
+			}
 			s.reads <- result{value: msg, err: err}
 		}
 	}

--- a/platform/view/services/comm/ids.go
+++ b/platform/view/services/comm/ids.go
@@ -6,8 +6,13 @@ SPDX-License-Identifier: Apache-2.0
 
 package comm
 
-import "encoding/base64"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
 
 func computeInternalSessionID(topic string, pkid []byte) string {
-	return topic + "." + base64.StdEncoding.EncodeToString(pkid)
+	hasher := sha256.New()
+	hasher.Write(pkid)
+	return topic + "." + hex.EncodeToString(hasher.Sum(nil))
 }

--- a/platform/view/services/comm/p2p.go
+++ b/platform/view/services/comm/p2p.go
@@ -24,9 +24,10 @@ import (
 )
 
 const (
-	masterSession                    = "master of puppets I'm pulling your strings"
-	contextIDLabel tracing.LabelName = "context_id"
-	sessionIDLabel tracing.LabelName = "session_id"
+	masterSession                       = "master of puppets I'm pulling your strings"
+	contextIDLabel    tracing.LabelName = "context_id"
+	sessionIDLabel    tracing.LabelName = "session_id"
+	defaultBufferSize                   = 4096
 )
 
 var errStreamNotFound = errors.New("stream not found")
@@ -209,7 +210,7 @@ func (p *P2PNode) handleIncomingStream(stream host2.P2PStream) {
 func (p *P2PNode) handleStream(stream host2.P2PStream) {
 	sh := &streamHandler{
 		stream: stream,
-		reader: io.NewVarintProtoReader(stream, 655360*2),
+		reader: io.NewVarintProtoReader(stream, defaultBufferSize),
 		writer: io.NewVarintProtoWriter(stream),
 		node:   p,
 	}

--- a/platform/view/services/comm/session.go
+++ b/platform/view/services/comm/session.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/comm/host"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"go.uber.org/zap/zapcore"
 )
 
 // NetworkStreamSession implements view.Session
@@ -82,7 +83,9 @@ func (n *NetworkStreamSession) closeInternal() {
 	logger.Debugf("closing session [%s] with [%d] streams", n.sessionID, len(n.streams))
 	toClose := make([]*streamHandler, 0, len(n.streams))
 	for stream := range n.streams {
-		logger.Debugf("session [%s], stream [%s], refCtr [%d]", n.sessionID, stream.stream.Hash(), stream.refCtr)
+		if logger.IsEnabledFor(zapcore.DebugLevel) {
+			logger.Debugf("session [%s], stream [%s], refCtr [%d]", n.sessionID, stream.stream.Hash(), stream.refCtr)
+		}
 		stream.refCtr--
 		if stream.refCtr == 0 {
 			toClose = append(toClose, stream)

--- a/platform/view/services/view/manager.go
+++ b/platform/view/services/view/manager.go
@@ -11,7 +11,6 @@ import (
 	"reflect"
 	"runtime/debug"
 	"sync"
-	"time"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
@@ -277,12 +276,7 @@ func (cm *Manager) respond(responder view.View, id view.Identity, msg *view.Mess
 	if isNew {
 		// delete context at the end of the execution
 		res, err = func(ctx view.Context, responder view.View) (interface{}, error) {
-			defer func() {
-				// TODO: this is a workaround
-				// give some time to flush anything can be in queues
-				time.Sleep(5 * time.Second)
-				cm.deleteContext(id, ctx.ID())
-			}()
+			defer cm.deleteContext(id, ctx.ID())
 			return ctx.RunView(responder)
 		}(ctx, responder)
 	} else {


### PR DESCRIPTION
The current stack suffers from high resource utilization (active number of goroutines and increasing memory usage) when invoking views through the p2p comm layer.
 
This PR tames the resource consumption.

- set reasonable read buffer size
- cleanup subcon when they are closed
- more efficient sessionID computation
- remove delayed subcon close
- remove delayed context deletion after view execution