### PR TITLE
fix: fix formatting of queryservice config

### DIFF
--- a/integration/nwo/fabricx/extensions/scv2/container.go
+++ b/integration/nwo/fabricx/extensions/scv2/container.go
@@ -53,7 +53,7 @@ var (
 )
 
 const (
-	queryServiceConfig = ` query-service:
+	queryServiceConfig = `query-service:
   server:
     endpoint:
       host: localhost


### PR DESCRIPTION
This PR fixes a formatting issue with the queryservice config template used in NWO for the fabric-x committer.

Thanks @arner for spotting this.