### PR TITLE
fix: Extend logger name replacer

### DIFF
--- a/platform/common/services/logging/config.go
+++ b/platform/common/services/logging/config.go
@@ -65,7 +65,7 @@ func OtelSanitize() bool {
 var (
 	replacersMutex sync.RWMutex
 	replacers      = map[string]string{
-		"github.com.hyperledger-labs.fabric-smart-client.platform": "fsc",
+		"github.com.hyperledger-labs.fabric-smart-client": "fsc",
 	}
 )
 

--- a/platform/common/services/logging/testlogger/logger_test.go
+++ b/platform/common/services/logging/testlogger/logger_test.go
@@ -19,7 +19,7 @@ func TestMustGetLogger_WithParams(t *testing.T) {
 
 	name := l.Zap().Name()
 
-	Expect(name).To(HaveSuffix("fsc.common.services.logging.testlogger_test.some.thing"))
+	Expect(name).To(HaveSuffix("fsc.platform.common.services.logging.testlogger_test.some.thing"))
 }
 
 func TestMustGetLogger_WithOutParams(t *testing.T) {
@@ -28,7 +28,7 @@ func TestMustGetLogger_WithOutParams(t *testing.T) {
 
 	name := l.Zap().Name()
 
-	Expect(name).To(HaveSuffix("fsc.common.services.logging.testlogger_test"))
+	Expect(name).To(HaveSuffix("fsc.platform.common.services.logging.testlogger_test"))
 }
 
 func level1() (string, error) {


### PR DESCRIPTION
The current logging framework uses a full package name for the logger name. With the replacer we can shorten the logger name.
By default, we use a replacer for `github.com.hyperledger-labs.fabric-smart-client.platform`. While this works well for the platform package, there are other packages, such as `integration/nwo`, `pkg`, which may benefit from shorter logger names.

Therefore, this PR replace all fsc loggers names with `fsc` prefix.