### PR TITLE
testing: consistent use of t.Helper()

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+version: "2"
+linters:
+  enable:
+    - thelper
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+run:
+  allow-parallel-runners: true

--- a/integration/benchmark/benchmark.go
+++ b/integration/benchmark/benchmark.go
@@ -11,5 +11,6 @@ import (
 )
 
 func ReportTPS(b *testing.B) {
+	b.Helper()
 	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "TPS")
 }

--- a/integration/benchmark/grpc/baseline_bench_test.go
+++ b/integration/benchmark/grpc/baseline_bench_test.go
@@ -39,6 +39,7 @@ func BenchmarkGRPCBaseline(b *testing.B) {
 }
 
 func runGPRCBaseline(b *testing.B, w string) {
+	b.Helper()
 	srvEndpoint := setupBaselineServer(b, w)
 
 	// we share a single connection among all client goroutines

--- a/integration/benchmark/grpc/grpc_bench_test.go
+++ b/integration/benchmark/grpc/grpc_bench_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/benchmark"
 	benchviews "github.com/hyperledger-labs/fabric-smart-client/integration/benchmark/views"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics/disabled"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/view/grpc/client"
@@ -82,6 +83,7 @@ func BenchmarkGRPCImpl(b *testing.B) {
 }
 
 func runGPRCImpl(b *testing.B, srvOptions []ServerOption, clientOptions []ClientOption) {
+	b.Helper()
 	srvEndpoint := setupServer(b, srvOptions...)
 
 	// we share a single connection among all client goroutines
@@ -102,6 +104,7 @@ func runGPRCImpl(b *testing.B, srvOptions []ServerOption, clientOptions []Client
 // setupCrypto generates certificates and writes them to temporary files.
 // It returns the paths and a cleanup function to delete the files after the test.
 func setupCrypto(tb testing.TB) (certPath, keyPath string) {
+	tb.Helper()
 	// 1. Call your helper to get PEM bytes
 	keyPEM, certPEM, err := makeSelfSignedCert()
 	require.NoError(tb, err)
@@ -134,43 +137,41 @@ type clientConfig struct {
 	signer client.SigningIdentity
 }
 
-type ServerOption func(tb testing.TB, c *serverConfig)
-type ClientOption func(tb testing.TB, c *clientConfig)
+type ServerOption func(c *serverConfig)
+type ClientOption func(c *clientConfig)
 
 // --- Server Options ---
 
 func WithNOOPWorkload() ServerOption {
-	return func(tb testing.TB, c *serverConfig) {
+	return func(c *serverConfig) {
 		factory := &benchviews.NoopViewFactory{}
-		v, _ := factory.NewView(nil)
+		v := utils.MustGet(factory.NewView(nil))
 		c.workload = v
 	}
 }
 
 func WithCPUWorkload(n int) ServerOption {
-	return func(tb testing.TB, c *serverConfig) {
+	return func(c *serverConfig) {
 		params := &benchviews.CPUParams{N: n}
 		input, _ := json.Marshal(params)
 		factory := &benchviews.CPUViewFactory{}
-		v, err := factory.NewView(input)
-		require.NoError(tb, err)
+		v := utils.MustGet(factory.NewView(input))
 		c.workload = v
 	}
 }
 
 func WithECDSAWorkload() ServerOption {
-	return func(tb testing.TB, c *serverConfig) {
+	return func(c *serverConfig) {
 		params := &benchviews.ECDSASignParams{}
 		input, _ := json.Marshal(params)
 		factory := &benchviews.ECDSASignViewFactory{}
-		v, err := factory.NewView(input)
-		require.NoError(tb, err)
+		v := utils.MustGet(factory.NewView(input))
 		c.workload = v
 	}
 }
 
 func WithServerMockSigner(id string) ServerOption {
-	return func(tb testing.TB, c *serverConfig) {
+	return func(c *serverConfig) {
 		mIdentity := view.Identity(id)
 		c.signer = &benchmark.MockSigner{
 			SerializeFunc: func() ([]byte, error) { return mIdentity.Bytes(), nil },
@@ -181,9 +182,8 @@ func WithServerMockSigner(id string) ServerOption {
 }
 
 func WithServerECDSASigner(certPath, keyPath string) ServerOption {
-	return func(tb testing.TB, c *serverConfig) {
-		signer, err := client.NewX509SigningIdentity(certPath, keyPath)
-		require.NoError(tb, err)
+	return func(c *serverConfig) {
+		signer := utils.MustGet(client.NewX509SigningIdentity(certPath, keyPath))
 		c.signer = signer
 		serialized, _ := signer.Serialize()
 		c.idProvider = &benchmark.MockIdentityProvider{DefaultSigner: serialized}
@@ -193,7 +193,7 @@ func WithServerECDSASigner(certPath, keyPath string) ServerOption {
 // --- Client Options ---
 
 func WithClientMockSigner(id string) ClientOption {
-	return func(tb testing.TB, c *clientConfig) {
+	return func(c *clientConfig) {
 		mIdentity := view.Identity(id)
 		c.signer = &benchmark.MockSigner{
 			SerializeFunc: func() ([]byte, error) { return mIdentity.Bytes(), nil },
@@ -203,9 +203,8 @@ func WithClientMockSigner(id string) ClientOption {
 }
 
 func WithClientECDSASigner(certPath, keyPath string) ClientOption {
-	return func(tb testing.TB, c *clientConfig) {
-		signer, err := client.NewX509SigningIdentity(certPath, keyPath)
-		require.NoError(tb, err)
+	return func(c *clientConfig) {
+		signer := utils.MustGet(client.NewX509SigningIdentity(certPath, keyPath))
 		c.signer = signer
 	}
 }
@@ -217,7 +216,7 @@ func setupServer(tb testing.TB, opts ...ServerOption) string {
 	cfg := &serverConfig{}
 	// Apply options
 	for _, opt := range opts {
-		opt(tb, cfg)
+		opt(cfg)
 	}
 
 	// Validate that the options successfully populated the config
@@ -281,7 +280,7 @@ func setupClient(tb testing.TB, srvEndpoint string, opts ...ClientOption) (*benc
 	cfg := &clientConfig{}
 	// Apply options
 	for _, opt := range opts {
-		opt(tb, cfg)
+		opt(cfg)
 	}
 	// Validate that the signer is present before proceeding
 	require.NotNil(tb, cfg.signer, "client signer was not configured by options")

--- a/integration/benchmark/grpc/remote/client/benchmark_test.go
+++ b/integration/benchmark/grpc/remote/client/benchmark_test.go
@@ -38,6 +38,7 @@ func BenchmarkLocal(b *testing.B) {
 }
 
 func runBenchmark(b *testing.B, ccs []*grpc.ClientConn, makeCaller func(conn *grpc.ClientConn) workload.ClientFunc) {
+	b.Helper()
 	callers := make([]workload.ClientFunc, len(ccs))
 	for i, cc := range ccs {
 		callers[i] = makeCaller(cc)
@@ -63,5 +64,6 @@ func runBenchmark(b *testing.B, ccs []*grpc.ClientConn, makeCaller func(conn *gr
 }
 
 func ReportTPS(b *testing.B) {
+	b.Helper()
 	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "TPS")
 }

--- a/integration/benchmark/node/bench_helpers.go
+++ b/integration/benchmark/node/bench_helpers.go
@@ -58,6 +58,7 @@ var DefaultWorkloads = []Workload{
 // CreateClients creates numConn ViewClients using the given client config path.
 // It returns the clients and a cleanup function that closes all connections.
 func CreateClients(tb testing.TB, numConn int, clientConfPath string) ([]*benchmark.ViewClient, func()) {
+	tb.Helper()
 	ccs := make([]*benchmark.ViewClient, numConn)
 	closers := make([]func(), numConn)
 
@@ -78,6 +79,7 @@ func CreateClients(tb testing.TB, numConn int, clientConfPath string) ([]*benchm
 // round-robin caller selection. This is the core gRPC benchmark loop used by
 // both local and remote node benchmarks.
 func RunGRPCBenchmark(b *testing.B, ccs []*benchmark.ViewClient, makeCaller func(cli *benchmark.ViewClient) func(ctx context.Context) error) {
+	b.Helper()
 	callers := make([]func(ctx context.Context) error, len(ccs))
 	for i, cc := range ccs {
 		callers[i] = makeCaller(cc)
@@ -105,6 +107,7 @@ func RunGRPCBenchmark(b *testing.B, ccs []*benchmark.ViewClient, makeCaller func
 // for the given workload name and input. The signed command is created once
 // and reused across all calls for efficiency.
 func MakeGRPCCaller(tb testing.TB, cli *benchmark.ViewClient, fid string, input []byte) func(ctx context.Context) error {
+	tb.Helper()
 	sc, err := cli.CreateSignedCommand(buildCommand(fid, input))
 	require.NoError(tb, err)
 
@@ -144,6 +147,7 @@ func executeSignedCommand(cli *benchmark.ViewClient, sc *protos2.SignedCommand, 
 //   - f=0: reuses a single view instance per goroutine (measures pure view performance)
 //   - f=1: creates a new view per invocation (measures view + factory overhead)
 func RunAPIBenchmark(b *testing.B, vm ViewManager, wl Workload) {
+	b.Helper()
 	var in []byte
 	var err error
 	if wl.Params != nil {
@@ -193,6 +197,7 @@ func RunAPIBenchmark(b *testing.B, vm ViewManager, wl Workload) {
 // across multiple connection counts. It handles client creation, warmup,
 // and cleanup.
 func RunAPIGRPCBenchmark(b *testing.B, wl Workload, clientConfPath string, connCounts []int) {
+	b.Helper()
 	var in []byte
 	var err error
 	if wl.Params != nil {

--- a/integration/nwo/cmd/cryptogen/msp/msp_test.go
+++ b/integration/nwo/cmd/cryptogen/msp/msp_test.go
@@ -35,6 +35,7 @@ const (
 var testDir = filepath.Join(os.TempDir(), "msp-test")
 
 func testGenerateLocalMSP(t *testing.T, nodeOUs bool) {
+	t.Helper()
 	cleanup(testDir)
 
 	err := msp2.GenerateLocalMSP(testDir, testName, nil, &ca2.CA{}, &ca2.CA{}, msp2.PEER, nodeOUs, false, nil)
@@ -130,6 +131,7 @@ func TestGenerateLocalMSPWithoutNodeOU(t *testing.T) {
 }
 
 func testGenerateVerifyingMSP(t *testing.T, nodeOUs bool) {
+	t.Helper()
 	caDir := filepath.Join(testDir, "ca")
 	tlsCADir := filepath.Join(testDir, "tlsca")
 	mspDir := filepath.Join(testDir, "msp")

--- a/pkg/runner/batch_test.go
+++ b/pkg/runner/batch_test.go
@@ -74,6 +74,7 @@ func newBatchRunner() (BatchRunner[int], map[string]string, *uint32) {
 }
 
 func run(t *testing.T, ctr *atomic.Uint32, runner BatchRunner[int], times int) {
+	t.Helper()
 	var wg sync.WaitGroup
 	wg.Add(times)
 	for i := 0; i < times; i++ {

--- a/pkg/utils/uuid_test.go
+++ b/pkg/utils/uuid_test.go
@@ -86,6 +86,7 @@ func BenchmarkUUID(b *testing.B) {
 }
 
 func report(b *testing.B) {
+	b.Helper()
 	b.ReportAllocs()
 }
 

--- a/platform/common/core/generic/vault/bench_test.go
+++ b/platform/common/core/generic/vault/bench_test.go
@@ -30,7 +30,7 @@ func BenchmarkPostgresVault(b *testing.B) {
 	require.NotNil(b, ddb)
 	defer terminate()
 
-	BenchTestSetStateCommit(b, ddb)
+	runBenchmarkSetStateCommit(b, ddb)
 }
 
 func BenchmarkMemoryVault(b *testing.B) {
@@ -38,7 +38,7 @@ func BenchmarkMemoryVault(b *testing.B) {
 	require.NoError(b, err)
 	require.NotNil(b, ddb)
 
-	BenchTestSetStateCommit(b, ddb)
+	runBenchmarkSetStateCommit(b, ddb)
 }
 
 func BenchmarkSqliteVault(b *testing.B) {
@@ -46,10 +46,11 @@ func BenchmarkSqliteVault(b *testing.B) {
 	require.NoError(b, err)
 	require.NotNil(b, ddb)
 
-	BenchTestSetStateCommit(b, ddb)
+	runBenchmarkSetStateCommit(b, ddb)
 }
 
-func BenchTestSetStateCommit(b *testing.B, ddb driver.VaultStore) {
+func runBenchmarkSetStateCommit(b *testing.B, ddb driver.VaultStore) {
+	b.Helper()
 	vault, err := (&testArtifactProvider{}).NewNonCachedVault(ddb)
 	require.NoError(b, err)
 	defer func() { require.NoError(b, ddb.Close()) }()
@@ -81,6 +82,7 @@ func BenchTestSetStateCommit(b *testing.B, ddb driver.VaultStore) {
 }
 
 func verifyResult(b *testing.B, vault *Vault[ValidationCode]) {
+	b.Helper()
 	stateItr, err := vault.vaultStore.GetAllStates(context.Background(), namespace)
 	require.NoError(b, err)
 	states, err := collections.ReadAll(stateItr)
@@ -105,6 +107,7 @@ func newRWSet(vault *Vault[ValidationCode], commitIndex *txCommitIndex) error {
 }
 
 func runCommitter(b *testing.B, txs chan *txCommitIndex, vault *Vault[ValidationCode]) *sync.WaitGroup {
+	b.Helper()
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go func() {

--- a/platform/common/core/generic/vault/helpers.go
+++ b/platform/common/core/generic/vault/helpers.go
@@ -75,6 +75,7 @@ var DoubleDBCases = []struct {
 }
 
 func TTestInterceptorErr(t *testing.T, ddb driver2.VaultStore, vp artifactsProvider) {
+	t.Helper()
 	vault1, err := vp.NewNonCachedVault(ddb)
 	require.NoError(t, err)
 	rws, err := vault1.NewRWSet(context.Background(), "txid")
@@ -121,6 +122,7 @@ func TTestInterceptorErr(t *testing.T, ddb driver2.VaultStore, vp artifactsProvi
 }
 
 func TTestInterceptorConcurrency(t *testing.T, ddb driver2.VaultStore, vp artifactsProvider) {
+	t.Helper()
 	ns := "namespace"
 	k := "key1"
 
@@ -151,6 +153,7 @@ func TTestInterceptorConcurrency(t *testing.T, ddb driver2.VaultStore, vp artifa
 }
 
 func TTestInterceptorConcurrencyNoConsistency(t *testing.T, ddb driver2.VaultStore, vp artifactsProvider) {
+	t.Helper()
 	ns := "namespace"
 	k := "key1"
 	mk := "meyakey1"
@@ -196,6 +199,7 @@ func TTestInterceptorConcurrencyNoConsistency(t *testing.T, ddb driver2.VaultSto
 }
 
 func TTestQueryExecutor(t *testing.T, ddb driver2.VaultStore, vp artifactsProvider) {
+	t.Helper()
 	ns := "namespace"
 
 	aVault, err := vp.NewNonCachedVault(ddb)
@@ -266,6 +270,7 @@ func TTestQueryExecutor(t *testing.T, ddb driver2.VaultStore, vp artifactsProvid
 }
 
 func TTestShardLikeCommit(t *testing.T, ddb driver2.VaultStore, vp artifactsProvider) {
+	t.Helper()
 	ns := "namespace"
 	k1 := "key1"
 	k2 := "key2"
@@ -389,6 +394,7 @@ func TTestShardLikeCommit(t *testing.T, ddb driver2.VaultStore, vp artifactsProv
 }
 
 func TTestVaultErr(t *testing.T, ddb driver2.VaultStore, vp artifactsProvider) {
+	t.Helper()
 	vault1, err := vp.NewNonCachedVault(ddb)
 	require.NoError(t, err)
 	err = vault1.CommitTX(context.TODO(), "non-existent", 0, 0)
@@ -436,6 +442,7 @@ func TTestVaultErr(t *testing.T, ddb driver2.VaultStore, vp artifactsProvider) {
 }
 
 func TTestMerge(t *testing.T, ddb driver2.VaultStore, vp artifactsProvider) {
+	t.Helper()
 	ns := "namespace"
 	k1 := "key1"
 	k2 := "key2"
@@ -564,6 +571,7 @@ func TTestMerge(t *testing.T, ddb driver2.VaultStore, vp artifactsProvider) {
 }
 
 func TTestInspector(t *testing.T, ddb driver2.VaultStore, vp artifactsProvider) {
+	t.Helper()
 	txid := "txid"
 	ns := "ns"
 	k1 := "\x00k1"
@@ -631,6 +639,7 @@ func TTestInspector(t *testing.T, ddb driver2.VaultStore, vp artifactsProvider) 
 }
 
 func TTestRun(t *testing.T, db1, db2 driver2.VaultStore, vp artifactsProvider) {
+	t.Helper()
 	ns := "namespace"
 	k1 := "key1"
 	k1Meta := "key1Meta"
@@ -1029,6 +1038,7 @@ func TTestRun(t *testing.T, db1, db2 driver2.VaultStore, vp artifactsProvider) {
 }
 
 func compare(t *testing.T, ns string, db1, db2 driver2.VaultStore) {
+	t.Helper()
 	// we expect the underlying databases to be identical
 	itr, err := db1.GetAllStates(context.Background(), ns)
 	require.NoError(t, err)

--- a/platform/common/services/logging/logger.go
+++ b/platform/common/services/logging/logger.go
@@ -114,6 +114,7 @@ func GetPackageName() (string, error) {
 }
 
 func NewTestLogger(tb testing.TB, options ...Option) (Logger, *Recorder) {
+	tb.Helper()
 	l, r := floggingtest.NewTestLogger(tb, options...)
 	return &logger{fabricLogger: l}, r
 }

--- a/platform/common/utils/assert/retry.go
+++ b/platform/common/utils/assert/retry.go
@@ -17,6 +17,7 @@ import (
 // EventuallyWithRetry will call the function provided, and asserts that the
 // function returns with no error within the provided number of attempts.
 func EventuallyWithRetry(t *testing.T, attempts int, sleep time.Duration, f func() error, msgAndArgs ...interface{}) {
+	t.Helper()
 	assert.NoError(t, Retry(attempts, sleep, f), msgAndArgs...)
 }
 

--- a/platform/fabric/core/generic/discovery/client_test.go
+++ b/platform/fabric/core/generic/discovery/client_test.go
@@ -148,6 +148,7 @@ func loadFileOrPanic(file string) []byte {
 }
 
 func createConnector(t *testing.T, certificate tls.Certificate, targetPort int) func() (*grpc.ClientConn, error) {
+	t.Helper()
 	caCert := loadFileOrPanic(filepath.Join("testdata", "server", "ca.pem"))
 	tlsConf := &tls.Config{
 		RootCAs:      x509.NewCertPool(),

--- a/platform/fabric/core/generic/ledger/kvledger/rwsetutil/rwset_builder_test.go
+++ b/platform/fabric/core/generic/ledger/kvledger/rwsetutil/rwset_builder_test.go
@@ -385,17 +385,20 @@ func TestTxSimulationResultWithMetadata(t *testing.T) {
 	require.Equal(t, expectedPubRWSet, actualSimRes.PubSimulationResults)
 }
 
-func constructTestPvtKVReadHash(_ *testing.T, key string, version *version.Height) *kvrwset.KVReadHash {
+func constructTestPvtKVReadHash(t *testing.T, key string, version *version.Height) *kvrwset.KVReadHash {
+	t.Helper()
 	kvReadHash := newPvtKVReadHash(key, version)
 	return kvReadHash
 }
 
-func constructTestPvtKVWriteHash(_ *testing.T, key string, value []byte) *kvrwset.KVWriteHash {
+func constructTestPvtKVWriteHash(t *testing.T, key string, value []byte) *kvrwset.KVWriteHash {
+	t.Helper()
 	_, kvWriteHash := newPvtKVWriteAndHash(key, value)
 	return kvWriteHash
 }
 
 func serializeTestProtoMsg(t *testing.T, protoMsg proto.Message) []byte {
+	t.Helper()
 	msgBytes, err := proto.Marshal(protoMsg)
 	require.NoError(t, err)
 	return msgBytes

--- a/platform/fabric/core/generic/membership/channelconfig/util_test.go
+++ b/platform/fabric/core/generic/membership/channelconfig/util_test.go
@@ -32,6 +32,7 @@ import (
 // low code coverage count, so here they are.
 
 func basicTest(t *testing.T, sv *StandardConfigValue) {
+	t.Helper()
 	require.NotNil(t, sv)
 	require.NotEmpty(t, sv.Key())
 	require.NotNil(t, sv.Value())
@@ -55,6 +56,7 @@ func TestUtilsBasic(t *testing.T) {
 
 // createCfgBlockWithSupportedCapabilities will create a config block that contains valid capabilities and should be accepted by the peer
 func createCfgBlockWithSupportedCapabilities(t *testing.T) *cb.Block {
+	t.Helper()
 	// Create a config
 	config := &cb.Config{
 		Sequence:     0,
@@ -169,6 +171,7 @@ func createCfgBlockWithSupportedCapabilities(t *testing.T) *cb.Block {
 
 // createCfgBlockWithUnsupportedCapabilities will create a config block that contains mismatched capabilities and should be rejected by the peer
 func createCfgBlockWithUnsupportedCapabilities(t *testing.T) *cb.Block {
+	t.Helper()
 	// Create a config
 	config := &cb.Config{
 		Sequence:     0,

--- a/platform/fabric/core/msp/cert_test.go
+++ b/platform/fabric/core/msp/cert_test.go
@@ -126,6 +126,7 @@ func TestCertExpiration(t *testing.T) {
 }
 
 func generateSelfSignedCert(t *testing.T, now time.Time) (*ecdsa.PrivateKey, *x509.Certificate) {
+	t.Helper()
 	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
 

--- a/platform/fabric/core/msp/msp_test.go
+++ b/platform/fabric/core/msp/msp_test.go
@@ -1418,6 +1418,7 @@ func TestMain(m *testing.M) {
 }
 
 func getIdentity(t *testing.T, path string) Identity {
+	t.Helper()
 	mspDir := "testdata/sampleconfig"
 	pems, err := getPemMaterialFromDir(filepath.Join(mspDir, path))
 	require.NoError(t, err)
@@ -1429,6 +1430,7 @@ func getIdentity(t *testing.T, path string) Identity {
 }
 
 func getLocalMSPWithVersionAndError(t *testing.T, dir string, version MSPVersion) (MSP, error) {
+	t.Helper()
 	conf, err := GetLocalMspConfig(dir, nil, "SampleOrg")
 	require.NoError(t, err)
 
@@ -1443,6 +1445,7 @@ func getLocalMSPWithVersionAndError(t *testing.T, dir string, version MSPVersion
 }
 
 func getLocalMSP(t *testing.T, dir string) MSP {
+	t.Helper()
 	conf, err := GetLocalMspConfig(dir, nil, "SampleOrg")
 	require.NoError(t, err)
 
@@ -1460,6 +1463,7 @@ func getLocalMSP(t *testing.T, dir string) MSP {
 }
 
 func getLocalMSPWithVersion(t *testing.T, dir string, version MSPVersion) MSP {
+	t.Helper()
 	conf, err := GetLocalMspConfig(dir, nil, "SampleOrg")
 	require.NoError(t, err)
 

--- a/platform/fabric/core/msp/tlsgen/ca_test.go
+++ b/platform/fabric/core/msp/tlsgen/ca_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func createTLSService(t *testing.T, ca CA, host string) *grpc.Server {
+	t.Helper()
 	keyPair, err := ca.NewServerCertKeyPair(host)
 	require.NoError(t, err)
 	cert, err := tls.X509KeyPair(keyPair.Cert, keyPair.Key)

--- a/platform/fabric/services/db/driver/sql/common/data_test.go
+++ b/platform/fabric/services/db/driver/sql/common/data_test.go
@@ -22,6 +22,7 @@ type (
 )
 
 func GetData(t *testing.T, get getFunc) {
+	t.Helper()
 	RegisterTestingT(t)
 
 	db, mockDB, err := sqlmock.New()
@@ -44,6 +45,7 @@ func GetData(t *testing.T, get getFunc) {
 }
 
 func GetData_NoData(t *testing.T, get getFunc) {
+	t.Helper()
 	RegisterTestingT(t)
 
 	db, mockDB, err := sqlmock.New()
@@ -65,6 +67,7 @@ func GetData_NoData(t *testing.T, get getFunc) {
 }
 
 func ExistData_True(t *testing.T, exists existsFunc) {
+	t.Helper()
 	RegisterTestingT(t)
 
 	db, mockDB, err := sqlmock.New()
@@ -87,6 +90,7 @@ func ExistData_True(t *testing.T, exists existsFunc) {
 }
 
 func ExistData_False(t *testing.T, exist existsFunc) {
+	t.Helper()
 	RegisterTestingT(t)
 
 	db, mockDB, err := sqlmock.New()
@@ -108,6 +112,7 @@ func ExistData_False(t *testing.T, exist existsFunc) {
 }
 
 func PutData_Success(t *testing.T, put putFunc) {
+	t.Helper()
 	RegisterTestingT(t)
 
 	db, mockDB, err := sqlmock.New()
@@ -129,6 +134,7 @@ func PutData_Success(t *testing.T, put putFunc) {
 }
 
 func PutData_Conflict(t *testing.T, put putFunc) {
+	t.Helper()
 	RegisterTestingT(t)
 
 	db, mockDB, err := sqlmock.New()

--- a/platform/fabric/services/db/driver/sql/common/helpers.go
+++ b/platform/fabric/services/db/driver/sql/common/helpers.go
@@ -69,6 +69,7 @@ var ErrorCases = []struct {
 }
 
 func TTestDuplicate(t *testing.T, _ *sql.DB, writeDB common.WriteDB, errorWrapper driver.SQLErrorWrapper, table string) {
+	t.Helper()
 	ns := "namespace"
 
 	tx, err := writeDB.Begin()
@@ -88,6 +89,7 @@ func TTestDuplicate(t *testing.T, _ *sql.DB, writeDB common.WriteDB, errorWrappe
 }
 
 func TTestRangeQueries(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "namespace"
 	populateForRangeQueries(t, db, ns)
 
@@ -153,6 +155,7 @@ func TTestRangeQueries(t *testing.T, db driver.KeyValueStore) {
 }
 
 func TTestSimpleReadWrite(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "ns"
 	key := "key"
 
@@ -212,6 +215,7 @@ func TTestSimpleReadWrite(t *testing.T, db driver.KeyValueStore) {
 }
 
 func populateDB(t *testing.T, db driver.KeyValueStore, ns, key, keyWithSuffix string) {
+	t.Helper()
 	err := db.BeginUpdate()
 	require.NoError(t, err)
 
@@ -242,6 +246,7 @@ func populateDB(t *testing.T, db driver.KeyValueStore, ns, key, keyWithSuffix st
 }
 
 func populateForRangeQueries(t *testing.T, db driver.KeyValueStore, ns string) {
+	t.Helper()
 	err := db.BeginUpdate()
 	require.NoError(t, err)
 
@@ -259,6 +264,7 @@ func populateForRangeQueries(t *testing.T, db driver.KeyValueStore, ns string) {
 }
 
 func TTestGetNonExistent(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "namespace"
 	key := "foo"
 
@@ -268,6 +274,7 @@ func TTestGetNonExistent(t *testing.T, db driver.KeyValueStore) {
 }
 
 func TTestDB1(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "namespace"
 	key := "foo"
 	keyWithSuffix := key + "/suffix"
@@ -288,6 +295,7 @@ func TTestDB1(t *testing.T, db driver.KeyValueStore) {
 }
 
 func TTestDB2(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "namespace"
 	key := "foo"
 	keyWithSuffix := key + "/suffix"
@@ -308,6 +316,7 @@ func TTestDB2(t *testing.T, db driver.KeyValueStore) {
 }
 
 func TTestRangeQueries1(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "namespace"
 
 	err := db.BeginUpdate()
@@ -350,6 +359,7 @@ func TTestRangeQueries1(t *testing.T, db driver.KeyValueStore) {
 }
 
 func TTestMultiWritesAndRangeQueries(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "namespace"
 	require.NoError(t, db.BeginUpdate())
 
@@ -429,6 +439,7 @@ func TTestMultiWritesAndRangeQueries(t *testing.T, db driver.KeyValueStore) {
 }
 
 func TTestMultiWrites(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "namespace"
 	var wg sync.WaitGroup
 	n := 20
@@ -476,6 +487,7 @@ func createCompositeKey(objectType string, attributes []string) (string, error) 
 }
 
 func TTestCompositeKeys(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "namespace"
 	keyPrefix := "prefix"
 
@@ -538,6 +550,7 @@ func TTestCompositeKeys(t *testing.T, db driver.KeyValueStore) {
 // Postgres doesn't like non-utf8 in TEXT fields, so we made it a BYTEA.
 // cannot check if key exists: pq: invalid byte sequence for encoding "UTF8": 0xc2 0x32]
 func TTestNonUTF8keys(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "namespace"
 
 	// adapted from https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php#54805
@@ -600,6 +613,7 @@ var (
 )
 
 func TTestUnversionedRange(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	var err error
 
 	ns := "namespace"
@@ -661,6 +675,7 @@ func TTestUnversionedRange(t *testing.T, db driver.KeyValueStore) {
 }
 
 func TTestUnversionedSimple(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "ns"
 	key := "key"
 
@@ -764,6 +779,7 @@ func waitForResults[V any](ch <-chan V, times int, timeout time.Duration) ([]V, 
 }
 
 func TTestUnversionedNotifierSimple(t *testing.T, db driver.UnversionedNotifier) {
+	t.Helper()
 	ch, err := subscribe(db)
 	require.NoError(t, err)
 

--- a/platform/fabricx/core/transaction/transaction_test.go
+++ b/platform/fabricx/core/transaction/transaction_test.go
@@ -135,6 +135,7 @@ func TestTransactionFrom(t *testing.T) {
 			name:  "copies fields",
 			input: src,
 			assert: func(t *testing.T, dst *Transaction) {
+				t.Helper()
 				require.Equal(t, src.TCreator, dst.TCreator)
 				require.Equal(t, src.TNonce, dst.TNonce)
 				require.Equal(t, src.TTxID, dst.TTxID)
@@ -277,6 +278,7 @@ func TestAppendProposalResponse(t *testing.T) {
 			response:      &peer.ProposalResponse{Endorsement: &peer.Endorsement{Endorser: []byte("endorser-1")}},
 			expectedCount: 1,
 			assert: func(t *testing.T, tx *Transaction) {
+				t.Helper()
 				require.Equal(t, []byte("endorser-1"), tx.TProposalResponses[0].Endorsement.Endorser)
 			},
 		},
@@ -317,6 +319,7 @@ func TestAppendProposalResponseDriverWrapper(t *testing.T) {
 			name:     "wrapped proposal response",
 			response: wrappedResp,
 			assert: func(t *testing.T, tx *Transaction) {
+				t.Helper()
 				require.Len(t, tx.TProposalResponses, 1)
 			},
 		},

--- a/platform/view/services/comm/host/libp2p/conn_test.go
+++ b/platform/view/services/comm/host/libp2p/conn_test.go
@@ -105,6 +105,7 @@ func id(pk crypto.PubKey) (string, error) {
 }
 
 func newBootstrapNode(t *testing.T, port int) (*node, error) {
+	t.Helper()
 	sk, pk, err := crypto.GenerateKeyPair(crypto.ECDSA, 0)
 	if err != nil {
 		return nil, err
@@ -135,6 +136,7 @@ func newBootstrapNode(t *testing.T, port int) (*node, error) {
 }
 
 func newNode(t *testing.T, port int, bootstrapNode *node) (*node, error) {
+	t.Helper()
 	sk, pk, err := crypto.GenerateKeyPair(crypto.ECDSA, 0)
 	if err != nil {
 		return nil, err

--- a/platform/view/services/comm/host/libp2p/p2p_test.go
+++ b/platform/view/services/comm/host/libp2p/p2p_test.go
@@ -96,6 +96,7 @@ func freeLibP2PAddresses(t *testing.T, n int) []string {
 }
 
 func setupTwoNodes(t *testing.T) (*comm.HostNode, *comm.HostNode) {
+	t.Helper()
 	bootstrapSK, bootstrapID := generateKey(t)
 	nodeSK, nodeID := generateKey(t)
 
@@ -124,6 +125,7 @@ func setupTwoNodes(t *testing.T) (*comm.HostNode, *comm.HostNode) {
 }
 
 func setupThreeNodes(t *testing.T) (*comm.HostNode, *comm.HostNode, *comm.HostNode) {
+	t.Helper()
 	bootstrapSK, bootstrapID := generateKey(t)
 	node1SK, node1ID := generateKey(t)
 	node2SK, node2ID := generateKey(t)

--- a/platform/view/services/comm/host/websocket/p2p_test.go
+++ b/platform/view/services/comm/host/websocket/p2p_test.go
@@ -111,6 +111,7 @@ func TestMTLSCallerIdentityBinding(t *testing.T) {
 }
 
 func setupTwoNodes(t *testing.T) (*comm.HostNode, *comm.HostNode) {
+	t.Helper()
 	tlsFiles := generateTLSFiles(t)
 
 	bootstrapAddress := freeTCPAddress(t)
@@ -162,6 +163,7 @@ func TestSessionsTwoNodesTestRound(t *testing.T) {
 }
 
 func setupThreeNodes(t *testing.T) (*comm.HostNode, *comm.HostNode, *comm.HostNode) {
+	t.Helper()
 	// Create TLS certificates for three nodes: bootstrap, node1, node2
 	dir := t.TempDir()
 
@@ -515,6 +517,7 @@ func generateThreeNodesTLSFiles(t *testing.T) threeNodesTLSFiles {
 }
 
 func setupTwoNodesFromTLS(t *testing.T, alice, bob nodeTLSFiles, caCert string) (*comm.HostNode, *comm.HostNode) {
+	t.Helper()
 	aliceAddr := freeTCPAddress(t)
 	bobAddr := freeTCPAddress(t)
 	aliceID := mustPeerIDFromCert(t, alice.cert)

--- a/platform/view/services/comm/host/websocket/ws/reproduction_test.go
+++ b/platform/view/services/comm/host/websocket/ws/reproduction_test.go
@@ -137,6 +137,7 @@ func TestAttack_HijackSessionID(t *testing.T) {
 }
 
 func startTestServer(t *testing.T, p websocket.StreamProvider, tlsConfig *tls.Config, newStreamCallback func(s host.P2PStream)) *httptest.Server {
+	t.Helper()
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		err := p.NewServerStream(w, r, newStreamCallback)
 		assert.NoError(t, err)

--- a/platform/view/services/comm/io/test_utils.go
+++ b/platform/view/services/comm/io/test_utils.go
@@ -24,6 +24,7 @@ type networkNode interface {
 }
 
 func SessionTwoParties(t *testing.T, network ...networkNode) {
+	t.Helper()
 	ctx := t.Context()
 	for _, node := range network {
 		node.Start(ctx)

--- a/platform/view/services/comm/sessions_test_utils.go
+++ b/platform/view/services/comm/sessions_test_utils.go
@@ -20,6 +20,7 @@ import (
 
 // SessionsNodesTestRound tests multiple parallel sessions between an initiator node and multiple other nodes
 func SessionsNodesTestRound(t *testing.T, initiator *HostNode, nodes []*HostNode, numSessionsPerNode int) {
+	t.Helper()
 	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
 	defer cancel()
 
@@ -50,6 +51,7 @@ func SessionsNodesTestRound(t *testing.T, initiator *HostNode, nodes []*HostNode
 }
 
 func runInitiator(t *testing.T, ctx context.Context, bootstrapNode *HostNode, targetNode *HostNode, numSessionsPerNode int) {
+	t.Helper()
 	for i := 0; i < numSessionsPerNode; i++ {
 		select {
 		case <-ctx.Done():
@@ -108,6 +110,7 @@ func runInitiator(t *testing.T, ctx context.Context, bootstrapNode *HostNode, ta
 }
 
 func RunResponder(t *testing.T, ctx context.Context, node *HostNode) {
+	t.Helper()
 	masterSession, err := node.MasterSession()
 	require.NoError(t, err)
 	require.NotNil(t, masterSession)
@@ -137,6 +140,7 @@ func RunResponder(t *testing.T, ctx context.Context, node *HostNode) {
 }
 
 func runResponder(t *testing.T, ctx context.Context, node *HostNode, msg *view.Message) {
+	t.Helper()
 	messagesToReceive := messages(msg.SessionID)
 	if string(messagesToReceive[0]) != string(msg.Payload) {
 		t.Errorf("Responder [%s]: expected first message %s, got %s", msg.SessionID, string(messagesToReceive[0]), string(msg.Payload))

--- a/platform/view/services/comm/stress_test.go
+++ b/platform/view/services/comm/stress_test.go
@@ -41,6 +41,7 @@ func TestLargeMessages(t *testing.T) {
 }
 
 func runLargeMessageTest(t *testing.T, p *P2PNode, size int) {
+	t.Helper()
 	payload := make([]byte, size)
 	for i := range payload {
 		payload[i] = byte(i % 256)

--- a/platform/view/services/comm/test_utils.go
+++ b/platform/view/services/comm/test_utils.go
@@ -27,6 +27,7 @@ type HostNode struct {
 }
 
 func P2PLayerTestRound(t *testing.T, bootstrapNode *HostNode, node *HostNode) {
+	t.Helper()
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -75,6 +76,7 @@ func P2PLayerTestRound(t *testing.T, bootstrapNode *HostNode, node *HostNode) {
 }
 
 func SessionsTestRound(t *testing.T, bootstrapNode *HostNode, node *HostNode) {
+	t.Helper()
 	ctx := t.Context()
 	bootstrapNode.Start(ctx)
 	node.Start(ctx)
@@ -129,6 +131,7 @@ func SessionsTestRound(t *testing.T, bootstrapNode *HostNode, node *HostNode) {
 }
 
 func SessionsForMPCTestRound(t *testing.T, bootstrapNode *HostNode, node *HostNode) {
+	t.Helper()
 	ctx := t.Context()
 	bootstrapNode.Start(ctx)
 	node.Start(ctx)
@@ -172,6 +175,7 @@ func SessionsForMPCTestRound(t *testing.T, bootstrapNode *HostNode, node *HostNo
 }
 
 func SessionsMultipleMessagesTestRound(t *testing.T, bootstrapNode *HostNode, node *HostNode) {
+	t.Helper()
 	numSessions := 100
 	// numWorkers := 20
 	// Set numWorkers to 20 to test true concurrency

--- a/platform/view/services/config/provider_test.go
+++ b/platform/view/services/config/provider_test.go
@@ -102,6 +102,7 @@ func TestEnvSubstitution(t *testing.T) {
 }
 
 func testMerge(t *testing.T, p *Provider) {
+	t.Helper()
 	newKey := p.GetString("newKey")
 	assert.Empty(t, newKey)
 	wg := sync.WaitGroup{}
@@ -146,6 +147,7 @@ func testMerge(t *testing.T, p *Provider) {
 }
 
 func testBasics(t *testing.T, p *Provider) {
+	t.Helper()
 	path, _ := filepath.Abs("testdata/file.name")
 
 	assert.Equal(t, "a string", p.GetString("str"))

--- a/platform/view/services/grpc/server_test.go
+++ b/platform/view/services/grpc/server_test.go
@@ -841,6 +841,7 @@ func TestWithSignedIntermediateCertificates(t *testing.T) {
 
 // utility function for testing client / server communication using TLS
 func runMutualAuth(t *testing.T, servers []testServer, trustedClients, unTrustedClients []*tls.Config) error {
+	t.Helper()
 	// loop through all the test servers
 	for i := 0; i < len(servers); i++ {
 		// create listener

--- a/platform/view/services/grpc/tlsgen/ca_test.go
+++ b/platform/view/services/grpc/tlsgen/ca_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func createTLSService(t *testing.T, ca CA, host string) *grpc.Server {
+	t.Helper()
 	keyPair, err := ca.NewServerCertKeyPair(host)
 	require.NoError(t, err)
 	cert, err := tls.X509KeyPair(keyPair.Cert, keyPair.Key)

--- a/platform/view/services/storage/driver/sql/common/bench.go
+++ b/platform/view/services/storage/driver/sql/common/bench.go
@@ -28,6 +28,7 @@ var (
 )
 
 func ReadExisting(b *testing.B, db driver.KeyValueStore) {
+	b.Helper()
 	require.NoError(b, db.BeginUpdate())
 	require.NoError(b, db.SetState(context.Background(), namespace, key, payload))
 	require.NoError(b, db.Commit())
@@ -45,6 +46,7 @@ func ReadExisting(b *testing.B, db driver.KeyValueStore) {
 }
 
 func ReadNonExisting(b *testing.B, db driver.KeyValueStore) {
+	b.Helper()
 	var v []byte
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -58,6 +60,7 @@ func ReadNonExisting(b *testing.B, db driver.KeyValueStore) {
 }
 
 func WriteOne(b *testing.B, db driver.KeyValueStore) {
+	b.Helper()
 	var err error
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -74,6 +77,7 @@ func WriteOne(b *testing.B, db driver.KeyValueStore) {
 }
 
 func WriteMany(b *testing.B, db driver.KeyValueStore) {
+	b.Helper()
 	var err error
 	var k string
 	b.Logf("before: %+v", db.Stats())
@@ -100,6 +104,7 @@ func WriteMany(b *testing.B, db driver.KeyValueStore) {
 }
 
 func WriteParallel(b *testing.B, db driver.KeyValueStore) {
+	b.Helper()
 	var err error
 	var k string
 	var i int

--- a/platform/view/services/storage/driver/sql/common/helpers.go
+++ b/platform/view/services/storage/driver/sql/common/helpers.go
@@ -64,6 +64,7 @@ var ErrorCases = []struct {
 }
 
 func TTestDuplicate(t *testing.T, _ *sql.DB, writeDB WriteDB, errorWrapper driver.SQLErrorWrapper, table string) {
+	t.Helper()
 	ns := "namespace"
 
 	tx, err := writeDB.Begin()
@@ -83,6 +84,7 @@ func TTestDuplicate(t *testing.T, _ *sql.DB, writeDB WriteDB, errorWrapper drive
 }
 
 func TTestRangeQueries(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "namespace"
 	entries := map[string]driver.UnversionedValue{
 		"k1":   driver.UnversionedValue("k1_value"),
@@ -155,6 +157,7 @@ func TTestRangeQueries(t *testing.T, db driver.KeyValueStore) {
 }
 
 func TTestSimpleReadWrite(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "ns"
 	key := "key"
 	defer cleanupDB(t, db, ns)
@@ -215,6 +218,7 @@ func TTestSimpleReadWrite(t *testing.T, db driver.KeyValueStore) {
 }
 
 func populateDB(t *testing.T, db driver.KeyValueStore, ns string, entries map[string]driver.UnversionedValue) {
+	t.Helper()
 	require.NoError(t, db.BeginUpdate())
 	require.Empty(t, db.SetStates(t.Context(), ns, entries))
 	require.NoError(t, db.Commit())
@@ -235,6 +239,7 @@ func populateDB(t *testing.T, db driver.KeyValueStore, ns string, entries map[st
 }
 
 func cleanupDB(t *testing.T, db driver.KeyValueStore, ns string) {
+	t.Helper()
 	require.NoError(t, db.BeginUpdate())
 	itr, err := db.GetStateRangeScanIterator(t.Context(), ns, "", "")
 	require.NoError(t, err)
@@ -253,6 +258,7 @@ func cleanupDB(t *testing.T, db driver.KeyValueStore, ns string) {
 }
 
 func TTestGetNonExistent(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "namespace"
 	key := "foo"
 
@@ -262,6 +268,7 @@ func TTestGetNonExistent(t *testing.T, db driver.KeyValueStore) {
 }
 
 func TTestDB1(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "namespace"
 	key := "foo"
 	keyWithSuffix := key + "/suffix"
@@ -286,6 +293,7 @@ func TTestDB1(t *testing.T, db driver.KeyValueStore) {
 }
 
 func TTestDB2(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "namespace"
 	key := "foo"
 	keyWithSuffix := key + "/suffix"
@@ -310,6 +318,7 @@ func TTestDB2(t *testing.T, db driver.KeyValueStore) {
 }
 
 func TTestRangeQueries1(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "namespace"
 	entries := map[string]driver.UnversionedValue{
 		"k2":   driver.UnversionedValue("k2_value"),
@@ -345,6 +354,7 @@ func TTestRangeQueries1(t *testing.T, db driver.KeyValueStore) {
 }
 
 func TTestMultiWritesAndRangeQueries(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "namespace"
 	entries := map[string]driver.UnversionedValue{
 		"k1":   driver.UnversionedValue("k1_value"),
@@ -414,6 +424,7 @@ func TTestMultiWritesAndRangeQueries(t *testing.T, db driver.KeyValueStore) {
 }
 
 func TTestMultiWrites(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "namespace"
 	key := "test_key"
 	defer cleanupDB(t, db, ns)
@@ -463,6 +474,7 @@ func createCompositeKey(objectType string, attributes []string) (string, error) 
 }
 
 func TTestCompositeKeys(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "namespace"
 	keyPrefix := "prefix"
 	defer cleanupDB(t, db, ns)
@@ -526,6 +538,7 @@ func TTestCompositeKeys(t *testing.T, db driver.KeyValueStore) {
 // Postgres doesn't like non-utf8 in TEXT fields, so we made it a BYTEA.
 // cannot check if key exists: pq: invalid byte sequence for encoding "UTF8": 0xc2 0x32]
 func TTestNonUTF8keys(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "namespace"
 	key := "test_key"
 	defer cleanupDB(t, db, ns)
@@ -581,6 +594,7 @@ func TTestNonUTF8keys(t *testing.T, db driver.KeyValueStore) {
 }
 
 func TTestUnversionedRange(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	var err error
 
 	ns := "namespace"
@@ -643,6 +657,7 @@ func TTestUnversionedRange(t *testing.T, db driver.KeyValueStore) {
 }
 
 func TTestUnversionedSimple(t *testing.T, db driver.KeyValueStore) {
+	t.Helper()
 	ns := "ns"
 	key := "key"
 	defer cleanupDB(t, db, ns)
@@ -727,6 +742,7 @@ func waitForResults[V any](ch <-chan V, times int, timeout time.Duration) ([]V, 
 }
 
 func TTestUnversionedNotifierSimple(t *testing.T, db driver.UnversionedNotifier) {
+	t.Helper()
 	ch, err := subscribe(db)
 	require.NoError(t, err)
 

--- a/platform/view/services/storage/kvs/kvs_test.go
+++ b/platform/view/services/storage/kvs/kvs_test.go
@@ -40,6 +40,7 @@ type stuff struct {
 }
 
 func testRound(t *testing.T, drv driver2.Driver) {
+	t.Helper()
 	kvstore, err := kvs2.New(utils.MustGet(drv.NewKVS("")), "_default", kvs2.DefaultCacheSize)
 	require.NoError(t, err)
 	defer kvstore.Stop()
@@ -128,6 +129,7 @@ func createCompositeKey(objectType string, attributes []string) (string, error) 
 }
 
 func testParallelWrites(t *testing.T, drv driver2.Driver) {
+	t.Helper()
 	kvstore, err := kvs2.New(utils.MustGet(drv.NewKVS("")), "_default", kvs2.DefaultCacheSize)
 	require.NoError(t, err)
 	defer kvstore.Stop()

--- a/platform/view/view/context_test.go
+++ b/platform/view/view/context_test.go
@@ -35,6 +35,7 @@ func TestCompileRunViewOptions(t *testing.T) {
 			name: "No_Options_Returns_Zero_Value",
 			opts: nil,
 			check: func(t *testing.T, opts *RunViewOptions) {
+				t.Helper()
 				require.NotNil(t, opts)
 				require.Nil(t, opts.Session)
 				require.False(t, opts.AsInitiator)
@@ -47,6 +48,7 @@ func TestCompileRunViewOptions(t *testing.T) {
 			name: "AsInitiator_Sets_Flag",
 			opts: []RunViewOption{AsInitiator()},
 			check: func(t *testing.T, opts *RunViewOptions) {
+				t.Helper()
 				require.True(t, opts.AsInitiator)
 			},
 		},
@@ -54,6 +56,7 @@ func TestCompileRunViewOptions(t *testing.T) {
 			name: "AsResponder_Sets_Session",
 			opts: []RunViewOption{AsResponder(nil)},
 			check: func(t *testing.T, opts *RunViewOptions) {
+				t.Helper()
 				require.Nil(t, opts.Session)
 			},
 		},
@@ -61,6 +64,7 @@ func TestCompileRunViewOptions(t *testing.T) {
 			name: "WithViewCall_Sets_Call_Function",
 			opts: []RunViewOption{WithViewCall(callFn)},
 			check: func(t *testing.T, opts *RunViewOptions) {
+				t.Helper()
 				require.NotNil(t, opts.Call)
 				result, err := opts.Call(nil)
 				require.NoError(t, err)
@@ -71,6 +75,7 @@ func TestCompileRunViewOptions(t *testing.T) {
 			name: "WithSameContext_Sets_Flag_Without_Ctx",
 			opts: []RunViewOption{WithSameContext()},
 			check: func(t *testing.T, opts *RunViewOptions) {
+				t.Helper()
 				require.True(t, opts.SameContext)
 				require.Nil(t, opts.Ctx)
 			},
@@ -79,6 +84,7 @@ func TestCompileRunViewOptions(t *testing.T) {
 			name: "WithContext_Sets_Both_SameContext_And_Ctx",
 			opts: []RunViewOption{WithContext(ctx1)},
 			check: func(t *testing.T, opts *RunViewOptions) {
+				t.Helper()
 				require.True(t, opts.SameContext)
 				require.Equal(t, ctx1, opts.Ctx)
 			},
@@ -87,6 +93,7 @@ func TestCompileRunViewOptions(t *testing.T) {
 			name: "Multiple_Options_All_Applied_In_Order",
 			opts: []RunViewOption{AsInitiator(), WithViewCall(callFn), WithContext(ctx1)},
 			check: func(t *testing.T, opts *RunViewOptions) {
+				t.Helper()
 				require.True(t, opts.AsInitiator)
 				require.NotNil(t, opts.Call)
 				require.True(t, opts.SameContext)
@@ -97,6 +104,7 @@ func TestCompileRunViewOptions(t *testing.T) {
 			name: "Later_Option_Overrides_Earlier",
 			opts: []RunViewOption{AsInitiator(), resetInitiator},
 			check: func(t *testing.T, opts *RunViewOptions) {
+				t.Helper()
 				require.False(t, opts.AsInitiator)
 			},
 		},
@@ -104,6 +112,7 @@ func TestCompileRunViewOptions(t *testing.T) {
 			name: "Later_WithContext_Overrides_Earlier",
 			opts: []RunViewOption{WithContext(ctx1), WithContext(ctx2)},
 			check: func(t *testing.T, opts *RunViewOptions) {
+				t.Helper()
 				require.Equal(t, ctx2, opts.Ctx)
 			},
 		},


### PR DESCRIPTION
This PR introduces consistent use of `t.Helper()` function to improve readability or error messages during tests.