### PR TITLE
fix: clean fsccli generated output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ $(addprefix integration-tests-,$(INTEGRATION_TARGETS)) : integration-tests-%:
 
 .PHONY: clean
 clean: $(addprefix clean-,$(INTEGRATION_TARGETS)) ## Clean generated testdata
-	rm -rf ./cmd/fsccli/cmd
+	rm -rf ./cmd/fsccli/out
 
 $(addprefix clean-,$(INTEGRATION_TARGETS)) : clean-%:
 	rm -rf ./integration/$(firstword $(subst -, ,$*))/$(subst $(firstword $(subst -, ,$*))-,,$*)/out


### PR DESCRIPTION
This PR fixes the clean target. 
I have missed that in https://github.com/hyperledger-labs/fabric-smart-client/commit/5ceb3a6893ed2245c59ec6eec7c76291bfee3d7b