### PR TITLE
fix(tests): fix flaky tests

### DIFF
--- a/platform/fabricx/core/vault/queryservice/query_test.go
+++ b/platform/fabricx/core/vault/queryservice/query_test.go
@@ -384,7 +384,6 @@ func TestQueryService(t *testing.T) {
 		qs, fake := setupTest(t)
 
 		t.Run("happy path", func(t *testing.T) {
-			t.Parallel()
 			// return a response with one status
 			fake.GetTransactionStatusReturns(&protoqueryservice.TxStatusResponse{
 				Statuses: []*protonotify.TxStatusEvent{
@@ -400,7 +399,6 @@ func TestQueryService(t *testing.T) {
 		})
 
 		t.Run("client error", func(t *testing.T) {
-			t.Parallel()
 			expectedError := errors.New("some error")
 			fake.GetTransactionStatusReturns(nil, expectedError)
 
@@ -409,7 +407,6 @@ func TestQueryService(t *testing.T) {
 		})
 
 		t.Run("no statuses", func(t *testing.T) {
-			t.Parallel()
 			fake.GetTransactionStatusReturns(&protoqueryservice.TxStatusResponse{Statuses: []*protonotify.TxStatusEvent{}}, nil)
 
 			_, err := qs.GetTransactionStatus("tx3")

--- a/platform/view/services/grpc/client_test.go
+++ b/platform/view/services/grpc/client_test.go
@@ -259,7 +259,7 @@ func TestNewConnection(t *testing.T) {
 				MaxVersion:   tls.VersionTLS12, // https://github.com/golang/go/issues/33368
 			},
 			success:  false,
-			errorMsg: "tls: bad certificate",
+			errorMsg: "(tls: bad certificate|handshake failure)",
 		},
 		{
 			name: "client TLS / server TLS client cert",


### PR DESCRIPTION
- Remove t.Parrallel() from GetTransactionStatus subtests sharing the same moock to prevent race condietion causing intermittent test failures.

```bash
--- FAIL: TestQueryService (0.00s)
    --- FAIL: TestQueryService/GetTransactionStatus (0.00s)
        --- FAIL: TestQueryService/GetTransactionStatus/happy_path (0.00s)
            query_test.go:398: 
                	Error Trace:	/home/runner/work/fabric-smart-client/fabric-smart-client/platform/fabricx/core/vault/queryservice/query_test.go:398
                	Error:      	Received unexpected error:
                	            	QS GetTransactionStatus: no statuses for tx tx1
                	            	(1) attached stack trace
                	            	  -- stack trace:
                	            	  | github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors.Errorf
                	            	  | 	/home/runner/work/fabric-smart-client/fabric-smart-client/pkg/utils/errors/errors.go:64
                	            	  | github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/vault/queryservice.(*RemoteQueryService).GetTransactionStatus
                	            	  | 	/home/runner/work/fabric-smart-client/fabric-smart-client/platform/fabricx/core/vault/queryservice/query.go:84
                	            	  | github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/vault/queryservice_test.TestQueryService.func8.1
                	            	  | 	/home/runner/work/fabric-smart-client/fabric-smart-client/platform/fabricx/core/vault/queryservice/query_test.go:397
                	            	  | testing.tRunner
                	            	  | 	/opt/hostedtoolcache/go/1.24.12/x64/src/testing/testing.go:1792
                	            	  | runtime.goexit
                	            	  | 	/opt/hostedtoolcache/go/1.24.12/x64/src/runtime/asm_amd64.s:1700
                	            	Wraps: (2) QS GetTransactionStatus: no statuses for tx tx1
                	            	Error types: (1) *withstack.withStack (2) *errutil.leafError
                	Test:       	TestQueryService/GetTransactionStatus/happy_path
FAIL
```

- Extend error message regex for client grpc tests.
```
--- FAIL: TestQueryService (0.00s)
    --- FAIL: TestQueryService/GetTransactionStatus (0.00s)
        --- FAIL: TestQueryService/GetTransactionStatus/happy_path (0.00s)
            query_test.go:398: 
                	Error Trace:	/home/runner/work/fabric-smart-client/fabric-smart-client/platform/fabricx/core/vault/queryservice/query_test.go:398
                	Error:      	Received unexpected error:
                	            	QS GetTransactionStatus: no statuses for tx tx1
                	            	(1) attached stack trace
                	            	  -- stack trace:
                	            	  | github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors.Errorf
                	            	  | 	/home/runner/work/fabric-smart-client/fabric-smart-client/pkg/utils/errors/errors.go:64
                	            	  | github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/vault/queryservice.(*RemoteQueryService).GetTransactionStatus
                	            	  | 	/home/runner/work/fabric-smart-client/fabric-smart-client/platform/fabricx/core/vault/queryservice/query.go:84
                	            	  | github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/vault/queryservice_test.TestQueryService.func8.1
                	            	  | 	/home/runner/work/fabric-smart-client/fabric-smart-client/platform/fabricx/core/vault/queryservice/query_test.go:397
                	            	  | testing.tRunner
                	            	  | 	/opt/hostedtoolcache/go/1.24.12/x64/src/testing/testing.go:1792
                	            	  | runtime.goexit
                	            	  | 	/opt/hostedtoolcache/go/1.24.12/x64/src/runtime/asm_amd64.s:1700
                	            	Wraps: (2) QS GetTransactionStatus: no statuses for tx tx1
                	            	Error types: (1) *withstack.withStack (2) *errutil.leafError
                	Test:       	TestQueryService/GetTransactionStatus/happy_path
FAIL
```