### PR TITLE
fix: createLockTag returns int64

### DIFF
--- a/platform/view/services/storage/driver/sql/postgres/notifier.go
+++ b/platform/view/services/storage/driver/sql/postgres/notifier.go
@@ -214,7 +214,7 @@ func concatenateIDs(keys []string) string {
 	return strings.Join(fields, fmt.Sprintf(" || '%s' || ", keySeparator))
 }
 
-func createLockTag(m string) uint64 {
+func createLockTag(m string) int64 {
 	h := sha256.Sum256([]byte(m))
-	return binary.BigEndian.Uint64(h[:])
+	return int64(binary.BigEndian.Uint64(h[:]))
 }


### PR DESCRIPTION
This PR fixes a bug introduced https://github.com/hyperledger-labs/fabric-smart-client/commit/ea5aa2095c1dab12b0130b08f6db325803df013c#diff-65733d2b46f196197a0740de95a8e1ba1ff8cc35fba42e7d967e8b52a92d8b3dR217. The `createLockTag` must return a `int64` value as `pg_advisory_xact_lock(bigint)` requires `bigint`. Passing a `uint64` may not fit into a signed 64-bit integer.