### PR TITLE
Introduce P2PCommunicationType constants

### DIFF
--- a/integration/nwo/fsc/topology.go
+++ b/integration/nwo/fsc/topology.go
@@ -9,6 +9,8 @@ package fsc
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc/node"
 	node2 "github.com/hyperledger-labs/fabric-smart-client/pkg/node"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/comm/host/libp2p"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/comm/host/rest"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/tracing"
 )
 
@@ -25,8 +27,8 @@ type Logging struct {
 type P2PCommunicationType = string
 
 const (
-	LibP2P    P2PCommunicationType = "libp2p"
-	WebSocket P2PCommunicationType = "websocket"
+	LibP2P    P2PCommunicationType = libp2p.P2PCommunicationType
+	WebSocket P2PCommunicationType = rest.P2PCommunicationType
 )
 
 type Topology struct {

--- a/platform/view/services/comm/host/libp2p/provider.go
+++ b/platform/view/services/comm/host/libp2p/provider.go
@@ -17,6 +17,9 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
+// P2PCommunicationType is a string identifier for the libp2p implementation of the p2p comm stack.
+const P2PCommunicationType = "libp2p"
+
 type libp2pConfig interface {
 	PrivateKeyPath() string
 	Bootstrap() bool

--- a/platform/view/services/comm/host/rest/provider.go
+++ b/platform/view/services/comm/host/rest/provider.go
@@ -14,6 +14,9 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/id"
 )
 
+// P2PCommunicationType is a string identifier for the websocket implementation of the p2p comm stack.
+const P2PCommunicationType = "websocket"
+
 type pkiExtractor interface {
 	ExtractPKI(id []byte) []byte
 }

--- a/platform/view/services/comm/provider/provider.go
+++ b/platform/view/services/comm/provider/provider.go
@@ -9,7 +9,6 @@ package provider
 import (
 	"strings"
 
-	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/comm"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/comm/host"
@@ -32,7 +31,7 @@ func NewHostProvider(
 		return nil, err
 	}
 
-	if p2pCommType := config.GetString("fsc.p2p.type"); strings.EqualFold(p2pCommType, fsc.WebSocket) {
+	if p2pCommType := config.GetString("fsc.p2p.type"); strings.EqualFold(p2pCommType, rest.P2PCommunicationType) {
 		return NewWebSocketHostProvider(config, endpointService, tracerProvider, metricsProvider)
 	} else {
 		return NewLibP2PHostProvider(config, endpointService, metricsProvider), nil


### PR DESCRIPTION
Both, the libp2p and websocket implementations now are define a constant to help identify the selected implementation via FSC configuration.

These constants were previously defined within the NWO space; however as addressing #434, NWO now consumes these constants from the corresponding p2p comm packages.