### PR TITLE
platform/view/services/comm/host/rest/websocket/multiplexed_provider.go: metric pollution #1089

### DIFF
--- a/platform/view/services/comm/host/rest/websocket/multiplexed_provider.go
+++ b/platform/view/services/comm/host/rest/websocket/multiplexed_provider.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	contextIDLabel        tracing.LabelName = "context_id"
-	defaultContextIDLabel                   = "context"
+	defaultContextIDLabel string            = "context"
 )
 
 type SubConnId = string


### PR DESCRIPTION
This PR uses the same label for all spans