### PR TITLE
chore(nwo): fabricx sidecar configuration

### DIFF
--- a/platform/fabricx/core/committer/v3/test_utils.go
+++ b/platform/fabricx/core/committer/v3/test_utils.go
@@ -30,5 +30,6 @@ func ContainerEnvVars(peerMSPDir, scMSPID, channelName, ordererEndpoint string) 
 		"SC_ORDERER_BLOCK_SIZE=1",
 		"SC_VC_LOGGING_LOGSPEC=DEBUG",
 		"SC_VERIFIER_LOGGING_LOGSPEC=INFO",
+		"SC_SIDECAR_SERVER_MAX_CONCURRENT_STREAMS=0",
 	}
 }


### PR DESCRIPTION
This PR sets this env variable  `"SC_SIDECAR_SERVER_MAX_CONCURRENT_STREAMS=0",` to make sure the fabricx committer used in NWO does not limit the number of concurrent streams. This is helpful in tests where many nodes are using the same committer node like it is happening in the token-sdk.