### PR TITLE
test(view): add unit tests for session, context.

### DIFF
--- a/platform/view/view/context_test.go
+++ b/platform/view/view/context_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package view
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompileRunViewOptions(t *testing.T) {
+	ctx1 := t.Context()
+	ctx2, cancel := context.WithCancel(ctx1)
+	t.Cleanup(cancel)
+
+	callFn := func(Context) (interface{}, error) { return "ok", nil }
+	resetInitiator := func(o *RunViewOptions) error {
+		o.AsInitiator = false
+		return nil
+	}
+
+	tests := []struct {
+		name        string
+		opts        []RunViewOption
+		check       func(t *testing.T, opts *RunViewOptions)
+		expectedErr string
+	}{
+		{
+			name: "No_Options_Returns_Zero_Value",
+			opts: nil,
+			check: func(t *testing.T, opts *RunViewOptions) {
+				require.NotNil(t, opts)
+				require.Nil(t, opts.Session)
+				require.False(t, opts.AsInitiator)
+				require.Nil(t, opts.Call)
+				require.False(t, opts.SameContext)
+				require.Nil(t, opts.Ctx)
+			},
+		},
+		{
+			name: "AsInitiator_Sets_Flag",
+			opts: []RunViewOption{AsInitiator()},
+			check: func(t *testing.T, opts *RunViewOptions) {
+				require.True(t, opts.AsInitiator)
+			},
+		},
+		{
+			name: "AsResponder_Sets_Session",
+			opts: []RunViewOption{AsResponder(nil)},
+			check: func(t *testing.T, opts *RunViewOptions) {
+				require.Nil(t, opts.Session)
+			},
+		},
+		{
+			name: "WithViewCall_Sets_Call_Function",
+			opts: []RunViewOption{WithViewCall(callFn)},
+			check: func(t *testing.T, opts *RunViewOptions) {
+				require.NotNil(t, opts.Call)
+				result, err := opts.Call(nil)
+				require.NoError(t, err)
+				require.Equal(t, "ok", result)
+			},
+		},
+		{
+			name: "WithSameContext_Sets_Flag_Without_Ctx",
+			opts: []RunViewOption{WithSameContext()},
+			check: func(t *testing.T, opts *RunViewOptions) {
+				require.True(t, opts.SameContext)
+				require.Nil(t, opts.Ctx)
+			},
+		},
+		{
+			name: "WithContext_Sets_Both_SameContext_And_Ctx",
+			opts: []RunViewOption{WithContext(ctx1)},
+			check: func(t *testing.T, opts *RunViewOptions) {
+				require.True(t, opts.SameContext)
+				require.Equal(t, ctx1, opts.Ctx)
+			},
+		},
+		{
+			name: "Multiple_Options_All_Applied_In_Order",
+			opts: []RunViewOption{AsInitiator(), WithViewCall(callFn), WithContext(ctx1)},
+			check: func(t *testing.T, opts *RunViewOptions) {
+				require.True(t, opts.AsInitiator)
+				require.NotNil(t, opts.Call)
+				require.True(t, opts.SameContext)
+				require.Equal(t, ctx1, opts.Ctx)
+			},
+		},
+		{
+			name: "Later_Option_Overrides_Earlier",
+			opts: []RunViewOption{AsInitiator(), resetInitiator},
+			check: func(t *testing.T, opts *RunViewOptions) {
+				require.False(t, opts.AsInitiator)
+			},
+		},
+		{
+			name: "Later_WithContext_Overrides_Earlier",
+			opts: []RunViewOption{WithContext(ctx1), WithContext(ctx2)},
+			check: func(t *testing.T, opts *RunViewOptions) {
+				require.Equal(t, ctx2, opts.Ctx)
+			},
+		},
+		{
+			name:        "Stops_On_First_Error",
+			opts:        []RunViewOption{WithSameContext(), func(o *RunViewOptions) error { return errors.New("option failed") }, AsInitiator()},
+			expectedErr: "option failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts, err := CompileRunViewOptions(tt.opts...)
+
+			if tt.expectedErr != "" {
+				require.EqualError(t, err, tt.expectedErr)
+				require.Nil(t, opts)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, opts)
+			}
+		})
+	}
+}

