### PR TITLE
Revert "view manager does not pass correctly the context to the view …

### DIFF
--- a/platform/view/services/view/manager.go
+++ b/platform/view/services/view/manager.go
@@ -41,6 +41,7 @@ type Manager struct {
 	metrics              *Metrics
 	localIdentityChecker LocalIdentityChecker
 
+	ctx        context.Context
 	contexts   map[string]disposableContext
 	contextsMu sync.RWMutex
 }
@@ -118,15 +119,15 @@ func (cm *Manager) InitiateView(view view.View, ctx context.Context) (interface{
 	return cm.InitiateViewWithIdentity(view, cm.me(), ctx)
 }
 
-// InitiateViewWithIdentity executes the given view with given identity and context.
-// The function creates a new `view context` and run the view over it.
-// From the view context, ctx is reachable.
 func (cm *Manager) InitiateViewWithIdentity(view view.View, id view.Identity, ctx context.Context) (interface{}, error) {
 	// Get the managers context
-	if ctx == nil {
-		ctx = context.Background()
+	cm.contextsMu.Lock()
+	cctx := cm.ctx
+	cm.contextsMu.Unlock()
+	if cctx == nil {
+		cctx = context.Background()
 	}
-	ctx = trace.ContextWithSpanContext(ctx, trace.SpanContextFromContext(ctx))
+	ctx = trace.ContextWithSpanContext(cctx, trace.SpanContextFromContext(ctx))
 	viewContext, err := NewContextForInitiator(
 		"",
 		ctx,
@@ -160,15 +161,15 @@ func (cm *Manager) InitiateViewWithIdentity(view view.View, id view.Identity, ct
 }
 
 func (cm *Manager) InitiateContext(view view.View) (view.Context, error) {
-	return cm.InitiateContextFrom(context.Background(), view, cm.me(), "")
+	return cm.InitiateContextFrom(cm.getCurrentContext(), view, cm.me(), "")
 }
 
 func (cm *Manager) InitiateContextWithIdentity(view view.View, id view.Identity) (view.Context, error) {
-	return cm.InitiateContextFrom(context.Background(), view, id, "")
+	return cm.InitiateContextFrom(cm.getCurrentContext(), view, id, "")
 }
 
 func (cm *Manager) InitiateContextWithIdentityAndID(view view.View, id view.Identity, contextID string) (view.Context, error) {
-	return cm.InitiateContextFrom(context.Background(), view, id, contextID)
+	return cm.InitiateContextFrom(cm.getCurrentContext(), view, id, contextID)
 }
 
 func (cm *Manager) InitiateContextFrom(ctx context.Context, view view.View, id view.Identity, contextID string) (view.Context, error) {
@@ -201,10 +202,9 @@ func (cm *Manager) InitiateContextFrom(ctx context.Context, view view.View, id v
 	return c, nil
 }
 
-// Start listens to the messages coming into the master session of the communication layer.
-// These messages trigger the execution of the responder views.
-// The function is blocking. If the passed context gets canceled, Start terminates its execution.
 func (cm *Manager) Start(ctx context.Context) {
+	cm.setCurrentContext(ctx)
+
 	session, err := cm.commLayer.MasterSession()
 	if err != nil {
 		return
@@ -421,4 +421,17 @@ func (cm *Manager) callView(msg *view.Message) {
 
 func (cm *Manager) me() view.Identity {
 	return cm.identityProvider.DefaultIdentity()
+}
+
+func (cm *Manager) getCurrentContext() context.Context {
+	cm.contextsMu.Lock()
+	ctx := cm.ctx
+	cm.contextsMu.Unlock()
+	return ctx
+}
+
+func (cm *Manager) setCurrentContext(ctx context.Context) {
+	cm.contextsMu.Lock()
+	cm.ctx = ctx
+	cm.contextsMu.Unlock()
 }

--- a/platform/view/services/view/manager_test.go
+++ b/platform/view/services/view/manager_test.go
@@ -50,23 +50,6 @@ func (a DummyView) Call(context view.Context) (interface{}, error) {
 	return nil, nil
 }
 
-type ContextKey string
-
-type CheckContextView struct {
-	Key ContextKey
-}
-
-func (a *CheckContextView) Call(context view.Context) (interface{}, error) {
-	v, ok := context.Context().Value(a.Key).(string)
-	if !ok {
-		panic("context value is not valid")
-	}
-	if len(v) == 0 {
-		panic("context value is empty")
-	}
-	return nil, nil
-}
-
 type DummyFactory struct{}
 
 func (d *DummyFactory) NewView(in []byte) (view.View, error) {
@@ -110,11 +93,10 @@ func TestManagerRace(t *testing.T) {
 
 	wg := &sync.WaitGroup{}
 	for i := 0; i < 100; i++ {
-		wg.Add(8)
+		wg.Add(7)
 		go registerFactory(t, wg, manager)
 		go newView(t, wg, manager)
 		go callView(t, wg, manager)
-		go checkContext(t, wg, manager)
 		go getContext(t, wg, manager)
 		go initiateView(t, wg, manager)
 		go start(t, wg, manager, ctx)
@@ -167,15 +149,6 @@ func registerResponder(t *testing.T, wg *sync.WaitGroup, m Manager) {
 
 func callView(t *testing.T, wg *sync.WaitGroup, m Manager) {
 	_, err := m.InitiateView(&DummyView{}, context.Background())
-	wg.Done()
-	assert.NoError(t, err)
-}
-
-func checkContext(t *testing.T, wg *sync.WaitGroup, m Manager) {
-	k := ContextKey("pineapple")
-	ctx := t.Context()
-	ctx = context.WithValue(ctx, k, "sweet")
-	_, err := m.InitiateView(&CheckContextView{Key: k}, ctx)
 	wg.Done()
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
…#1071 (#1072)"

This reverts commit c03d8bcb0787c510dd116e296ff15d1e0da92fc5.