### PR TITLE
refactor!: Remove consul sdk dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
-	github.com/hashicorp/consul/sdk v0.16.1
 	github.com/hyperledger/fabric v1.4.0-rc1.0.20250510200036-435a7f1a780a
 	github.com/hyperledger/fabric-chaincode-go/v2 v2.3.0
 	github.com/hyperledger/fabric-contract-api-go/v2 v2.2.0
@@ -101,7 +100,7 @@ require (
 	github.com/consensys/bavard v0.1.22 // indirect
 	github.com/consensys/gnark-crypto v0.14.0 // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
-	github.com/containerd/errdefs v1.0.0 // indirect
+	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1054,8 +1054,6 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4Zs
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3/go.mod h1:o//XUCC/F+yRGJoPO/VU0GSB0f8Nhgmxx0VIRUvaC0w=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 h1:asbCHRVmodnJTuQ3qamDwqVOIjwqUPTYmYuemVOx+Ys=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0/go.mod h1:ggCgvZ2r7uOoQjOyu2Y1NhHmEPPzzuhWgcza5M1Ji1I=
-github.com/hashicorp/consul/sdk v0.16.1 h1:V8TxTnImoPD5cj0U9Spl0TUxcytjcbbJeADFF07KdHg=
-github.com/hashicorp/consul/sdk v0.16.1/go.mod h1:fSXvwxB2hmh1FMZCNl6PwX0Q/1wdWtHJcZ7Ea5tns0s=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/integration/fabric/atsa/atsa_test.go
+++ b/integration/fabric/atsa/atsa_test.go
@@ -45,8 +45,8 @@ var _ = Describe("EndToEnd", func() {
 					"approvers": 2,
 				},
 				SQLConfigs: map[string]*postgres.ContainerConfig{
-					"alice": postgres.DefaultConfig("alice-db"),
-					"bob":   postgres.DefaultConfig("bob-db"),
+					"alice": postgres.DefaultConfig(postgres.WithDBName("alice-db")),
+					"bob":   postgres.DefaultConfig(postgres.WithDBName("bob-db")),
 				},
 			})
 

--- a/integration/fabric/iou/iou_test.go
+++ b/integration/fabric/iou/iou_test.go
@@ -46,8 +46,8 @@ var _ = Describe("EndToEnd", func() {
 					"lender":   2,
 				},
 				SQLConfigs: map[string]*postgres.ContainerConfig{
-					"borrower": postgres.DefaultConfig("borrower-db"),
-					"lender":   postgres.DefaultConfig("lender-db"),
+					"borrower": postgres.DefaultConfig(postgres.WithDBName("borrower-db")),
+					"lender":   postgres.DefaultConfig(postgres.WithDBName("lender-db")),
 				},
 			},
 			true,

--- a/integration/fabric/iouhsm/iou_test.go
+++ b/integration/fabric/iouhsm/iou_test.go
@@ -37,8 +37,8 @@ var _ = Describe("EndToEnd", func() {
 				"lender":   2,
 			},
 			SQLConfigs: map[string]*postgres.ContainerConfig{
-				"borrower": postgres.DefaultConfig("borrower-db"),
-				"lender":   postgres.DefaultConfig("lender-db"),
+				"borrower": postgres.DefaultConfig(postgres.WithDBName("borrower-db")),
+				"lender":   postgres.DefaultConfig(postgres.WithDBName("lender-db")),
 			},
 		})
 		BeforeEach(s.Setup)

--- a/integration/nwo/fabric/topology.go
+++ b/integration/nwo/fabric/topology.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc/node"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/postgres"
 )
 
 var (
@@ -184,11 +183,15 @@ func NewTopologyWithName(name string) *topology.Topology {
 	}
 }
 
