### PR TITLE
chore: remove unused min func

### DIFF
--- a/platform/view/services/comm/io/streamio/reader.go
+++ b/platform/view/services/comm/io/streamio/reader.go
@@ -68,13 +68,6 @@ func (r *Reader) Read(p []byte) (int, error) {
 	return n, err
 }
 
-func min(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
-}
-
 func MD5Hash(in []byte) []byte {
 	h := md5.New()
 	h.Write(in)


### PR DESCRIPTION

Go 1.21 adds built-in functions min and max.   https://tip.golang.org/doc/go1.21
Therefore, we can directly remove our own implementations and use the built-in methods with the same names. 