--- a/platform/view/view/session.go
+++ b/platform/view/view/session.go
@@ -45,7 +45,7 @@ type SessionInfo struct {
 }
 
 func (i *SessionInfo) String() string {
-	return fmt.Sprintf("session info [%s,%s,%s,%s,%s,%v]", i.ID, i.Caller, i.Caller, i.Endpoint, i.EndpointPKID, i.Closed)
+	return fmt.Sprintf("session info [%s,%s,%s,%s,%s,%v]", i.ID, i.Caller, i.CallerViewID, i.Endpoint, i.EndpointPKID, i.Closed)
 }
 
 // Session encapsulates a communication channel to an endpoint

--- a/platform/view/view/session_test.go
+++ b/platform/view/view/session_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package view
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConstants(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, 200, OK)
+	require.Equal(t, 500, ERROR)
+}
+
+func TestMessage_String(t *testing.T) {
+	t.Parallel()
+
+	table := []struct {
+		name        string
+		msg         Message
+		contains    []string
+		notContains []string
+	}{
+		{
+			name: "All Fields Populated",
+			msg: Message{
+				SessionID:    "session-1",
+				ContextID:    "ctx-1",
+				Caller:       "view-caller",
+				FromEndpoint: "endpoint-1",
+				FromPKID:     []byte("pk-id"),
+				Status:       OK,
+				Payload:      []byte("hello"),
+				Ctx:          context.Background(),
+			},
+			contains: []string{
+				"session:session-1",
+				"context:ctx-1",
+				"caller:view-caller",
+				"endpoint:endpoint-1",
+			},
+		},
+		{
+			name: "Empty Fields",
+			msg:  Message{},
+			contains: []string{
+				"session:",
+				"context:",
+				"caller:",
+				"endpoint:",
+			},
+		},
+		{
+			name: "Does Not Include Payload Or Status",
+			msg: Message{
+				SessionID: "s1",
+				Status:    ERROR,
+				Payload:   []byte("secret-data"),
+			},
+			contains:    []string{"session:s1"},
+			notContains: []string{"secret-data", "500"},
+		},
+	}
+
+	for _, tc := range table {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := tc.msg.String()
+
+			for _, s := range tc.contains {
+				require.Contains(t, result, s)
+			}
+			for _, s := range tc.notContains {
+				require.NotContains(t, result, s)
+			}
+		})
+	}
+}
+
+func TestSessionInfo_String(t *testing.T) {
+	t.Parallel()
+
+	caller := Identity("caller-identity")
+
+	table := []struct {
+		name     string
+		info     SessionInfo
+		contains []string
+	}{
+		{
+			name: "All Fields Populated",
+			info: SessionInfo{
+				ID:           "info-1",
+				Caller:       caller,
+				CallerViewID: "caller-view",
+				Endpoint:     "ep-1",
+				EndpointPKID: []byte("pk-1"),
+				Closed:       false,
+			},
+			contains: []string{"info-1", caller.String(), "caller-view", "ep-1", "pk-1", "false"},
+		},
+		{
+			name: "Closed Session",
+			info: SessionInfo{
+				ID:     "closed-session",
+				Closed: true,
+			},
+			contains: []string{"closed-session", "true"},
+		},
+		{
+			name:     "Empty Fields",
+			info:     SessionInfo{},
+			contains: []string{"session info", "false"},
+		},
+	}
+
+	for _, tc := range table {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := tc.info.String()
+
+			for _, s := range tc.contains {
+				require.Contains(t, result, s)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add comprehensive test coverage for view package.

Fix bug in SessionInfo.String() where Caller was printed twice instead of CallerViewID.