-func WithDefaultPostgresPersistence(config postgres.DataSourceProvider) node.Option {
+type DataSourceProvider interface {
+	DataSource() string
+}
+
+func WithDefaultPostgresPersistence(config DataSourceProvider) node.Option {
 	return WithPostgresPersistence(common.DefaultPersistence, config)
 }
 
-func WithPostgresPersistence(name driver.PersistenceName, config postgres.DataSourceProvider) node.Option {
+func WithPostgresPersistence(name driver.PersistenceName, config DataSourceProvider) node.Option {
 	return func(o *node.Options) error {
 		if config != nil {
 			o.PutPostgresPersistence(name, node.SQLOpts{

--- a/platform/view/services/storage/driver/sql/postgres/bench_test.go
+++ b/platform/view/services/storage/driver/sql/postgres/bench_test.go
@@ -16,11 +16,7 @@ import (
 )
 
 func BenchmarkReadExistingPostgres(b *testing.B) {
-	terminate, pgConnStr, err := StartPostgres(b, false)
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer terminate()
+	pgConnStr := setupDB(b)
 	cp := NewConfigProvider(testing2.MockConfig(Config{
 		DataSource:   pgConnStr,
 		MaxOpenConns: 50,
@@ -35,12 +31,7 @@ func BenchmarkReadExistingPostgres(b *testing.B) {
 }
 
 func BenchmarkReadNonExistingPostgres(b *testing.B) {
-	terminate, pgConnStr, err := StartPostgres(b, false)
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer terminate()
-
+	pgConnStr := setupDB(b)
 	cp := NewConfigProvider(testing2.MockConfig(Config{
 		DataSource:   pgConnStr,
 		MaxOpenConns: 50,
@@ -55,12 +46,7 @@ func BenchmarkReadNonExistingPostgres(b *testing.B) {
 }
 
 func BenchmarkWriteOnePostgres(b *testing.B) {
-	terminate, pgConnStr, err := StartPostgres(b, false)
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer terminate()
-
+	pgConnStr := setupDB(b)
 	cp := NewConfigProvider(testing2.MockConfig(Config{
 		DataSource:   pgConnStr,
 		MaxOpenConns: 50,
@@ -75,11 +61,7 @@ func BenchmarkWriteOnePostgres(b *testing.B) {
 }
 
 func BenchmarkWriteManyPostgres(b *testing.B) {
-	terminate, pgConnStr, err := StartPostgres(b, false)
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer terminate()
+	pgConnStr := setupDB(b)
 	cp := NewConfigProvider(testing2.MockConfig(Config{
 		DataSource:   pgConnStr,
 		MaxOpenConns: 50,
@@ -94,11 +76,7 @@ func BenchmarkWriteManyPostgres(b *testing.B) {
 }
 
 func BenchmarkWriteManyPostgresWithIdle(b *testing.B) {
-	terminate, pgConnStr, err := StartPostgres(b, false)
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer terminate()
+	pgConnStr := setupDB(b)
 	cp := NewConfigProvider(testing2.MockConfig(Config{
 		DataSource:   pgConnStr,
 		MaxOpenConns: 50,

--- a/platform/view/services/storage/driver/sql/postgres/sql_test.go
+++ b/platform/view/services/storage/driver/sql/postgres/sql_test.go
@@ -16,13 +16,20 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-func TestPostgres(t *testing.T) {
-	t.Log("starting postgres")
-	terminate, pgConnStr, err := StartPostgres(t, false)
+func setupDB(tb testing.TB) string {
+	tb.Helper()
+
+	terminate, pgConnStr, err := StartPostgres(tb.Context(), ConfigFromEnv(), nil)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
-	defer terminate()
+	tb.Cleanup(terminate)
+
+	return pgConnStr
+}
+
+func TestPostgres(t *testing.T) {
+	pgConnStr := setupDB(t)
 	t.Log("postgres ready")
 
 	cp := NewConfigProvider(testing2.MockConfig(Config{

--- a/platform/view/services/storage/kvs/kvs_test.go
+++ b/platform/view/services/storage/kvs/kvs_test.go
@@ -176,16 +176,12 @@ func TestSQLiteKVS(t *testing.T) {
 }
 
 func TestPostgresKVS(t *testing.T) {
-	// When running this test together with other tests; it may happen that a container instance is still running
-	// we give this test a slow start ...
-	time.Sleep(5 * time.Second)
-
 	t.Log("starting postgres")
-	terminate, pgConnStr, err := postgres2.StartPostgres(t, false)
+	terminate, pgConnStr, err := postgres2.StartPostgres(t.Context(), postgres2.ConfigFromEnv(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer terminate()
+	t.Cleanup(terminate)
 	t.Log("postgres ready")
 
 	cp := multiplexed.MockTypeConfig(postgres2.Persistence, postgres2.Config{


### PR DESCRIPTION
This PR refactors the postgres container code. In particular, it removes a consul sdk dep to pick a free port for the postgres instances we run within NWO and unit-tests. We let NWO select a free container port or let the container runtime select the port during unit-tests.

This PR contributes to #828 and #434

Overview:
- let NWO select the ports for the postgres containers
- in unit-tests, the container runtime selects the port
- introduce options for `postgres.DefaultConfig`

> [!NOTE]
> This PR changes the API of `postgres.DefaultConfig`, which is also used by the TokenSDK for testing.