### PR TITLE
refactor(fabricx): consistent use of errors package

### DIFF
--- a/platform/fabricx/core/finality/config.go
+++ b/platform/fabricx/core/finality/config.go
@@ -7,8 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package finality
 
 import (
-	"fmt"
 	"time"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
 
 const DefaultRequestTimeout = 30 * time.Second
@@ -37,7 +38,7 @@ func NewConfig(configService ConfigService) (*Config, error) {
 
 	err := configService.UnmarshalKey("notificationService", &config)
 	if err != nil {
-		return config, fmt.Errorf("cannot get notify service config: %w", err)
+		return config, errors.Wrap(err, "unmarshal notificationService")
 	}
 
 	return config, nil

--- a/platform/fabricx/core/finality/grpc.go
+++ b/platform/fabricx/core/finality/grpc.go
@@ -7,23 +7,22 @@ SPDX-License-Identifier: Apache-2.0
 package finality
 
 import (
-	"errors"
-	"fmt"
 	"os"
 	"time"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-var ErrInvalidAddress = fmt.Errorf("empty address")
+var ErrInvalidAddress = errors.New("empty address")
 
 func GrpcClient(c *Config) (*grpc.ClientConn, error) {
 	// no endpoints in config
 	if len(c.Endpoints) != 1 {
-		return nil, fmt.Errorf("we need a single endpoint")
+		return nil, errors.New("we need a single endpoint")
 	}
 
 	// currently we only support connections to a single query service

--- a/platform/fabricx/core/finality/nlm.go
+++ b/platform/fabricx/core/finality/nlm.go
@@ -8,11 +8,11 @@ package finality
 
 import (
 	"context"
-	"errors"
 	"slices"
 	"sync"
 	"time"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"

--- a/platform/fabricx/core/finality/nlm_test.go
+++ b/platform/fabricx/core/finality/nlm_test.go
@@ -8,12 +8,12 @@ package finality
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"

--- a/platform/fabricx/core/finality/provider_test.go
+++ b/platform/fabricx/core/finality/provider_test.go
@@ -8,12 +8,12 @@ package finality
 
 import (
 	"context"
-	"errors"
 	"reflect"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/driver/config"
 	mock2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/finality/mock"

--- a/platform/fabricx/core/ledger/dispatcher.go
+++ b/platform/fabricx/core/ledger/dispatcher.go
@@ -8,9 +8,9 @@ package ledger
 
 import (
 	"context"
-	"errors"
 	"sync"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
 )

--- a/platform/fabricx/core/membership/endpoint.go
+++ b/platform/fabricx/core/membership/endpoint.go
@@ -7,9 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package membership
 
 import (
-	"fmt"
 	"regexp"
 	"strconv"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
 
 const (
@@ -19,7 +20,7 @@ const (
 
 var (
 	myExp                    = regexp.MustCompile(`id=(\d+),(` + OrdererBroadcastType + `|` + OrdererDeliverType + `),(.*)`)
-	ErrInvalidEndpointFormat = fmt.Errorf("invalid endpoint format")
+	ErrInvalidEndpointFormat = errors.New("invalid endpoint format")
 )
 
 type endpoint struct {
@@ -37,7 +38,7 @@ func parseEndpoint(str string) (*endpoint, error) {
 
 	id, err := strconv.Atoi(match[1])
 	if err != nil {
-		return nil, fmt.Errorf("invalid endpoint id: %w", err)
+		return nil, errors.Wrap(err, "invalid endpoint id")
 	}
 
 	return &endpoint{

--- a/platform/fabricx/core/transaction/manager.go
+++ b/platform/fabricx/core/transaction/manager.go
@@ -8,7 +8,6 @@ package transaction
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
@@ -46,7 +45,7 @@ func (m *Manager) transactionFactory(transactionType driver.TransactionType) (dr
 	logger.Debugf("transactionFactory called with transactionType [%v]", transactionType)
 	f, ok := m.transactionFactories.Load(transactionType)
 	if !ok {
-		return nil, fmt.Errorf("no transaction factory found for transaction type %v", transactionType)
+		return nil, errors.Errorf("no transaction factory found for transaction type %v", transactionType)
 	}
 
 	txFactory, ok := f.(driver.TransactionFactory)

--- a/platform/fabricx/core/vault/interceptor.go
+++ b/platform/fabricx/core/vault/interceptor.go
@@ -8,9 +8,9 @@ package vault
 
 import (
 	"context"
-	"errors"
 	"sync/atomic"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/core/generic/vault"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger/fabric-x-committer/api/types"

--- a/platform/fabricx/core/vault/queryservice/config.go
+++ b/platform/fabricx/core/vault/queryservice/config.go
@@ -7,8 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package queryservice
 
 import (
-	"fmt"
 	"time"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
 
 const DefaultQueryTimeout = 30 * time.Second
@@ -37,7 +38,7 @@ func NewConfig(configService ConfigService) (*Config, error) {
 
 	err := configService.UnmarshalKey("queryService", &config)
 	if err != nil {
-		return config, fmt.Errorf("cannot get query service config: %w", err)
+		return config, errors.Wrap(err, "unmarshal queryService")
 	}
 
 	return config, nil

--- a/platform/fabricx/core/vault/queryservice/grpc.go
+++ b/platform/fabricx/core/vault/queryservice/grpc.go
@@ -7,23 +7,22 @@ SPDX-License-Identifier: Apache-2.0
 package queryservice
 
 import (
-	"errors"
-	"fmt"
 	"os"
 	"time"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-var ErrInvalidAddress = fmt.Errorf("empty address")
+var ErrInvalidAddress = errors.New("empty address")
 
 func GrpcClient(c *Config) (*grpc.ClientConn, error) {
 	// no endpoints in config
 	if len(c.Endpoints) != 1 {
-		return nil, fmt.Errorf("we need a single query service endpoint")
+		return nil, errors.New("we need a single query service endpoint")
 	}
 
 	// currently we only support connections to a single query service

--- a/platform/fabricx/core/vault/queryservice/provider.go
+++ b/platform/fabricx/core/vault/queryservice/provider.go
@@ -7,9 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package queryservice
 
 import (
-	"fmt"
 	"reflect"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/driver/config"
 	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
@@ -25,12 +25,12 @@ type QueryService interface {
 func NewRemoteQueryServiceFromConfig(configService fdriver.ConfigService) (*RemoteQueryService, error) {
 	c, err := NewConfig(configService)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get config for query service: %w", err)
+		return nil, errors.Wrap(err, "get config")
 	}
 
 	conn, err := GrpcClient(c)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get grpc client for query service: %w", err)
+		return nil, errors.Wrap(err, "get grpc client for query service")
 	}
 
 	return NewRemoteQueryService(c, protoqueryservice.NewQueryServiceClient(conn)), nil
@@ -53,7 +53,7 @@ type RemoteQueryServiceProvider struct {
 func (r *RemoteQueryServiceProvider) Get(network, channel string) (QueryService, error) {
 	configService, err := r.ConfigProvider.GetConfig(network)
 	if err != nil {
-		return nil, fmt.Errorf("could not get mapping provider for %s: %w", channel, err)
+		return nil, errors.Wrapf(err, "get mapping provider for [channel=%s]", channel)
 	}
 
 	return NewRemoteQueryServiceFromConfig(configService)
@@ -62,7 +62,7 @@ func (r *RemoteQueryServiceProvider) Get(network, channel string) (QueryService,
 func GetQueryService(sp services.Provider, network, channel string) (QueryService, error) {
 	qsp, err := sp.GetService(reflect.TypeOf((*Provider)(nil)))
 	if err != nil {
-		return nil, fmt.Errorf("could not find provider: %w", err)
+		return nil, errors.Wrap(err, "could not find provider")
 	}
 	return qsp.(Provider).Get(network, channel)
 }

--- a/platform/fabricx/core/vault/queryservice/query.go
+++ b/platform/fabricx/core/vault/queryservice/query.go
@@ -8,9 +8,9 @@ package queryservice
 
 import (
 	"context"
-	"fmt"
 	"time"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
 	"github.com/hyperledger/fabric-x-committer/api/protoqueryservice"
@@ -20,7 +20,7 @@ import (
 var (
 	logger = logging.MustGetLogger()
 
-	ErrInvalidQueryInput = fmt.Errorf("invalid query input")
+	ErrInvalidQueryInput = errors.New("invalid query input")
 )
 
 type RemoteQueryService struct {
@@ -47,7 +47,7 @@ func (s *RemoteQueryService) GetState(ns driver.Namespace, key driver.PKey) (*dr
 	logger.Debugf("QS GetState %v %v", ns, key)
 	res, err := s.GetStates(m)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "get states")
 	}
 
 	// ensure that ns exists
@@ -83,7 +83,7 @@ func (s *RemoteQueryService) query(m map[driver.Namespace][]driver.PKey) (map[dr
 	res, err := s.client.GetRows(ctx, q)
 	if err != nil {
 		logger.Warnf("QS GetState: error calling getRows: %v", err)
-		return nil, err
+		return nil, errors.Wrap(err, "query get rows")
 	}
 	logger.Debugf("QS GetState: got response in %v", time.Since(now))
 

--- a/platform/fabricx/core/vault/queryservice/query_test.go
+++ b/platform/fabricx/core/vault/queryservice/query_test.go
@@ -7,10 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package queryservice_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/vault/queryservice"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/vault/queryservice/fakes"
@@ -369,7 +369,7 @@ func TestQueryService(t *testing.T) {
 		t.Parallel()
 		qs, fake := setupTest(t)
 
-		expectedError := fmt.Errorf("some error")
+		expectedError := errors.New("some error")
 
 		fake.GetRowsReturns(nil, expectedError)
 		_, err := qs.GetState("ns", "key1")

--- a/platform/fabricx/sdk/dig/providers.go
+++ b/platform/fabricx/sdk/dig/providers.go
@@ -7,8 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package sdk
 
 import (
-	"errors"
-
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/core/generic/committer"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core"

--- a/platform/fabricx/sdk/dig/sdk.go
+++ b/platform/fabricx/sdk/dig/sdk.go
@@ -8,8 +8,8 @@ package sdk
 
 import (
 	"context"
-	"errors"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	common "github.com/hyperledger-labs/fabric-smart-client/platform/common/sdk/dig"
 	digutils "github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/dig"
 	fabric "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk/dig"


### PR DESCRIPTION
This PR refactors error handling in the fabric-x platform and uses `github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors`.

This is the follow-up PR as mentioned in #1101 