### PR TITLE
fix(gha): pin docker version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -60,8 +60,8 @@ jobs:
 
   itest:
     needs:
-    - checks
-    - itest-list
+      - checks
+      - itest-list
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -74,6 +74,7 @@ jobs:
         uses: docker/setup-docker-action@v4
         with:
           version: 28.5.2 # we pin the docker version temporary until the release of fabric v3.1.4
+          set-host: true
       - run: docker version
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
@@ -92,10 +93,8 @@ jobs:
       - name: Set up Softhsm
         # we only need this for a subset of integration tests
         if: endsWith(matrix.tests, 'hsm')
-        run: | 
+        run: |
           make install-softhsm
           ./ci/scripts/setup_softhsm.sh
-
-      - run: docker images
 
       - run: make integration-tests-${{ matrix.tests }}


### PR DESCRIPTION
Docker v29 causes some issue with current Fabric versions. This commit pins the version of docker used in GHA temporarly until a new release of Fabric is available.