### PR TITLE
testing: use t.Parallel where possible

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,8 @@ version: "2"
 linters:
   enable:
     - thelper
+    - tparallel
+    - paralleltest
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/ci/codeql/node/main_test.go
+++ b/ci/codeql/node/main_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestCompile(t *testing.T) {
+	t.Parallel()
 	gt := NewGomegaWithT(t)
 	_, err := gexec.Build("github.com/hyperledger-labs/fabric-smart-client/ci/codeql/node")
 	gt.Expect(err).NotTo(HaveOccurred())

--- a/cmd/fsccli/main_test.go
+++ b/cmd/fsccli/main_test.go
@@ -20,13 +20,14 @@ import (
 )
 
 func TestCompile(t *testing.T) {
+	t.Parallel()
 	gt := NewGomegaWithT(t)
 	_, err := gexec.Build("github.com/hyperledger-labs/fabric-smart-client/cmd/fsccli")
 	gt.Expect(err).NotTo(HaveOccurred())
 	defer gexec.CleanupBuildArtifacts()
 }
 
-func TestArtifactsGen(t *testing.T) {
+func TestArtifactsGen(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(func(message string, callerSkip ...int) {
 		panic(message)
 	})

--- a/integration/benchmark/grpc/baseline_bench_test.go
+++ b/integration/benchmark/grpc/baseline_bench_test.go
@@ -150,6 +150,9 @@ func setupBaselineServer(tb testing.TB, workloadType string) string {
 	// setup server
 	lis, err := net.Listen("tcp", "localhost:0")
 	require.NoError(tb, err)
+	tb.Cleanup(func() {
+		_ = lis.Close()
+	})
 
 	var opts []grpc.ServerOption
 	opts = append(opts, grpc.Creds(credentials.NewTLS(serverTLS)))

--- a/integration/fabric/atsa/atsa_suite_test.go
+++ b/integration/fabric/atsa/atsa_suite_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndToEnd(t *testing.T) {
+func TestEndToEnd(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Asset Transfer Secured Agreement (With Approvers)")
 }

--- a/integration/fabric/atsa/states/states_test.go
+++ b/integration/fabric/atsa/states/states_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestJson(t *testing.T) {
+	t.Parallel()
 	asset := &Asset{
 		ObjectType:        "coin",
 		ID:                "1234",

--- a/integration/fabric/atsachaincode/atsa_suite_test.go
+++ b/integration/fabric/atsachaincode/atsa_suite_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration"
 )
 
-func TestEndToEnd(t *testing.T) {
+func TestEndToEnd(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Asset Transfer Secured Agreement (With Chaincode)")
 }

--- a/integration/fabric/events/events_suite_test.go
+++ b/integration/fabric/events/events_suite_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndToEnd(t *testing.T) {
+func TestEndToEnd(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Events (With Chaincode)")
 }

--- a/integration/fabric/iou/iou_suite_test.go
+++ b/integration/fabric/iou/iou_suite_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndToEnd(t *testing.T) {
+func TestEndToEnd(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "IOU Suite")
 }

--- a/integration/fabric/stoprestart/stoprestart_suite_test.go
+++ b/integration/fabric/stoprestart/stoprestart_suite_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration"
 )
 
-func TestEndToEnd(t *testing.T) {
+func TestEndToEnd(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Stop and Restart with Fabric Suite")
 }

--- a/integration/fabric/twonets/twonets_suite_test.go
+++ b/integration/fabric/twonets/twonets_suite_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration"
 )
 
-func TestEndToEnd(t *testing.T) {
+func TestEndToEnd(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Two Fabric Networks Suite")
 }

--- a/integration/fabricx/deployment/deployment_suite_test.go
+++ b/integration/fabricx/deployment/deployment_suite_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndToEnd(t *testing.T) {
+func TestEndToEnd(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "deployment Suite")
 }

--- a/integration/fabricx/iou/iou_suite_test.go
+++ b/integration/fabricx/iou/iou_suite_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndToEnd(t *testing.T) {
+func TestEndToEnd(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "IOU Suite")
 }

--- a/integration/fabricx/multiendorsement/multiendorsement_suite_test.go
+++ b/integration/fabricx/multiendorsement/multiendorsement_suite_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndToEnd(t *testing.T) {
+func TestEndToEnd(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "multiendorsement Suite")
 }

--- a/integration/fabricx/simple/simple_test.go
+++ b/integration/fabricx/simple/simple_test.go
@@ -22,7 +22,7 @@ import (
 
 const testDataPath = "./out/testdata"
 
-func TestEndToEnd(t *testing.T) {
+func TestEndToEnd(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "simple suite")
 }

--- a/integration/fsc/pingpong/pingpong_suite_test.go
+++ b/integration/fsc/pingpong/pingpong_suite_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration"
 )
 
-func TestEndToEnd(t *testing.T) {
+func TestEndToEnd(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Ping Pong Suite")
 }

--- a/integration/fsc/stoprestart/stoprestart_suite_test.go
+++ b/integration/fsc/stoprestart/stoprestart_suite_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration"
 )
 
-func TestEndToEnd(t *testing.T) {
+func TestEndToEnd(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Stop and Restart Suite")
 }

--- a/integration/nwo/cmd/cryptogen/ca/ca_test.go
+++ b/integration/nwo/cmd/cryptogen/ca/ca_test.go
@@ -37,6 +37,7 @@ const (
 )
 
 func TestLoadCertificateECDSA(t *testing.T) {
+	t.Parallel()
 	testDir, err := os.MkdirTemp("", "ca-test")
 	if err != nil {
 		t.Fatalf("Failed to create test directory: %s", err)
@@ -81,6 +82,7 @@ func TestLoadCertificateECDSA(t *testing.T) {
 }
 
 func TestLoadCertificateECDSA_wrongEncoding(t *testing.T) {
+	t.Parallel()
 	testDir, err := os.MkdirTemp("", "wrongEncoding")
 	require.NoError(t, err, "failed to create test directory")
 	defer utils.IgnoreErrorWithOneArg(os.RemoveAll, testDir)
@@ -95,6 +97,7 @@ func TestLoadCertificateECDSA_wrongEncoding(t *testing.T) {
 }
 
 func TestLoadCertificateECDSA_empty_DER_cert(t *testing.T) {
+	t.Parallel()
 	testDir, err := os.MkdirTemp("", "ca-test")
 	require.NoError(t, err, "failed to create test directory")
 	defer utils.IgnoreErrorWithOneArg(os.RemoveAll, testDir)
@@ -111,6 +114,7 @@ func TestLoadCertificateECDSA_empty_DER_cert(t *testing.T) {
 }
 
 func TestNewCA(t *testing.T) {
+	t.Parallel()
 	testDir, err := os.MkdirTemp("", "ca-test")
 	if err != nil {
 		t.Fatalf("Failed to create test directory: %s", err)
@@ -156,6 +160,7 @@ func TestNewCA(t *testing.T) {
 }
 
 func TestGenerateSignCertificate(t *testing.T) {
+	t.Parallel()
 	testDir, err := os.MkdirTemp("", "ca-test")
 	if err != nil {
 		t.Fatalf("Failed to create test directory: %s", err)

--- a/integration/nwo/cmd/cryptogen/csp/csp_internal_test.go
+++ b/integration/nwo/cmd/cryptogen/csp/csp_internal_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestToLowS(t *testing.T) {
+	t.Parallel()
 	curve := elliptic.P256()
 	halfOrder := new(big.Int).Div(curve.Params().N, big.NewInt(2))
 
@@ -65,6 +66,7 @@ func TestToLowS(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			curve := elliptic.P256()
 			key := ecdsa.PublicKey{
 				Curve: curve,

--- a/integration/nwo/cmd/cryptogen/csp/csp_test.go
+++ b/integration/nwo/cmd/cryptogen/csp/csp_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestLoadPrivateKey(t *testing.T) {
+	t.Parallel()
 	testDir, err := os.MkdirTemp("", "csp-test")
 	if err != nil {
 		t.Fatalf("Failed to create test directory: %s", err)
@@ -44,13 +45,9 @@ func TestLoadPrivateKey(t *testing.T) {
 	require.Equal(t, priv, loadedPriv, "Expected private keys to match")
 }
 
-func TestLoadPrivateKey_BadPEM(t *testing.T) {
-	testDir, err := os.MkdirTemp("", "csp-test")
-	if err != nil {
-		t.Fatalf("Failed to create test directory: %s", err)
-	}
-	defer utils.IgnoreErrorWithOneArg(os.RemoveAll, testDir)
-
+func TestLoadPrivateKey_BadPEM(t *testing.T) { //nolint:tparallel
+	t.Parallel()
+	testDir := t.TempDir()
 	badPEMFile := filepath.Join(testDir, "badpem_sk")
 
 	rsaKey, err := rsa.GenerateKey(rand.Reader, 1024)
@@ -70,7 +67,7 @@ func TestLoadPrivateKey_BadPEM(t *testing.T) {
 	}
 	pkcs1RSAPem := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pkcs1Encoded})
 
-	for _, test := range []struct {
+	for _, test := range []struct { //nolint: tparallel,paralleltest
 		name   string
 		data   []byte
 		errMsg string
@@ -107,6 +104,7 @@ func TestLoadPrivateKey_BadPEM(t *testing.T) {
 }
 
 func TestGeneratePrivateKey(t *testing.T) {
+	t.Parallel()
 	testDir, err := os.MkdirTemp("", "csp-test")
 	if err != nil {
 		t.Fatalf("Failed to create test directory: %s", err)
@@ -125,6 +123,7 @@ func TestGeneratePrivateKey(t *testing.T) {
 }
 
 func TestECDSASigner(t *testing.T) {
+	t.Parallel()
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		t.Fatalf("Failed to generate private key: %s", err)

--- a/integration/nwo/cmd/cryptogen/metadata/metadata_test.go
+++ b/integration/nwo/cmd/cryptogen/metadata/metadata_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestGetVersionInfo(t *testing.T) {
+	t.Parallel()
 	expected := fmt.Sprintf(
 		"%s:\n Version: %s\n Commit SHA: %s\n Go version: %s\n OS/Arch: %s",
 		metadata2.ProgramName,

--- a/integration/nwo/cmd/cryptogen/msp/msp_test.go
+++ b/integration/nwo/cmd/cryptogen/msp/msp_test.go
@@ -13,7 +13,6 @@ import (
 
 	ca2 "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/cmd/cryptogen/ca"
 	msp2 "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/cmd/cryptogen/msp"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
 	fabricmsp "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/msp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,11 +31,9 @@ const (
 	testPostalCode         = "123456"
 )
 
-var testDir = filepath.Join(os.TempDir(), "msp-test")
-
 func testGenerateLocalMSP(t *testing.T, nodeOUs bool) {
 	t.Helper()
-	cleanup(testDir)
+	testDir := t.TempDir()
 
 	err := msp2.GenerateLocalMSP(testDir, testName, nil, &ca2.CA{}, &ca2.CA{}, msp2.PEER, nodeOUs, false, nil)
 	require.Error(t, err, "Empty CA should have failed")
@@ -119,19 +116,19 @@ func testGenerateLocalMSP(t *testing.T, nodeOUs bool) {
 	err = msp2.GenerateLocalMSP(testDir, testName, nil, signCA, tlsCA, msp2.ORDERER, nodeOUs, false, nil)
 	require.Error(t, err, "Should have failed with CA name 'test/fail'")
 	t.Log(err)
-	cleanup(testDir)
 }
 
-func TestGenerateLocalMSPWithNodeOU(t *testing.T) {
+func TestGenerateLocalMSPWithNodeOU(t *testing.T) { //nolint:paralleltest
 	testGenerateLocalMSP(t, true)
 }
 
-func TestGenerateLocalMSPWithoutNodeOU(t *testing.T) {
+func TestGenerateLocalMSPWithoutNodeOU(t *testing.T) { //nolint:paralleltest
 	testGenerateLocalMSP(t, false)
 }
 
 func testGenerateVerifyingMSP(t *testing.T, nodeOUs bool) {
 	t.Helper()
+	testDir := t.TempDir()
 	caDir := filepath.Join(testDir, "ca")
 	tlsCADir := filepath.Join(testDir, "tlsca")
 	mspDir := filepath.Join(testDir, "msp")
@@ -169,19 +166,18 @@ func testGenerateVerifyingMSP(t *testing.T, nodeOUs bool) {
 	err = msp2.GenerateVerifyingMSP(mspDir, signCA, tlsCA, nodeOUs)
 	require.Error(t, err, "Should have failed with CA name 'test/fail'")
 	t.Log(err)
-	cleanup(testDir)
-
 }
 
-func TestGenerateVerifyingMSPWithNodeOU(t *testing.T) {
+func TestGenerateVerifyingMSPWithNodeOU(t *testing.T) { //nolint:paralleltest
 	testGenerateVerifyingMSP(t, true)
 }
 
-func TestGenerateVerifyingMSPWithoutNodeOU(t *testing.T) {
+func TestGenerateVerifyingMSPWithoutNodeOU(t *testing.T) { //nolint:paralleltest
 	testGenerateVerifyingMSP(t, true)
 }
 
-func TestExportConfig(t *testing.T) {
+func TestExportConfig(t *testing.T) { //nolint:paralleltest
+	testDir := t.TempDir()
 	path := filepath.Join(testDir, "export-test")
 	configFile := filepath.Join(path, "config.yaml")
 	caFile := "ca.pem"
@@ -207,10 +203,6 @@ func TestExportConfig(t *testing.T) {
 	assert.Equal(t, msp2.ADMINOU, config.NodeOUs.AdminOUIdentifier.OrganizationalUnitIdentifier)
 	assert.Equal(t, caFile, config.NodeOUs.OrdererOUIdentifier.Certificate)
 	assert.Equal(t, msp2.ORDEREROU, config.NodeOUs.OrdererOUIdentifier.OrganizationalUnitIdentifier)
-}
-
-func cleanup(dir string) {
-	utils.IgnoreErrorWithOneArg(os.RemoveAll, dir)
 }
 
 func checkForFile(file string) bool {

--- a/integration/nwo/fabric/packager/ccmetadata/validators_test.go
+++ b/integration/nwo/fabric/packager/ccmetadata/validators_test.go
@@ -19,6 +19,7 @@ import (
 var packageTestDir = filepath.Join(os.TempDir(), "ccmetadata-validator-test")
 
 func TestGoodIndexJSON(t *testing.T) {
+	t.Parallel()
 	testDir := filepath.Join(packageTestDir, "GoodIndexJSON")
 	defer utils.IgnoreError(cleanupDir(testDir))
 
@@ -30,6 +31,7 @@ func TestGoodIndexJSON(t *testing.T) {
 }
 
 func TestBadIndexJSON(t *testing.T) {
+	t.Parallel()
 	testDir := filepath.Join(packageTestDir, "BadIndexJSON")
 	defer utils.IgnoreError(cleanupDir(testDir))
 
@@ -49,6 +51,7 @@ func TestBadIndexJSON(t *testing.T) {
 }
 
 func TestIndexWrongLocation(t *testing.T) {
+	t.Parallel()
 	testDir := filepath.Join(packageTestDir, "IndexWrongLocation")
 	defer utils.IgnoreError(cleanupDir(testDir))
 
@@ -67,6 +70,7 @@ func TestIndexWrongLocation(t *testing.T) {
 }
 
 func TestInvalidMetadataType(t *testing.T) {
+	t.Parallel()
 	testDir := filepath.Join(packageTestDir, "InvalidMetadataType")
 	defer utils.IgnoreError(cleanupDir(testDir))
 
@@ -83,6 +87,7 @@ func TestInvalidMetadataType(t *testing.T) {
 }
 
 func TestBadMetadataExtension(t *testing.T) {
+	t.Parallel()
 	testDir := filepath.Join(packageTestDir, "BadMetadataExtension")
 	defer utils.IgnoreError(cleanupDir(testDir))
 
@@ -95,6 +100,7 @@ func TestBadMetadataExtension(t *testing.T) {
 }
 
 func TestBadFilePaths(t *testing.T) {
+	t.Parallel()
 	testDir := filepath.Join(packageTestDir, "BadMetadataExtension")
 	defer utils.IgnoreError(cleanupDir(testDir))
 
@@ -156,6 +162,7 @@ func TestBadFilePaths(t *testing.T) {
 }
 
 func TestIndexValidation(t *testing.T) {
+	t.Parallel()
 
 	// Test valid index with field sorts
 	indexDef := []byte(`{"index":{"fields":[{"size":"desc"}, {"color":"desc"}]},"ddoc":"indexSizeSortName", "name":"indexSizeSortName","type":"json"}`)
@@ -195,6 +202,7 @@ func TestIndexValidation(t *testing.T) {
 }
 
 func TestIndexValidationInvalidParameters(t *testing.T) {
+	t.Parallel()
 	// Test numeric values passed in for parameters
 	indexDef := []byte(`{"index":{"fields":[{"size":"desc"}, {"color":"desc"}]},"ddoc":1, "name":"indexSizeSortName","type":"json"}`)
 	_, indexDefinition := isJSON(indexDef)
@@ -240,6 +248,7 @@ func TestIndexValidationInvalidParameters(t *testing.T) {
 }
 
 func TestIndexValidationInvalidFields(t *testing.T) {
+	t.Parallel()
 
 	// Test invalid fields parameter
 	indexDef := []byte(`{"index":{"fields1":[{"size":"desc"}, {"color":"desc"}]},"ddoc":"indexSizeSortName", "name":"indexSizeSortName","type":"json"}`)

--- a/integration/nwo/fabric/packager/golang/writer_test.go
+++ b/integration/nwo/fabric/packager/golang/writer_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestWriteBytesToPackage(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 
 	buf := bytes.NewBuffer(nil)
@@ -45,7 +46,9 @@ func TestWriteBytesToPackage(t *testing.T) {
 	r := bytes.NewReader(buf.Bytes())
 	gr, err := gzip.NewReader(r)
 	require.NoError(t, err, "Error creating a gzip reader")
-	defer require.NoError(t, gr.Close())
+	t.Cleanup(func() {
+		require.NoError(t, gr.Close())
+	})
 
 	tr := tar.NewReader(gr)
 	header, err := tr.Next()
@@ -67,6 +70,7 @@ func TestWriteBytesToPackage(t *testing.T) {
 	require.Equal(t, filecontent, string(b), "file content from archive does not equal original content")
 
 	t.Run("non existent file", func(t *testing.T) {
+		t.Parallel()
 		tw := tar.NewWriter(&bytes.Buffer{})
 		err := WriteBytesToPackage([]byte(filecontent), "missing-file", "", tw)
 		require.Error(t, err, "expected error writing a non existent file")
@@ -74,6 +78,7 @@ func TestWriteBytesToPackage(t *testing.T) {
 	})
 
 	t.Run("closed tar writer", func(t *testing.T) {
+		t.Parallel()
 		tw := tar.NewWriter(&bytes.Buffer{})
 		require.NoError(t, tw.Close())
 		err := WriteBytesToPackage([]byte(filecontent), filePath, "test.txt", tw)
@@ -81,6 +86,7 @@ func TestWriteBytesToPackage(t *testing.T) {
 	})
 
 	t.Run("stream write failure", func(t *testing.T) {
+		t.Parallel()
 		failWriter := &failingWriter{failAt: 514}
 		tw := tar.NewWriter(failWriter)
 		err := WriteBytesToPackage([]byte(filecontent), filePath, "test.txt", tw)
@@ -89,6 +95,7 @@ func TestWriteBytesToPackage(t *testing.T) {
 }
 
 func TestWriteFileToPackage(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 
 	buf := bytes.NewBuffer(nil)
@@ -111,7 +118,9 @@ func TestWriteFileToPackage(t *testing.T) {
 	r := bytes.NewReader(buf.Bytes())
 	gr, err := gzip.NewReader(r)
 	require.NoError(t, err, "Error creating a gzip reader")
-	defer require.NoError(t, gr.Close())
+	t.Cleanup(func() {
+		require.NoError(t, gr.Close())
+	})
 
 	tr := tar.NewReader(gr)
 	header, err := tr.Next()
@@ -133,6 +142,7 @@ func TestWriteFileToPackage(t *testing.T) {
 	require.Equal(t, filecontent, string(b), "file content from archive does not equal original content")
 
 	t.Run("non existent file", func(t *testing.T) {
+		t.Parallel()
 		tw := tar.NewWriter(&bytes.Buffer{})
 		err := WriteFileToPackage("missing-file", "", tw)
 		require.Error(t, err, "expected error writing a non existent file")
@@ -140,6 +150,7 @@ func TestWriteFileToPackage(t *testing.T) {
 	})
 
 	t.Run("closed tar writer", func(t *testing.T) {
+		t.Parallel()
 		tw := tar.NewWriter(&bytes.Buffer{})
 		require.NoError(t, tw.Close())
 		err := WriteFileToPackage(filePath, "test.txt", tw)
@@ -147,6 +158,7 @@ func TestWriteFileToPackage(t *testing.T) {
 	})
 
 	t.Run("stream write failure", func(t *testing.T) {
+		t.Parallel()
 		failWriter := &failingWriter{failAt: 514}
 		tw := tar.NewWriter(failWriter)
 		err := WriteFileToPackage(filePath, "test.txt", tw)

--- a/integration/nwo/fabric/packager/label_test.go
+++ b/integration/nwo/fabric/packager/label_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestLabels(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		label   string
 		success bool
@@ -46,6 +47,7 @@ func TestLabels(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.label, func(t *testing.T) {
+			t.Parallel()
 			err := ValidateLabel(tt.label)
 			if tt.success {
 				require.NoError(t, err)

--- a/integration/nwo/fabric/packager/persistence_test.go
+++ b/integration/nwo/fabric/packager/persistence_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestPersistence(t *testing.T) {
+func TestPersistence(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Persistence Suite")
 }

--- a/integration/nwo/fabricx/network/network_test.go
+++ b/integration/nwo/fabricx/network/network_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestParseNamespaceList(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		output   string
@@ -81,6 +82,7 @@ func TestParseNamespaceList(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := parseNamespaceList(tt.output)
 			assert.Equal(t, tt.expected, result)
 		})

--- a/integration/nwo/fsc/fsc_suite_test.go
+++ b/integration/nwo/fsc/fsc_suite_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndToEnd(t *testing.T) {
+func TestEndToEnd(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Node")
 }

--- a/integration/nwo/fsc/node/node_test.go
+++ b/integration/nwo/fsc/node/node_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestNode_AddSDKWithBase(t *testing.T) {
+	t.Parallel()
 	node := NewNode("pineapple")
 	n := node.AddSDKWithBase(&sdk1.DummySDK{}, &sdk2.DummySDK{}, &sdk3.DummySDK{})
 	assert.NotNil(t, n)

--- a/integration/nwo/fsc/topology_test.go
+++ b/integration/nwo/fsc/topology_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestTopology_SetLogging(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		initial      *Logging
@@ -62,6 +63,7 @@ func TestTopology_SetLogging(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			top := &Topology{Logging: tt.initial}
 
 			top.SetLogging(tt.spec, tt.format)

--- a/node/start/diag/goroutine_test.go
+++ b/node/start/diag/goroutine_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestCaptureGoRoutines(t *testing.T) {
+	t.Parallel()
 	gt := NewGomegaWithT(t)
 	output, err := diag.CaptureGoRoutines()
 	gt.Expect(err).NotTo(HaveOccurred())
@@ -25,6 +26,7 @@ func TestCaptureGoRoutines(t *testing.T) {
 }
 
 func TestLogGoRoutines(t *testing.T) {
+	t.Parallel()
 	gt := NewGomegaWithT(t)
 	logger, recorder := logging.NewTestLogger(t, logging.Named("goroutine"))
 	diag.LogGoRoutines(logger)

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -69,17 +69,20 @@ func newTestNode() *Node {
 }
 
 func TestNode_ID(t *testing.T) {
+	t.Parallel()
 	n := newTestNode()
 	require.Equal(t, "test-node", n.ID())
 }
 
 func TestNode_AddSDK(t *testing.T) {
+	t.Parallel()
 	n := newTestNode()
 	n.AddSDK(&mockSDK{})
 	require.Len(t, n.sdks, 1)
 }
 
 func TestNode_AddSDK_Multiple(t *testing.T) {
+	t.Parallel()
 	n := newTestNode()
 	n.AddSDK(&mockSDK{})
 	n.AddSDK(&mockSDK{})
@@ -87,6 +90,7 @@ func TestNode_AddSDK_Multiple(t *testing.T) {
 }
 
 func TestNode_Start_Success(t *testing.T) {
+	t.Parallel()
 	n := newTestNode()
 	sdk := &mockSDK{}
 	n.AddSDK(sdk)
@@ -96,11 +100,13 @@ func TestNode_Start_Success(t *testing.T) {
 }
 
 func TestNode_Start_NoSDKs(t *testing.T) {
+	t.Parallel()
 	n := newTestNode()
 	require.NoError(t, n.Start())
 }
 
 func TestNode_Start_InstallError(t *testing.T) {
+	t.Parallel()
 	n := newTestNode()
 	n.AddSDK(&mockSDK{installErr: errors.New("install failed")})
 	require.Error(t, n.Start())
@@ -108,6 +114,7 @@ func TestNode_Start_InstallError(t *testing.T) {
 }
 
 func TestNode_Start_StartError(t *testing.T) {
+	t.Parallel()
 	n := newTestNode()
 	n.AddSDK(&mockSDK{startErr: errors.New("start failed")})
 	require.Error(t, n.Start())
@@ -115,6 +122,7 @@ func TestNode_Start_StartError(t *testing.T) {
 }
 
 func TestNode_Start_PostStart(t *testing.T) {
+	t.Parallel()
 	n := newTestNode()
 	sdk := &mockSDKWithPostStart{}
 	n.AddSDK(sdk)
@@ -123,12 +131,14 @@ func TestNode_Start_PostStart(t *testing.T) {
 }
 
 func TestNode_Start_PostStartError(t *testing.T) {
+	t.Parallel()
 	n := newTestNode()
 	n.AddSDK(&mockSDKWithPostStart{postStartErr: errors.New("post-start failed")})
 	require.Error(t, n.Start())
 }
 
 func TestNode_Start_PanicRecovery(t *testing.T) {
+	t.Parallel()
 	n := newTestNode()
 	n.AddSDK(&panicSDK{})
 	err := n.Start()
@@ -137,6 +147,7 @@ func TestNode_Start_PanicRecovery(t *testing.T) {
 }
 
 func TestNode_Stop(t *testing.T) {
+	t.Parallel()
 	n := newTestNode()
 	require.NoError(t, n.Start())
 	require.True(t, n.running)
@@ -145,6 +156,7 @@ func TestNode_Stop(t *testing.T) {
 }
 
 func TestNode_Stop_BeforeStart(t *testing.T) {
+	t.Parallel()
 	n := newTestNode()
 	// Stop without Start must not panic (cancel is nil)
 	require.NotPanics(t, func() { n.Stop() })
@@ -152,12 +164,14 @@ func TestNode_Stop_BeforeStart(t *testing.T) {
 }
 
 func TestNode_InstallSDK_WhenNotRunning(t *testing.T) {
+	t.Parallel()
 	n := newTestNode()
 	require.NoError(t, n.InstallSDK(&mockSDK{}))
 	require.Len(t, n.sdks, 1)
 }
 
 func TestNode_InstallSDK_WhenRunning(t *testing.T) {
+	t.Parallel()
 	n := newTestNode()
 	require.NoError(t, n.Start())
 	err := n.InstallSDK(&mockSDK{})
@@ -165,6 +179,7 @@ func TestNode_InstallSDK_WhenRunning(t *testing.T) {
 }
 
 func TestNode_RegisterAndGetService(t *testing.T) {
+	t.Parallel()
 	n := newTestNode()
 	svc := &mockSDK{}
 	require.NoError(t, n.RegisterService(svc))
@@ -174,6 +189,7 @@ func TestNode_RegisterAndGetService(t *testing.T) {
 }
 
 func TestNode_GetService_NotFound(t *testing.T) {
+	t.Parallel()
 	n := newTestNode()
 	_, err := n.GetService((*mockSDK)(nil))
 	require.Error(t, err)

--- a/pkg/utils/compose/compose_test.go
+++ b/pkg/utils/compose/compose_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAppendAttributes(t *testing.T) {
+	t.Parallel()
 	var sb strings.Builder
 	CreateCompositeKeyOrPanic(&sb, "ot", "1", "2")
 	k := AppendAttributesOrPanic(&sb, "3")
@@ -21,6 +22,7 @@ func TestAppendAttributes(t *testing.T) {
 }
 
 func TestCreateCompositeKey(t *testing.T) {
+	t.Parallel()
 	sb := &strings.Builder{}
 	key, err := CreateCompositeKey(sb, "myType", "attr1", "attr2")
 	require.NoError(t, err)
@@ -28,48 +30,56 @@ func TestCreateCompositeKey(t *testing.T) {
 }
 
 func TestCreateCompositeKey_InvalidUTF8(t *testing.T) {
+	t.Parallel()
 	sb := &strings.Builder{}
 	_, err := CreateCompositeKey(sb, "myType", string([]byte{0xFF, 0xFE}))
 	require.Error(t, err)
 }
 
 func TestCreateCompositeKey_ForbiddenMinRune(t *testing.T) {
+	t.Parallel()
 	sb := &strings.Builder{}
 	_, err := CreateCompositeKey(sb, "myType", string(rune(0)))
 	require.Error(t, err)
 }
 
 func TestCreateCompositeKey_ForbiddenMaxRune(t *testing.T) {
+	t.Parallel()
 	sb := &strings.Builder{}
 	_, err := CreateCompositeKey(sb, "myType", string(rune(0x10FFFF)))
 	require.Error(t, err)
 }
 
 func TestCreateCompositeKeyOrPanic_Panics(t *testing.T) {
+	t.Parallel()
 	require.Panics(t, func() {
 		CreateCompositeKeyOrPanic(&strings.Builder{}, string(rune(0)))
 	})
 }
 
 func TestAppendAttributes_InvalidUTF8(t *testing.T) {
+	t.Parallel()
 	sb := &strings.Builder{}
 	_, err := AppendAttributes(sb, string([]byte{0xFF}))
 	require.Error(t, err)
 }
 
 func TestAppendAttributesOrPanic_Panics(t *testing.T) {
+	t.Parallel()
 	require.Panics(t, func() {
 		AppendAttributesOrPanic(&strings.Builder{}, string(rune(0)))
 	})
 }
 
 func TestCreateTxTopic_WithTxID(t *testing.T) {
+	t.Parallel()
 	sb, key := CreateTxTopic("net", "chan", "txid")
 	require.NotNil(t, sb)
 	require.NotEmpty(t, key)
 }
 
 func TestCreateTxTopic_WithoutTxID(t *testing.T) {
+	t.Parallel()
 	_, keyNoTx := CreateTxTopic("net", "chan", "")
 	_, keyWithTx := CreateTxTopic("net", "chan", "txid")
 	require.NotEmpty(t, keyNoTx)

--- a/pkg/utils/errors/errors_test.go
+++ b/pkg/utils/errors/errors_test.go
@@ -13,18 +13,21 @@ import (
 )
 
 func TestWrapfSimpleNesting(t *testing.T) {
+	t.Parallel()
 	nestedErr := New("nested err")
 	err := Wrapf(nestedErr, "some error")
 	require.True(t, HasCause(err, nestedErr))
 }
 
 func TestWrapfDoubleNesting(t *testing.T) {
+	t.Parallel()
 	nestedErr := Errorf("nested err")
 	err := Wrapf(Wrapf(nestedErr, "some error"), "other error")
 	require.True(t, HasCause(err, nestedErr))
 }
 
 func TestHasCauseNil(t *testing.T) {
+	t.Parallel()
 	require.False(t, HasCause(New("some err"), nil))
 }
 
@@ -33,52 +36,61 @@ type newErrType struct{ msg string }
 func (e *newErrType) Error() string { return e.msg }
 
 func TestHasType(t *testing.T) {
+	t.Parallel()
 	nestedErr := &newErrType{msg: "nested err"}
 	err := Wrapf(nestedErr, "some error")
 	require.True(t, HasType(err, &newErrType{}))
 }
 
 func TestHasTypeNil(t *testing.T) {
+	t.Parallel()
 	require.False(t, HasType(New("some err"), nil))
 }
 
 func TestNew(t *testing.T) {
+	t.Parallel()
 	err := New("test error")
 	require.Error(t, err)
 	require.Equal(t, "test error", err.Error())
 }
 
 func TestErrorf(t *testing.T) {
+	t.Parallel()
 	err := Errorf("error %d", 42)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "error 42")
 }
 
 func TestWrap(t *testing.T) {
+	t.Parallel()
 	inner := New("inner")
 	wrapped := Wrap(inner, "outer")
 	require.True(t, HasCause(wrapped, inner))
 }
 
 func TestWithMessage(t *testing.T) {
+	t.Parallel()
 	inner := New("inner")
 	annotated := WithMessage(inner, "some message")
 	require.True(t, HasCause(annotated, inner))
 }
 
 func TestWithMessagef(t *testing.T) {
+	t.Parallel()
 	inner := New("inner")
 	annotated := WithMessagef(inner, "message %d", 1)
 	require.True(t, HasCause(annotated, inner))
 }
 
 func TestWithStack(t *testing.T) {
+	t.Parallel()
 	inner := New("inner")
 	stacked := WithStack(inner)
 	require.True(t, HasCause(stacked, inner))
 }
 
 func TestCause(t *testing.T) {
+	t.Parallel()
 	inner := New("inner")
 	wrapped := Wrapf(inner, "outer")
 	cause := Cause(wrapped)
@@ -86,16 +98,19 @@ func TestCause(t *testing.T) {
 }
 
 func TestIs(t *testing.T) {
+	t.Parallel()
 	inner := New("inner")
 	wrapped := Wrapf(inner, "outer")
 	require.True(t, Is(wrapped, inner))
 }
 
 func TestIs_Nil(t *testing.T) {
+	t.Parallel()
 	require.False(t, Is(New("err"), nil))
 }
 
 func TestJoin(t *testing.T) {
+	t.Parallel()
 	e1 := New("error 1")
 	e2 := New("error 2")
 	joined := Join(e1, e2)
@@ -105,6 +120,7 @@ func TestJoin(t *testing.T) {
 }
 
 func TestJoin_NilErrors(t *testing.T) {
+	t.Parallel()
 	result := Join(nil, nil)
 	require.NoError(t, result)
 }

--- a/pkg/utils/proto/proto_test.go
+++ b/pkg/utils/proto/proto_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
 	msg := wrapperspb.String("hello world")
 	b, err := Marshal(msg)
 	require.NoError(t, err)
@@ -24,30 +25,35 @@ func TestMarshalUnmarshal(t *testing.T) {
 }
 
 func TestMarshal_Empty(t *testing.T) {
+	t.Parallel()
 	b, err := Marshal(&wrapperspb.StringValue{})
 	require.NoError(t, err)
 	require.NotNil(t, b)
 }
 
 func TestUnmarshal_InvalidData(t *testing.T) {
+	t.Parallel()
 	// 0x0a = field 1 length-delimited, 0x80 0x01 = length 128, but no bytes follow
 	err := Unmarshal([]byte{0x0a, 0x80, 0x01}, &wrapperspb.StringValue{})
 	require.Error(t, err)
 }
 
 func TestEqual_True(t *testing.T) {
+	t.Parallel()
 	a := wrapperspb.String("same")
 	b := wrapperspb.String("same")
 	require.True(t, Equal(a, b))
 }
 
 func TestEqual_False(t *testing.T) {
+	t.Parallel()
 	a := wrapperspb.String("foo")
 	b := wrapperspb.String("bar")
 	require.False(t, Equal(a, b))
 }
 
 func TestClone(t *testing.T) {
+	t.Parallel()
 	msg := wrapperspb.String("original")
 	cloned, ok := Clone(msg).(*wrapperspb.StringValue)
 	require.True(t, ok)

--- a/pkg/utils/retry_test.go
+++ b/pkg/utils/retry_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestRetryRunner_SucceedsImmediately(t *testing.T) {
+	t.Parallel()
 	runner := NewRetryRunner(3, 0, false)
 	calls := 0
 	err := runner.Run(func() error {
@@ -26,6 +27,7 @@ func TestRetryRunner_SucceedsImmediately(t *testing.T) {
 }
 
 func TestRetryRunner_RetriesAndSucceeds(t *testing.T) {
+	t.Parallel()
 	runner := NewRetryRunner(5, 0, false)
 	calls := 0
 	err := runner.Run(func() error {
@@ -40,6 +42,7 @@ func TestRetryRunner_RetriesAndSucceeds(t *testing.T) {
 }
 
 func TestRetryRunner_ExceedsMaxRetries(t *testing.T) {
+	t.Parallel()
 	runner := NewRetryRunner(3, 0, false)
 	sentinelErr := errors.New("always fails")
 	err := runner.Run(func() error {
@@ -50,6 +53,7 @@ func TestRetryRunner_ExceedsMaxRetries(t *testing.T) {
 }
 
 func TestRetryRunner_ExceedsMaxRetries_NoErrors(t *testing.T) {
+	t.Parallel()
 	// RunWithErrors returning (false, nil) means retry but no error to collect.
 	// After maxTimes, ErrMaxRetriesExceeded is returned.
 	runner := NewRetryRunner(3, 0, false)
@@ -60,6 +64,7 @@ func TestRetryRunner_ExceedsMaxRetries_NoErrors(t *testing.T) {
 }
 
 func TestRetryRunner_RunWithErrors_TerminatesWithError(t *testing.T) {
+	t.Parallel()
 	runner := NewRetryRunner(3, 0, false)
 	sentinelErr := errors.New("terminal error")
 	err := runner.RunWithErrors(func() (bool, error) {
@@ -69,6 +74,7 @@ func TestRetryRunner_RunWithErrors_TerminatesWithError(t *testing.T) {
 }
 
 func TestRetryRunner_RunWithErrors_TerminatesSuccessfully(t *testing.T) {
+	t.Parallel()
 	runner := NewRetryRunner(3, 0, false)
 	err := runner.RunWithErrors(func() (bool, error) {
 		return true, nil
@@ -77,6 +83,7 @@ func TestRetryRunner_RunWithErrors_TerminatesSuccessfully(t *testing.T) {
 }
 
 func TestRetryRunner_Infinitely(t *testing.T) {
+	t.Parallel()
 	runner := NewRetryRunner(Infinitely, 0, false)
 	calls := 0
 	err := runner.Run(func() error {
@@ -91,6 +98,7 @@ func TestRetryRunner_Infinitely(t *testing.T) {
 }
 
 func TestRetryRunner_ExponentialBackoff(t *testing.T) {
+	t.Parallel()
 	runner := NewRetryRunner(3, time.Millisecond, true)
 	calls := 0
 	err := runner.Run(func() error {
@@ -105,6 +113,7 @@ func TestRetryRunner_ExponentialBackoff(t *testing.T) {
 }
 
 func TestTypedRetryRunner_ReturnsValue(t *testing.T) {
+	t.Parallel()
 	runner := NewTypedRetryRunner[string](3, 0, false)
 	calls := 0
 	val, err := runner.Run(func() (string, error) {
@@ -119,6 +128,7 @@ func TestTypedRetryRunner_ReturnsValue(t *testing.T) {
 }
 
 func TestTypedRetryRunner_ExceedsMax(t *testing.T) {
+	t.Parallel()
 	runner := NewTypedRetryRunner[int](2, 0, false)
 	val, err := runner.Run(func() (int, error) {
 		return 0, errors.New("always fails")
@@ -128,6 +138,7 @@ func TestTypedRetryRunner_ExceedsMax(t *testing.T) {
 }
 
 func TestProbabilisticRetryRunner_Succeeds(t *testing.T) {
+	t.Parallel()
 	runner := NewProbabilisticRetryRunner(3, 1, false)
 	calls := 0
 	err := runner.Run(func() error {
@@ -142,6 +153,7 @@ func TestProbabilisticRetryRunner_Succeeds(t *testing.T) {
 }
 
 func TestProbabilisticRetryRunner_ExceedsMax(t *testing.T) {
+	t.Parallel()
 	runner := NewProbabilisticRetryRunner(2, 1, false)
 	err := runner.Run(func() error {
 		return errors.New("always fails")

--- a/pkg/utils/uuid_test.go
+++ b/pkg/utils/uuid_test.go
@@ -91,22 +91,26 @@ func report(b *testing.B) {
 }
 
 func TestGenerateUUID_Format(t *testing.T) {
+	t.Parallel()
 	id := GenerateUUID()
 	_, err := uuid.Parse(id)
 	require.NoError(t, err)
 }
 
 func TestGenerateBytesUUID_Length(t *testing.T) {
+	t.Parallel()
 	b := GenerateBytesUUID()
 	require.Len(t, b, 16)
 }
 
 func TestGenerateUUID_Unique(t *testing.T) {
+	t.Parallel()
 	a, b := GenerateUUID(), GenerateUUID()
 	require.NotEqual(t, a, b)
 }
 
 func TestGenerateBytesUUID_Unique(t *testing.T) {
+	t.Parallel()
 	a, b := GenerateBytesUUID(), GenerateBytesUUID()
 	require.NotEqual(t, a, b)
 }

--- a/platform/common/core/generic/committer/finality_test.go
+++ b/platform/common/core/generic/committer/finality_test.go
@@ -38,6 +38,7 @@ func (m *MockFinalityListener) OnStatus(_ context.Context, txID driver.TxID, sta
 }
 
 func TestFinalityManager_AddListener(t *testing.T) {
+	t.Parallel()
 	listenerManager := newFinalityListenerManager[int](logging.MustGetLogger(), &noop.Tracer{})
 	vault := &MockVault{}
 	manager := NewFinalityManager[int](listenerManager, logging.MustGetLogger(), vault, noop.NewTracerProvider(), 10)
@@ -55,6 +56,7 @@ func TestFinalityManager_AddListener(t *testing.T) {
 }
 
 func TestFinalityManager_RemoveListener(t *testing.T) {
+	t.Parallel()
 	listenerManager := newFinalityListenerManager[int](logging.MustGetLogger(), &noop.Tracer{})
 	vault := &MockVault{}
 	manager := NewFinalityManager[int](listenerManager, logging.MustGetLogger(), vault, noop.NewTracerProvider(), 10)
@@ -71,6 +73,7 @@ func TestFinalityManager_RemoveListener(t *testing.T) {
 }
 
 func TestFinalityManager_Run(t *testing.T) {
+	t.Parallel()
 	listenerManager := newFinalityListenerManager[int](logging.MustGetLogger(), &noop.Tracer{})
 	vault := &MockVault{}
 	manager := NewFinalityManager[int](listenerManager, logging.MustGetLogger(), vault, noop.NewTracerProvider(), 10)
@@ -84,6 +87,7 @@ func TestFinalityManager_Run(t *testing.T) {
 }
 
 func TestFinalityManager_RunStatusListener(t *testing.T) {
+	t.Parallel()
 	event := driver.FinalityEvent[int]{
 		TxID:              "txID",
 		ValidationCode:    1,
@@ -132,6 +136,7 @@ func TestFinalityManager_RunStatusListener(t *testing.T) {
 }
 
 func TestFinalityManager_CloneListeners(t *testing.T) {
+	t.Parallel()
 	listenerManager := newFinalityListenerManager[int](logging.MustGetLogger(), &noop.Tracer{})
 	vault := &MockVault{}
 	manager := NewFinalityManager[int](listenerManager, logging.MustGetLogger(), vault, noop.NewTracerProvider(), 10)
@@ -144,6 +149,7 @@ func TestFinalityManager_CloneListeners(t *testing.T) {
 }
 
 func TestFinalityManager_Dispatch_PanicRecovery(t *testing.T) {
+	t.Parallel()
 	listenerManager := newFinalityListenerManager[int](logging.MustGetLogger(), &noop.Tracer{})
 	vault := &MockVault{}
 	manager := NewFinalityManager[int](listenerManager, logging.MustGetLogger(), vault, noop.NewTracerProvider(), 10)

--- a/platform/common/core/generic/vault/helpers.go
+++ b/platform/common/core/generic/vault/helpers.go
@@ -32,8 +32,6 @@ const (
 	unknown
 )
 
-var RemoveNils func(items []driver.VaultRead) []driver.VaultRead
-
 var VCProvider = driver.NewValidationCodeProvider(map[ValidationCode]driver.TxStatusCode{
 	valid:   driver.Valid,
 	invalid: driver.Invalid,
@@ -45,6 +43,7 @@ type artifactsProvider interface {
 	NewCachedVault(ddb driver2.VaultStore) (*Vault[ValidationCode], error)
 	NewNonCachedVault(ddb driver2.VaultStore) (*Vault[ValidationCode], error)
 	NewMarshaller() Marshaller
+	RemoveNils(items []driver.VaultRead) []driver.VaultRead
 }
 
 var SingleDBCases = []struct {
@@ -263,7 +262,7 @@ func TTestQueryExecutor(t *testing.T, ddb driver2.VaultStore, vp artifactsProvid
 	require.NoError(t, err)
 	res, err = collections.ReadAll(itr)
 	require.NoError(t, err)
-	var expected = RemoveNils([]driver.VaultRead{
+	var expected = vp.RemoveNils([]driver.VaultRead{
 		{Key: "k1", Raw: []byte("k1_value"), Version: versionBlockTxNumToBytes(35, 3)},
 	})
 	require.Equal(t, expected, res)

--- a/platform/common/core/generic/vault/interceptor_test.go
+++ b/platform/common/core/generic/vault/interceptor_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestConcurrency(t *testing.T) {
+	t.Parallel()
 	qe := mocks.NewMockQE()
 	idsr := mocks.MockTxStatusStore{}
 
@@ -63,6 +64,7 @@ func TestConcurrency(t *testing.T) {
 }
 
 func TestAddReadAt(t *testing.T) {
+	t.Parallel()
 	qe := mocks.MockQE{}
 	idsr := mocks.MockTxStatusStore{}
 	i := newInterceptor(logging.MustGetLogger(), context.Background(), EmptyRWSet(), qe, idsr, "1")

--- a/platform/common/core/generic/vault/vault_test.go
+++ b/platform/common/core/generic/vault/vault_test.go
@@ -26,7 +26,13 @@ import (
 
 //go:generate counterfeiter -o mocks/config.go -fake-name Config . config
 
-type testArtifactProvider struct{}
+type testArtifactProvider struct {
+	removeNils func([]driver2.VaultRead) []driver2.VaultRead
+}
+
+func (p *testArtifactProvider) RemoveNils(items []driver2.VaultRead) []driver2.VaultRead {
+	return p.removeNils(items)
+}
 
 func (p *testArtifactProvider) NewCachedVault(ddb driver.VaultStore) (*Vault[ValidationCode], error) {
 	vaultLogger := logging.MustGetLogger()
@@ -156,25 +162,27 @@ func (m *marshaller) Append(destination *ReadWriteSet, raw []byte, nss ...string
 	return nil
 }
 
-func TestMemory(t *testing.T) {
-	RemoveNils = func(items []driver2.VaultRead) []driver2.VaultRead { return items }
-	artifactProvider := &testArtifactProvider{}
-	for _, c := range SingleDBCases {
-		ddb, err := vault2.OpenMemoryVault(c.Name)
-		require.NoError(t, err)
-		require.NotNil(t, ddb)
+func TestMemory(t *testing.T) { //nolint:tparallel
+	t.Parallel()
+	artifactProvider := &testArtifactProvider{
+		removeNils: func(items []driver2.VaultRead) []driver2.VaultRead { return items },
+	}
+	for _, c := range SingleDBCases { //nolint:paralleltest
 		t.Run(c.Name, func(xt *testing.T) {
+			ddb, err := vault2.OpenMemoryVault(c.Name)
+			require.NoError(t, err)
+			require.NotNil(t, ddb)
 			defer utils.IgnoreErrorFunc(ddb.Close)
 			c.Fn(xt, ddb, artifactProvider)
 		})
 	}
 
-	for _, c := range DoubleDBCases {
-		db1, err := vault2.OpenMemoryVault(c.Name)
-		require.NoError(t, err)
-		db2, err := vault2.OpenMemoryVault(c.Name)
-		require.NoError(t, err)
+	for _, c := range DoubleDBCases { //nolint:paralleltest
 		t.Run(c.Name, func(xt *testing.T) {
+			db1, err := vault2.OpenMemoryVault(c.Name)
+			require.NoError(t, err)
+			db2, err := vault2.OpenMemoryVault(c.Name)
+			require.NoError(t, err)
 			defer utils.IgnoreErrorFunc(db1.Close)
 			defer utils.IgnoreErrorFunc(db2.Close)
 			c.Fn(xt, db1, db2, artifactProvider)
@@ -182,27 +190,29 @@ func TestMemory(t *testing.T) {
 	}
 }
 
-func TestSqlite(t *testing.T) {
-	RemoveNils = func(items []driver2.VaultRead) []driver2.VaultRead {
-		return slices.DeleteFunc(items, func(e driver2.VaultRead) bool { return e.Raw == nil })
+func TestSqlite(t *testing.T) { //nolint:tparallel
+	t.Parallel()
+	artifactProvider := &testArtifactProvider{
+		removeNils: func(items []driver2.VaultRead) []driver2.VaultRead {
+			return slices.DeleteFunc(items, func(e driver2.VaultRead) bool { return e.Raw == nil })
+		},
 	}
-	artifactProvider := &testArtifactProvider{}
 
-	for _, c := range SingleDBCases {
-		ddb, err := vault2.OpenSqliteVault("node1", t.TempDir())
-		require.NoError(t, err)
+	for _, c := range SingleDBCases { //nolint:paralleltest
 		t.Run(c.Name, func(xt *testing.T) {
+			ddb, err := vault2.OpenSqliteVault("node1", t.TempDir())
+			require.NoError(t, err)
 			defer utils.IgnoreErrorFunc(ddb.Close)
 			c.Fn(xt, ddb, artifactProvider)
 		})
 	}
 
-	for _, c := range DoubleDBCases {
-		db1, err := vault2.OpenSqliteVault("node1", t.TempDir())
-		require.NoError(t, err)
-		db2, err := vault2.OpenSqliteVault("node2", t.TempDir())
-		require.NoError(t, err)
+	for _, c := range DoubleDBCases { //nolint:paralleltest
 		t.Run(c.Name, func(xt *testing.T) {
+			db1, err := vault2.OpenSqliteVault("node1", t.TempDir())
+			require.NoError(t, err)
+			db2, err := vault2.OpenSqliteVault("node2", t.TempDir())
+			require.NoError(t, err)
 			defer utils.IgnoreErrorFunc(db1.Close)
 			defer utils.IgnoreErrorFunc(db2.Close)
 			c.Fn(xt, db1, db2, artifactProvider)
@@ -210,28 +220,30 @@ func TestSqlite(t *testing.T) {
 	}
 }
 
-func TestPostgres(t *testing.T) {
-	RemoveNils = func(items []driver2.VaultRead) []driver2.VaultRead {
-		return slices.DeleteFunc(items, func(e driver2.VaultRead) bool { return e.Raw == nil })
+func TestPostgres(t *testing.T) { //nolint:tparallel
+	t.Parallel()
+	artifactProvider := &testArtifactProvider{
+		removeNils: func(items []driver2.VaultRead) []driver2.VaultRead {
+			return slices.DeleteFunc(items, func(e driver2.VaultRead) bool { return e.Raw == nil })
+		},
 	}
-	artifactProvider := &testArtifactProvider{}
 
-	for _, c := range append(SingleDBCases, ReadCommittedDBCases...) {
-		ddb, terminate, err := vault2.OpenPostgresVault("common-sdk-node1")
-		require.NoError(t, err)
+	for _, c := range append(SingleDBCases, ReadCommittedDBCases...) { //nolint:paralleltest
 		t.Run(c.Name, func(xt *testing.T) {
+			ddb, terminate, err := vault2.OpenPostgresVault("common-sdk-node1")
+			require.NoError(t, err)
 			defer utils.IgnoreErrorFunc(ddb.Close)
 			defer terminate()
 			c.Fn(xt, ddb, artifactProvider)
 		})
 	}
 
-	for _, c := range DoubleDBCases {
-		db1, terminate1, err := vault2.OpenPostgresVault("common-sdk-node1")
-		require.NoError(t, err)
-		db2, terminate2, err := vault2.OpenPostgresVault("common-sdk-node2")
-		require.NoError(t, err)
+	for _, c := range DoubleDBCases { //nolint:paralleltest
 		t.Run(c.Name, func(xt *testing.T) {
+			db1, terminate1, err := vault2.OpenPostgresVault("common-sdk-node1")
+			require.NoError(t, err)
+			db2, terminate2, err := vault2.OpenPostgresVault("common-sdk-node2")
+			require.NoError(t, err)
 			defer utils.IgnoreErrorFunc(db1.Close)
 			defer utils.IgnoreErrorFunc(db2.Close)
 			defer terminate1()

--- a/platform/common/services/logging/testlogger/logger_test.go
+++ b/platform/common/services/logging/testlogger/logger_test.go
@@ -7,28 +7,25 @@ SPDX-License-Identifier: Apache-2.0
 package testlogger_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMustGetLogger_WithParams(t *testing.T) {
-	RegisterTestingT(t)
+	t.Parallel()
+	const expectedSuffix = "fsc.platform.common.services.logging.testlogger_test.some.thing"
 	l := logging.MustGetLogger("some", "thing")
-
-	name := l.Zap().Name()
-
-	Expect(name).To(HaveSuffix("fsc.platform.common.services.logging.testlogger_test.some.thing"))
+	require.True(t, strings.HasSuffix(l.Zap().Name(), expectedSuffix))
 }
 
 func TestMustGetLogger_WithOutParams(t *testing.T) {
-	RegisterTestingT(t)
+	t.Parallel()
+	const expectedSuffix = "fsc.platform.common.services.logging.testlogger_test"
 	l := logging.MustGetLogger()
-
-	name := l.Zap().Name()
-
-	Expect(name).To(HaveSuffix("fsc.platform.common.services.logging.testlogger_test"))
+	require.True(t, strings.HasSuffix(l.Zap().Name(), expectedSuffix))
 }
 
 func level1() (string, error) {
@@ -48,12 +45,11 @@ func level4() (string, error) {
 }
 
 func TestGetPackageName(t *testing.T) {
-	RegisterTestingT(t)
-
+	t.Parallel()
+	const expectedPkg = "github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging/testlogger_test"
 	pkg, err := level1()
-	Expect(err).NotTo(HaveOccurred())
-
-	Expect(pkg).To(BeIdenticalTo("github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging/testlogger_test"))
+	require.NoError(t, err)
+	require.Equal(t, expectedPkg, pkg)
 }
 
 type VersionInfoHandler struct{}
@@ -63,11 +59,10 @@ func (h *VersionInfoHandler) sendResponseLikeMethod() (string, error) {
 }
 
 func TestGetPackageName_FromStructMethod(t *testing.T) {
-	RegisterTestingT(t)
-
+	t.Parallel()
+	const expectedPkg = "github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging/testlogger_test"
 	handler := &VersionInfoHandler{}
 	pkg, err := handler.sendResponseLikeMethod()
-	Expect(err).NotTo(HaveOccurred())
-
-	Expect(pkg).To(BeIdenticalTo("github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging/testlogger_test"))
+	require.NoError(t, err)
+	require.Equal(t, expectedPkg, pkg)
 }

--- a/platform/common/services/logging/types_test.go
+++ b/platform/common/services/logging/types_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestFilterPrintable(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -59,6 +60,7 @@ func TestFilterPrintable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := FilterPrintableWithMarker(tt.input)
 			assert.Equal(t, tt.expected, got, "got %q, want %q", got, tt.expected)
 

--- a/platform/common/utils/cache/lru_test.go
+++ b/platform/common/utils/cache/lru_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestLRUSimple(t *testing.T) {
+	t.Parallel()
 	allEvicted := make(map[int]string)
 
 	c := cache.NewLRUCache(3, 2, func(evicted map[int]string) { collections.CopyMap(allEvicted, evicted) })
@@ -41,6 +42,7 @@ func TestLRUSimple(t *testing.T) {
 }
 
 func TestLRUSameKey(t *testing.T) {
+	t.Parallel()
 	allEvicted := make(map[int]string)
 
 	c := cache.NewLRUCache(3, 2, func(evicted map[int]string) { collections.CopyMap(allEvicted, evicted) })
@@ -88,6 +90,7 @@ func TestLRUSameKey(t *testing.T) {
 }
 
 func TestLRUParallel(t *testing.T) {
+	t.Parallel()
 	evictedCount := atomic.Int32{}
 	c := cache.NewLRUCache(3, 2, func(evicted map[int]string) { evictedCount.Add(int32(len(evicted))) })
 

--- a/platform/common/utils/cache/secondcache/second_chance_test.go
+++ b/platform/common/utils/cache/secondcache/second_chance_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestSecondChanceCache(t *testing.T) {
+	t.Parallel()
 	cache := New(2)
 	require.NotNil(t, cache)
 
@@ -65,6 +66,7 @@ func TestSecondChanceCache(t *testing.T) {
 }
 
 func TestSecondChanceCacheConcurrent(t *testing.T) {
+	t.Parallel()
 	cache := New(25)
 
 	workers := 16

--- a/platform/common/utils/cache/timeout_test.go
+++ b/platform/common/utils/cache/timeout_test.go
@@ -25,6 +25,7 @@ const (
 )
 
 func TestTimeoutSimple(t *testing.T) {
+	t.Parallel()
 	var mu sync.RWMutex
 	allEvicted := make(map[int]string)
 
@@ -63,6 +64,7 @@ func TestTimeoutSimple(t *testing.T) {
 }
 
 func TestTimeoutParallel(t *testing.T) {
+	t.Parallel()
 	numItem := 100
 
 	var evictedCount atomic.Int32

--- a/platform/common/utils/collections/iterators/batch_test.go
+++ b/platform/common/utils/collections/iterators/batch_test.go
@@ -45,7 +45,7 @@ var testMatrix = []struct {
 	},
 }
 
-func TestBatchedIterator(t *testing.T) {
+func TestBatchedIterator(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	for _, testCase := range testMatrix {

--- a/platform/common/utils/lazy/holder_test.go
+++ b/platform/common/utils/lazy/holder_test.go
@@ -27,6 +27,7 @@ func (d *dummyCloser) Close() error {
 }
 
 func TestLazyHolderRaceCondition(t *testing.T) {
+	t.Parallel()
 	// Provider function for the lazyHolder.
 	provider := func() (*dummyCloser, error) {
 		time.Sleep(10 * time.Millisecond) // Simulate some delay

--- a/platform/common/utils/lazy/provider_test.go
+++ b/platform/common/utils/lazy/provider_test.go
@@ -19,6 +19,7 @@ import (
 type entry struct{ key, value string }
 
 func TestNoErrors(t *testing.T) {
+	t.Parallel()
 	cache := newTestCache()
 
 	// Get non existing
@@ -54,6 +55,7 @@ func TestNoErrors(t *testing.T) {
 }
 
 func TestDeleteNonExisting(t *testing.T) {
+	t.Parallel()
 	cache := newTestCache()
 
 	val, ok := cache.Delete(entry{"key", "v1"})
@@ -62,6 +64,7 @@ func TestDeleteNonExisting(t *testing.T) {
 }
 
 func TestUpdateNonExisting(t *testing.T) {
+	t.Parallel()
 	cache := newTestCache()
 
 	oldVal, newVal, err := cache.Update(entry{"key", "v1"})
@@ -71,6 +74,7 @@ func TestUpdateNonExisting(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
+	t.Parallel()
 	cache := newTestCache()
 
 	val, err := cache.Get(entry{"error", "e1"})
@@ -83,6 +87,7 @@ func TestError(t *testing.T) {
 }
 
 func TestParallel(t *testing.T) {
+	t.Parallel()
 	const iterations = 100
 	cache := newTestCache()
 	vals := make(chan string, iterations)

--- a/platform/common/utils/metrics_test.go
+++ b/platform/common/utils/metrics_test.go
@@ -15,7 +15,9 @@ import (
 
 // Test Fix #1: Safer calculation method (Pow vs Exp/Log) - maintains exponential spacing
 func TestFix1_SaferCalculation_MaintainsExponentialSpacing(t *testing.T) {
+	t.Parallel()
 	t.Run("Verify exponential spacing with constant ratio", func(t *testing.T) {
+		t.Parallel()
 		buckets := ExponentialBucketTimeRange(0, 1*time.Second, 10)
 
 		// Calculate ratios between consecutive buckets
@@ -47,6 +49,7 @@ func TestFix1_SaferCalculation_MaintainsExponentialSpacing(t *testing.T) {
 
 // Test Fix #2: Guaranteed exact bucket count
 func TestFix2_GuaranteedExactBucketCount(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name    string
 		start   time.Duration
@@ -62,6 +65,7 @@ func TestFix2_GuaranteedExactBucketCount(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			result := ExponentialBucketTimeRange(tc.start, tc.end, tc.buckets)
 
 			if len(result) != tc.buckets {
@@ -76,7 +80,9 @@ func TestFix2_GuaranteedExactBucketCount(t *testing.T) {
 
 // Test Fix #3: Independent calculation (no error accumulation)
 func TestFix3_IndependentCalculation_NoErrorAccumulation(t *testing.T) {
+	t.Parallel()
 	t.Run("Verify monotonically increasing values", func(t *testing.T) {
+		t.Parallel()
 		buckets := ExponentialBucketTimeRange(0, 5*time.Second, 15)
 
 		for i := 1; i < len(buckets); i++ {
@@ -90,6 +96,7 @@ func TestFix3_IndependentCalculation_NoErrorAccumulation(t *testing.T) {
 	})
 
 	t.Run("Verify first and last buckets match start and end", func(t *testing.T) {
+		t.Parallel()
 		start := 0 * time.Second
 		end := 1 * time.Second
 		buckets := ExponentialBucketTimeRange(start, end, 10)
@@ -112,7 +119,9 @@ func TestFix3_IndependentCalculation_NoErrorAccumulation(t *testing.T) {
 
 // Test Fix #4: Rounding to significant digits produces clean values
 func TestFix4_RoundingProducesCleanValues(t *testing.T) {
+	t.Parallel()
 	t.Run("Verify Prometheus output format is clean", func(t *testing.T) {
+		t.Parallel()
 		buckets := ExponentialBucketTimeRange(0, 1*time.Second, 10)
 
 		for i, v := range buckets {
@@ -129,6 +138,7 @@ func TestFix4_RoundingProducesCleanValues(t *testing.T) {
 	})
 
 	t.Run("Compare internal vs Prometheus representation", func(t *testing.T) {
+		t.Parallel()
 		buckets := ExponentialBucketTimeRange(0, 100*time.Millisecond, 10)
 
 		t.Logf("\nInternal vs Prometheus representation:")
@@ -147,6 +157,7 @@ func TestFix4_RoundingProducesCleanValues(t *testing.T) {
 
 // Test Fix #5: Edge case handling
 func TestFix5_EdgeCaseHandling(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name           string
 		start          time.Duration
@@ -165,6 +176,7 @@ func TestFix5_EdgeCaseHandling(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			defer func() {
 				if r := recover(); r != nil {
 					if !tc.shouldPanic {
@@ -188,7 +200,9 @@ func TestFix5_EdgeCaseHandling(t *testing.T) {
 
 // Comprehensive test combining all fixes
 func TestAllFixes_Comprehensive(t *testing.T) {
+	t.Parallel()
 	t.Run("10 buckets from 0 to 1 second", func(t *testing.T) {
+		t.Parallel()
 		buckets := ExponentialBucketTimeRange(0, 1*time.Second, 10)
 
 		// Fix #2: Exact count
@@ -236,6 +250,7 @@ func TestAllFixes_Comprehensive(t *testing.T) {
 
 // Test for LinearBucketTimeRange (unchanged, for completeness)
 func TestLinearBucketTimeRange(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		start   time.Duration
@@ -248,6 +263,7 @@ func TestLinearBucketTimeRange(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			buckets := LinearBucketTimeRange(tt.start, tt.end, tt.buckets)
 
 			expectedLen := tt.buckets + 1
@@ -270,6 +286,7 @@ func TestLinearBucketTimeRange(t *testing.T) {
 
 // Test for LinearBucketRange (unchanged, for completeness)
 func TestLinearBucketRange(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		start   int64
@@ -282,6 +299,7 @@ func TestLinearBucketRange(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			buckets := LinearBucketRange(tt.start, tt.end, tt.buckets)
 
 			expectedLen := tt.buckets + 1

--- a/platform/fabric/core/generic/committer/event_test.go
+++ b/platform/fabric/core/generic/committer/event_test.go
@@ -14,8 +14,11 @@ import (
 )
 
 func TestEvent(t *testing.T) {
+	t.Parallel()
 	t.Run("validChaincodeEvent", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Returns true for valid chaincode event ", func(t *testing.T) {
+			t.Parallel()
 			event := &peer.ChaincodeEvent{
 				ChaincodeId: "1",
 				TxId:        "TXNID1",
@@ -28,6 +31,7 @@ func TestEvent(t *testing.T) {
 		})
 
 		t.Run("Returns false for empty transaction ID", func(t *testing.T) {
+			t.Parallel()
 			event := &peer.ChaincodeEvent{
 				ChaincodeId: "1",
 				TxId:        "",
@@ -40,6 +44,7 @@ func TestEvent(t *testing.T) {
 		})
 
 		t.Run("Returns false for empty event name", func(t *testing.T) {
+			t.Parallel()
 			event := &peer.ChaincodeEvent{
 				ChaincodeId: "1",
 				TxId:        "TXNID1",
@@ -52,6 +57,7 @@ func TestEvent(t *testing.T) {
 		})
 
 		t.Run("Returns false for empty chaincode ID", func(t *testing.T) {
+			t.Parallel()
 			event := &peer.ChaincodeEvent{
 				ChaincodeId: "",
 				TxId:        "TXNID1",

--- a/platform/fabric/core/generic/config/ds_test.go
+++ b/platform/fabric/core/generic/config/ds_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestLoad(t *testing.T) {
+	t.Parallel()
 	v := koanf.New(".")
 	require.NoError(t, v.Load(koanffile.Provider("./testdata/core.yaml"), configservice.LowercaseParser{Parser: koanfyaml.Parser()}))
 

--- a/platform/fabric/core/generic/config/service_test.go
+++ b/platform/fabric/core/generic/config/service_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestNewService_missingConfig(t *testing.T) {
+	t.Parallel()
 	m := &mock.Configuration{}
 	m.IsSetReturns(false)
 	// when defaultConfig=false and fabric.<name> is not set, error expected
@@ -28,6 +29,7 @@ func TestNewService_missingConfig(t *testing.T) {
 }
 
 func TestNewService_defaultsAndOrderers(t *testing.T) {
+	t.Parallel()
 	m := &mock.Configuration{}
 	// simulate fabirc.mynet present
 	m.IsSetReturnsOnCall(0, true)   // called for fabric.mynet check
@@ -76,6 +78,7 @@ func TestNewService_defaultsAndOrderers(t *testing.T) {
 }
 
 func TestClientKeepAliveConfig_UnmarshalError(t *testing.T) {
+	t.Parallel()
 	m := &mock.Configuration{}
 	m.IsSetReturns(true) // keepalive.interval is set
 	m.UnmarshalKeyReturnsOnCall(0, errors.New("boom"))
@@ -87,6 +90,7 @@ func TestClientKeepAliveConfig_UnmarshalError(t *testing.T) {
 }
 
 func TestVaultAndMSPSettings(t *testing.T) {
+	t.Parallel()
 	m := &mock.Configuration{}
 	// fabric prefix empty
 	m.GetStringReturnsOnCall(0, "persistenceName") // vault.persistence
@@ -113,6 +117,7 @@ func TestVaultAndMSPSettings(t *testing.T) {
 }
 
 func TestChannelHelpers(t *testing.T) {
+	t.Parallel()
 	ch := &cfg.Channel{}
 	// default values
 	require.Equal(t, time.Duration(5*time.Minute), ch.DiscoveryDefaultTTLS())
@@ -137,6 +142,7 @@ func TestChannelHelpers(t *testing.T) {
 }
 
 func TestCreatePeerMapAndPickPeer(t *testing.T) {
+	t.Parallel()
 	m := &mock.Configuration{}
 	m.IsSetReturnsOnCall(0, true) // fabric.network present for NewService
 	m.GetStringReturnsOnCall(0, "")
@@ -181,6 +187,7 @@ func TestCreatePeerMapAndPickPeer(t *testing.T) {
 }
 
 func TestPickOrderer_nilAndSetConfigOrderers(t *testing.T) {
+	t.Parallel()
 	m := &mock.Configuration{}
 	svc := &cfg.Service{Configuration: m}
 	// nil case
@@ -194,6 +201,7 @@ func TestPickOrderer_nilAndSetConfigOrderers(t *testing.T) {
 }
 
 func TestServiceGetters(t *testing.T) {
+	t.Parallel()
 	m := &mock.Configuration{}
 	// Initialize with some basic setup to avoid NewService errors
 	m.IsSetReturns(true)
@@ -283,9 +291,11 @@ func TestServiceGetters(t *testing.T) {
 }
 
 func TestService_MoreCases(t *testing.T) {
+	t.Parallel()
 	m := &mock.Configuration{}
 
 	t.Run("NewService_Errors", func(t *testing.T) {
+		t.Parallel()
 		m := &mock.Configuration{}
 		m.IsSetReturns(true)
 		// Error in readItems (orderers)
@@ -323,6 +333,7 @@ func TestService_MoreCases(t *testing.T) {
 	})
 
 	t.Run("MSPs_Resolvers", func(t *testing.T) {
+		t.Parallel()
 		svc := &cfg.Service{Configuration: m}
 		m.UnmarshalKeyReturns(errors.New("unmarshal-err"))
 		_, err := svc.MSPs()
@@ -340,6 +351,7 @@ func TestService_MoreCases(t *testing.T) {
 	})
 
 	t.Run("PickPeer_Fallback", func(t *testing.T) {
+		t.Parallel()
 		m := &mock.Configuration{}
 		m.IsSetReturns(true)
 		m.UnmarshalKeyStub = func(key string, rawVal interface{}) error {
@@ -363,6 +375,7 @@ func TestService_MoreCases(t *testing.T) {
 	})
 
 	t.Run("Vault_TranslatePath", func(t *testing.T) {
+		t.Parallel()
 		m := &mock.Configuration{}
 		svc := &cfg.Service{Configuration: m}
 		m.GetStringReturnsOnCall(0, "p1")
@@ -373,6 +386,7 @@ func TestService_MoreCases(t *testing.T) {
 	})
 
 	t.Run("Channels", func(t *testing.T) {
+		t.Parallel()
 		m := &mock.Configuration{}
 		m.IsSetReturns(true)
 		m.UnmarshalKeyStub = func(key string, rawVal interface{}) error {

--- a/platform/fabric/core/generic/discovery/client_test.go
+++ b/platform/fabric/core/generic/discovery/client_test.go
@@ -165,6 +165,7 @@ func createConnector(t *testing.T, certificate tls.Certificate, targetPort int) 
 }
 
 func TestClient(t *testing.T) {
+	t.Parallel()
 	clientCert := loadFileOrPanic(filepath.Join("testdata", "client", "cert.pem"))
 	clientKey := loadFileOrPanic(filepath.Join("testdata", "client", "key.pem"))
 	clientTLSCert, err := tls.X509KeyPair(clientCert, clientKey)
@@ -248,6 +249,7 @@ func TestClient(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Channel mismatch", func(t *testing.T) {
+		t.Parallel()
 		// Check behavior for channels that we didn't query for.
 		fakeChannel := r.ForChannel("fakeChannel")
 		peers, err := fakeChannel.Peers()
@@ -264,6 +266,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("Peer membership query", func(t *testing.T) {
+		t.Parallel()
 		// Check response for the correct channel
 		mychannel := r.ForChannel("mychannel")
 		conf, err := mychannel.Config()
@@ -276,6 +279,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("Endorser query without chaincode installed", func(t *testing.T) {
+		t.Parallel()
 		mychannel := r.ForChannel("mychannel")
 		endorsers, err := mychannel.Endorsers(ccCall("mycc"), NoFilter)
 		// However, since we didn't provide any chaincodes to these peers - the server shouldn't
@@ -286,6 +290,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("Endorser query with chaincodes installed", func(t *testing.T) {
+		t.Parallel()
 		// Next, we check the case when the peers publish chaincode for themselves.
 		// TODO: produce output
 
@@ -382,6 +387,7 @@ func computeSHA256(bytes []byte) []byte {
 }
 
 func TestUnableToSign(t *testing.T) {
+	t.Parallel()
 	signer := func(msg []byte) ([]byte, error) {
 		return nil, errors.New("not enough entropy")
 	}
@@ -400,6 +406,7 @@ func TestUnableToSign(t *testing.T) {
 }
 
 func TestUnableToConnect(t *testing.T) {
+	t.Parallel()
 	signer := func(msg []byte) ([]byte, error) {
 		return msg, nil
 	}
@@ -418,6 +425,7 @@ func TestUnableToConnect(t *testing.T) {
 }
 
 func TestBadResponses(t *testing.T) {
+	t.Parallel()
 	signer := func(msg []byte) ([]byte, error) {
 		return msg, nil
 	}
@@ -528,6 +536,7 @@ func TestBadResponses(t *testing.T) {
 }
 
 func TestAddEndorsersQueryInvalidInput(t *testing.T) {
+	t.Parallel()
 	_, err := NewRequest().AddEndorsersQuery()
 	require.Contains(t, err.Error(), "no chaincode interests given")
 
@@ -544,6 +553,7 @@ func TestAddEndorsersQueryInvalidInput(t *testing.T) {
 }
 
 func TestValidateAliveMessage(t *testing.T) {
+	t.Parallel()
 	am := aliveMessage(1)
 	msg, _ := EnvelopeToGossipMessage(am)
 
@@ -567,6 +577,7 @@ func TestValidateAliveMessage(t *testing.T) {
 }
 
 func TestValidateStateInfoMessage(t *testing.T) {
+	t.Parallel()
 	si := stateInfoWithHeight(100)
 
 	// Scenario I: Valid state info message
@@ -589,6 +600,7 @@ func TestValidateStateInfoMessage(t *testing.T) {
 }
 
 func TestString(t *testing.T) {
+	t.Parallel()
 	var ic InvocationChain
 	ic = append(ic, &peer.ChaincodeCall{
 		Name:            "foo",

--- a/platform/fabric/core/generic/discovery/querytype_test.go
+++ b/platform/fabric/core/generic/discovery/querytype_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestGetQueryType(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		q        *discovery.Query
 		expected QueryType
@@ -29,6 +30,7 @@ func TestGetQueryType(t *testing.T) {
 
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
 			require.Equal(t, tt.expected, GetQueryType(tt.q))
 		})
 	}

--- a/platform/fabric/core/generic/id/info_test.go
+++ b/platform/fabric/core/generic/id/info_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestInfoIdemix(t *testing.T) {
+	t.Parallel()
 	driver := mem.NewDriver()
 	persistence, err := driver.NewKVS("")
 	require.NoError(t, err)
@@ -47,6 +48,7 @@ func TestInfoIdemix(t *testing.T) {
 }
 
 func TestInfoX509(t *testing.T) {
+	t.Parallel()
 	p, err := x509.NewProvider("./testdata/x509", "", "apple", nil)
 	require.NoError(t, err)
 	id, _, err := p.Identity(nil)

--- a/platform/fabric/core/generic/ledger/kvledger/rwsetutil/kvrwset_proto_util_test.go
+++ b/platform/fabric/core/generic/ledger/kvledger/rwsetutil/kvrwset_proto_util_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestSetRawReads(t *testing.T) {
+	t.Parallel()
 	rqi := &kvrwset.RangeQueryInfo{StartKey: "start", EndKey: "end"}
 	kvReads := []*kvrwset.KVRead{{Key: "key1"}, {Key: "key2"}}
 
@@ -30,6 +31,7 @@ func TestSetRawReads(t *testing.T) {
 }
 
 func TestSetMerkelSummary(t *testing.T) {
+	t.Parallel()
 	rqi := &kvrwset.RangeQueryInfo{StartKey: "start", EndKey: "end"}
 	merkleSummary := &kvrwset.QueryReadsMerkleSummary{MaxDegree: 12, MaxLevel: 99}
 

--- a/platform/fabric/core/generic/ledger/kvledger/rwsetutil/rwset_builder_test.go
+++ b/platform/fabric/core/generic/ledger/kvledger/rwsetutil/rwset_builder_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestTxSimulationResultWithOnlyPubData(t *testing.T) {
+	t.Parallel()
 	rwSetBuilder := NewRWSetBuilder()
 
 	rwSetBuilder.AddToReadSet("ns1", "key2", version.NewHeight(1, 2))
@@ -75,6 +76,7 @@ func TestTxSimulationResultWithOnlyPubData(t *testing.T) {
 }
 
 func TestTxSimulationResultWithPvtData(t *testing.T) {
+	t.Parallel()
 	rwSetBuilder := NewRWSetBuilder()
 	// public rws ns1 + ns2
 	rwSetBuilder.AddToReadSet("ns1", "key1", version.NewHeight(1, 1))
@@ -259,6 +261,7 @@ func TestTxSimulationResultWithPvtData(t *testing.T) {
 }
 
 func TestTxSimulationResultWithMetadata(t *testing.T) {
+	t.Parallel()
 	rwSetBuilder := NewRWSetBuilder()
 	// public rws ns1
 	rwSetBuilder.AddToReadSet("ns1", "key1", version.NewHeight(1, 1))
@@ -405,7 +408,9 @@ func serializeTestProtoMsg(t *testing.T, protoMsg proto.Message) []byte {
 }
 
 func TestNilOrZeroLengthByteArrayValueConvertedToDelete(t *testing.T) {
+	t.Parallel()
 	t.Run("public_writeset", func(t *testing.T) {
+		t.Parallel()
 		rwsetBuilder := NewRWSetBuilder()
 		rwsetBuilder.AddToWriteSet("ns", "key1", nil)
 		rwsetBuilder.AddToWriteSet("ns", "key2", []byte{})
@@ -429,6 +434,7 @@ func TestNilOrZeroLengthByteArrayValueConvertedToDelete(t *testing.T) {
 	})
 
 	t.Run("pvtdata_and_hashes_writesets", func(t *testing.T) {
+		t.Parallel()
 		rwsetBuilder := NewRWSetBuilder()
 		rwsetBuilder.AddToPvtAndHashedWriteSet("ns", "coll", "key1", nil)
 		rwsetBuilder.AddToPvtAndHashedWriteSet("ns", "coll", "key2", []byte{})
@@ -437,6 +443,7 @@ func TestNilOrZeroLengthByteArrayValueConvertedToDelete(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run("hashed_writeset", func(t *testing.T) {
+			t.Parallel()
 			hashedRWSet := &kvrwset.HashedRWSet{}
 			require.NoError(
 				t,
@@ -454,6 +461,7 @@ func TestNilOrZeroLengthByteArrayValueConvertedToDelete(t *testing.T) {
 		})
 
 		t.Run("pvtdata_writeset", func(t *testing.T) {
+			t.Parallel()
 			pvtWSet := &kvrwset.KVRWSet{}
 			require.NoError(
 				t,

--- a/platform/fabric/core/generic/ledger/kvledger/rwsetutil/rwset_proto_util_test.go
+++ b/platform/fabric/core/generic/ledger/kvledger/rwsetutil/rwset_proto_util_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestTxRWSetMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
 	txRwSet := &TxRwSet{}
 
 	rqi1 := &kvrwset.RangeQueryInfo{StartKey: "k0", EndKey: "k9", ItrExhausted: true}
@@ -73,6 +74,7 @@ func TestTxRWSetMarshalUnmarshal(t *testing.T) {
 }
 
 func TestTxRwSetConversion(t *testing.T) {
+	t.Parallel()
 	txRwSet := sampleTxRwSet()
 	protoMsg, err := txRwSet.toProtoMsg()
 	require.NoError(t, err)
@@ -92,6 +94,7 @@ func TestTxRwSetConversion(t *testing.T) {
 }
 
 func TestNsRwSetConversion(t *testing.T) {
+	t.Parallel()
 	nsRwSet := sampleNsRwSet("ns-1")
 	protoMsg, err := nsRwSet.toProtoMsg()
 	require.NoError(t, err)
@@ -108,6 +111,7 @@ func TestNsRwSetConversion(t *testing.T) {
 }
 
 func TestNsRWSetConversionNoCollHashedRWs(t *testing.T) {
+	t.Parallel()
 	nsRwSet := sampleNsRwSetWithNoCollHashedRWs("ns-1")
 	protoMsg, err := nsRwSet.toProtoMsg()
 	require.NoError(t, err)
@@ -115,6 +119,7 @@ func TestNsRWSetConversionNoCollHashedRWs(t *testing.T) {
 }
 
 func TestCollHashedRwSetConversion(t *testing.T) {
+	t.Parallel()
 	collHashedRwSet := sampleCollHashedRwSet("coll-1")
 	protoMsg, err := collHashedRwSet.toProtoMsg()
 	require.NoError(t, err)
@@ -126,6 +131,7 @@ func TestCollHashedRwSetConversion(t *testing.T) {
 }
 
 func TestNumCollections(t *testing.T) {
+	t.Parallel()
 	var txRwSet *TxRwSet
 	require.Equal(t, 0, txRwSet.NumCollections())         // nil TxRwSet
 	require.Equal(t, 0, (&TxRwSet{}).NumCollections())    // empty TxRwSet
@@ -192,6 +198,7 @@ func sampleCollHashedRwSet(collectionName string) *CollHashedRwSet {
 // /////////////////////////////////////////////////////////////////////////////
 
 func TestTxPvtRwSetConversion(t *testing.T) {
+	t.Parallel()
 	txPvtRwSet := sampleTxPvtRwSet()
 	protoMsg, err := txPvtRwSet.ToProtoMsg()
 	require.NoError(t, err)
@@ -233,6 +240,7 @@ func sampleCollPvtRwSet(collectionName string) *CollPvtRwSet {
 }
 
 func TestVersionConversion(t *testing.T) {
+	t.Parallel()
 	protoVer := &kvrwset.Version{BlockNum: 5, TxNum: 2}
 	internalVer := version.NewHeight(5, 2)
 	// convert proto to internal
@@ -245,7 +253,9 @@ func TestVersionConversion(t *testing.T) {
 }
 
 func TestIsDelete(t *testing.T) {
+	t.Parallel()
 	t.Run("kvWrite", func(t *testing.T) {
+		t.Parallel()
 		kvWritesToBeInterpretedAsDelete := []*kvrwset.KVWrite{
 			{Value: nil, IsDelete: true},
 			{Value: nil, IsDelete: false},
@@ -259,6 +269,7 @@ func TestIsDelete(t *testing.T) {
 	})
 
 	t.Run("kvhashwrite", func(t *testing.T) {
+		t.Parallel()
 		kvHashesWritesToBeInterpretedAsDelete := []*kvrwset.KVWriteHash{
 			{ValueHash: nil, IsDelete: true},
 			{ValueHash: nil, IsDelete: false},

--- a/platform/fabric/core/generic/ledger/version/util_test.go
+++ b/platform/fabric/core/generic/ledger/version/util_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestBasicEncodingDecoding(t *testing.T) {
+	t.Parallel()
 	for i := 0; i < 10000; i++ {
 		value := encodeOrderPreservingVarUint64(uint64(i))
 		nextValue := encodeOrderPreservingVarUint64(uint64(i + 1))
@@ -36,6 +37,7 @@ func TestBasicEncodingDecoding(t *testing.T) {
 }
 
 func TestDecodingAppendedValues(t *testing.T) {
+	t.Parallel()
 	appendedValues := []byte{}
 	for i := 0; i < 1000; i++ {
 		appendedValues = append(appendedValues, encodeOrderPreservingVarUint64(uint64(i))...)
@@ -53,6 +55,7 @@ func TestDecodingAppendedValues(t *testing.T) {
 }
 
 func TestDecodingBadInputBytes(t *testing.T) {
+	t.Parallel()
 	// error case when num consumed bytes > 1
 	sizeBytes := protowire.AppendVarint(nil, uint64(1000))
 	_, _, err := decodeOrderPreservingVarUint64(sizeBytes)

--- a/platform/fabric/core/generic/ledger/version/version_test.go
+++ b/platform/fabric/core/generic/ledger/version/version_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestVersionSerialization(t *testing.T) {
+	t.Parallel()
 	h1 := NewHeight(10, 100)
 	b := h1.ToBytes()
 	h2, n, err := NewHeightFromBytes(b)
@@ -37,6 +38,7 @@ func TestVersionSerialization(t *testing.T) {
 }
 
 func TestVersionComparison(t *testing.T) {
+	t.Parallel()
 	require.Equal(t, 1, NewHeight(10, 100).Compare(NewHeight(9, 1000)))
 	require.Equal(t, 1, NewHeight(10, 100).Compare(NewHeight(10, 90)))
 	require.Equal(t, -1, NewHeight(10, 100).Compare(NewHeight(11, 1)))
@@ -48,6 +50,7 @@ func TestVersionComparison(t *testing.T) {
 }
 
 func TestVersionExtraBytes(t *testing.T) {
+	t.Parallel()
 	extraBytes := []byte("junk")
 	h1 := NewHeight(10, 100)
 	b := h1.ToBytes()
@@ -60,6 +63,7 @@ func TestVersionExtraBytes(t *testing.T) {
 }
 
 func TestVersionString(t *testing.T) {
+	t.Parallel()
 	h1 := NewHeight(10, 100)
 	require.Equal(t, fmt.Sprintf("{BlockNum: %d, TxNum: %d}", 10, 100), h1.String())
 

--- a/platform/fabric/core/generic/membership/channelconfig/acls_test.go
+++ b/platform/fabric/core/generic/membership/channelconfig/acls_test.go
@@ -27,20 +27,24 @@ var sampleAPIsProvider = map[string]*pb.APIResource{
 }
 
 func TestGreenAPIsPath(t *testing.T) {
+	t.Parallel()
 	ag := newAPIsProvider(sampleAPIsProvider)
 	require.NotNil(t, ag)
 
 	t.Run("PresentAPIs", func(t *testing.T) {
+		t.Parallel()
 		require.Equal(t, "/Channel/Application/"+sampleAPI1PolicyRef, ag.PolicyRefForAPI(sampleAPI1Name))
 		require.Equal(t, sampleAPI2PolicyRef, ag.PolicyRefForAPI(sampleAPI2Name))
 	})
 
 	t.Run("MissingAPIs", func(t *testing.T) {
+		t.Parallel()
 		require.Empty(t, ag.PolicyRefForAPI("missing"))
 	})
 }
 
 func TestNilACLs(t *testing.T) {
+	t.Parallel()
 	ccg := newAPIsProvider(nil)
 
 	require.NotNil(t, ccg)
@@ -49,6 +53,7 @@ func TestNilACLs(t *testing.T) {
 }
 
 func TestEmptyACLs(t *testing.T) {
+	t.Parallel()
 	ccg := newAPIsProvider(map[string]*pb.APIResource{})
 
 	require.NotNil(t, ccg)
@@ -57,6 +62,7 @@ func TestEmptyACLs(t *testing.T) {
 }
 
 func TestEmptyPolicyRef(t *testing.T) {
+	t.Parallel()
 	ars := map[string]*pb.APIResource{
 		"unsetAPI": {PolicyRef: ""},
 	}

--- a/platform/fabric/core/generic/membership/channelconfig/application_test.go
+++ b/platform/fabric/core/generic/membership/channelconfig/application_test.go
@@ -17,10 +17,12 @@ import (
 )
 
 func TestApplicationInterface(t *testing.T) {
+	t.Parallel()
 	_ = Application((*ApplicationConfig)(nil))
 }
 
 func TestACL(t *testing.T) {
+	t.Parallel()
 	g := NewGomegaWithT(t)
 	cgt := &cb.ConfigGroup{
 		Values: map[string]*cb.ConfigValue{
@@ -40,6 +42,7 @@ func TestACL(t *testing.T) {
 	}
 
 	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
 		cg := proto.Clone(cgt).(*cb.ConfigGroup)
 		_, err := NewApplicationConfig(proto.Clone(cg).(*cb.ConfigGroup), nil)
 		g.Expect(err).NotTo(HaveOccurred())

--- a/platform/fabric/core/generic/membership/channelconfig/applicationorg_test.go
+++ b/platform/fabric/core/generic/membership/channelconfig/applicationorg_test.go
@@ -11,5 +11,6 @@ import (
 )
 
 func TestApplicationOrgInterface(t *testing.T) {
+	t.Parallel()
 	_ = ApplicationOrg(&ApplicationOrgConfig{})
 }

--- a/platform/fabric/core/generic/membership/channelconfig/capabilities/application_test.go
+++ b/platform/fabric/core/generic/membership/channelconfig/capabilities/application_test.go
@@ -14,11 +14,13 @@ import (
 )
 
 func TestApplicationV10(t *testing.T) {
+	t.Parallel()
 	ap := NewApplicationProvider(map[string]*cb.Capability{})
 	require.NoError(t, ap.Supported())
 }
 
 func TestApplicationV11(t *testing.T) {
+	t.Parallel()
 	ap := NewApplicationProvider(map[string]*cb.Capability{
 		ApplicationV1_1: {},
 	})
@@ -28,6 +30,7 @@ func TestApplicationV11(t *testing.T) {
 }
 
 func TestApplicationV12(t *testing.T) {
+	t.Parallel()
 	ap := NewApplicationProvider(map[string]*cb.Capability{
 		ApplicationV1_2: {},
 	})
@@ -41,6 +44,7 @@ func TestApplicationV12(t *testing.T) {
 }
 
 func TestApplicationV13(t *testing.T) {
+	t.Parallel()
 	ap := NewApplicationProvider(map[string]*cb.Capability{
 		ApplicationV1_3: {},
 	})
@@ -56,6 +60,7 @@ func TestApplicationV13(t *testing.T) {
 }
 
 func TestApplicationV142(t *testing.T) {
+	t.Parallel()
 	ap := NewApplicationProvider(map[string]*cb.Capability{
 		ApplicationV1_4_2: {},
 	})
@@ -72,6 +77,7 @@ func TestApplicationV142(t *testing.T) {
 }
 
 func TestApplicationV20(t *testing.T) {
+	t.Parallel()
 	ap := NewApplicationProvider(map[string]*cb.Capability{
 		ApplicationV2_0: {},
 	})
@@ -90,6 +96,7 @@ func TestApplicationV20(t *testing.T) {
 }
 
 func TestApplicationV25(t *testing.T) {
+	t.Parallel()
 	ap := NewApplicationProvider(map[string]*cb.Capability{
 		ApplicationV2_5: {},
 	})
@@ -109,6 +116,7 @@ func TestApplicationV25(t *testing.T) {
 }
 
 func TestApplicationPvtDataExperimental(t *testing.T) {
+	t.Parallel()
 	ap := NewApplicationProvider(map[string]*cb.Capability{
 		ApplicationPvtDataExperimental: {},
 	})
@@ -116,6 +124,7 @@ func TestApplicationPvtDataExperimental(t *testing.T) {
 }
 
 func TestHasCapability(t *testing.T) {
+	t.Parallel()
 	ap := NewApplicationProvider(map[string]*cb.Capability{})
 	require.True(t, ap.HasCapability(ApplicationV1_1))
 	require.True(t, ap.HasCapability(ApplicationV1_2))

--- a/platform/fabric/core/generic/membership/channelconfig/capabilities/capabilities_test.go
+++ b/platform/fabric/core/generic/membership/channelconfig/capabilities/capabilities_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestSatisfied(t *testing.T) {
+	t.Parallel()
 	var capsMap map[string]*cb.Capability
 	for _, provider := range []*registry{
 		NewChannelProvider(capsMap).registry,
@@ -25,6 +26,7 @@ func TestSatisfied(t *testing.T) {
 }
 
 func TestNotSatisfied(t *testing.T) {
+	t.Parallel()
 	capsMap := map[string]*cb.Capability{
 		"FakeCapability": {},
 	}

--- a/platform/fabric/core/generic/membership/channelconfig/capabilities/channel_test.go
+++ b/platform/fabric/core/generic/membership/channelconfig/capabilities/channel_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestChannelV10(t *testing.T) {
+	t.Parallel()
 	cp := NewChannelProvider(map[string]*cb.Capability{})
 	require.NoError(t, cp.Supported())
 	require.EqualValues(t, msp.MSPv1_0, cp.MSPVersion())
@@ -24,6 +25,7 @@ func TestChannelV10(t *testing.T) {
 }
 
 func TestChannelV11(t *testing.T) {
+	t.Parallel()
 	cp := NewChannelProvider(map[string]*cb.Capability{
 		ChannelV1_1: {},
 	})
@@ -35,6 +37,7 @@ func TestChannelV11(t *testing.T) {
 }
 
 func TestChannelV13(t *testing.T) {
+	t.Parallel()
 	cp := NewChannelProvider(map[string]*cb.Capability{
 		ChannelV1_1: {},
 		ChannelV1_3: {},
@@ -56,6 +59,7 @@ func TestChannelV13(t *testing.T) {
 }
 
 func TestChannelV142(t *testing.T) {
+	t.Parallel()
 	cp := NewChannelProvider(map[string]*cb.Capability{
 		ChannelV1_3:   {},
 		ChannelV1_4_2: {},
@@ -77,6 +81,7 @@ func TestChannelV142(t *testing.T) {
 }
 
 func TestChannelV143(t *testing.T) {
+	t.Parallel()
 	cp := NewChannelProvider(map[string]*cb.Capability{
 		ChannelV1_3:   {},
 		ChannelV1_4_2: {},
@@ -99,6 +104,7 @@ func TestChannelV143(t *testing.T) {
 }
 
 func TestChannelV20(t *testing.T) {
+	t.Parallel()
 	cp := NewChannelProvider(map[string]*cb.Capability{
 		ChannelV2_0: {},
 	})
@@ -110,6 +116,7 @@ func TestChannelV20(t *testing.T) {
 }
 
 func TestChannelV30(t *testing.T) {
+	t.Parallel()
 	cp := NewChannelProvider(map[string]*cb.Capability{
 		ChannelV3_0: {},
 	})
@@ -121,6 +128,7 @@ func TestChannelV30(t *testing.T) {
 }
 
 func TestChannelNotSupported(t *testing.T) {
+	t.Parallel()
 	cp := NewChannelProvider(map[string]*cb.Capability{
 		ChannelV1_1:           {},
 		ChannelV1_3:           {},

--- a/platform/fabric/core/generic/membership/channelconfig/capabilities/orderer_test.go
+++ b/platform/fabric/core/generic/membership/channelconfig/capabilities/orderer_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestOrdererV10(t *testing.T) {
+	t.Parallel()
 	op := NewOrdererProvider(map[string]*cb.Capability{})
 	require.NoError(t, op.Supported())
 	require.Equal(t, ordererTypeName, op.Type())
@@ -25,6 +26,7 @@ func TestOrdererV10(t *testing.T) {
 }
 
 func TestOrdererV11(t *testing.T) {
+	t.Parallel()
 	op := NewOrdererProvider(map[string]*cb.Capability{
 		OrdererV1_1: {},
 	})
@@ -37,6 +39,7 @@ func TestOrdererV11(t *testing.T) {
 }
 
 func TestOrdererV142(t *testing.T) {
+	t.Parallel()
 	op := NewOrdererProvider(map[string]*cb.Capability{
 		OrdererV1_4_2: {},
 	})
@@ -49,6 +52,7 @@ func TestOrdererV142(t *testing.T) {
 }
 
 func TestOrdererV20(t *testing.T) {
+	t.Parallel()
 	op := NewOrdererProvider(map[string]*cb.Capability{
 		OrdererV2_0: {},
 	})
@@ -61,6 +65,7 @@ func TestOrdererV20(t *testing.T) {
 }
 
 func TestNotSupported(t *testing.T) {
+	t.Parallel()
 	op := NewOrdererProvider(map[string]*cb.Capability{
 		OrdererV1_1: {}, OrdererV2_0: {}, "Bogus_Not_Supported": {},
 	})

--- a/platform/fabric/core/generic/membership/channelconfig/channel_test.go
+++ b/platform/fabric/core/generic/membership/channelconfig/channel_test.go
@@ -16,10 +16,12 @@ import (
 )
 
 func TestInterface(t *testing.T) {
+	t.Parallel()
 	_ = Channel(&ChannelConfig{})
 }
 
 func TestChannelConfig(t *testing.T) {
+	t.Parallel()
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	require.NoError(t, err)
 
@@ -32,6 +34,7 @@ func TestChannelConfig(t *testing.T) {
 }
 
 func TestBlockDataHashingStructure(t *testing.T) {
+	t.Parallel()
 	cc := &ChannelConfig{protos: &ChannelProtos{BlockDataHashingStructure: &cb.BlockDataHashingStructure{}}}
 	require.Error(t, cc.validateBlockDataHashingStructure(), "Must supply block data hashing structure")
 
@@ -46,6 +49,7 @@ func TestBlockDataHashingStructure(t *testing.T) {
 }
 
 func TestOrdererAddresses(t *testing.T) {
+	t.Parallel()
 	cc := &ChannelConfig{protos: &ChannelProtos{OrdererAddresses: &cb.OrdererAddresses{}}}
 	require.Error(t, cc.validateOrdererAddresses(), "Must supply orderer addresses")
 
@@ -56,6 +60,7 @@ func TestOrdererAddresses(t *testing.T) {
 }
 
 func TestConsortiumName(t *testing.T) {
+	t.Parallel()
 	cc := &ChannelConfig{protos: &ChannelProtos{Consortium: &cb.Consortium{Name: "TestConsortium"}}}
 	require.Equal(t, "TestConsortium", cc.ConsortiumName(), "Unexpected consortium name returned")
 }

--- a/platform/fabric/core/generic/membership/channelconfig/consortium_test.go
+++ b/platform/fabric/core/generic/membership/channelconfig/consortium_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestConsortiumConfig(t *testing.T) {
+	t.Parallel()
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	require.NoError(t, err)
 	cc, err := NewConsortiumConfig(&cb.ConfigGroup{}, NewMSPConfigHandler(msp.MSPv1_0, cryptoProvider))

--- a/platform/fabric/core/generic/membership/channelconfig/consortiums_test.go
+++ b/platform/fabric/core/generic/membership/channelconfig/consortiums_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestConsortiums(t *testing.T) {
+	t.Parallel()
 	_, err := NewConsortiumsConfig(&cb.ConfigGroup{}, nil)
 	require.NoError(t, err)
 }

--- a/platform/fabric/core/generic/membership/channelconfig/msp_test.go
+++ b/platform/fabric/core/generic/membership/channelconfig/msp_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestMSPConfigManager(t *testing.T) {
+	t.Parallel()
 	mspDir := getDevMspDir()
 	conf, err := msp.GetLocalMspConfig(mspDir, nil, "SampleOrg")
 	require.NoError(t, err)
@@ -59,17 +60,20 @@ func getDevMspDir() string {
 }
 
 func TestMSPConfigFailure(t *testing.T) {
+	t.Parallel()
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	require.NoError(t, err)
 	mspCH := NewMSPConfigHandler(msp.MSPv1_0, cryptoProvider)
 
 	// begin/propose/commit
 	t.Run("Bad proto", func(t *testing.T) {
+		t.Parallel()
 		_, err := mspCH.ProposeMSP(&mspprotos.MSPConfig{Config: []byte("BARF!")})
 		require.Error(t, err)
 	})
 
 	t.Run("Bad MSP Type", func(t *testing.T) {
+		t.Parallel()
 		_, err := mspCH.ProposeMSP(&mspprotos.MSPConfig{Type: int32(10)})
 		require.Error(t, err)
 	})

--- a/platform/fabric/core/generic/membership/channelconfig/orderer_test.go
+++ b/platform/fabric/core/generic/membership/channelconfig/orderer_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestBatchSize(t *testing.T) {
+	t.Parallel()
 	validMaxMessageCount := uint32(10)
 	validAbsoluteMaxBytes := uint32(1000)
 	validPreferredMaxBytes := uint32(500)
@@ -32,6 +33,7 @@ func TestBatchSize(t *testing.T) {
 }
 
 func TestBatchTimeout(t *testing.T) {
+	t.Parallel()
 	oc := &OrdererConfig{protos: &OrdererProtos{BatchTimeout: &ab.BatchTimeout{Timeout: "1s"}}}
 	require.NoError(t, oc.validateBatchTimeout(), "Valid batch timeout")
 

--- a/platform/fabric/core/generic/membership/channelconfig/organization_test.go
+++ b/platform/fabric/core/generic/membership/channelconfig/organization_test.go
@@ -11,5 +11,6 @@ import (
 )
 
 func TestOrganization(t *testing.T) {
+	t.Parallel()
 	_ = Org(&OrganizationConfig{})
 }

--- a/platform/fabric/core/generic/membership/channelconfig/standardvalues_test.go
+++ b/platform/fabric/core/generic/membership/channelconfig/standardvalues_test.go
@@ -37,6 +37,7 @@ type unexported struct {
 }
 
 func TestSingle(t *testing.T) {
+	t.Parallel()
 	fooVal := &foo{}
 	sv, err := NewStandardValues(fooVal)
 	require.NoError(t, err, "Valid non-nested structure provided")
@@ -53,6 +54,7 @@ func TestSingle(t *testing.T) {
 }
 
 func TestPair(t *testing.T) {
+	t.Parallel()
 	fooVal := &foo{}
 	barVal := &bar{}
 	sv, err := NewStandardValues(fooVal, barVal)
@@ -75,26 +77,31 @@ func TestPair(t *testing.T) {
 }
 
 func TestPairConflict(t *testing.T) {
+	t.Parallel()
 	_, err := NewStandardValues(&foo{}, &conflict{})
 	require.Error(t, err, "Conflicting keys provided")
 }
 
 func TestNonProtosStruct(t *testing.T) {
+	t.Parallel()
 	_, err := NewStandardValues(&nonProtos{})
 	require.Error(t, err, "Structure with non-struct non-proto fields provided")
 }
 
 func TestUnexportedField(t *testing.T) {
+	t.Parallel()
 	_, err := NewStandardValues(&unexported{msg: nil})
 	require.Error(t, err, "Structure with unexported fields")
 }
 
 func TestNonPointerParam(t *testing.T) {
+	t.Parallel()
 	_, err := NewStandardValues(foo{})
 	require.Error(t, err, "Parameter must be pointer")
 }
 
 func TestPointerToNonStruct(t *testing.T) {
+	t.Parallel()
 	nonStruct := "foo"
 	_, err := NewStandardValues(&nonStruct)
 	require.Error(t, err, "Pointer must be to a struct")

--- a/platform/fabric/core/generic/membership/channelconfig/util_test.go
+++ b/platform/fabric/core/generic/membership/channelconfig/util_test.go
@@ -39,6 +39,7 @@ func basicTest(t *testing.T, sv *StandardConfigValue) {
 }
 
 func TestUtilsBasic(t *testing.T) {
+	t.Parallel()
 	basicTest(t, ConsortiumValue("foo"))
 	basicTest(t, HashingAlgorithmValue())
 	basicTest(t, BlockDataHashingStructureValue())
@@ -285,6 +286,7 @@ func createCfgBlockWithUnsupportedCapabilities(t *testing.T) *cb.Block {
 }
 
 func TestValidateCapabilities(t *testing.T) {
+	t.Parallel()
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	require.NoError(t, err)
 
@@ -300,6 +302,7 @@ func TestValidateCapabilities(t *testing.T) {
 }
 
 func TestExtractMSPIDsForApplicationOrgs(t *testing.T) {
+	t.Parallel()
 	// load test_configblock.json that contains the application group
 	// and other properties needed to build channel config and extract MSPIDs
 	blockData, err := os.ReadFile("testdata/test_configblock.json")
@@ -316,6 +319,7 @@ func TestExtractMSPIDsForApplicationOrgs(t *testing.T) {
 }
 
 func TestMarshalEtcdRaftMetadata(t *testing.T) {
+	t.Parallel()
 	md := &etcdraft.ConfigMetadata{
 		Consenters: []*etcdraft.Consenter{
 			{

--- a/platform/fabric/core/generic/msp/idemix/cache_test.go
+++ b/platform/fabric/core/generic/msp/idemix/cache_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIdentityCache(t *testing.T) {
+func TestIdentityCache(t *testing.T) { //nolint:paralleltest
 	c := NewIdentityCache(func(opts *api2.IdentityOptions) (view.Identity, []byte, error) {
 		return []byte("hello world"), []byte("audit"), nil
 	}, 100, nil)

--- a/platform/fabric/core/generic/msp/idemix/provider_test.go
+++ b/platform/fabric/core/generic/msp/idemix/provider_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProvider(t *testing.T) {
+func TestProvider(t *testing.T) { //nolint:paralleltest
 	kvss, err := kvs.New(newKVS(), "", kvs.DefaultCacheSize)
 	require.NoError(t, err)
 
@@ -57,7 +57,7 @@ func newKVS() driver.KeyValueStore {
 	return utils.MustGet(mem.NewDriver().NewKVS(""))
 }
 
-func TestIdentityWithEidRhNymPolicy(t *testing.T) {
+func TestIdentityWithEidRhNymPolicy(t *testing.T) { //nolint:paralleltest
 	kvss, err := kvs.New(newKVS(), "", kvs.DefaultCacheSize)
 	require.NoError(t, err)
 
@@ -119,7 +119,7 @@ func TestIdentityWithEidRhNymPolicy(t *testing.T) {
 	require.NoError(t, verifier.Verify([]byte("hello world!!!"), sigma))
 }
 
-func TestIdentityStandard(t *testing.T) {
+func TestIdentityStandard(t *testing.T) { //nolint:paralleltest
 	kvss, err := kvs.New(newKVS(), "", kvs.DefaultCacheSize)
 	require.NoError(t, err)
 
@@ -183,7 +183,7 @@ func TestIdentityStandard(t *testing.T) {
 	require.NoError(t, verifier.Verify([]byte("hello world!!!"), sigma))
 }
 
-func TestAuditWithEidRhNymPolicy(t *testing.T) {
+func TestAuditWithEidRhNymPolicy(t *testing.T) { //nolint:paralleltest
 	kvss, err := kvs.New(newKVS(), "", kvs.DefaultCacheSize)
 	require.NoError(t, err)
 	sigService := sig.NewService(sig.NewMultiplexDeserializer(), newAuditInfo(), newSignerInfo())
@@ -221,7 +221,7 @@ func TestAuditWithEidRhNymPolicy(t *testing.T) {
 	require.Error(t, auditInfo.Match(id))
 }
 
-func TestProvider_DeserializeSigner(t *testing.T) {
+func TestProvider_DeserializeSigner(t *testing.T) { //nolint:paralleltest
 	kvss, err := kvs.New(newKVS(), "", kvs.DefaultCacheSize)
 	require.NoError(t, err)
 
@@ -274,7 +274,7 @@ func TestProvider_DeserializeSigner(t *testing.T) {
 	require.NoError(t, verifier.Verify(msg, sigma))
 }
 
-func TestIdentityFromFabricCA(t *testing.T) {
+func TestIdentityFromFabricCA(t *testing.T) { //nolint:paralleltest
 	kvss, err := kvs.New(newKVS(), "", kvs.DefaultCacheSize)
 	require.NoError(t, err)
 	sigService := sig.NewService(sig.NewMultiplexDeserializer(), newAuditInfo(), newSignerInfo())
@@ -337,7 +337,7 @@ func TestIdentityFromFabricCA(t *testing.T) {
 	require.NoError(t, verifier.Verify([]byte("hello world!!!"), sigma))
 }
 
-func TestIdentityFromFabricCAWithEidRhNymPolicy(t *testing.T) {
+func TestIdentityFromFabricCAWithEidRhNymPolicy(t *testing.T) { //nolint:paralleltest
 	kvss, err := kvs.New(newKVS(), "", kvs.DefaultCacheSize)
 	require.NoError(t, err)
 	sigService := sig.NewService(sig.NewMultiplexDeserializer(), newAuditInfo(), newSignerInfo())

--- a/platform/fabric/core/generic/msp/service_test.go
+++ b/platform/fabric/core/generic/msp/service_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRegisterIdemixLocalMSP(t *testing.T) {
+func TestRegisterIdemixLocalMSP(t *testing.T) { //nolint:paralleltest
 	cp := &mock.ConfigProvider{}
 	cp.IsSetReturns(false)
 
@@ -46,7 +46,7 @@ func TestRegisterIdemixLocalMSP(t *testing.T) {
 	require.Nil(t, info)
 }
 
-func TestIdemixTypeFolder(t *testing.T) {
+func TestIdemixTypeFolder(t *testing.T) { //nolint:paralleltest
 	cp, err := config.NewProvider("./testdata/idemixtypefolder")
 	require.NoError(t, err)
 	kvss, err := kvs.New(utils.MustGet(mem.NewDriver().NewKVS("")), "", kvs.DefaultCacheSize)
@@ -64,7 +64,7 @@ func TestIdemixTypeFolder(t *testing.T) {
 	}
 }
 
-func TestRegisterX509LocalMSP(t *testing.T) {
+func TestRegisterX509LocalMSP(t *testing.T) { //nolint:paralleltest
 	cp := &mock.ConfigProvider{}
 	cp.IsSetReturns(false)
 
@@ -88,7 +88,7 @@ func TestRegisterX509LocalMSP(t *testing.T) {
 	require.NotNil(t, info)
 }
 
-func TestX509TypeFolder(t *testing.T) {
+func TestX509TypeFolder(t *testing.T) { //nolint:paralleltest
 	cp, err := config.NewProvider("./testdata/x509typefolder")
 	require.NoError(t, err)
 
@@ -110,6 +110,7 @@ func TestX509TypeFolder(t *testing.T) {
 }
 
 func TestRefresh(t *testing.T) {
+	t.Parallel()
 	cp, err := config.NewProvider("./testdata/x509typefolder")
 	require.NoError(t, err)
 

--- a/platform/fabric/core/generic/msp/x509/x509_test.go
+++ b/platform/fabric/core/generic/msp/x509/x509_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestDeserializer(t *testing.T) {
+	t.Parallel()
 	p, err := NewProvider("./testdata/msp", "", "apple", nil)
 	require.NoError(t, err)
 	id, auditInfo, err := p.Identity(nil)

--- a/platform/fabric/core/generic/vault/vault_test.go
+++ b/platform/fabric/core/generic/vault/vault_test.go
@@ -23,7 +23,13 @@ import (
 
 //go:generate counterfeiter -o mocks/config.go -fake-name Config . config
 
-type artifactsProvider struct{}
+type artifactsProvider struct {
+	removeNils func([]driver2.VaultRead) []driver2.VaultRead
+}
+
+func (p *artifactsProvider) RemoveNils(items []driver2.VaultRead) []driver2.VaultRead {
+	return p.removeNils(items)
+}
 
 func (p *artifactsProvider) NewCachedVault(ddb dbdriver.VaultStore) (*vault.Vault[fdriver.ValidationCode], error) {
 	return NewVault(vault2.NewCachedVault(ddb, 100), &disabled.Provider{}, &noop.TracerProvider{}), nil
@@ -38,8 +44,10 @@ func (p *artifactsProvider) NewMarshaller() vault.Marshaller {
 }
 
 func TestMemory(t *testing.T) {
-	vault.RemoveNils = func(items []driver2.VaultRead) []driver2.VaultRead { return items }
-	ap := &artifactsProvider{}
+	t.Parallel()
+	ap := &artifactsProvider{
+		removeNils: func(items []driver2.VaultRead) []driver2.VaultRead { return items },
+	}
 	for _, c := range vault.SingleDBCases {
 		ddb, err := vault2.OpenMemoryVault(c.Name)
 		require.NoError(t, err)
@@ -55,6 +63,7 @@ func TestMemory(t *testing.T) {
 		db2, err := vault2.OpenMemoryVault(c.Name)
 		require.NoError(t, err)
 		t.Run(c.Name, func(xt *testing.T) {
+			xt.Parallel()
 			defer utils.IgnoreErrorFunc(db1.Close)
 			defer utils.IgnoreErrorFunc(db2.Close)
 			c.Fn(xt, db1, db2, ap)
@@ -63,10 +72,12 @@ func TestMemory(t *testing.T) {
 }
 
 func TestSqlite(t *testing.T) {
-	vault.RemoveNils = func(items []driver2.VaultRead) []driver2.VaultRead {
-		return slices.DeleteFunc(items, func(e driver2.VaultRead) bool { return e.Raw == nil })
+	t.Parallel()
+	ap := &artifactsProvider{
+		removeNils: func(items []driver2.VaultRead) []driver2.VaultRead {
+			return slices.DeleteFunc(items, func(e driver2.VaultRead) bool { return e.Raw == nil })
+		},
 	}
-	ap := &artifactsProvider{}
 	for _, c := range vault.SingleDBCases {
 		ddb, err := vault2.OpenSqliteVault("node1", t.TempDir())
 		require.NoError(t, err)
@@ -82,6 +93,7 @@ func TestSqlite(t *testing.T) {
 		db2, err := vault2.OpenSqliteVault("node2", t.TempDir())
 		require.NoError(t, err)
 		t.Run(c.Name, func(xt *testing.T) {
+			xt.Parallel()
 			defer utils.IgnoreErrorFunc(db1.Close)
 			defer utils.IgnoreErrorFunc(db2.Close)
 			c.Fn(xt, db1, db2, ap)
@@ -90,10 +102,12 @@ func TestSqlite(t *testing.T) {
 }
 
 func TestPostgres(t *testing.T) {
-	vault.RemoveNils = func(items []driver2.VaultRead) []driver2.VaultRead {
-		return slices.DeleteFunc(items, func(e driver2.VaultRead) bool { return e.Raw == nil })
+	t.Parallel()
+	ap := &artifactsProvider{
+		removeNils: func(items []driver2.VaultRead) []driver2.VaultRead {
+			return slices.DeleteFunc(items, func(e driver2.VaultRead) bool { return e.Raw == nil })
+		},
 	}
-	ap := &artifactsProvider{}
 	for _, c := range vault.SingleDBCases {
 		ddb, terminate, err := vault2.OpenPostgresVault("fabric-sdk-node1")
 		require.NoError(t, err)
@@ -110,6 +124,7 @@ func TestPostgres(t *testing.T) {
 		db2, terminate2, err := vault2.OpenPostgresVault("fabric-sdk-node2")
 		require.NoError(t, err)
 		t.Run(c.Name, func(xt *testing.T) {
+			xt.Parallel()
 			defer utils.IgnoreErrorFunc(db1.Close)
 			defer utils.IgnoreErrorFunc(db2.Close)
 			defer terminate1()

--- a/platform/fabric/core/msp/cache/cache_test.go
+++ b/platform/fabric/core/msp/cache/cache_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestNewCacheMsp(t *testing.T) {
+	t.Parallel()
 	i, err := New(nil)
 	require.Error(t, err)
 	require.Nil(t, i)
@@ -31,6 +32,7 @@ func TestNewCacheMsp(t *testing.T) {
 }
 
 func TestSetup(t *testing.T) {
+	t.Parallel()
 	mockMSP := &mocks.MockMSP{}
 	i, err := New(mockMSP)
 	require.NoError(t, err)
@@ -42,6 +44,7 @@ func TestSetup(t *testing.T) {
 }
 
 func TestGetType(t *testing.T) {
+	t.Parallel()
 	mockMSP := &mocks.MockMSP{}
 	i, err := New(mockMSP)
 	require.NoError(t, err)
@@ -52,6 +55,7 @@ func TestGetType(t *testing.T) {
 }
 
 func TestGetIdentifier(t *testing.T) {
+	t.Parallel()
 	mockMSP := &mocks.MockMSP{}
 	i, err := New(mockMSP)
 	require.NoError(t, err)
@@ -64,6 +68,7 @@ func TestGetIdentifier(t *testing.T) {
 }
 
 func TestGetDefaultSigningIdentity(t *testing.T) {
+	t.Parallel()
 	mockMSP := &mocks.MockMSP{}
 	i, err := New(mockMSP)
 	require.NoError(t, err)
@@ -77,6 +82,7 @@ func TestGetDefaultSigningIdentity(t *testing.T) {
 }
 
 func TestGetTLSRootCerts(t *testing.T) {
+	t.Parallel()
 	mockMSP := &mocks.MockMSP{}
 	i, err := New(mockMSP)
 	require.NoError(t, err)
@@ -88,6 +94,7 @@ func TestGetTLSRootCerts(t *testing.T) {
 }
 
 func TestGetTLSIntermediateCerts(t *testing.T) {
+	t.Parallel()
 	mockMSP := &mocks.MockMSP{}
 	i, err := New(mockMSP)
 	require.NoError(t, err)
@@ -99,6 +106,7 @@ func TestGetTLSIntermediateCerts(t *testing.T) {
 }
 
 func TestDeserializeIdentity(t *testing.T) {
+	t.Parallel()
 	mockMSP := &mocks.MockMSP{}
 	wrappedMSP, err := New(mockMSP)
 	require.NoError(t, err)
@@ -161,6 +169,7 @@ func TestDeserializeIdentity(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
+	t.Parallel()
 	mockMSP := &mocks.MockMSP{}
 	i, err := New(mockMSP)
 	require.NoError(t, err)
@@ -200,6 +209,7 @@ func TestValidate(t *testing.T) {
 }
 
 func TestSatisfiesValidateIndirectCall(t *testing.T) {
+	t.Parallel()
 	mockMSP := &mocks.MockMSP{}
 
 	mockIdentity := &mocks.MockIdentity{ID: "Alice"}
@@ -229,6 +239,7 @@ func TestSatisfiesValidateIndirectCall(t *testing.T) {
 }
 
 func TestSatisfiesPrincipalIndirectCall(t *testing.T) {
+	t.Parallel()
 	mockMSP := &mocks.MockMSP{}
 	mockMSPPrincipal := &msp2.MSPPrincipal{PrincipalClassification: msp2.MSPPrincipal_IDENTITY, Principal: []byte{1, 2, 3}}
 
@@ -260,6 +271,7 @@ func TestSatisfiesPrincipalIndirectCall(t *testing.T) {
 }
 
 func TestSatisfiesPrincipal(t *testing.T) {
+	t.Parallel()
 	mockMSP := &mocks.MockMSP{}
 	i, err := New(mockMSP)
 	require.NoError(t, err)

--- a/platform/fabric/core/msp/cert_test.go
+++ b/platform/fabric/core/msp/cert_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSanitizeCertWithRSA(t *testing.T) {
+func TestSanitizeCertWithRSA(t *testing.T) { //nolint:paralleltest
 	cert := &x509.Certificate{}
 	cert.SignatureAlgorithm = x509.MD2WithRSA
 	result := isECDSASignedCert(cert)
@@ -44,7 +44,7 @@ func TestSanitizeCertWithRSA(t *testing.T) {
 	require.True(t, result)
 }
 
-func TestSanitizeCertInvalidInput(t *testing.T) {
+func TestSanitizeCertInvalidInput(t *testing.T) { //nolint:paralleltest
 	_, err := sanitizeECDSASignedCert(nil, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "certificate must be different from nil")
@@ -67,7 +67,7 @@ func TestSanitizeCertInvalidInput(t *testing.T) {
 	require.Contains(t, err.Error(), "asn1: structure error: tags don't match")
 }
 
-func TestSanitizeCert(t *testing.T) {
+func TestSanitizeCert(t *testing.T) { //nolint:paralleltest
 	var k *ecdsa.PrivateKey
 	var cert *x509.Certificate
 	for {
@@ -96,7 +96,7 @@ func TestSanitizeCert(t *testing.T) {
 	require.True(t, lowS)
 }
 
-func TestCertExpiration(t *testing.T) {
+func TestCertExpiration(t *testing.T) { //nolint:paralleltest
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	require.NoError(t, err)
 	msp := &bccspmsp{bccsp: cryptoProvider}

--- a/platform/fabric/core/msp/configbuilder_test.go
+++ b/platform/fabric/core/msp/configbuilder_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSetupBCCSPKeystoreConfig(t *testing.T) {
+func TestSetupBCCSPKeystoreConfig(t *testing.T) { //nolint:paralleltest
 	keystoreDir := "/tmp"
 
 	// Case 1 : Check with empty FactoryOpts
@@ -80,18 +80,18 @@ func TestSetupBCCSPKeystoreConfig(t *testing.T) {
 	require.Equal(t, rtnConfig.SW.FileKeystore.KeyStorePath, keystoreDir)
 }
 
-func TestGetLocalMspConfig(t *testing.T) {
+func TestGetLocalMspConfig(t *testing.T) { //nolint:paralleltest
 	mspDir := "testdata/sampleconfig"
 	_, err := GetLocalMspConfig(mspDir, nil, "SampleOrg")
 	require.NoError(t, err)
 }
 
-func TestGetLocalMspConfigFails(t *testing.T) {
+func TestGetLocalMspConfigFails(t *testing.T) { //nolint:paralleltest
 	_, err := GetLocalMspConfig("/tmp/", nil, "SampleOrg")
 	require.Error(t, err)
 }
 
-func TestGetPemMaterialFromDirWithFile(t *testing.T) {
+func TestGetPemMaterialFromDirWithFile(t *testing.T) { //nolint:paralleltest
 	tempDir := t.TempDir()
 	tempFile, err := os.CreateTemp(tempDir, "fabric-msp-test")
 	require.NoError(t, err)
@@ -102,7 +102,7 @@ func TestGetPemMaterialFromDirWithFile(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestGetPemMaterialFromDirWithSymlinks(t *testing.T) {
+func TestGetPemMaterialFromDirWithSymlinks(t *testing.T) { //nolint:paralleltest
 	mspDir, err := filepath.Abs("testdata/sampleconfig")
 	require.NoError(t, err)
 	tempDir := t.TempDir()
@@ -123,7 +123,7 @@ func TestGetPemMaterialFromDirWithSymlinks(t *testing.T) {
 	require.Equal(t, expected, pemdataSymlink)
 }
 
-func TestReadFileUtils(t *testing.T) {
+func TestReadFileUtils(t *testing.T) { //nolint:paralleltest
 	// test that reading a file with an empty path doesn't crash
 	_, err := readPemFile("")
 	require.Error(t, err)

--- a/platform/fabric/core/msp/factory_test.go
+++ b/platform/fabric/core/msp/factory_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewInvalidOpts(t *testing.T) {
+func TestNewInvalidOpts(t *testing.T) { //nolint:paralleltest
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	require.NoError(t, err)
 
@@ -35,7 +35,7 @@ func TestNewInvalidOpts(t *testing.T) {
 	require.Nil(t, i)
 }
 
-func TestNew(t *testing.T) {
+func TestNew(t *testing.T) { //nolint:paralleltest
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	require.NoError(t, err)
 

--- a/platform/fabric/core/msp/identities_test.go
+++ b/platform/fabric/core/msp/identities_test.go
@@ -103,10 +103,10 @@ UdiVmT6jldSKIETZm+kszfkANWxzKZXcXg==
 // sign the MESSAGE, while the ECDSA signing will
 // sign the DIGEST
 // The same applies to the Verify function
-func TestSignatureAlgorithms(t *testing.T) {
+func TestSignatureAlgorithms(t *testing.T) { //nolint:paralleltest
 	gt := gomega.NewGomegaWithT(t)
 
-	t.Run("Test ecdsa sign with digest and ed25519 sign with full message", func(t *testing.T) {
+	t.Run("Test ecdsa sign with digest and ed25519 sign with full message", func(t *testing.T) { //nolint:paralleltest
 		bccspDefault := factory.GetDefault()
 		mspImpl, _ := newBccspMsp(MSPv3_0, bccspDefault)
 		mspImpl.(*bccspmsp).cryptoConfig = &msp.FabricCryptoConfig{
@@ -166,9 +166,9 @@ func TestSignatureAlgorithms(t *testing.T) {
 	})
 }
 
-func TestIdentityValidation(t *testing.T) {
+func TestIdentityValidation(t *testing.T) { //nolint:paralleltest
 	gt := gomega.NewGomegaWithT(t)
-	t.Run("Test MSPv3_0 ed2551 identity validation", func(t *testing.T) {
+	t.Run("Test MSPv3_0 ed2551 identity validation", func(t *testing.T) { //nolint:paralleltest
 		bccspDefault := factory.GetDefault()
 		mspImpl, _ := newBccspMsp(MSPv1_4_3, bccspDefault)
 		cryptoConfig := &msp.FabricCryptoConfig{

--- a/platform/fabric/core/msp/mgmt/mgmt_test.go
+++ b/platform/fabric/core/msp/mgmt/mgmt_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetManagerForChains(t *testing.T) {
+func TestGetManagerForChains(t *testing.T) { //nolint:paralleltest
 	// MSPManager for channel does not exist prior to this call
 	mspMgr1 := GetManagerForChain("test")
 	// ensure MSPManager is set
@@ -34,7 +34,7 @@ func TestGetManagerForChains(t *testing.T) {
 	}
 }
 
-func TestGetManagerForChains_usingMSPConfigHandlers(t *testing.T) {
+func TestGetManagerForChains_usingMSPConfigHandlers(t *testing.T) { //nolint:paralleltest
 	XXXSetMSPManager("foo", msp.NewMSPManager())
 	msp2 := GetManagerForChain("foo")
 	// return value should be set because the MSPManager was initialized
@@ -43,7 +43,7 @@ func TestGetManagerForChains_usingMSPConfigHandlers(t *testing.T) {
 	}
 }
 
-func TestGetIdentityDeserializer(t *testing.T) {
+func TestGetIdentityDeserializer(t *testing.T) { //nolint:paralleltest
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	require.NoError(t, err)
 
@@ -54,7 +54,7 @@ func TestGetIdentityDeserializer(t *testing.T) {
 	require.NotNil(t, ids)
 }
 
-func TestUpdateLocalMspCache(t *testing.T) {
+func TestUpdateLocalMspCache(t *testing.T) { //nolint:paralleltest
 	// reset localMsp to force it to be initialized on the first call
 	localMsp = nil
 
@@ -77,7 +77,7 @@ func TestUpdateLocalMspCache(t *testing.T) {
 	}
 }
 
-func TestNewMSPMgmtMgr(t *testing.T) {
+func TestNewMSPMgmtMgr(t *testing.T) { //nolint:paralleltest
 	cryptoProvider, err := LoadMSPSetupForTesting()
 	require.NoError(t, err)
 
@@ -126,7 +126,7 @@ func LoadMSPSetupForTesting() (bccsp.BCCSP, error) {
 	return cryptoProvider, nil
 }
 
-func TestLocalMSP(t *testing.T) {
+func TestLocalMSP(t *testing.T) { //nolint:paralleltest
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	require.NoError(t, err)
 

--- a/platform/fabric/core/msp/mgmt/testtools/config_test.go
+++ b/platform/fabric/core/msp/mgmt/testtools/config_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestFakeSetup(t *testing.T) {
+	t.Parallel()
 	err := LoadMSPSetupForTesting()
 	if err != nil {
 		t.Fatalf("LoadLocalMsp failed, err %s", err)

--- a/platform/fabric/core/msp/msp_test.go
+++ b/platform/fabric/core/msp/msp_test.go
@@ -47,7 +47,7 @@ RgIhAOTTpQYkGO+gwVe1LQOcNMD5fzFViOwBUraMrk6dRMlmAiEA8z2dpXKGwHrj
 FRBbKkDnSpaVcZgjns+mLdHV2JkF0gk=
 -----END X509 CRL-----`
 
-func TestMSPParsers(t *testing.T) {
+func TestMSPParsers(t *testing.T) { //nolint:paralleltest
 	_, _, err := localMsp.(*bccspmsp).getIdentityFromConf(nil)
 	require.Error(t, err)
 	_, _, err = localMsp.(*bccspmsp).getIdentityFromConf([]byte("barf"))
@@ -68,7 +68,7 @@ func TestMSPParsers(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestGetSigningIdentityFromConfWithWrongPrivateCert(t *testing.T) {
+func TestGetSigningIdentityFromConfWithWrongPrivateCert(t *testing.T) { //nolint:paralleltest
 	// Temporary Replace root certs
 	oldRoots := localMsp.(*bccspmsp).opts.Roots
 	defer func() {
@@ -92,7 +92,7 @@ func TestGetSigningIdentityFromConfWithWrongPrivateCert(t *testing.T) {
 	require.EqualError(t, err, "MyPrivateKey: wrong PEM encoding")
 }
 
-func TestMSPSetupNoCryptoConf(t *testing.T) {
+func TestMSPSetupNoCryptoConf(t *testing.T) { //nolint:paralleltest
 	mspDir := "testdata/sampleconfig"
 	conf, err := GetLocalMspConfig(mspDir, nil, "SampleOrg")
 	if err != nil {
@@ -143,14 +143,14 @@ func TestMSPSetupNoCryptoConf(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestGetters(t *testing.T) {
+func TestGetters(t *testing.T) { //nolint:paralleltest
 	typ := localMsp.GetType()
 	require.Equal(t, FABRIC, typ)
 	require.NotNil(t, localMsp.GetTLSRootCerts())
 	require.NotNil(t, localMsp.GetTLSIntermediateCerts())
 }
 
-func TestMSPSetupBad(t *testing.T) {
+func TestMSPSetupBad(t *testing.T) { //nolint:paralleltest
 	_, err := GetLocalMspConfig("barf", nil, "SampleOrg")
 	if err == nil {
 		t.Fatalf("Setup should have failed on an invalid config file")
@@ -164,7 +164,7 @@ func TestMSPSetupBad(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestDoubleSetup(t *testing.T) {
+func TestDoubleSetup(t *testing.T) { //nolint:paralleltest
 	// note that we've already called setup once on this
 	err := mspMgr.Setup(nil)
 	require.NoError(t, err)
@@ -178,7 +178,7 @@ func (*bccspNoKeyLookupKS) GetKey(ski []byte) (k bccsp.Key, err error) {
 	return nil, errors.New("not found")
 }
 
-func TestNotFoundInBCCSP(t *testing.T) {
+func TestNotFoundInBCCSP(t *testing.T) { //nolint:paralleltest
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	require.NoError(t, err)
 
@@ -200,7 +200,7 @@ func TestNotFoundInBCCSP(t *testing.T) {
 	require.Contains(t, "KeyMaterial not found in SigningIdentityInfo", err.Error())
 }
 
-func TestGetIdentities(t *testing.T) {
+func TestGetIdentities(t *testing.T) { //nolint:paralleltest
 	_, err := localMsp.GetDefaultSigningIdentity()
 	if err != nil {
 		t.Fatalf("GetDefaultSigningIdentity failed with err %s", err)
@@ -208,7 +208,7 @@ func TestGetIdentities(t *testing.T) {
 	}
 }
 
-func TestDeserializeIdentityFails(t *testing.T) {
+func TestDeserializeIdentityFails(t *testing.T) { //nolint:paralleltest
 	_, err := localMsp.DeserializeIdentity([]byte("barf"))
 	require.Error(t, err)
 
@@ -225,7 +225,7 @@ func TestDeserializeIdentityFails(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestGetSigningIdentityFromVerifyingMSP(t *testing.T) {
+func TestGetSigningIdentityFromVerifyingMSP(t *testing.T) { //nolint:paralleltest
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	require.NoError(t, err)
 
@@ -245,7 +245,7 @@ func TestGetSigningIdentityFromVerifyingMSP(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestValidateDefaultSigningIdentity(t *testing.T) {
+func TestValidateDefaultSigningIdentity(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -253,7 +253,7 @@ func TestValidateDefaultSigningIdentity(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestSerializeIdentities(t *testing.T) {
+func TestSerializeIdentities(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	if err != nil {
 		t.Fatalf("GetDefaultSigningIdentity should have succeeded, got err %s", err)
@@ -295,6 +295,7 @@ func computeSKI(key *ecdsa.PublicKey) ([]byte, error) {
 }
 
 func TestValidHostname(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		valid bool
@@ -321,7 +322,7 @@ func TestValidHostname(t *testing.T) {
 	}
 }
 
-func TestValidateCANameConstraintsMitigation(t *testing.T) {
+func TestValidateCANameConstraintsMitigation(t *testing.T) { //nolint:paralleltest
 	// Prior to Go 1.15, if a signing certificate contains a name constraint, the
 	// leaf certificate does not include a SAN, and the leaf common name looks
 	// like a valid hostname, the certificate chain would fail to validate.
@@ -374,7 +375,7 @@ func TestValidateCANameConstraintsMitigation(t *testing.T) {
 	leafCertPem := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafCertBytes})
 	leafKeyPem := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
 
-	t.Run("VerifyNameConstraintsSingleCert", func(t *testing.T) {
+	t.Run("VerifyNameConstraintsSingleCert", func(t *testing.T) { //nolint:paralleltest
 		for _, der := range [][]byte{caCertBytes, leafCertBytes} {
 			cert, err := x509.ParseCertificate(der)
 			require.NoError(t, err, "failed to parse certificate")
@@ -384,7 +385,7 @@ func TestValidateCANameConstraintsMitigation(t *testing.T) {
 		}
 	})
 
-	t.Run("VerifyNameConstraints", func(t *testing.T) {
+	t.Run("VerifyNameConstraints", func(t *testing.T) { //nolint:paralleltest
 		var certs []*x509.Certificate
 		for _, der := range [][]byte{leafCertBytes, caCertBytes} {
 			cert, err := x509.ParseCertificate(der)
@@ -399,7 +400,7 @@ func TestValidateCANameConstraintsMitigation(t *testing.T) {
 		require.Equal(t, x509.NameConstraintsWithoutSANs, cie.Reason)
 	})
 
-	t.Run("VerifyNameConstraintsWithSAN", func(t *testing.T) {
+	t.Run("VerifyNameConstraintsWithSAN", func(t *testing.T) { //nolint:paralleltest
 		caCert, err := x509.ParseCertificate(caCertBytes)
 		require.NoError(t, err)
 
@@ -416,7 +417,7 @@ func TestValidateCANameConstraintsMitigation(t *testing.T) {
 		require.NoError(t, err, "signer with name constraints and leaf with SANs should be valid")
 	})
 
-	t.Run("ValidationAtSetup", func(t *testing.T) {
+	t.Run("ValidationAtSetup", func(t *testing.T) { //nolint:paralleltest
 		fabricMSPConfig := &msp.FabricMSPConfig{
 			Name:      "ConstraintsMSP",
 			RootCerts: [][]byte{caCertPem},
@@ -449,7 +450,7 @@ func TestValidateCANameConstraintsMitigation(t *testing.T) {
 	})
 }
 
-func TestIsWellFormed(t *testing.T) {
+func TestIsWellFormed(t *testing.T) { //nolint:paralleltest
 	mspMgr := NewMSPManager()
 
 	id, err := localMsp.GetDefaultSigningIdentity()
@@ -552,14 +553,14 @@ type rst struct {
 	R, S, T *big.Int
 }
 
-func TestValidateCAIdentity(t *testing.T) {
+func TestValidateCAIdentity(t *testing.T) { //nolint:paralleltest
 	caID := getIdentity(t, cacerts)
 
 	err := localMsp.Validate(caID)
 	require.Error(t, err)
 }
 
-func TestBadAdminIdentity(t *testing.T) {
+func TestBadAdminIdentity(t *testing.T) { //nolint:paralleltest
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	require.NoError(t, err)
 
@@ -578,14 +579,14 @@ func TestBadAdminIdentity(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestValidateAdminIdentity(t *testing.T) {
+func TestValidateAdminIdentity(t *testing.T) { //nolint:paralleltest
 	caID := getIdentity(t, admincerts)
 
 	err := localMsp.Validate(caID)
 	require.NoError(t, err)
 }
 
-func TestSerializeIdentitiesWithWrongMSP(t *testing.T) {
+func TestSerializeIdentitiesWithWrongMSP(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	if err != nil {
 		t.Fatalf("GetDefaultSigningIdentity should have succeeded, got err %s", err)
@@ -611,7 +612,7 @@ func TestSerializeIdentitiesWithWrongMSP(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestSerializeIdentitiesWithMSPManager(t *testing.T) {
+func TestSerializeIdentitiesWithMSPManager(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	if err != nil {
 		t.Fatalf("GetDefaultSigningIdentity should have succeeded, got err %s", err)
@@ -645,7 +646,7 @@ func TestSerializeIdentitiesWithMSPManager(t *testing.T) {
 	require.Contains(t, err.Error(), "could not deserialize")
 }
 
-func TestIdentitiesGetters(t *testing.T) {
+func TestIdentitiesGetters(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	if err != nil {
 		t.Fatalf("GetDefaultSigningIdentity should have succeeded, got err %s", err)
@@ -659,7 +660,7 @@ func TestIdentitiesGetters(t *testing.T) {
 	require.False(t, id.Anonymous())
 }
 
-func TestSignAndVerify(t *testing.T) {
+func TestSignAndVerify(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	if err != nil {
 		t.Fatalf("GetDefaultSigningIdentity should have succeeded")
@@ -703,7 +704,7 @@ func TestSignAndVerify(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestSignAndVerifyFailures(t *testing.T) {
+func TestSignAndVerifyFailures(t *testing.T) { //nolint:paralleltest
 	msg := []byte("foo")
 
 	id, err := localMspBad.GetDefaultSigningIdentity()
@@ -734,7 +735,7 @@ func TestSignAndVerifyFailures(t *testing.T) {
 	id.(*signingidentity).msp.cryptoConfig.SignatureHashFamily = hash
 }
 
-func TestSignAndVerifyOtherHash(t *testing.T) {
+func TestSignAndVerifyOtherHash(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	if err != nil {
 		t.Fatalf("GetDefaultSigningIdentity should have succeeded")
@@ -757,7 +758,7 @@ func TestSignAndVerifyOtherHash(t *testing.T) {
 	id.(*signingidentity).msp.cryptoConfig.SignatureHashFamily = hash
 }
 
-func TestSignAndVerify_longMessage(t *testing.T) {
+func TestSignAndVerify_longMessage(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	if err != nil {
 		t.Fatalf("GetDefaultSigningIdentity should have succeeded")
@@ -796,7 +797,7 @@ func TestSignAndVerify_longMessage(t *testing.T) {
 	}
 }
 
-func TestGetOU(t *testing.T) {
+func TestGetOU(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	if err != nil {
 		t.Fatalf("GetDefaultSigningIdentity should have succeeded")
@@ -806,7 +807,7 @@ func TestGetOU(t *testing.T) {
 	require.Equal(t, "COP", id.GetOrganizationalUnits()[0].OrganizationalUnitIdentifier)
 }
 
-func TestGetOUFail(t *testing.T) {
+func TestGetOUFail(t *testing.T) { //nolint:paralleltest
 	id, err := localMspBad.GetDefaultSigningIdentity()
 	if err != nil {
 		t.Fatalf("GetDefaultSigningIdentity should have succeeded")
@@ -828,7 +829,7 @@ func TestGetOUFail(t *testing.T) {
 	id.(*signingidentity).msp.opts = opts
 }
 
-func TestCertificationIdentifierComputation(t *testing.T) {
+func TestCertificationIdentifierComputation(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -851,7 +852,7 @@ func TestCertificationIdentifierComputation(t *testing.T) {
 	require.Equal(t, sum, id.GetOrganizationalUnits()[0].CertifiersIdentifier)
 }
 
-func TestOUPolicyPrincipal(t *testing.T) {
+func TestOUPolicyPrincipal(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -875,7 +876,7 @@ func TestOUPolicyPrincipal(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestOUPolicyPrincipalBadPrincipal(t *testing.T) {
+func TestOUPolicyPrincipalBadPrincipal(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -888,7 +889,7 @@ func TestOUPolicyPrincipalBadPrincipal(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestOUPolicyPrincipalBadMSPID(t *testing.T) {
+func TestOUPolicyPrincipalBadMSPID(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -912,7 +913,7 @@ func TestOUPolicyPrincipalBadMSPID(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestOUPolicyPrincipalBadPath(t *testing.T) {
+func TestOUPolicyPrincipalBadPath(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -949,7 +950,7 @@ func TestOUPolicyPrincipalBadPath(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestPolicyPrincipalBogusType(t *testing.T) {
+func TestPolicyPrincipalBogusType(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -965,7 +966,7 @@ func TestPolicyPrincipalBogusType(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestPolicyPrincipalBogusRole(t *testing.T) {
+func TestPolicyPrincipalBogusRole(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -981,7 +982,7 @@ func TestPolicyPrincipalBogusRole(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestPolicyPrincipalWrongMSPID(t *testing.T) {
+func TestPolicyPrincipalWrongMSPID(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -997,7 +998,7 @@ func TestPolicyPrincipalWrongMSPID(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestMemberPolicyPrincipal(t *testing.T) {
+func TestMemberPolicyPrincipal(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -1013,7 +1014,7 @@ func TestMemberPolicyPrincipal(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestAdminPolicyPrincipal(t *testing.T) {
+func TestAdminPolicyPrincipal(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -1045,7 +1046,7 @@ func createCombinedPrincipal(principals ...*msp.MSPPrincipal) (*msp.MSPPrincipal
 	return principalsCombined, nil
 }
 
-func TestMultilevelAdminAndMemberPolicyPrincipal(t *testing.T) {
+func TestMultilevelAdminAndMemberPolicyPrincipal(t *testing.T) { //nolint:paralleltest
 	id, err := localMspV13.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -1084,7 +1085,7 @@ func TestMultilevelAdminAndMemberPolicyPrincipal(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestMultilevelAdminAndMemberPolicyPrincipalPreV12(t *testing.T) {
+func TestMultilevelAdminAndMemberPolicyPrincipalPreV12(t *testing.T) { //nolint:paralleltest
 	id, err := localMspV11.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -1123,7 +1124,7 @@ func TestMultilevelAdminAndMemberPolicyPrincipalPreV12(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestAdminPolicyPrincipalFails(t *testing.T) {
+func TestAdminPolicyPrincipalFails(t *testing.T) { //nolint:paralleltest
 	id, err := localMspV13.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -1142,7 +1143,7 @@ func TestAdminPolicyPrincipalFails(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestMultilevelAdminAndMemberPolicyPrincipalFails(t *testing.T) {
+func TestMultilevelAdminAndMemberPolicyPrincipalFails(t *testing.T) { //nolint:paralleltest
 	id, err := localMspV13.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -1184,7 +1185,7 @@ func TestMultilevelAdminAndMemberPolicyPrincipalFails(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestIdentityExpiresAt(t *testing.T) {
+func TestIdentityExpiresAt(t *testing.T) { //nolint:paralleltest
 	thisMSP := getLocalMSP(t, "testdata/expiration")
 	require.NotNil(t, thisMSP)
 	si, err := thisMSP.GetDefaultSigningIdentity()
@@ -1193,7 +1194,7 @@ func TestIdentityExpiresAt(t *testing.T) {
 	require.Equal(t, time.Date(2027, 8, 17, 12, 19, 48, 0, time.UTC), expirationDate)
 }
 
-func TestIdentityExpired(t *testing.T) {
+func TestIdentityExpired(t *testing.T) { //nolint:paralleltest
 	cryptoProvider, err := sw.NewDefaultSecurityLevelWithKeystore(sw.NewDummyKeyStore())
 	require.NoError(t, err)
 
@@ -1219,7 +1220,7 @@ func TestIdentityExpired(t *testing.T) {
 	}
 }
 
-func TestIdentityPolicyPrincipal(t *testing.T) {
+func TestIdentityPolicyPrincipal(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -1236,6 +1237,7 @@ func TestIdentityPolicyPrincipal(t *testing.T) {
 }
 
 func TestIdentityPolicyPrincipalBadBytes(t *testing.T) {
+	t.Parallel()
 	id, err := localMsp.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -1248,7 +1250,7 @@ func TestIdentityPolicyPrincipalBadBytes(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestMSPOus(t *testing.T) {
+func TestMSPOus(t *testing.T) { //nolint:paralleltest
 	// Set the OUIdentifiers
 	backup := localMsp.(*bccspmsp).ouIdentifiers
 	defer func() { localMsp.(*bccspmsp).ouIdentifiers = backup }()
@@ -1302,7 +1304,7 @@ HeamPGiDTQ==
 -----END CERTIFICATE-----
 `
 
-func TestIdentityPolicyPrincipalFails(t *testing.T) {
+func TestIdentityPolicyPrincipalFails(t *testing.T) { //nolint:paralleltest
 	id, err := localMsp.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -1480,7 +1482,7 @@ func getLocalMSPWithVersion(t *testing.T, dir string, version MSPVersion) MSP {
 	return thisMSP
 }
 
-func TestCollectEmptyCombinedPrincipal(t *testing.T) {
+func TestCollectEmptyCombinedPrincipal(t *testing.T) { //nolint:paralleltest
 	var principalsArray []*msp.MSPPrincipal
 	combinedPrincipal := &msp.CombinedPrincipal{Principals: principalsArray}
 	combinedPrincipalBytes, err := proto.Marshal(combinedPrincipal)
@@ -1490,7 +1492,7 @@ func TestCollectEmptyCombinedPrincipal(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestCollectPrincipalContainingEmptyCombinedPrincipal(t *testing.T) {
+func TestCollectPrincipalContainingEmptyCombinedPrincipal(t *testing.T) { //nolint:paralleltest
 	var principalsArray []*msp.MSPPrincipal
 	combinedPrincipal := &msp.CombinedPrincipal{Principals: principalsArray}
 	combinedPrincipalBytes, err := proto.Marshal(combinedPrincipal)
@@ -1502,7 +1504,7 @@ func TestCollectPrincipalContainingEmptyCombinedPrincipal(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestMSPIdentityIdentifier(t *testing.T) {
+func TestMSPIdentityIdentifier(t *testing.T) { //nolint:paralleltest
 	// testdata/mspid
 	// 1) a key and a signcert (used to populate the default signing identity) with the cert having a HighS signature
 	thisMSP := getLocalMSP(t, "testdata/mspid")
@@ -1559,7 +1561,7 @@ func TestMSPIdentityIdentifier(t *testing.T) {
 	require.NotEqual(t, idid.Id, hex.EncodeToString(digest))
 }
 
-func TestAnonymityIdentity(t *testing.T) {
+func TestAnonymityIdentity(t *testing.T) { //nolint:paralleltest
 	id, err := localMspV13.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -1575,7 +1577,7 @@ func TestAnonymityIdentity(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestAnonymityIdentityPreV12Fail(t *testing.T) {
+func TestAnonymityIdentityPreV12Fail(t *testing.T) { //nolint:paralleltest
 	id, err := localMspV11.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -1591,7 +1593,7 @@ func TestAnonymityIdentityPreV12Fail(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestAnonymityIdentityFail(t *testing.T) {
+func TestAnonymityIdentityFail(t *testing.T) { //nolint:paralleltest
 	id, err := localMspV13.GetDefaultSigningIdentity()
 	require.NoError(t, err)
 
@@ -1607,7 +1609,7 @@ func TestAnonymityIdentityFail(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestProviderTypeToString(t *testing.T) {
+func TestProviderTypeToString(t *testing.T) { //nolint:paralleltest
 	// Check that the provider type is found for FABRIC
 	pt := ProviderTypeToString(FABRIC)
 	require.Equal(t, "bccsp", pt)

--- a/platform/fabric/core/msp/mspimplsetup_test.go
+++ b/platform/fabric/core/msp/mspimplsetup_test.go
@@ -81,10 +81,10 @@ oVYZAX2M8G3clTu+f6Si5KrRezNflbVHmvCrJWM=
 -----END CERTIFICATE-----`
 )
 
-func TestTLSCAValidation(t *testing.T) {
+func TestTLSCAValidation(t *testing.T) { //nolint:paralleltest
 	gt := gomega.NewGomegaWithT(t)
 
-	t.Run("GoodCert", func(t *testing.T) {
+	t.Run("GoodCert", func(t *testing.T) { //nolint:paralleltest
 		mspImpl := &bccspmsp{
 			opts: &x509.VerifyOptions{Roots: x509.NewCertPool(), Intermediates: x509.NewCertPool()},
 		}
@@ -95,7 +95,7 @@ func TestTLSCAValidation(t *testing.T) {
 		gt.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
-	t.Run("ExpiredCert", func(t *testing.T) {
+	t.Run("ExpiredCert", func(t *testing.T) { //nolint:paralleltest
 		mspImpl := &bccspmsp{
 			opts: &x509.VerifyOptions{Roots: x509.NewCertPool(), Intermediates: x509.NewCertPool()},
 		}
@@ -106,7 +106,7 @@ func TestTLSCAValidation(t *testing.T) {
 		gt.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
-	t.Run("NonCACert", func(t *testing.T) {
+	t.Run("NonCACert", func(t *testing.T) { //nolint:paralleltest
 		mspImpl := &bccspmsp{
 			opts: &x509.VerifyOptions{Roots: x509.NewCertPool(), Intermediates: x509.NewCertPool()},
 		}
@@ -117,7 +117,7 @@ func TestTLSCAValidation(t *testing.T) {
 		gt.Expect(err).To(gomega.MatchError("CA Certificate did not have the CA attribute, (SN: c9dff7f76657d46f082570f6965051f5)"))
 	})
 
-	t.Run("NoSKICert", func(t *testing.T) {
+	t.Run("NoSKICert", func(t *testing.T) { //nolint:paralleltest
 		mspImpl := &bccspmsp{
 			opts: &x509.VerifyOptions{Roots: x509.NewCertPool(), Intermediates: x509.NewCertPool()},
 		}
@@ -129,7 +129,7 @@ func TestTLSCAValidation(t *testing.T) {
 	})
 }
 
-func TestMalformedCertsChainSetup(t *testing.T) {
+func TestMalformedCertsChainSetup(t *testing.T) { //nolint:paralleltest
 	gt := gomega.NewGomegaWithT(t)
 
 	ca, err := tlsgen.NewCA()
@@ -167,10 +167,10 @@ func TestMalformedCertsChainSetup(t *testing.T) {
 	gt.Expect(err.Error()).To(gomega.ContainSubstring("failed to traverse certificate verification chain"))
 }
 
-func TestCAValidation(t *testing.T) {
+func TestCAValidation(t *testing.T) { //nolint:paralleltest
 	gt := gomega.NewGomegaWithT(t)
 
-	t.Run("GoodCert", func(t *testing.T) {
+	t.Run("GoodCert", func(t *testing.T) { //nolint:paralleltest
 		mspImpl := &bccspmsp{
 			opts: &x509.VerifyOptions{Roots: x509.NewCertPool(), Intermediates: x509.NewCertPool()},
 		}
@@ -184,7 +184,7 @@ func TestCAValidation(t *testing.T) {
 		gt.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
-	t.Run("NonCACert", func(t *testing.T) {
+	t.Run("NonCACert", func(t *testing.T) { //nolint:paralleltest
 		mspImpl := &bccspmsp{
 			opts: &x509.VerifyOptions{Roots: x509.NewCertPool(), Intermediates: x509.NewCertPool()},
 		}
@@ -198,7 +198,7 @@ func TestCAValidation(t *testing.T) {
 		gt.Expect(err).To(gomega.MatchError("CA Certificate did not have the CA attribute, (SN: c9dff7f76657d46f082570f6965051f5)"))
 	})
 
-	t.Run("NoSKICert", func(t *testing.T) {
+	t.Run("NoSKICert", func(t *testing.T) { //nolint:paralleltest
 		mspImpl := &bccspmsp{
 			opts: &x509.VerifyOptions{Roots: x509.NewCertPool(), Intermediates: x509.NewCertPool()},
 		}

--- a/platform/fabric/core/msp/mspwithintermediatecas_test.go
+++ b/platform/fabric/core/msp/mspwithintermediatecas_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMSPWithIntermediateCAs(t *testing.T) {
+func TestMSPWithIntermediateCAs(t *testing.T) { //nolint:paralleltest
 	// testdata/intermediate contains the credentials for a test MSP setup that has
 	// 1) a key and a signcert (used to populate the default signing identity);
 	//    signcert is not signed by a CA directly but by an intermediate CA
@@ -60,7 +60,7 @@ func TestMSPWithIntermediateCAs(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestMSPWithExternalIntermediateCAs(t *testing.T) {
+func TestMSPWithExternalIntermediateCAs(t *testing.T) { //nolint:paralleltest
 	// testdata/external contains the credentials for a test MSP setup
 	// identical to testdata/intermediate with the exception that it has
 	// been generated independently of the fabric environment using
@@ -82,7 +82,7 @@ func TestMSPWithExternalIntermediateCAs(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestIntermediateCAIdentityValidity(t *testing.T) {
+func TestIntermediateCAIdentityValidity(t *testing.T) { //nolint:paralleltest
 	// testdata/intermediate contains the credentials for a test MSP setup that has
 	// 1) a key and a signcert (used to populate the default signing identity);
 	//    signcert is not signed by a CA directly but by an intermediate CA
@@ -94,7 +94,7 @@ func TestIntermediateCAIdentityValidity(t *testing.T) {
 	require.Error(t, id.Validate())
 }
 
-func TestMSPWithIntermediateCAs2(t *testing.T) {
+func TestMSPWithIntermediateCAs2(t *testing.T) { //nolint:paralleltest
 	// testdata/intermediate2 contains the credentials for a test MSP setup that has
 	// 1) a key and a signcert (used to populate the default signing identity);
 	//    signcert is not signed by a CA directly but by an intermediate CA

--- a/platform/fabric/core/msp/nodeous_test.go
+++ b/platform/fabric/core/msp/nodeous_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInvalidAdminNodeOU(t *testing.T) {
+func TestInvalidAdminNodeOU(t *testing.T) { //nolint:paralleltest
 	// testdata/nodeous1:
 	// the configuration enables NodeOUs but the administrator does not carry
 	// any valid NodeOUS. Therefore MSP initialization must fail
@@ -40,8 +40,8 @@ func TestInvalidAdminNodeOU(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestInvalidSigningIdentityNodeOU(t *testing.T) {
-	t.Run("signing_identity_validation_fails_with_MSPv1_4_3", func(t *testing.T) {
+func TestInvalidSigningIdentityNodeOU(t *testing.T) { //nolint:paralleltest
+	t.Run("signing_identity_validation_fails_with_MSPv1_4_3", func(t *testing.T) { //nolint:paralleltest
 		// testdata/nodeous2:
 		// the configuration enables NodeOUs but the signing identity does not carry
 		// any valid NodeOUS. Therefore signing identity validation should fail
@@ -55,7 +55,7 @@ func TestInvalidSigningIdentityNodeOU(t *testing.T) {
 		require.EqualError(t, err, "could not validate identity's OUs: the identity does not have an OU that resolves to client, peer, orderer, or admin role. OUs: [], MSP: [SampleOrg]")
 	})
 
-	t.Run("signing_identity_validation_fails_with_MSPv1_1", func(t *testing.T) {
+	t.Run("signing_identity_validation_fails_with_MSPv1_1", func(t *testing.T) { //nolint:paralleltest
 		// testdata/nodeous2:
 		// the configuration enables NodeOUs but the signing identity does not carry
 		// any valid NodeOUS. Therefore signing identity validation should fail
@@ -69,7 +69,7 @@ func TestInvalidSigningIdentityNodeOU(t *testing.T) {
 		require.EqualError(t, err, "could not validate identity's OUs: the identity does not have an OU that resolves to client or peer. OUs: [], MSP: [SampleOrg]")
 	})
 
-	t.Run("signing_identity_validation_succeeds_with_MSPv1_0", func(t *testing.T) {
+	t.Run("signing_identity_validation_succeeds_with_MSPv1_0", func(t *testing.T) { //nolint:paralleltest
 		// MSPv1_0 should not fail, node OUs not yet implemented in 1_0
 		thisMSP, err := getLocalMSPWithVersionAndError(t, "testdata/nodeous1", MSPv1_0)
 		require.False(t, thisMSP.(*bccspmsp).ouEnforcement)
@@ -83,7 +83,7 @@ func TestInvalidSigningIdentityNodeOU(t *testing.T) {
 	})
 }
 
-func TestValidMSPWithNodeOU(t *testing.T) {
+func TestValidMSPWithNodeOU(t *testing.T) { //nolint:paralleltest
 	// testdata/nodeous3:
 	// the configuration enables NodeOUs and admin and signing identity are valid
 	thisMSP := getLocalMSPWithVersion(t, "testdata/nodeous3", MSPv1_1)
@@ -106,7 +106,7 @@ func TestValidMSPWithNodeOU(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestValidMSPWithNodeOUAndOrganizationalUnits(t *testing.T) {
+func TestValidMSPWithNodeOUAndOrganizationalUnits(t *testing.T) { //nolint:paralleltest
 	// testdata/nodeous6:
 	// the configuration enables NodeOUs and OrganizationalUnits, and admin and signing identity are valid
 	thisMSP := getLocalMSPWithVersion(t, "testdata/nodeous6", MSPv1_1)
@@ -129,7 +129,7 @@ func TestValidMSPWithNodeOUAndOrganizationalUnits(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestInvalidMSPWithNodeOUAndOrganizationalUnits(t *testing.T) {
+func TestInvalidMSPWithNodeOUAndOrganizationalUnits(t *testing.T) { //nolint:paralleltest
 	// testdata/nodeous6:
 	// the configuration enables NodeOUs and OrganizationalUnits,
 	// and admin and signing identity are not valid because they don't have
@@ -146,7 +146,7 @@ func TestInvalidMSPWithNodeOUAndOrganizationalUnits(t *testing.T) {
 	require.Contains(t, err.Error(), "could not validate identity's OUs: none of the identity's organizational units")
 }
 
-func TestInvalidAdminOU(t *testing.T) {
+func TestInvalidAdminOU(t *testing.T) { //nolint:paralleltest
 	// testdata/nodeous4:
 	// the configuration enables NodeOUs and admin does not match the certifier chain specified at config
 	thisMSP, err := getLocalMSPWithVersionAndError(t, "testdata/nodeous4", MSPv1_1)
@@ -160,7 +160,7 @@ func TestInvalidAdminOU(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestInvalidAdminOUNotAClient(t *testing.T) {
+func TestInvalidAdminOUNotAClient(t *testing.T) { //nolint:paralleltest
 	// testdata/nodeous4:
 	// the configuration enables NodeOUs and admin is not a client
 	thisMSP, err := getLocalMSPWithVersionAndError(t, "testdata/nodeous8", MSPv1_1)
@@ -174,7 +174,7 @@ func TestInvalidAdminOUNotAClient(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestSatisfiesPrincipalPeer(t *testing.T) {
+func TestSatisfiesPrincipalPeer(t *testing.T) { //nolint:paralleltest
 	// testdata/nodeous3:
 	// the configuration enables NodeOUs and admin and signing identity are valid
 	thisMSP := getLocalMSPWithVersion(t, "testdata/nodeous3", MSPv1_1)
@@ -187,7 +187,7 @@ func TestSatisfiesPrincipalPeer(t *testing.T) {
 	err = id.Validate()
 	require.NoError(t, err)
 
-	require.True(t, t.Run("Check that id is a peer", func(t *testing.T) {
+	require.True(t, t.Run("Check that id is a peer", func(t *testing.T) { //nolint:paralleltest
 		// Check that id is a peer
 		mspID, err := thisMSP.GetIdentifier()
 		require.NoError(t, err)
@@ -201,7 +201,7 @@ func TestSatisfiesPrincipalPeer(t *testing.T) {
 		require.NoError(t, err)
 	}))
 
-	require.True(t, t.Run("Check that id is not a client", func(t *testing.T) {
+	require.True(t, t.Run("Check that id is not a client", func(t *testing.T) { //nolint:paralleltest
 		// Check that id is not a client
 		mspID, err := thisMSP.GetIdentifier()
 		require.NoError(t, err)
@@ -217,7 +217,7 @@ func TestSatisfiesPrincipalPeer(t *testing.T) {
 	}))
 }
 
-func TestSatisfiesPrincipalClient(t *testing.T) {
+func TestSatisfiesPrincipalClient(t *testing.T) { //nolint:paralleltest
 	// testdata/nodeous3:
 	// the configuration enables NodeOUs and admin and signing identity are valid
 	thisMSP := getLocalMSPWithVersion(t, "testdata/nodeous3", MSPv1_1)
@@ -231,7 +231,7 @@ func TestSatisfiesPrincipalClient(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check that id is a client
-	require.True(t, t.Run("Check that id is a client", func(t *testing.T) {
+	require.True(t, t.Run("Check that id is a client", func(t *testing.T) { //nolint:paralleltest
 		mspID, err := thisMSP.GetIdentifier()
 		require.NoError(t, err)
 		principalBytes, err := proto.Marshal(&msp.MSPRole{Role: msp.MSPRole_CLIENT, MspIdentifier: mspID})
@@ -244,7 +244,7 @@ func TestSatisfiesPrincipalClient(t *testing.T) {
 		require.NoError(t, err)
 	}))
 
-	require.True(t, t.Run("Check that id is not a peer", func(t *testing.T) {
+	require.True(t, t.Run("Check that id is not a peer", func(t *testing.T) { //nolint:paralleltest
 		// Check that id is not a peer
 		mspID, err := thisMSP.GetIdentifier()
 		require.NoError(t, err)
@@ -260,7 +260,7 @@ func TestSatisfiesPrincipalClient(t *testing.T) {
 	}))
 }
 
-func TestSatisfiesPrincipalAdmin(t *testing.T) {
+func TestSatisfiesPrincipalAdmin(t *testing.T) { //nolint:paralleltest
 	// testdata/nodeouadmin:
 	// the configuration enables NodeOUs (with adminOU) and admin and signing identity are valid
 	thisMSP := getLocalMSPWithVersion(t, "testdata/nodeouadmin", MSPv1_4_3)
@@ -282,7 +282,7 @@ func TestSatisfiesPrincipalAdmin(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestLoad142MSPWithInvalidAdminConfiguration(t *testing.T) {
+func TestLoad142MSPWithInvalidAdminConfiguration(t *testing.T) { //nolint:paralleltest
 	// testdata/nodeouadmin2:
 	// the configuration enables NodeOUs (with adminOU) but no valid identifier for the AdminOU
 	conf, err := GetLocalMspConfig("testdata/nodeouadmin2", nil, "SampleOrg")
@@ -314,7 +314,7 @@ func TestLoad142MSPWithInvalidAdminConfiguration(t *testing.T) {
 	require.Equal(t, "administrators must be declared when no admin ou classification is set", err.Error())
 }
 
-func TestAdminInAdmincertsWith143MSP(t *testing.T) {
+func TestAdminInAdmincertsWith143MSP(t *testing.T) { //nolint:paralleltest
 	// testdata/nodeouadminclient enables NodeOU classification and contains in the admincerts folder
 	// a certificate classified as client. This test checks that identity is considered an admin anyway.
 	// testdata/nodeouadminclient2 enables NodeOU classification and contains in the admincerts folder
@@ -346,7 +346,7 @@ func TestAdminInAdmincertsWith143MSP(t *testing.T) {
 	}
 }
 
-func TestSatisfiesPrincipalOrderer(t *testing.T) {
+func TestSatisfiesPrincipalOrderer(t *testing.T) { //nolint:paralleltest
 	// testdata/nodeouorderer:
 	// the configuration enables NodeOUs (with orderOU)
 	thisMSP := getLocalMSPWithVersion(t, "testdata/nodeouorderer", MSPv1_4_3)
@@ -365,7 +365,7 @@ func TestSatisfiesPrincipalOrderer(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestLoad142MSPWithInvalidOrdererConfiguration(t *testing.T) {
+func TestLoad142MSPWithInvalidOrdererConfiguration(t *testing.T) { //nolint:paralleltest
 	// testdata/nodeouorderer2:
 	// the configuration enables NodeOUs (with orderOU) but no valid identifier for the OrdererOU
 	conf, err := GetLocalMspConfig("testdata/nodeouorderer2", nil, "SampleOrg")
@@ -419,7 +419,7 @@ func TestLoad142MSPWithInvalidOrdererConfiguration(t *testing.T) {
 	require.Equal(t, "The identity is not a [ORDERER] under this MSP [SampleOrg]: cannot test for classification, node ou for type [ORDERER], not defined, msp: [SampleOrg]", err.Error())
 }
 
-func TestValidMSPWithNodeOUMissingClassification(t *testing.T) {
+func TestValidMSPWithNodeOUMissingClassification(t *testing.T) { //nolint:paralleltest
 	// testdata/nodeousbadconf1:
 	// the configuration enables NodeOUs but client ou identifier is missing
 	_, err := getLocalMSPWithVersionAndError(t, "testdata/nodeousbadconf1", MSPv1_3)

--- a/platform/fabric/core/msp/ouconfig_test.go
+++ b/platform/fabric/core/msp/ouconfig_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBadConfigOU(t *testing.T) {
+func TestBadConfigOU(t *testing.T) { //nolint:paralleltest
 	// testdata/badconfigou:
 	// the configuration is such that only identities
 	// with OU=COP2 and signed by the root ca should be validated
@@ -40,7 +40,7 @@ func TestBadConfigOU(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestBadConfigOUCert(t *testing.T) {
+func TestBadConfigOUCert(t *testing.T) { //nolint:paralleltest
 	// testdata/badconfigoucert:
 	// the configuration of the OU identifier points to a
 	// certificate that is neither a CA nor an intermediate CA for the msp.
@@ -56,7 +56,7 @@ func TestBadConfigOUCert(t *testing.T) {
 	require.Contains(t, err.Error(), "] not in root or intermediate certs")
 }
 
-func TestValidateIntermediateConfigOU(t *testing.T) {
+func TestValidateIntermediateConfigOU(t *testing.T) { //nolint:paralleltest
 	// testdata/external:
 	// the configuration is such that only identities with
 	// OU=Hyperledger Testing and signed by the intermediate ca should be validated

--- a/platform/fabric/core/msp/revocation_test.go
+++ b/platform/fabric/core/msp/revocation_test.go
@@ -30,8 +30,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRevocation(t *testing.T) {
-	t.Run("ValidCRLSignature", func(t *testing.T) {
+func TestRevocation(t *testing.T) { //nolint:paralleltest
+	t.Run("ValidCRLSignature", func(t *testing.T) { //nolint:paralleltest
 		// testdata/revocation
 		// 1) a key and a signcert (used to populate the default signing identity);
 		// 2) cacert is the CA that signed the intermediate;
@@ -46,7 +46,7 @@ func TestRevocation(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("MalformedCRLSignature", func(t *testing.T) {
+	t.Run("MalformedCRLSignature", func(t *testing.T) { //nolint:paralleltest
 		// This test appends an extra int to the CRL signature. This extra data is
 		// ignored in go 1.14, the signature is considered valid, and the identity
 		// is treated as revoked.
@@ -109,7 +109,7 @@ func TestRevocation(t *testing.T) {
 		require.EqualError(t, err, "could not validate identity against certification chain: The certificate has been revoked")
 	})
 
-	t.Run("InvalidCRLSignature", func(t *testing.T) {
+	t.Run("InvalidCRLSignature", func(t *testing.T) { //nolint:paralleltest
 		// This MSP is identical to the previous one, with only 1 difference:
 		// the signature on the CRL is invalid
 		thisMSP := getLocalMSP(t, "testdata/revocation2")
@@ -124,7 +124,7 @@ func TestRevocation(t *testing.T) {
 	})
 }
 
-func TestIdentityPolicyPrincipalAgainstRevokedIdentity(t *testing.T) {
+func TestIdentityPolicyPrincipalAgainstRevokedIdentity(t *testing.T) { //nolint:paralleltest
 	// testdata/revocation
 	// 1) a key and a signcert (used to populate the default signing identity);
 	// 2) cacert is the CA that signed the intermediate;
@@ -146,7 +146,7 @@ func TestIdentityPolicyPrincipalAgainstRevokedIdentity(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestRevokedIntermediateCA(t *testing.T) {
+func TestRevokedIntermediateCA(t *testing.T) { //nolint:paralleltest
 	// testdata/revokedica
 	// 1) a key and a signcert (used to populate the default signing identity);
 	// 2) cacert is the CA that signed the intermediate;

--- a/platform/fabric/core/msp/tls_test.go
+++ b/platform/fabric/core/msp/tls_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTLSCAs(t *testing.T) {
+func TestTLSCAs(t *testing.T) { //nolint:paralleltest
 	// testdata/tls contains TLS a root CA and an intermediate CA
 	thisMSP := getLocalMSP(t, "testdata/tls")
 

--- a/platform/fabric/core/msp/tlsgen/ca_test.go
+++ b/platform/fabric/core/msp/tlsgen/ca_test.go
@@ -39,6 +39,7 @@ func createTLSService(t *testing.T, ca CA, host string) *grpc.Server {
 }
 
 func TestTLSCA(t *testing.T) {
+	t.Parallel()
 	// This test checks that the CA can create certificates
 	// and corresponding keys that are signed by itself
 
@@ -109,6 +110,7 @@ func TestTLSCA(t *testing.T) {
 }
 
 func TestTLSCASigner(t *testing.T) {
+	t.Parallel()
 	tlsCA, err := NewCA()
 	require.NoError(t, err)
 	require.Equal(t, tlsCA.(*ca).caCert.Signer, tlsCA.Signer())

--- a/platform/fabric/core/msp/tlsgen/key_test.go
+++ b/platform/fabric/core/msp/tlsgen/key_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestLoadCert(t *testing.T) {
+	t.Parallel()
 	pair, err := newCertKeyPair(false, false, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, pair)

--- a/platform/fabric/core/protoutil/commonutils_test.go
+++ b/platform/fabric/core/protoutil/commonutils_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestNonceRandomness(t *testing.T) {
+	t.Parallel()
 	n1, err := CreateNonce()
 	if err != nil {
 		t.Fatal(err)
@@ -30,6 +31,7 @@ func TestNonceRandomness(t *testing.T) {
 }
 
 func TestNonceLength(t *testing.T) {
+	t.Parallel()
 	n, err := CreateNonce()
 	if err != nil {
 		t.Fatal(err)
@@ -42,6 +44,7 @@ func TestNonceLength(t *testing.T) {
 }
 
 func TestUnmarshalPayload(t *testing.T) {
+	t.Parallel()
 	var payload *cb.Payload
 	good, _ := proto.Marshal(&cb.Payload{
 		Data: []byte("payload"),
@@ -52,13 +55,16 @@ func TestUnmarshalPayload(t *testing.T) {
 }
 
 func TestUnmarshalSignatureHeader(t *testing.T) {
+	t.Parallel()
 	t.Run("invalid header", func(t *testing.T) {
+		t.Parallel()
 		sighdrBytes := []byte("invalid signature header")
 		_, err := UnmarshalSignatureHeader(sighdrBytes)
 		require.Error(t, err, "Expected unmarshalling error")
 	})
 
 	t.Run("valid empty header", func(t *testing.T) {
+		t.Parallel()
 		sighdr := &cb.SignatureHeader{}
 		sighdrBytes := MarshalOrPanic(sighdr)
 		sighdr, err := UnmarshalSignatureHeader(sighdrBytes)
@@ -68,6 +74,7 @@ func TestUnmarshalSignatureHeader(t *testing.T) {
 	})
 
 	t.Run("valid header", func(t *testing.T) {
+		t.Parallel()
 		sighdr := &cb.SignatureHeader{
 			Creator: []byte("creator"),
 			Nonce:   []byte("nonce"),
@@ -81,6 +88,7 @@ func TestUnmarshalSignatureHeader(t *testing.T) {
 }
 
 func TestUnmarshalEnvelope(t *testing.T) {
+	t.Parallel()
 	var env *cb.Envelope
 	good, _ := proto.Marshal(&cb.Envelope{})
 	env, err := UnmarshalEnvelope(good)
@@ -89,6 +97,7 @@ func TestUnmarshalEnvelope(t *testing.T) {
 }
 
 func TestUnmarshalBlock(t *testing.T) {
+	t.Parallel()
 	var env *cb.Block
 	good, _ := proto.Marshal(&cb.Block{})
 	env, err := UnmarshalBlock(good)
@@ -97,6 +106,7 @@ func TestUnmarshalBlock(t *testing.T) {
 }
 
 func TestUnmarshalEnvelopeOfType(t *testing.T) {
+	t.Parallel()
 	env := &cb.Envelope{}
 
 	env.Payload = []byte("bad payload")
@@ -160,12 +170,14 @@ func TestUnmarshalEnvelopeOfType(t *testing.T) {
 }
 
 func TestExtractEnvelopeNilData(t *testing.T) {
+	t.Parallel()
 	block := &cb.Block{}
 	_, err := ExtractEnvelope(block, 0)
 	require.Error(t, err, "Nil data")
 }
 
 func TestExtractEnvelopeWrongIndex(t *testing.T) {
+	t.Parallel()
 	block := testBlock()
 	if _, err := ExtractEnvelope(block, len(block.GetData().Data)); err == nil {
 		t.Fatal("Expected envelope extraction to fail (wrong index)")
@@ -173,6 +185,7 @@ func TestExtractEnvelopeWrongIndex(t *testing.T) {
 }
 
 func TestExtractEnvelope(t *testing.T) {
+	t.Parallel()
 	if envelope, err := ExtractEnvelope(testBlock(), 0); err != nil {
 		t.Fatalf("Expected envelop extraction to succeed: %s", err)
 	} else if !proto.Equal(envelope, testEnvelope()) {
@@ -181,6 +194,7 @@ func TestExtractEnvelope(t *testing.T) {
 }
 
 func TestExtractPayload(t *testing.T) {
+	t.Parallel()
 	if payload, err := UnmarshalPayload(testEnvelope().Payload); err != nil {
 		t.Fatalf("Expected payload extraction to succeed: %s", err)
 	} else if !proto.Equal(payload, testPayload()) {
@@ -214,6 +228,7 @@ func testBlock() *cb.Block {
 }
 
 func TestGetRandomNonce(t *testing.T) {
+	t.Parallel()
 	key1, err := getRandomNonce()
 	require.NoErrorf(t, err, "error getting random bytes")
 	require.Len(t, key1, NonceSize)

--- a/platform/fabric/core/protoutil/proputils_test.go
+++ b/platform/fabric/core/protoutil/proputils_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestComputeProposalTxID(t *testing.T) {
+	t.Parallel()
 	txid := protoutil.ComputeTxID([]byte{1}, []byte{1})
 
 	// Compute the function computed by ComputeTxID,

--- a/platform/fabric/core/protoutil/txutils_test.go
+++ b/platform/fabric/core/protoutil/txutils_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestGetPayloads(t *testing.T) {
+	t.Parallel()
 	var txAction *pb.TransactionAction
 	var err error
 
@@ -118,6 +119,7 @@ func TestGetPayloads(t *testing.T) {
 }
 
 func TestDeduplicateEndorsements(t *testing.T) {
+	t.Parallel()
 	signID := &fakes.SignerSerializer{}
 	signID.SerializeReturns([]byte("signer"), nil)
 	signerBytes, err := signID.Serialize()
@@ -153,6 +155,7 @@ func TestDeduplicateEndorsements(t *testing.T) {
 }
 
 func TestCreateSignedTx(t *testing.T) {
+	t.Parallel()
 	var err error
 	prop := &pb.Proposal{}
 
@@ -269,11 +272,13 @@ func TestCreateSignedTx(t *testing.T) {
 }
 
 func TestCreateSignedTxNoSigner(t *testing.T) {
+	t.Parallel()
 	_, err := protoutil.CreateSignedTx(nil, nil, &pb.ProposalResponse{})
 	require.ErrorContains(t, err, "signer is required when creating a signed transaction")
 }
 
 func TestCreateSignedTxStatus(t *testing.T) {
+	t.Parallel()
 	serializedExtension, err := proto.Marshal(&pb.ChaincodeHeaderExtension{})
 	require.NoError(t, err)
 	serializedChannelHeader, err := proto.Marshal(&cb.ChannelHeader{
@@ -315,6 +320,7 @@ func TestCreateSignedTxStatus(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(strconv.Itoa(int(tc.status)), func(t *testing.T) {
+			t.Parallel()
 			response := &pb.ProposalResponse{
 				Payload:     []byte("payload"),
 				Endorsement: &pb.Endorsement{},
@@ -335,6 +341,7 @@ func TestCreateSignedTxStatus(t *testing.T) {
 }
 
 func TestCreateSignedEnvelope(t *testing.T) {
+	t.Parallel()
 	var env *cb.Envelope
 	channelID := "mychannelID"
 	msg := &cb.ConfigEnvelope{}
@@ -362,6 +369,7 @@ func TestCreateSignedEnvelope(t *testing.T) {
 }
 
 func TestCreateSignedEnvelopeNilSigner(t *testing.T) {
+	t.Parallel()
 	var env *cb.Envelope
 	channelID := "mychannelID"
 	msg := &cb.ConfigEnvelope{}
@@ -381,6 +389,7 @@ func TestCreateSignedEnvelopeNilSigner(t *testing.T) {
 }
 
 func TestGetSignedProposal(t *testing.T) {
+	t.Parallel()
 	var signedProp *pb.SignedProposal
 	var err error
 
@@ -405,6 +414,7 @@ func TestGetSignedProposal(t *testing.T) {
 }
 
 func TestGetBytesProposalPayloadForTx(t *testing.T) {
+	t.Parallel()
 	input := &pb.ChaincodeProposalPayload{
 		Input:        []byte("input"),
 		TransientMap: make(map[string][]byte),

--- a/platform/fabric/events_test.go
+++ b/platform/fabric/events_test.go
@@ -55,6 +55,7 @@ func (m *mockSubscriber) Publish(chaincodeName string, event *committer.Chaincod
 }
 
 func TestEventListener(t *testing.T) {
+	t.Parallel()
 	subscriber := &mockSubscriber{}
 	listener := newEventListener(subscriber, "testChaincode")
 	ch := listener.ChaincodeEvents()
@@ -121,6 +122,7 @@ func TestEventListener(t *testing.T) {
 }
 
 func TestEventServiceMultipleClose(t *testing.T) {
+	t.Parallel()
 	subscriber := &mockSubscriber{}
 	listener := newEventListener(subscriber, "testChaincode")
 	ch := listener.ChaincodeEvents()
@@ -148,6 +150,7 @@ func TestEventServiceMultipleClose(t *testing.T) {
 }
 
 func TestEventListenerDeadlock(t *testing.T) {
+	t.Parallel()
 	subscriber := &mockSubscriber{}
 
 	const customBufferLen = 1

--- a/platform/fabric/sdk/dig/sdk_test.go
+++ b/platform/fabric/sdk/dig/sdk_test.go
@@ -14,5 +14,6 @@ import (
 )
 
 func TestWiring(t *testing.T) {
+	t.Parallel()
 	assert.NoError(t, sdk.DryRunWiring(NewFrom, sdk.WithBool("fabric.enabled", true)))
 }

--- a/platform/fabric/services/db/driver/sql/common/endorsetx_test.go
+++ b/platform/fabric/services/db/driver/sql/common/endorsetx_test.go
@@ -15,37 +15,37 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/sqlite"
 )
 
-func TestEnvelope_GetData(t *testing.T) {
+func TestEnvelope_GetData(t *testing.T) { //nolint:paralleltest
 	GetData(t, func(db *sql.DB, key string) ([]byte, error) {
 		return mockEnvelopeStore(db).GetEnvelope(context.Background(), key)
 	})
 }
 
-func TestEnvelope_GetData_NoData(t *testing.T) {
+func TestEnvelope_GetData_NoData(t *testing.T) { //nolint:paralleltest
 	GetData_NoData(t, func(db *sql.DB, key string) ([]byte, error) {
 		return mockEnvelopeStore(db).GetEnvelope(context.Background(), key)
 	})
 }
 
-func TestEnvelope_ExistData_True(t *testing.T) {
+func TestEnvelope_ExistData_True(t *testing.T) { //nolint:paralleltest
 	ExistData_True(t, func(db *sql.DB, key string) (bool, error) {
 		return mockEnvelopeStore(db).ExistsEnvelope(context.Background(), key)
 	})
 }
 
-func TestEnvelope_ExistData_False(t *testing.T) {
+func TestEnvelope_ExistData_False(t *testing.T) { //nolint:paralleltest
 	ExistData_False(t, func(db *sql.DB, key string) (bool, error) {
 		return mockEnvelopeStore(db).ExistsEnvelope(context.Background(), key)
 	})
 }
 
-func TestEnvelope_PutData_Success(t *testing.T) {
+func TestEnvelope_PutData_Success(t *testing.T) { //nolint:paralleltest
 	PutData_Success(t, func(db *sql.DB, key string, data []byte) error {
 		return mockEnvelopeStore(db).PutEnvelope(context.Background(), key, data)
 	})
 }
 
-func TestEnvelope_PutData_Conflict(t *testing.T) {
+func TestEnvelope_PutData_Conflict(t *testing.T) { //nolint:paralleltest
 	PutData_Conflict(t, func(db *sql.DB, key string, data []byte) error {
 		return mockEnvelopeStore(db).PutEnvelope(context.Background(), key, data)
 	})

--- a/platform/fabric/services/db/driver/sql/common/envelope_test.go
+++ b/platform/fabric/services/db/driver/sql/common/envelope_test.go
@@ -15,37 +15,37 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/sqlite"
 )
 
-func TestEndorseTX_GetData(t *testing.T) {
+func TestEndorseTX_GetData(t *testing.T) { //nolint:paralleltest
 	GetData(t, func(db *sql.DB, key string) ([]byte, error) {
 		return mockEndorseTXStore(db).GetEndorseTx(context.Background(), key)
 	})
 }
 
-func TestEndorseTX_GetData_NoData(t *testing.T) {
+func TestEndorseTX_GetData_NoData(t *testing.T) { //nolint:paralleltest
 	GetData_NoData(t, func(db *sql.DB, key string) ([]byte, error) {
 		return mockEndorseTXStore(db).GetEndorseTx(context.Background(), key)
 	})
 }
 
-func TestEndorseTX_ExistData_True(t *testing.T) {
+func TestEndorseTX_ExistData_True(t *testing.T) { //nolint:paralleltest
 	ExistData_True(t, func(db *sql.DB, key string) (bool, error) {
 		return mockEndorseTXStore(db).ExistsEndorseTx(context.Background(), key)
 	})
 }
 
-func TestEndorseTX_ExistData_False(t *testing.T) {
+func TestEndorseTX_ExistData_False(t *testing.T) { //nolint:paralleltest
 	ExistData_False(t, func(db *sql.DB, key string) (bool, error) {
 		return mockEndorseTXStore(db).ExistsEndorseTx(context.Background(), key)
 	})
 }
 
-func TestEndorseTX_PutData_Success(t *testing.T) {
+func TestEndorseTX_PutData_Success(t *testing.T) { //nolint:paralleltest
 	PutData_Success(t, func(db *sql.DB, key string, data []byte) error {
 		return mockEndorseTXStore(db).PutEndorseTx(context.Background(), key, data)
 	})
 }
 
-func TestEndorseTX_PutData_Conflict(t *testing.T) {
+func TestEndorseTX_PutData_Conflict(t *testing.T) { //nolint:paralleltest
 	PutData_Conflict(t, func(db *sql.DB, key string, data []byte) error {
 		return mockEndorseTXStore(db).PutEndorseTx(context.Background(), key, data)
 	})

--- a/platform/fabric/services/db/driver/sql/common/metadata_test.go
+++ b/platform/fabric/services/db/driver/sql/common/metadata_test.go
@@ -15,37 +15,37 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/sqlite"
 )
 
-func TestMetadata_GetData(t *testing.T) {
+func TestMetadata_GetData(t *testing.T) { //nolint:paralleltest
 	GetData(t, func(db *sql.DB, key string) ([]byte, error) {
 		return mockMetadataStore(db).GetMetadata(context.Background(), key)
 	})
 }
 
-func TestMetadata_GetData_NoData(t *testing.T) {
+func TestMetadata_GetData_NoData(t *testing.T) { //nolint:paralleltest
 	GetData_NoData(t, func(db *sql.DB, key string) ([]byte, error) {
 		return mockMetadataStore(db).GetMetadata(context.Background(), key)
 	})
 }
 
-func TestMetadata_ExistData_True(t *testing.T) {
+func TestMetadata_ExistData_True(t *testing.T) { //nolint:paralleltest
 	ExistData_True(t, func(db *sql.DB, key string) (bool, error) {
 		return mockMetadataStore(db).ExistMetadata(context.Background(), key)
 	})
 }
 
-func TestMetadata_ExistData_False(t *testing.T) {
+func TestMetadata_ExistData_False(t *testing.T) { //nolint:paralleltest
 	ExistData_False(t, func(db *sql.DB, key string) (bool, error) {
 		return mockMetadataStore(db).ExistMetadata(context.Background(), key)
 	})
 }
 
-func TestMetadata_PutData_Success(t *testing.T) {
+func TestMetadata_PutData_Success(t *testing.T) { //nolint:paralleltest
 	PutData_Success(t, func(db *sql.DB, key string, data []byte) error {
 		return mockMetadataStore(db).PutMetadata(context.Background(), key, data)
 	})
 }
 
-func TestMetadata_PutData_Conflict(t *testing.T) {
+func TestMetadata_PutData_Conflict(t *testing.T) { //nolint:paralleltest
 	PutData_Conflict(t, func(db *sql.DB, key string, data []byte) error {
 		return mockMetadataStore(db).PutMetadata(context.Background(), key, data)
 	})

--- a/platform/fabric/services/state/namespace_test.go
+++ b/platform/fabric/services/state/namespace_test.go
@@ -40,6 +40,7 @@ type Asset struct {
 }
 
 func TestMarshalTagsPointerToStruct(t *testing.T) {
+	t.Parallel()
 	n := &Namespace{}
 	h := &House{
 		Address:   "Universe Drive",
@@ -59,6 +60,7 @@ func TestMarshalTagsPointerToStruct(t *testing.T) {
 }
 
 func TestMarshalTagsPointerToStruct2(t *testing.T) {
+	t.Parallel()
 	n := &Namespace{}
 	h := &Asset{
 		ObjectType:        "otype",

--- a/platform/fabric/services/storage/vault/vaultstore_test.go
+++ b/platform/fabric/services/storage/vault/vaultstore_test.go
@@ -261,7 +261,7 @@ func testPagination(store driver.VaultStore) {
 	}
 }
 
-func TestPaginationStoreMem(t *testing.T) {
+func TestPaginationStoreMem(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 	db, err := OpenMemoryVault("testdb")
 	require.NoError(t, err)
@@ -273,7 +273,7 @@ func TestPaginationStoreMem(t *testing.T) {
 	testPagination(db)
 }
 
-func TestPaginationStoreSqlite(t *testing.T) {
+func TestPaginationStoreSqlite(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 	db, err := OpenSqliteVault("testdb", t.TempDir())
 	require.NoError(t, err)
@@ -285,7 +285,7 @@ func TestPaginationStoreSqlite(t *testing.T) {
 	testPagination(db)
 }
 
-func TestPaginationStoreSPostgres(t *testing.T) {
+func TestPaginationStoreSPostgres(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 	db, terminate, err := OpenPostgresVault("testdb")
 	require.NoError(t, err)
@@ -295,7 +295,7 @@ func TestPaginationStoreSPostgres(t *testing.T) {
 	testPagination(db)
 }
 
-func TestVaultStoreMem(t *testing.T) {
+func TestVaultStoreMem(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 	db, err := OpenMemoryVault("testdb")
 	require.NoError(t, err)
@@ -308,7 +308,7 @@ func TestVaultStoreMem(t *testing.T) {
 	testOneMore(t, db)
 }
 
-func TestVaultStoreSqlite(t *testing.T) {
+func TestVaultStoreSqlite(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 	db, err := OpenSqliteVault("testdb", t.TempDir())
 	require.NoError(t, err)
@@ -321,7 +321,7 @@ func TestVaultStoreSqlite(t *testing.T) {
 	testOneMore(t, db)
 }
 
-func TestVaultStorePostgres(t *testing.T) {
+func TestVaultStorePostgres(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 	db, terminate, err := OpenPostgresVault("testdb")
 	require.NoError(t, err)

--- a/platform/fabricx/core/channel/config/config_test.go
+++ b/platform/fabricx/core/channel/config/config_test.go
@@ -16,7 +16,9 @@ import (
 )
 
 func TestNewConfig(t *testing.T) {
+	t.Parallel()
 	t.Run("with default values", func(t *testing.T) {
+		t.Parallel()
 		cs := &mock.ConfigService{}
 		config, err := channelconfig.NewConfig(cs)
 		require.NoError(t, err)
@@ -28,6 +30,7 @@ func TestNewConfig(t *testing.T) {
 	})
 
 	t.Run("with custom values", func(t *testing.T) {
+		t.Parallel()
 		cs := &mock.ConfigService{}
 		cs.IsSetReturnsOnCall(0, true) // pollInterval
 		cs.GetDurationReturnsOnCall(0, 30*time.Second)
@@ -48,6 +51,7 @@ func TestNewConfig(t *testing.T) {
 	})
 
 	t.Run("with all custom values set", func(t *testing.T) {
+		t.Parallel()
 		cs := &mock.ConfigService{}
 		cs.IsSetReturns(true)
 		cs.GetDurationReturns(45 * time.Second)
@@ -60,7 +64,9 @@ func TestNewConfig(t *testing.T) {
 }
 
 func TestConfigValidate(t *testing.T) {
+	t.Parallel()
 	t.Run("valid configuration", func(t *testing.T) {
+		t.Parallel()
 		config := &channelconfig.Config{
 			PollInterval:      1 * time.Minute,
 			MaxRetries:        5,
@@ -72,6 +78,7 @@ func TestConfigValidate(t *testing.T) {
 	})
 
 	t.Run("invalid poll interval - zero", func(t *testing.T) {
+		t.Parallel()
 		config := &channelconfig.Config{
 			PollInterval:      0,
 			MaxRetries:        5,
@@ -84,6 +91,7 @@ func TestConfigValidate(t *testing.T) {
 	})
 
 	t.Run("invalid poll interval - negative", func(t *testing.T) {
+		t.Parallel()
 		config := &channelconfig.Config{
 			PollInterval:      -1 * time.Second,
 			MaxRetries:        5,
@@ -96,6 +104,7 @@ func TestConfigValidate(t *testing.T) {
 	})
 
 	t.Run("invalid max retries - negative", func(t *testing.T) {
+		t.Parallel()
 		config := &channelconfig.Config{
 			PollInterval:      1 * time.Minute,
 			MaxRetries:        -1,
@@ -108,6 +117,7 @@ func TestConfigValidate(t *testing.T) {
 	})
 
 	t.Run("valid max retries - zero", func(t *testing.T) {
+		t.Parallel()
 		config := &channelconfig.Config{
 			PollInterval:      1 * time.Minute,
 			MaxRetries:        0,
@@ -119,6 +129,7 @@ func TestConfigValidate(t *testing.T) {
 	})
 
 	t.Run("invalid initial retry delay - zero", func(t *testing.T) {
+		t.Parallel()
 		config := &channelconfig.Config{
 			PollInterval:      1 * time.Minute,
 			MaxRetries:        5,
@@ -131,6 +142,7 @@ func TestConfigValidate(t *testing.T) {
 	})
 
 	t.Run("invalid max retry delay - zero", func(t *testing.T) {
+		t.Parallel()
 		config := &channelconfig.Config{
 			PollInterval:      1 * time.Minute,
 			MaxRetries:        5,
@@ -143,6 +155,7 @@ func TestConfigValidate(t *testing.T) {
 	})
 
 	t.Run("invalid - initial delay exceeds max delay", func(t *testing.T) {
+		t.Parallel()
 		config := &channelconfig.Config{
 			PollInterval:      1 * time.Minute,
 			MaxRetries:        5,

--- a/platform/fabricx/core/channel/config/monitor_test.go
+++ b/platform/fabricx/core/channel/config/monitor_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestNewChannelConfigMonitor(t *testing.T) {
+	t.Parallel()
 	config := &channelconfig.Config{
 		PollInterval:      1 * time.Minute,
 		MaxRetries:        5,
@@ -33,6 +34,7 @@ func TestNewChannelConfigMonitor(t *testing.T) {
 	configService := &mock.ConfigService{}
 
 	t.Run("successful creation", func(t *testing.T) {
+		t.Parallel()
 		monitor, err := channelconfig.NewChannelConfigMonitor(
 			config,
 			queryService,
@@ -48,6 +50,7 @@ func TestNewChannelConfigMonitor(t *testing.T) {
 	})
 
 	t.Run("nil config", func(t *testing.T) {
+		t.Parallel()
 		monitor, err := channelconfig.NewChannelConfigMonitor(
 			nil,
 			queryService,
@@ -63,6 +66,7 @@ func TestNewChannelConfigMonitor(t *testing.T) {
 	})
 
 	t.Run("nil query service", func(t *testing.T) {
+		t.Parallel()
 		monitor, err := channelconfig.NewChannelConfigMonitor(
 			config,
 			nil,
@@ -78,6 +82,7 @@ func TestNewChannelConfigMonitor(t *testing.T) {
 	})
 
 	t.Run("nil membership service", func(t *testing.T) {
+		t.Parallel()
 		monitor, err := channelconfig.NewChannelConfigMonitor(
 			config,
 			queryService,
@@ -93,6 +98,7 @@ func TestNewChannelConfigMonitor(t *testing.T) {
 	})
 
 	t.Run("nil ordering service", func(t *testing.T) {
+		t.Parallel()
 		monitor, err := channelconfig.NewChannelConfigMonitor(
 			config,
 			queryService,
@@ -108,6 +114,7 @@ func TestNewChannelConfigMonitor(t *testing.T) {
 	})
 
 	t.Run("nil config service", func(t *testing.T) {
+		t.Parallel()
 		monitor, err := channelconfig.NewChannelConfigMonitor(
 			config,
 			queryService,
@@ -123,6 +130,7 @@ func TestNewChannelConfigMonitor(t *testing.T) {
 	})
 
 	t.Run("empty channel name", func(t *testing.T) {
+		t.Parallel()
 		monitor, err := channelconfig.NewChannelConfigMonitor(
 			config,
 			queryService,
@@ -139,6 +147,7 @@ func TestNewChannelConfigMonitor(t *testing.T) {
 }
 
 func TestServiceLifecycle(t *testing.T) {
+	t.Parallel()
 	config := &channelconfig.Config{
 		PollInterval:      100 * time.Millisecond,
 		MaxRetries:        2,
@@ -157,6 +166,7 @@ func TestServiceLifecycle(t *testing.T) {
 	}, nil)
 
 	t.Run("start and stop", func(t *testing.T) {
+		t.Parallel()
 		monitor, err := channelconfig.NewChannelConfigMonitor(
 			config, queryService, membershipService,
 			orderingService, configService, "testnet", "mychannel",
@@ -181,6 +191,7 @@ func TestServiceLifecycle(t *testing.T) {
 	})
 
 	t.Run("start already running", func(t *testing.T) {
+		t.Parallel()
 		monitor, err := channelconfig.NewChannelConfigMonitor(
 			config, queryService, membershipService,
 			orderingService, configService, "testnet", "mychannel",
@@ -200,6 +211,7 @@ func TestServiceLifecycle(t *testing.T) {
 	})
 
 	t.Run("stop not running", func(t *testing.T) {
+		t.Parallel()
 		monitor, err := channelconfig.NewChannelConfigMonitor(
 			config, queryService, membershipService,
 			orderingService, configService, "testnet", "mychannel",
@@ -212,6 +224,7 @@ func TestServiceLifecycle(t *testing.T) {
 	})
 
 	t.Run("start with nil context", func(t *testing.T) {
+		t.Parallel()
 		monitor, err := channelconfig.NewChannelConfigMonitor(
 			config, queryService, membershipService,
 			orderingService, configService, "testnet", "mychannel",
@@ -228,6 +241,7 @@ func TestServiceLifecycle(t *testing.T) {
 }
 
 func TestConfigurationUpdate(t *testing.T) {
+	t.Parallel()
 	config := &channelconfig.Config{
 		PollInterval:      100 * time.Millisecond,
 		MaxRetries:        2,
@@ -236,6 +250,7 @@ func TestConfigurationUpdate(t *testing.T) {
 	}
 
 	t.Run("successful update on new version", func(t *testing.T) {
+		t.Parallel()
 		queryService := &mock.QueryService{}
 		membershipService := &mock.MembershipService{}
 		orderingService := &mock.OrderingService{}
@@ -300,6 +315,7 @@ func TestConfigurationUpdate(t *testing.T) {
 	})
 
 	t.Run("no update on same version", func(t *testing.T) {
+		t.Parallel()
 		queryService := &mock.QueryService{}
 		membershipService := &mock.MembershipService{}
 		orderingService := &mock.OrderingService{}
@@ -337,6 +353,7 @@ func TestConfigurationUpdate(t *testing.T) {
 }
 
 func TestErrorHandling(t *testing.T) {
+	t.Parallel()
 	config := &channelconfig.Config{
 		PollInterval:      50 * time.Millisecond,
 		MaxRetries:        2,
@@ -345,6 +362,7 @@ func TestErrorHandling(t *testing.T) {
 	}
 
 	t.Run("query service error with retry", func(t *testing.T) {
+		t.Parallel()
 		queryService := &mock.QueryService{}
 		membershipService := &mock.MembershipService{}
 		orderingService := &mock.OrderingService{}
@@ -383,6 +401,7 @@ func TestErrorHandling(t *testing.T) {
 	})
 
 	t.Run("membership update error", func(t *testing.T) {
+		t.Parallel()
 		queryService := &mock.QueryService{}
 		membershipService := &mock.MembershipService{}
 		orderingService := &mock.OrderingService{}
@@ -416,6 +435,7 @@ func TestErrorHandling(t *testing.T) {
 	})
 
 	t.Run("nil config transaction info", func(t *testing.T) {
+		t.Parallel()
 		queryService := &mock.QueryService{}
 		membershipService := &mock.MembershipService{}
 		orderingService := &mock.OrderingService{}
@@ -443,6 +463,7 @@ func TestErrorHandling(t *testing.T) {
 }
 
 func TestContextCancellation(t *testing.T) {
+	t.Parallel()
 	config := &channelconfig.Config{
 		PollInterval:      1 * time.Second,
 		MaxRetries:        5,
@@ -461,6 +482,7 @@ func TestContextCancellation(t *testing.T) {
 	}, nil)
 
 	t.Run("context cancellation stops monitoring", func(t *testing.T) {
+		t.Parallel()
 		monitor, err := channelconfig.NewChannelConfigMonitor(
 			config, queryService, membershipService,
 			orderingService, configService, "testnet", "mychannel",

--- a/platform/fabricx/core/committer/config/config_test.go
+++ b/platform/fabricx/core/committer/config/config_test.go
@@ -17,7 +17,9 @@ import (
 )
 
 func TestNewNotificationServiceConfig(t *testing.T) {
+	t.Parallel()
 	t.Run("success", func(t *testing.T) {
+		t.Parallel()
 		fakeConfigService := &mock.ServiceBackend{}
 		fakeConfigService.UnmarshalKeyStub = func(key string, rawVal interface{}) error {
 			if key == "notificationService" {
@@ -38,6 +40,7 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 	})
 
 	t.Run("default timeout", func(t *testing.T) {
+		t.Parallel()
 		fakeConfigService := &mock.ServiceBackend{}
 		fakeConfigService.UnmarshalKeyReturns(nil)
 
@@ -48,6 +51,7 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 	})
 
 	t.Run("error unmarshal", func(t *testing.T) {
+		t.Parallel()
 		fakeConfigService := &mock.ServiceBackend{}
 		fakeConfigService.UnmarshalKeyReturns(errors.New("unmarshal-error"))
 
@@ -59,7 +63,9 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 }
 
 func TestNewQueryServiceConfig(t *testing.T) {
+	t.Parallel()
 	t.Run("success", func(t *testing.T) {
+		t.Parallel()
 		fakeConfigService := &mock.ServiceBackend{}
 		fakeConfigService.UnmarshalKeyStub = func(key string, rawVal interface{}) error {
 			if key == "queryService" {
@@ -80,6 +86,7 @@ func TestNewQueryServiceConfig(t *testing.T) {
 	})
 
 	t.Run("default timeout", func(t *testing.T) {
+		t.Parallel()
 		fakeConfigService := &mock.ServiceBackend{}
 		fakeConfigService.UnmarshalKeyReturns(nil)
 
@@ -90,6 +97,7 @@ func TestNewQueryServiceConfig(t *testing.T) {
 	})
 
 	t.Run("error unmarshal", func(t *testing.T) {
+		t.Parallel()
 		fakeConfigService := &mock.ServiceBackend{}
 		fakeConfigService.UnmarshalKeyReturns(errors.New("unmarshal-error"))
 

--- a/platform/fabricx/core/committer/config/provider_test.go
+++ b/platform/fabricx/core/committer/config/provider_test.go
@@ -17,7 +17,9 @@ import (
 )
 
 func TestConfigProvider_NotificationServiceConfig(t *testing.T) {
+	t.Parallel()
 	t.Run("success", func(t *testing.T) {
+		t.Parallel()
 		fakeConfigProvider := &mock.FabricConfigProvider{}
 		fakeConfigService := &mock.FabricConfigService{}
 		fakeConfigProvider.GetConfigReturns(fakeConfigService, nil)
@@ -42,6 +44,7 @@ func TestConfigProvider_NotificationServiceConfig(t *testing.T) {
 	})
 
 	t.Run("config provider error", func(t *testing.T) {
+		t.Parallel()
 		fakeConfigProvider := &mock.FabricConfigProvider{}
 		fakeConfigProvider.GetConfigReturns(nil, errors.New("config-error"))
 
@@ -53,6 +56,7 @@ func TestConfigProvider_NotificationServiceConfig(t *testing.T) {
 	})
 
 	t.Run("new config error", func(t *testing.T) {
+		t.Parallel()
 		fakeConfigProvider := &mock.FabricConfigProvider{}
 		fakeConfigService := &mock.FabricConfigService{}
 		fakeConfigProvider.GetConfigReturns(fakeConfigService, nil)
@@ -67,7 +71,9 @@ func TestConfigProvider_NotificationServiceConfig(t *testing.T) {
 }
 
 func TestConfigProvider_QueryServiceConfig(t *testing.T) {
+	t.Parallel()
 	t.Run("success", func(t *testing.T) {
+		t.Parallel()
 		fakeConfigProvider := &mock.FabricConfigProvider{}
 		fakeConfigService := &mock.FabricConfigService{}
 		fakeConfigProvider.GetConfigReturns(fakeConfigService, nil)
@@ -92,6 +98,7 @@ func TestConfigProvider_QueryServiceConfig(t *testing.T) {
 	})
 
 	t.Run("config provider error", func(t *testing.T) {
+		t.Parallel()
 		fakeConfigProvider := &mock.FabricConfigProvider{}
 		fakeConfigProvider.GetConfigReturns(nil, errors.New("config-error"))
 
@@ -103,6 +110,7 @@ func TestConfigProvider_QueryServiceConfig(t *testing.T) {
 	})
 
 	t.Run("new config error", func(t *testing.T) {
+		t.Parallel()
 		fakeConfigProvider := &mock.FabricConfigProvider{}
 		fakeConfigService := &mock.FabricConfigService{}
 		fakeConfigProvider.GetConfigReturns(fakeConfigService, nil)

--- a/platform/fabricx/core/committer/grpc/grpc_test.go
+++ b/platform/fabricx/core/committer/grpc/grpc_test.go
@@ -403,6 +403,9 @@ func startTestServer(t *testing.T, opts ...grpc.ServerOption) string {
 
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = lis.Close()
+	})
 
 	srv := grpc.NewServer(opts...)
 	hs := health.NewServer()

--- a/platform/fabricx/core/committer/queryservice/query_test.go
+++ b/platform/fabricx/core/committer/queryservice/query_test.go
@@ -45,6 +45,7 @@ func raw(u uint64) []byte {
 }
 
 func TestQueryService(t *testing.T) {
+	t.Parallel()
 	t.Run("GetState happy path", func(t *testing.T) {
 		t.Parallel()
 		qs, fake := setupTest(t)
@@ -389,6 +390,7 @@ func TestQueryService(t *testing.T) {
 		qs, fake := setupTest(t)
 
 		t.Run("happy path", func(t *testing.T) {
+			t.Parallel()
 			// return a response with one status
 			fake.GetTransactionStatusReturns(&committerpb.TxStatusResponse{
 				Statuses: []*committerpb.TxStatus{
@@ -404,6 +406,7 @@ func TestQueryService(t *testing.T) {
 		})
 
 		t.Run("client error", func(t *testing.T) {
+			t.Parallel()
 			expectedError := errors.New("some error")
 			fake.GetTransactionStatusReturns(nil, expectedError)
 
@@ -412,6 +415,7 @@ func TestQueryService(t *testing.T) {
 		})
 
 		t.Run("no statuses", func(t *testing.T) {
+			t.Parallel()
 			fake.GetTransactionStatusReturns(&committerpb.TxStatusResponse{Statuses: []*committerpb.TxStatus{}}, nil)
 
 			_, err := qs.GetTransactionStatus("tx3")
@@ -425,6 +429,7 @@ func TestQueryService(t *testing.T) {
 		qs, fake := setupTest(t)
 
 		t.Run("happy path", func(t *testing.T) {
+			t.Parallel()
 			// Create a valid protobuf envelope
 			envelope := &cb.Envelope{
 				Payload:   []byte("test-payload"),
@@ -449,6 +454,7 @@ func TestQueryService(t *testing.T) {
 		})
 
 		t.Run("client error", func(t *testing.T) {
+			t.Parallel()
 			expectedError := errors.New("some error")
 			fake.GetConfigTransactionReturns(nil, expectedError)
 

--- a/platform/fabricx/core/finality/nlm_test.go
+++ b/platform/fabricx/core/finality/nlm_test.go
@@ -139,6 +139,7 @@ func runManager(t *testing.T, nlm *notificationListenerManager) {
 }
 
 func TestNotificationListenerManager(t *testing.T) {
+	t.Parallel()
 	t.Run("Listen_Shutdown_Lifecycle_And_Cleanup", func(t *testing.T) {
 		t.Parallel()
 		nlm, fakeStream := setupTest(t)

--- a/platform/fabricx/core/finality/provider_test.go
+++ b/platform/fabricx/core/finality/provider_test.go
@@ -73,6 +73,7 @@ func setupMockNotificationManager(t *testing.T, streamBehavior func(context.Cont
 }
 
 func TestProvider_Initialize(t *testing.T) {
+	t.Parallel()
 	t.Run("Sets_BaseContext_On_First_Call", func(t *testing.T) {
 		t.Parallel()
 		mockGRPC := &mockGRPCClientProvider{}
@@ -122,6 +123,7 @@ func TestProvider_Initialize(t *testing.T) {
 }
 
 func TestProvider_NewManager(t *testing.T) {
+	t.Parallel()
 	t.Run("Panics_If_Not_Initialized", func(t *testing.T) {
 		t.Parallel()
 		mockGRPC := &mockGRPCClientProvider{}
@@ -389,6 +391,7 @@ func TestProvider_NewManager(t *testing.T) {
 }
 
 func TestGetListenerManager(t *testing.T) {
+	t.Parallel()
 	t.Run("Returns_Manager_From_Service_Provider", func(t *testing.T) {
 		t.Parallel()
 

--- a/platform/fabricx/core/ledger/ledger_test.go
+++ b/platform/fabricx/core/ledger/ledger_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestLedger_GetLedgerInfo(t *testing.T) {
+	t.Parallel()
 	fakeBlockClient := &mock.BlockQueryServiceClient{}
 	fakeQueryService := &mock.QueryService{}
 	ctx := context.Background()
@@ -45,6 +46,7 @@ func TestLedger_GetLedgerInfo(t *testing.T) {
 }
 
 func TestLedger_GetTransactionByID(t *testing.T) {
+	t.Parallel()
 	fakeBlockClient := &mock.BlockQueryServiceClient{}
 	fakeQueryService := &mock.QueryService{}
 	ctx := context.Background()
@@ -92,6 +94,7 @@ func TestLedger_GetTransactionByID(t *testing.T) {
 }
 
 func TestLedger_GetBlockNumberByTxID(t *testing.T) {
+	t.Parallel()
 	fakeBlockClient := &mock.BlockQueryServiceClient{}
 	fakeQueryService := &mock.QueryService{}
 	ctx := context.Background()
@@ -111,6 +114,7 @@ func TestLedger_GetBlockNumberByTxID(t *testing.T) {
 }
 
 func TestLedger_GetBlockByNumber(t *testing.T) {
+	t.Parallel()
 	fakeBlockClient := &mock.BlockQueryServiceClient{}
 	fakeQueryService := &mock.QueryService{}
 	ctx := context.Background()
@@ -134,6 +138,7 @@ func TestLedger_GetBlockByNumber(t *testing.T) {
 }
 
 func TestProcessedTransaction_IsValid(t *testing.T) {
+	t.Parallel()
 	pt := ledger.NewProcessedTransaction("", nil, int32(committerpb.Status_COMMITTED), nil)
 	require.True(t, pt.IsValid())
 
@@ -142,18 +147,21 @@ func TestProcessedTransaction_IsValid(t *testing.T) {
 }
 
 func TestProcessedTransaction_Envelope(t *testing.T) {
+	t.Parallel()
 	env := []byte("test-payload")
 	pt := ledger.NewProcessedTransaction("", nil, int32(committerpb.Status_COMMITTED), env)
 	require.Equal(t, env, pt.Envelope())
 }
 
 func TestProcessedTransaction_Results(t *testing.T) {
+	t.Parallel()
 	results := []byte("rwset-data")
 	pt := ledger.NewProcessedTransaction("", results, int32(committerpb.Status_COMMITTED), nil)
 	require.Equal(t, results, pt.Results())
 }
 
 func TestLedger_GetLedgerInfo_Error(t *testing.T) {
+	t.Parallel()
 	fakeBlockClient := &mock.BlockQueryServiceClient{}
 	fakeQueryService := &mock.QueryService{}
 	ctx := context.Background()
@@ -169,6 +177,7 @@ func TestLedger_GetLedgerInfo_Error(t *testing.T) {
 }
 
 func TestLedger_GetTransactionByID_GetTxByIDError(t *testing.T) {
+	t.Parallel()
 	fakeBlockClient := &mock.BlockQueryServiceClient{}
 	fakeQueryService := &mock.QueryService{}
 	ctx := context.Background()
@@ -185,6 +194,7 @@ func TestLedger_GetTransactionByID_GetTxByIDError(t *testing.T) {
 }
 
 func TestLedger_GetTransactionByID_GetTransactionStatusError(t *testing.T) {
+	t.Parallel()
 	fakeBlockClient := &mock.BlockQueryServiceClient{}
 	fakeQueryService := &mock.QueryService{}
 	ctx := context.Background()
@@ -222,6 +232,7 @@ func TestLedger_GetTransactionByID_GetTransactionStatusError(t *testing.T) {
 }
 
 func TestLedger_GetTransactionByID_NoStatusReturned(t *testing.T) {
+	t.Parallel()
 	fakeBlockClient := &mock.BlockQueryServiceClient{}
 	fakeQueryService := &mock.QueryService{}
 	ctx := context.Background()
@@ -259,6 +270,7 @@ func TestLedger_GetTransactionByID_NoStatusReturned(t *testing.T) {
 }
 
 func TestLedger_GetTransactionByID_InvalidPayload(t *testing.T) {
+	t.Parallel()
 	fakeBlockClient := &mock.BlockQueryServiceClient{}
 	fakeQueryService := &mock.QueryService{}
 	ctx := context.Background()
@@ -279,6 +291,7 @@ func TestLedger_GetTransactionByID_InvalidPayload(t *testing.T) {
 }
 
 func TestLedger_GetTransactionByID_InvalidHeaderType(t *testing.T) {
+	t.Parallel()
 	fakeBlockClient := &mock.BlockQueryServiceClient{}
 	fakeQueryService := &mock.QueryService{}
 	ctx := context.Background()
@@ -315,6 +328,7 @@ func TestLedger_GetTransactionByID_InvalidHeaderType(t *testing.T) {
 }
 
 func TestLedger_GetBlockNumberByTxID_Error(t *testing.T) {
+	t.Parallel()
 	fakeBlockClient := &mock.BlockQueryServiceClient{}
 	fakeQueryService := &mock.QueryService{}
 	ctx := context.Background()
@@ -331,6 +345,7 @@ func TestLedger_GetBlockNumberByTxID_Error(t *testing.T) {
 }
 
 func TestLedger_GetBlockByNumber_Error(t *testing.T) {
+	t.Parallel()
 	fakeBlockClient := &mock.BlockQueryServiceClient{}
 	fakeQueryService := &mock.QueryService{}
 	ctx := context.Background()
@@ -347,6 +362,7 @@ func TestLedger_GetBlockByNumber_Error(t *testing.T) {
 }
 
 func TestBlock_DataAt(t *testing.T) {
+	t.Parallel()
 	data := [][]byte{
 		[]byte("tx1"),
 		[]byte("tx2"),
@@ -366,6 +382,7 @@ func TestBlock_DataAt(t *testing.T) {
 }
 
 func TestBlock_ProcessedTransaction(t *testing.T) {
+	t.Parallel()
 	txID := "test-tx-id"
 
 	// Create a valid transaction envelope
@@ -416,6 +433,7 @@ func TestBlock_ProcessedTransaction(t *testing.T) {
 }
 
 func TestBlock_ProcessedTransaction_UnmarshalError(t *testing.T) {
+	t.Parallel()
 	block := &ledger.Block{
 		Block: &cb.Block{
 			Data: &cb.BlockData{
@@ -431,6 +449,7 @@ func TestBlock_ProcessedTransaction_UnmarshalError(t *testing.T) {
 }
 
 func TestBlock_ProcessedTransaction_InvalidPayload(t *testing.T) {
+	t.Parallel()
 	// Create an envelope with invalid payload that will fail unpackResults
 	env := &cb.Envelope{Payload: []byte("invalid-payload")}
 	envRaw, err := protoutil.Marshal(env)
@@ -458,12 +477,14 @@ func TestBlock_ProcessedTransaction_InvalidPayload(t *testing.T) {
 }
 
 func TestProcessedTransaction_TxID(t *testing.T) {
+	t.Parallel()
 	txID := "test-tx-id"
 	pt := ledger.NewProcessedTransaction(txID, nil, 0, nil)
 	assert.Equal(t, txID, pt.TxID())
 }
 
 func TestProcessedTransaction_ValidationCode(t *testing.T) {
+	t.Parallel()
 	code := int32(committerpb.Status_COMMITTED)
 	pt := ledger.NewProcessedTransaction("", nil, code, nil)
 	assert.Equal(t, code, pt.ValidationCode())

--- a/platform/fabricx/core/ledger/provider_test.go
+++ b/platform/fabricx/core/ledger/provider_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestProvider_Initialize(t *testing.T) {
+	t.Parallel()
 	mockGRPC := &mock.GRPCClientProvider{}
 	mockQS := &mock.QueryServiceProvider{}
 	p := ledger.NewProvider(mockGRPC, mockQS)
@@ -34,6 +35,7 @@ func TestProvider_Initialize(t *testing.T) {
 }
 
 func TestProvider_NewLedger(t *testing.T) {
+	t.Parallel()
 	mockGRPC := &mock.GRPCClientProvider{}
 	mockQS := &mock.QueryServiceProvider{}
 	mockGRPC.NotificationServiceClientReturns(&grpc.ClientConn{}, nil)
@@ -67,6 +69,7 @@ func TestProvider_NewLedger(t *testing.T) {
 }
 
 func TestGetLedgerProvider(t *testing.T) {
+	t.Parallel()
 	fakeSP := &mock.ServicesProvider{}
 	p := ledger.NewProvider(nil, nil)
 
@@ -82,6 +85,7 @@ func TestGetLedgerProvider(t *testing.T) {
 }
 
 func TestProvider_NewLedger_GRPCClientError(t *testing.T) {
+	t.Parallel()
 	mockGRPC := &mock.GRPCClientProvider{}
 	mockQS := &mock.QueryServiceProvider{}
 	expectedErr := errors.New("grpc connection error")
@@ -98,6 +102,7 @@ func TestProvider_NewLedger_GRPCClientError(t *testing.T) {
 }
 
 func TestGetLedgerProvider_Error(t *testing.T) {
+	t.Parallel()
 	fakeSP := &mock.ServicesProvider{}
 	expectedErr := errors.New("service not found")
 	fakeSP.GetServiceReturns(nil, expectedErr)

--- a/platform/fabricx/core/membership/membership_test.go
+++ b/platform/fabricx/core/membership/membership_test.go
@@ -176,6 +176,7 @@ func appChannelGenesisEnvelope(t *testing.T, channelID string) *cb.Envelope {
 // --- tests ---
 
 func TestNewService(t *testing.T) {
+	t.Parallel()
 	s := NewService("mychannel")
 	require.NotNil(t, s)
 	require.Equal(t, "mychannel", s.channelID)
@@ -183,7 +184,9 @@ func TestNewService(t *testing.T) {
 }
 
 func TestToMSPIdentity(t *testing.T) {
+	t.Parallel()
 	t.Run("valid identity", func(t *testing.T) {
+		t.Parallel()
 		data := serializedIdentity(t, "Org1MSP")
 		result, err := toMSPIdentity(data)
 		require.NoError(t, err)
@@ -191,6 +194,7 @@ func TestToMSPIdentity(t *testing.T) {
 	})
 
 	t.Run("empty bytes yield empty identity", func(t *testing.T) {
+		t.Parallel()
 		result, err := toMSPIdentity([]byte{})
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -198,6 +202,7 @@ func TestToMSPIdentity(t *testing.T) {
 	})
 
 	t.Run("invalid proto bytes return error", func(t *testing.T) {
+		t.Parallel()
 		// 0xff is an incomplete varint — invalid protobuf
 		_, err := toMSPIdentity([]byte{0xff})
 		require.Error(t, err)
@@ -205,7 +210,9 @@ func TestToMSPIdentity(t *testing.T) {
 }
 
 func TestCapabilitiesSupported(t *testing.T) {
+	t.Parallel()
 	t.Run("no application config returns error with channel id", func(t *testing.T) {
+		t.Parallel()
 		r := &mockResources{
 			appCfgOK:    false,
 			txValidator: &mockConfigtxValidator{id: "ch1"},
@@ -216,6 +223,7 @@ func TestCapabilitiesSupported(t *testing.T) {
 	})
 
 	t.Run("application capabilities not supported", func(t *testing.T) {
+		t.Parallel()
 		r := &mockResources{
 			appCfg:      &mockApplication{caps: &mockAppCapabilities{err: errors.New("app cap unsupported")}},
 			appCfgOK:    true,
@@ -227,6 +235,7 @@ func TestCapabilitiesSupported(t *testing.T) {
 	})
 
 	t.Run("channel capabilities not supported", func(t *testing.T) {
+		t.Parallel()
 		r := &mockResources{
 			appCfg:      &mockApplication{caps: &mockAppCapabilities{}},
 			appCfgOK:    true,
@@ -239,6 +248,7 @@ func TestCapabilitiesSupported(t *testing.T) {
 	})
 
 	t.Run("all capabilities supported", func(t *testing.T) {
+		t.Parallel()
 		r := &mockResources{
 			appCfg:   &mockApplication{caps: &mockAppCapabilities{}},
 			appCfgOK: true,
@@ -250,13 +260,16 @@ func TestCapabilitiesSupported(t *testing.T) {
 }
 
 func TestService_Update(t *testing.T) {
+	t.Parallel()
 	t.Run("invalid envelope payload returns error", func(t *testing.T) {
+		t.Parallel()
 		s := NewService("ch1")
 		err := s.Update(&cb.Envelope{Payload: []byte("not-a-proto")})
 		require.Error(t, err)
 	})
 
 	t.Run("valid genesis envelope succeeds", func(t *testing.T) {
+		t.Parallel()
 		s := NewService("testchannel")
 		env := appChannelGenesisEnvelope(t, "testchannel")
 		err := s.Update(env)
@@ -266,13 +279,16 @@ func TestService_Update(t *testing.T) {
 }
 
 func TestService_DryUpdate(t *testing.T) {
+	t.Parallel()
 	t.Run("invalid envelope payload returns error", func(t *testing.T) {
+		t.Parallel()
 		s := NewService("ch1")
 		err := s.DryUpdate(&cb.Envelope{Payload: []byte("not-a-proto")})
 		require.Error(t, err)
 	})
 
 	t.Run("valid genesis envelope succeeds without mutating resources", func(t *testing.T) {
+		t.Parallel()
 		s := NewService("testchannel")
 		env := appChannelGenesisEnvelope(t, "testchannel")
 		err := s.DryUpdate(env)
@@ -282,7 +298,9 @@ func TestService_DryUpdate(t *testing.T) {
 }
 
 func TestService_IsValid(t *testing.T) {
+	t.Parallel()
 	t.Run("invalid identity bytes return error", func(t *testing.T) {
+		t.Parallel()
 		s := NewService("ch1")
 		s.channelResources = &mockResources{}
 		err := s.IsValid([]byte{0xff})
@@ -290,6 +308,7 @@ func TestService_IsValid(t *testing.T) {
 	})
 
 	t.Run("deserialization error is propagated", func(t *testing.T) {
+		t.Parallel()
 		s := NewService("ch1")
 		s.channelResources = &mockResources{
 			mspMgr: &mockMSPManager{deserializeErr: errors.New("deserialization failed")},
@@ -300,6 +319,7 @@ func TestService_IsValid(t *testing.T) {
 	})
 
 	t.Run("validate error is propagated", func(t *testing.T) {
+		t.Parallel()
 		s := NewService("ch1")
 		s.channelResources = &mockResources{
 			mspMgr: &mockMSPManager{identity: &mockMSPIdentity{validateErr: errors.New("invalid cert")}},
@@ -310,6 +330,7 @@ func TestService_IsValid(t *testing.T) {
 	})
 
 	t.Run("valid identity returns nil", func(t *testing.T) {
+		t.Parallel()
 		s := NewService("ch1")
 		s.channelResources = &mockResources{
 			mspMgr: &mockMSPManager{identity: &mockMSPIdentity{}},
@@ -320,7 +341,9 @@ func TestService_IsValid(t *testing.T) {
 }
 
 func TestService_GetVerifier(t *testing.T) {
+	t.Parallel()
 	t.Run("invalid identity bytes return error", func(t *testing.T) {
+		t.Parallel()
 		s := NewService("ch1")
 		s.channelResources = &mockResources{}
 		_, err := s.GetVerifier([]byte{0xff})
@@ -328,6 +351,7 @@ func TestService_GetVerifier(t *testing.T) {
 	})
 
 	t.Run("deserialization error is propagated", func(t *testing.T) {
+		t.Parallel()
 		s := NewService("ch1")
 		s.channelResources = &mockResources{
 			mspMgr: &mockMSPManager{deserializeErr: errors.New("deserialization failed")},
@@ -337,6 +361,7 @@ func TestService_GetVerifier(t *testing.T) {
 	})
 
 	t.Run("success returns verifier", func(t *testing.T) {
+		t.Parallel()
 		s := NewService("ch1")
 		identity := &mockMSPIdentity{}
 		s.channelResources = &mockResources{
@@ -349,13 +374,16 @@ func TestService_GetVerifier(t *testing.T) {
 }
 
 func TestService_GetMSPIDs(t *testing.T) {
+	t.Parallel()
 	t.Run("no application config returns nil", func(t *testing.T) {
+		t.Parallel()
 		s := NewService("ch1")
 		s.channelResources = &mockResources{appCfgOK: false}
 		require.Nil(t, s.GetMSPIDs())
 	})
 
 	t.Run("nil organizations returns nil", func(t *testing.T) {
+		t.Parallel()
 		s := NewService("ch1")
 		s.channelResources = &mockResources{
 			appCfg:   &mockApplication{orgs: nil},
@@ -365,6 +393,7 @@ func TestService_GetMSPIDs(t *testing.T) {
 	})
 
 	t.Run("returns MSP IDs from all organizations", func(t *testing.T) {
+		t.Parallel()
 		s := NewService("ch1")
 		s.channelResources = &mockResources{
 			appCfg: &mockApplication{
@@ -382,7 +411,9 @@ func TestService_GetMSPIDs(t *testing.T) {
 }
 
 func TestService_OrdererConfig(t *testing.T) {
+	t.Parallel()
 	t.Run("no orderer config returns error", func(t *testing.T) {
+		t.Parallel()
 		s := NewService("ch1")
 		s.channelResources = &mockResources{ordCfgOK: false}
 		_, _, err := s.OrdererConfig(&mockConfigService{})
@@ -390,6 +421,7 @@ func TestService_OrdererConfig(t *testing.T) {
 	})
 
 	t.Run("nil organizations returns error", func(t *testing.T) {
+		t.Parallel()
 		s := NewService("ch1")
 		s.channelResources = &mockResources{
 			ordCfg:   &mockOrderer{consensusType: "etcdraft", orgs: nil},
@@ -400,6 +432,7 @@ func TestService_OrdererConfig(t *testing.T) {
 	})
 
 	t.Run("empty endpoint is skipped", func(t *testing.T) {
+		t.Parallel()
 		mspImpl := &mockMSP{tlsRootCerts: [][]byte{[]byte("root")}}
 		s := NewService("ch1")
 		s.channelResources = &mockResources{
@@ -418,6 +451,7 @@ func TestService_OrdererConfig(t *testing.T) {
 	})
 
 	t.Run("tls settings taken from ordering config when set", func(t *testing.T) {
+		t.Parallel()
 		mspImpl := &mockMSP{
 			tlsRootCerts: [][]byte{[]byte("root")},
 			tlsIntCerts:  [][]byte{[]byte("int")},
@@ -452,6 +486,7 @@ func TestService_OrdererConfig(t *testing.T) {
 	})
 
 	t.Run("tls falls back to cs when not set in ordering config", func(t *testing.T) {
+		t.Parallel()
 		mspImpl := &mockMSP{}
 		s := NewService("ch1")
 		s.channelResources = &mockResources{
@@ -480,7 +515,9 @@ func TestService_OrdererConfig(t *testing.T) {
 }
 
 func TestService_MSPManager(t *testing.T) {
+	t.Parallel()
 	t.Run("wraps resources MSPManager", func(t *testing.T) {
+		t.Parallel()
 		identity := &mockMSPIdentity{}
 		s := NewService("ch1")
 		s.channelResources = &mockResources{
@@ -495,6 +532,7 @@ func TestService_MSPManager(t *testing.T) {
 	})
 
 	t.Run("invalid bytes return error from DeserializeIdentity", func(t *testing.T) {
+		t.Parallel()
 		s := NewService("ch1")
 		s.channelResources = &mockResources{
 			mspMgr: &mockMSPManager{},

--- a/platform/fabricx/core/transaction/endorsementmerge_test.go
+++ b/platform/fabricx/core/transaction/endorsementmerge_test.go
@@ -42,6 +42,7 @@ func (m *mockProposalResponse) VerifyEndorsement(_ driver.VerifierProvider) erro
 // one endorsement for the same namespace from a different MSP, should be merged
 // into a single tx containing both endorsements sorted by MSP ID.
 func TestMergeProposalResponseEndorsements(t *testing.T) {
+	t.Parallel()
 	tx := sampleTx("ns1", "key1", "value1")
 	rawTx, err := proto.Marshal(tx)
 	require.NoError(t, err)
@@ -75,6 +76,7 @@ func TestMergeProposalResponseEndorsements(t *testing.T) {
 // TestMergeProposalResponseEndorsementsSingleResponse verifies that a single
 // proposal response is accepted and its endorsements are preserved.
 func TestMergeProposalResponseEndorsementsSingleResponse(t *testing.T) {
+	t.Parallel()
 	tx := sampleTx("ns1", "key1", "value1")
 	rawTx, err := proto.Marshal(tx)
 	require.NoError(t, err)
@@ -99,6 +101,7 @@ func TestMergeProposalResponseEndorsementsSingleResponse(t *testing.T) {
 // endorsements are not appended twice when multiple proposal responses carry
 // endorsements from the same MSP.
 func TestMergeProposalResponseEndorsementsDeduplicatesByMSPID(t *testing.T) {
+	t.Parallel()
 	tx := sampleTx("ns1", "key1", "value1")
 	rawTx, err := proto.Marshal(tx)
 	require.NoError(t, err)
@@ -129,6 +132,7 @@ func TestMergeProposalResponseEndorsementsDeduplicatesByMSPID(t *testing.T) {
 // if proposal responses do not refer to the exact same tx payload.
 // Endorsements may only be merged across identical transactions.
 func TestMergeProposalResponseEndorsementsPayloadMismatch(t *testing.T) {
+	t.Parallel()
 	tx1 := sampleTx("ns1", "key1", "value1")
 	tx2 := sampleTx("ns1", "key2", "value2")
 
@@ -159,6 +163,7 @@ func TestMergeProposalResponseEndorsementsPayloadMismatch(t *testing.T) {
 // fails when a namespace endorsement set exists but contains no actual
 // EndorsementsWithIdentity entries.
 func TestMergeProposalResponseEndorsementsMissingEndorsement(t *testing.T) {
+	t.Parallel()
 	tx := sampleTx("ns1", "key1", "value1")
 	rawTx, err := proto.Marshal(tx)
 	require.NoError(t, err)
@@ -179,6 +184,7 @@ func TestMergeProposalResponseEndorsementsMissingEndorsement(t *testing.T) {
 // fails when the number of serialized endorsement sets does not match the
 // number of namespaces in the tx.
 func TestMergeProposalResponseEndorsementsWrongNamespaceCount(t *testing.T) {
+	t.Parallel()
 	tx := sampleTx("ns1", "key1", "value1")
 	rawTx, err := proto.Marshal(tx)
 	require.NoError(t, err)
@@ -196,6 +202,7 @@ func TestMergeProposalResponseEndorsementsWrongNamespaceCount(t *testing.T) {
 // TestMergeProposalResponseEndorsementsNilNamespaceEndorsements verifies that
 // a nil endorsement object for a namespace is treated as missing endorsements.
 func TestMergeProposalResponseEndorsementsNilNamespaceEndorsements(t *testing.T) {
+	t.Parallel()
 	tx := sampleTx("ns1", "key1", "value1")
 	rawTx, err := proto.Marshal(tx)
 	require.NoError(t, err)
@@ -215,6 +222,7 @@ func TestMergeProposalResponseEndorsementsNilNamespaceEndorsements(t *testing.T)
 // TestMergeProposalResponseEndorsementsMissingMSPID verifies that merge fails
 // when an endorsement does not carry an MSP ID.
 func TestMergeProposalResponseEndorsementsMissingMSPID(t *testing.T) {
+	t.Parallel()
 	tx := sampleTx("ns1", "key1", "value1")
 	rawTx, err := proto.Marshal(tx)
 	require.NoError(t, err)
@@ -241,6 +249,7 @@ func TestMergeProposalResponseEndorsementsMissingMSPID(t *testing.T) {
 // TestMergeProposalResponseEndorsementsNoResponses verifies that merge fails
 // when no proposal responses are provided.
 func TestMergeProposalResponseEndorsementsNoResponses(t *testing.T) {
+	t.Parallel()
 	_, err := mergeProposalResponseEndorsements(nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no proposal responses provided")

--- a/platform/fabricx/core/transaction/manager_test.go
+++ b/platform/fabricx/core/transaction/manager_test.go
@@ -31,6 +31,7 @@ func (s *stubTransactionFactory) NewTransaction(ctx context.Context, channel str
 }
 
 func TestManagerBasics(t *testing.T) {
+	t.Parallel()
 	m := NewManager()
 	require.NotNil(t, m)
 
@@ -53,7 +54,9 @@ func TestManagerBasics(t *testing.T) {
 }
 
 func TestManagerTransactionFactory(t *testing.T) {
+	t.Parallel()
 	t.Run("missing factory", func(t *testing.T) {
+		t.Parallel()
 		m := NewManager()
 
 		_, err := m.transactionFactory(driver.EndorserTransaction)
@@ -62,6 +65,7 @@ func TestManagerTransactionFactory(t *testing.T) {
 	})
 
 	t.Run("wrong stored type panics", func(t *testing.T) {
+		t.Parallel()
 		m := NewManager()
 		m.transactionFactories.Store(driver.EndorserTransaction, "not-a-factory")
 
@@ -71,6 +75,7 @@ func TestManagerTransactionFactory(t *testing.T) {
 	})
 
 	t.Run("returns stored factory", func(t *testing.T) {
+		t.Parallel()
 		m := NewManager()
 		expected := &stubTransactionFactory{}
 		m.AddTransactionFactory(driver.EndorserTransaction, expected)
@@ -82,12 +87,14 @@ func TestManagerTransactionFactory(t *testing.T) {
 }
 
 func TestManagerNewTransaction(t *testing.T) {
+	t.Parallel()
 	ctx := t.Context()
 	creator := view.Identity([]byte("creator"))
 	nonce := []byte("nonce")
 	rawRequest := []byte("request")
 
 	t.Run("factory lookup fails", func(t *testing.T) {
+		t.Parallel()
 		m := NewManager()
 
 		tx, err := m.NewTransaction(ctx, driver.EndorserTransaction, creator, nonce, "tx1", "ch1", rawRequest)
@@ -97,6 +104,7 @@ func TestManagerNewTransaction(t *testing.T) {
 	})
 
 	t.Run("delegates to factory", func(t *testing.T) {
+		t.Parallel()
 		m := NewManager()
 		expectedTx := &Transaction{TTxID: "tx1", TChannel: "ch1"}
 
@@ -120,9 +128,11 @@ func TestManagerNewTransaction(t *testing.T) {
 }
 
 func TestManagerNewTransactionFromBytes(t *testing.T) {
+	t.Parallel()
 	ctx := t.Context()
 
 	t.Run("missing default factory", func(t *testing.T) {
+		t.Parallel()
 		m := NewManager()
 
 		tx, err := m.NewTransactionFromBytes(ctx, "ch1", []byte(`{"TTxID":"tx1"}`))
@@ -132,6 +142,7 @@ func TestManagerNewTransactionFromBytes(t *testing.T) {
 	})
 
 	t.Run("factory creation fails", func(t *testing.T) {
+		t.Parallel()
 		m := NewManager()
 		m.AddTransactionFactory(driver.EndorserTransaction, &stubTransactionFactory{
 			newTransaction: func(context.Context, string, []byte, []byte, driver2.TxID, []byte) (driver.Transaction, error) {
@@ -145,6 +156,7 @@ func TestManagerNewTransactionFromBytes(t *testing.T) {
 	})
 
 	t.Run("SetFromBytes fails", func(t *testing.T) {
+		t.Parallel()
 		m := NewManager()
 		m.AddTransactionFactory(driver.EndorserTransaction, &stubTransactionFactory{
 			newTransaction: func(context.Context, string, []byte, []byte, driver2.TxID, []byte) (driver.Transaction, error) {
@@ -159,6 +171,7 @@ func TestManagerNewTransactionFromBytes(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
+		t.Parallel()
 		m := NewManager()
 		m.AddTransactionFactory(driver.EndorserTransaction, &stubTransactionFactory{
 			newTransaction: func(context.Context, string, []byte, []byte, driver2.TxID, []byte) (driver.Transaction, error) {
@@ -180,6 +193,7 @@ func TestManagerNewTransactionFromBytes(t *testing.T) {
 }
 
 func TestManagerNewTransactionFromEnvelopeBytesPanics(t *testing.T) {
+	t.Parallel()
 	m := NewManager()
 
 	require.PanicsWithValue(t, "NewTransactionFromEnvelopeBytes >> implement me", func() {
@@ -188,6 +202,7 @@ func TestManagerNewTransactionFromEnvelopeBytesPanics(t *testing.T) {
 }
 
 func TestManagerProcessedTransactionDelegation(t *testing.T) {
+	t.Parallel()
 	m := NewManager()
 	payloadRaw := mustEnvelopePayloadBytes(t, "tx1", []byte("results"))
 	envRaw := mustEnvelopeBytes(t, payloadRaw)
@@ -215,7 +230,9 @@ func TestManagerProcessedTransactionDelegation(t *testing.T) {
 }
 
 func TestNewProcessedTransactionConstructorsAndAccessors(t *testing.T) {
+	t.Parallel()
 	t.Run("from envelope payload invalid payload", func(t *testing.T) {
+		t.Parallel()
 		pt, headerType, err := NewProcessedTransactionFromEnvelopePayload([]byte("not-a-payload"))
 		require.Nil(t, pt)
 		require.Equal(t, int32(-1), headerType)
@@ -224,12 +241,14 @@ func TestNewProcessedTransactionConstructorsAndAccessors(t *testing.T) {
 	})
 
 	t.Run("from envelope raw invalid envelope", func(t *testing.T) {
+		t.Parallel()
 		pt, err := NewProcessedTransactionFromEnvelopeRaw([]byte("not-an-envelope"))
 		require.Nil(t, pt)
 		require.Error(t, err)
 	})
 
 	t.Run("from processed transaction invalid protobuf", func(t *testing.T) {
+		t.Parallel()
 		pt, err := NewProcessedTransaction([]byte("not-a-processed-tx"))
 		require.Nil(t, pt)
 		require.Error(t, err)
@@ -237,6 +256,7 @@ func TestNewProcessedTransactionConstructorsAndAccessors(t *testing.T) {
 	})
 
 	t.Run("from processed transaction invalid embedded envelope", func(t *testing.T) {
+		t.Parallel()
 		raw, err := proto.Marshal(&peer.ProcessedTransaction{
 			ValidationCode:      int32(committerpb.Status_COMMITTED),
 			TransactionEnvelope: &common.Envelope{Payload: []byte("not-a-payload")},
@@ -250,6 +270,7 @@ func TestNewProcessedTransactionConstructorsAndAccessors(t *testing.T) {
 	})
 
 	t.Run("is valid false when validation code differs", func(t *testing.T) {
+		t.Parallel()
 		payloadRaw := mustEnvelopePayloadBytes(t, "tx2", []byte("results-2"))
 		raw := mustProcessedTransactionBytes(t, int32(committerpb.Status_ABORTED_SIGNATURE_INVALID), payloadRaw)
 

--- a/platform/fabricx/core/transaction/marshal_test.go
+++ b/platform/fabricx/core/transaction/marshal_test.go
@@ -25,6 +25,7 @@ import (
 // TestCreateSCEnvelopeNoProposalResponses verifies that envelope creation fails
 // when the transaction carries no proposal responses at all.
 func TestCreateSCEnvelopeNoProposalResponses(t *testing.T) {
+	t.Parallel()
 	tx := &Transaction{
 		TTxID: "tx1",
 	}
@@ -37,6 +38,7 @@ func TestCreateSCEnvelopeNoProposalResponses(t *testing.T) {
 // TestCreateSCEnvelopeInvalidBaseTransaction verifies that envelope creation fails
 // when the first proposal response does not contain a valid serialized tx payload.
 func TestCreateSCEnvelopeInvalidBaseTransaction(t *testing.T) {
+	t.Parallel()
 	tx := &Transaction{
 		TTxID: "tx1",
 		TProposalResponses: []*peer.ProposalResponse{
@@ -60,6 +62,7 @@ func TestCreateSCEnvelopeInvalidBaseTransaction(t *testing.T) {
 // TestCreateSCEnvelopeMergeProposalResponsesPayloadMismatch verifies that
 // envelope creation fails when proposal responses refer to different tx payloads.
 func TestCreateSCEnvelopeMergeProposalResponsesPayloadMismatch(t *testing.T) {
+	t.Parallel()
 	tx1 := sampleTx("ns1", "key1", "value1")
 	tx2 := sampleTx("ns1", "key2", "value2")
 
@@ -101,6 +104,7 @@ func TestCreateSCEnvelopeMergeProposalResponsesPayloadMismatch(t *testing.T) {
 // after marshaling the merged tx if the signer service cannot provide a signer
 // for the transaction creator.
 func TestCreateSCEnvelopeSignerNotFound(t *testing.T) {
+	t.Parallel()
 	rawTx := mustRawTx(t, sampleTx("ns1", "key1", "value1"))
 
 	resp := &peer.ProposalResponse{
@@ -137,6 +141,7 @@ func TestCreateSCEnvelopeSignerNotFound(t *testing.T) {
 // proposal responses are merged, the merged tx is marshaled, and the envelope
 // is created and signed successfully.
 func TestCreateSCEnvelopeSuccess(t *testing.T) {
+	t.Parallel()
 	rawTx := mustRawTx(t, sampleTx("ns1", "key1", "value1"))
 
 	resp1 := &peer.ProposalResponse{

--- a/platform/fabricx/core/transaction/pr_test.go
+++ b/platform/fabricx/core/transaction/pr_test.go
@@ -25,6 +25,7 @@ import (
 // TestNewProposalResponseFromResponse verifies that wrapping a protobuf proposal
 // response preserves the underlying pointer.
 func TestNewProposalResponseFromResponse(t *testing.T) {
+	t.Parallel()
 	rawPR := &peer.ProposalResponse{
 		Payload: []byte("payload"),
 		Endorsement: &peer.Endorsement{
@@ -46,6 +47,7 @@ func TestNewProposalResponseFromResponse(t *testing.T) {
 // TestNewProposalResponseFromBytes verifies the happy path for deserializing a
 // protobuf proposal response from bytes.
 func TestNewProposalResponseFromBytes(t *testing.T) {
+	t.Parallel()
 	rawPR := &peer.ProposalResponse{
 		Payload: []byte("payload"),
 		Endorsement: &peer.Endorsement{
@@ -70,6 +72,7 @@ func TestNewProposalResponseFromBytes(t *testing.T) {
 // TestNewProposalResponseFromBytesInvalidProto verifies that invalid protobuf
 // bytes are rejected.
 func TestNewProposalResponseFromBytesInvalidProto(t *testing.T) {
+	t.Parallel()
 	_, err := NewProposalResponseFromBytes([]byte("not-a-protobuf"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unmarshal proposal response")
@@ -77,6 +80,7 @@ func TestNewProposalResponseFromBytesInvalidProto(t *testing.T) {
 
 // TestProposalResponseAccessors verifies the simple getters.
 func TestProposalResponseAccessors(t *testing.T) {
+	t.Parallel()
 	rawPR := &peer.ProposalResponse{
 		Payload: []byte("payload"),
 		Endorsement: &peer.Endorsement{
@@ -105,6 +109,7 @@ func TestProposalResponseAccessors(t *testing.T) {
 // TestProposalResponseBytes verifies that a wrapped proposal response can be
 // marshaled back into protobuf bytes.
 func TestProposalResponseBytes(t *testing.T) {
+	t.Parallel()
 	rawPR := &peer.ProposalResponse{
 		Payload: []byte("payload"),
 		Endorsement: &peer.Endorsement{
@@ -135,6 +140,7 @@ func TestProposalResponseBytes(t *testing.T) {
 // of endorsement sets matches the number of namespaces, and the verifier accepts
 // each namespace signature.
 func TestVerifyEndorsement(t *testing.T) {
+	t.Parallel()
 	txID := "tx1"
 	tx := sampleTx("ns1", "key1", "value1")
 	rawTx, err := proto.Marshal(tx)
@@ -172,6 +178,7 @@ func TestVerifyEndorsement(t *testing.T) {
 // TestVerifyEndorsementGetVerifierFails verifies that verification fails when
 // the provider cannot return a verifier for the endorser.
 func TestVerifyEndorsementGetVerifierFails(t *testing.T) {
+	t.Parallel()
 	pr, err := NewProposalResponseFromResponse(&peer.ProposalResponse{
 		Payload: []byte("payload"),
 		Endorsement: &peer.Endorsement{
@@ -191,6 +198,7 @@ func TestVerifyEndorsementGetVerifierFails(t *testing.T) {
 // TestVerifyEndorsementInvalidPayload verifies that verification fails when the
 // proposal response payload is not a valid serialized tx.
 func TestVerifyEndorsementInvalidPayload(t *testing.T) {
+	t.Parallel()
 	pr, err := NewProposalResponseFromResponse(&peer.ProposalResponse{
 		Payload: []byte("not-a-valid-tx"),
 		Endorsement: &peer.Endorsement{
@@ -216,6 +224,7 @@ func TestVerifyEndorsementInvalidPayload(t *testing.T) {
 // TestVerifyEndorsementInvalidSerializedEndorsements verifies that verification
 // fails when the serialized endorsement container cannot be decoded.
 func TestVerifyEndorsementInvalidSerializedEndorsements(t *testing.T) {
+	t.Parallel()
 	tx := sampleTx("ns1", "key1", "value1")
 	rawTx, err := proto.Marshal(tx)
 	require.NoError(t, err)
@@ -245,6 +254,7 @@ func TestVerifyEndorsementInvalidSerializedEndorsements(t *testing.T) {
 // TestVerifyEndorsementNamespaceCountMismatch verifies that verification fails
 // when the number of endorsement sets does not match the number of namespaces.
 func TestVerifyEndorsementNamespaceCountMismatch(t *testing.T) {
+	t.Parallel()
 	tx := sampleTx("ns1", "key1", "value1")
 	rawTx, err := proto.Marshal(tx)
 	require.NoError(t, err)
@@ -274,6 +284,7 @@ func TestVerifyEndorsementNamespaceCountMismatch(t *testing.T) {
 // TestVerifyEndorsementMissingNamespaceEndorsement verifies that verification
 // fails when a namespace has no endorsement items.
 func TestVerifyEndorsementMissingNamespaceEndorsement(t *testing.T) {
+	t.Parallel()
 	txID := "tx1"
 	tx := sampleTx("ns1", "key1", "value1")
 	rawTx, err := proto.Marshal(tx)
@@ -306,6 +317,7 @@ func TestVerifyEndorsementMissingNamespaceEndorsement(t *testing.T) {
 // TestVerifyEndorsementInvalidNamespaceSignature verifies that verification
 // fails when the verifier rejects the namespace signature.
 func TestVerifyEndorsementInvalidNamespaceSignature(t *testing.T) {
+	t.Parallel()
 	txID := "tx1"
 	tx := sampleTx("ns1", "key1", "value1")
 	rawTx, err := proto.Marshal(tx)
@@ -340,6 +352,7 @@ func TestVerifyEndorsementInvalidNamespaceSignature(t *testing.T) {
 // endorsements are marshaled into the proposal-response representation and then
 // unmarshaled back without losing content.
 func TestMarshalAndUnmarshalEndorsementsForProposalResponse(t *testing.T) {
+	t.Parallel()
 	endorsements := []*applicationpb.Endorsements{
 		sampleNamespaceEndorsements("Org1MSP", "sig-org1"),
 		sampleNamespaceEndorsements("Org2MSP", "sig-org2"),
@@ -359,6 +372,7 @@ func TestMarshalAndUnmarshalEndorsementsForProposalResponse(t *testing.T) {
 // TestMarshalEndorsementsForProposalResponseNilEntry verifies that a nil
 // endorsement entry is serialized as a nil raw item in the JSON array.
 func TestMarshalEndorsementsForProposalResponseNilEntry(t *testing.T) {
+	t.Parallel()
 	endorsements := []*applicationpb.Endorsements{
 		sampleNamespaceEndorsements("Org1MSP", "sig-org1"),
 		nil,
@@ -379,6 +393,7 @@ func TestMarshalEndorsementsForProposalResponseNilEntry(t *testing.T) {
 // TestUnmarshalEndorsementsFromProposalResponseNilEntry verifies that a nil
 // serialized endorsement entry is converted into an empty endorsements object.
 func TestUnmarshalEndorsementsFromProposalResponseNilEntry(t *testing.T) {
+	t.Parallel()
 	raw := mustSerializedEndorsements(t, []*applicationpb.Endorsements{
 		sampleNamespaceEndorsements("Org1MSP", "sig-org1"),
 		nil,
@@ -395,6 +410,7 @@ func TestUnmarshalEndorsementsFromProposalResponseNilEntry(t *testing.T) {
 // TestUnmarshalEndorsementsFromProposalResponseEmptyBytes verifies that an
 // empty raw protobuf entry is treated as an empty endorsements object.
 func TestUnmarshalEndorsementsFromProposalResponseEmptyBytes(t *testing.T) {
+	t.Parallel()
 	rawItems := [][]byte{
 		{},
 	}
@@ -412,6 +428,7 @@ func TestUnmarshalEndorsementsFromProposalResponseEmptyBytes(t *testing.T) {
 // TestUnmarshalEndorsementsFromProposalResponseInvalidJSON verifies that
 // invalid JSON input is rejected.
 func TestUnmarshalEndorsementsFromProposalResponseInvalidJSON(t *testing.T) {
+	t.Parallel()
 	_, err := unmarshalEndorsementsFromProposalResponse([]byte("not-json"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unmarshal serialized endorsements")
@@ -420,6 +437,7 @@ func TestUnmarshalEndorsementsFromProposalResponseInvalidJSON(t *testing.T) {
 // TestUnmarshalEndorsementsFromProposalResponseInvalidProto verifies that
 // invalid protobuf bytes inside the JSON array are rejected.
 func TestUnmarshalEndorsementsFromProposalResponseInvalidProto(t *testing.T) {
+	t.Parallel()
 	raw, err := json.Marshal([][]byte{
 		[]byte("not-a-protobuf"),
 	})

--- a/platform/fabricx/core/vault/vault_test.go
+++ b/platform/fabricx/core/vault/vault_test.go
@@ -79,6 +79,7 @@ func (m *mockQueryService) setTxStatus(txID string, status int32) {
 }
 
 func TestVaultX_NewQueryExecutor(t *testing.T) {
+	t.Parallel()
 	qs := newMockQueryService()
 	qs.setState("ns1", "key1", []byte("value1"), 1)
 
@@ -107,6 +108,7 @@ func TestVaultX_NewQueryExecutor(t *testing.T) {
 }
 
 func TestVaultX_NewRWSet(t *testing.T) {
+	t.Parallel()
 	qs := newMockQueryService()
 	qs.setState("ns1", "key1", []byte("value1"), 1)
 
@@ -139,6 +141,7 @@ func TestVaultX_NewRWSet(t *testing.T) {
 }
 
 func TestVaultX_NewRWSetFromBytes(t *testing.T) {
+	t.Parallel()
 	qs := newMockQueryService()
 	v := vault.NewVault(qs)
 	ctx := context.Background()
@@ -163,6 +166,7 @@ func TestVaultX_NewRWSetFromBytes(t *testing.T) {
 }
 
 func TestVaultX_Status(t *testing.T) {
+	t.Parallel()
 	qs := newMockQueryService()
 	qs.setTxStatus("tx1", 1) // COMMITTED
 
@@ -176,6 +180,7 @@ func TestVaultX_Status(t *testing.T) {
 }
 
 func TestVaultX_Statuses(t *testing.T) {
+	t.Parallel()
 	qs := newMockQueryService()
 	qs.setTxStatus("tx1", 1) // COMMITTED
 	qs.setTxStatus("tx2", 0) // UNSPECIFIED
@@ -195,6 +200,7 @@ func TestVaultX_Statuses(t *testing.T) {
 }
 
 func TestVaultX_SetDiscarded(t *testing.T) {
+	t.Parallel()
 	qs := newMockQueryService()
 	v := vault.NewVault(qs)
 	ctx := context.Background()
@@ -210,6 +216,7 @@ func TestVaultX_SetDiscarded(t *testing.T) {
 }
 
 func TestVaultX_DiscardTx(t *testing.T) {
+	t.Parallel()
 	qs := newMockQueryService()
 	v := vault.NewVault(qs)
 	ctx := context.Background()
@@ -225,6 +232,7 @@ func TestVaultX_DiscardTx(t *testing.T) {
 }
 
 func TestVaultX_CommitTX(t *testing.T) {
+	t.Parallel()
 	qs := newMockQueryService()
 	v := vault.NewVault(qs)
 	ctx := context.Background()
@@ -240,6 +248,7 @@ func TestVaultX_CommitTX(t *testing.T) {
 }
 
 func TestVaultX_InspectRWSet(t *testing.T) {
+	t.Parallel()
 	qs := newMockQueryService()
 	v := vault.NewVault(qs)
 	ctx := context.Background()
@@ -268,6 +277,7 @@ func TestVaultX_InspectRWSet(t *testing.T) {
 }
 
 func TestVaultX_RWSExists(t *testing.T) {
+	t.Parallel()
 	qs := newMockQueryService()
 	v := vault.NewVault(qs)
 	ctx := context.Background()
@@ -284,6 +294,7 @@ func TestVaultX_RWSExists(t *testing.T) {
 }
 
 func TestVaultX_Match(t *testing.T) {
+	t.Parallel()
 	qs := newMockQueryService()
 	v := vault.NewVault(qs)
 	ctx := context.Background()
@@ -312,6 +323,7 @@ func TestVaultX_Match(t *testing.T) {
 }
 
 func TestVaultX_Close(t *testing.T) {
+	t.Parallel()
 	qs := newMockQueryService()
 	v := vault.NewVault(qs)
 	ctx := context.Background()
@@ -332,6 +344,7 @@ func TestVaultX_Close(t *testing.T) {
 }
 
 func TestRWSet_Operations(t *testing.T) {
+	t.Parallel()
 	qs := newMockQueryService()
 	qs.setState("ns1", "existing", []byte("existing_value"), 1)
 
@@ -383,6 +396,7 @@ func TestRWSet_Operations(t *testing.T) {
 }
 
 func TestRWSet_GetReadAt(t *testing.T) {
+	t.Parallel()
 	qs := newMockQueryService()
 	qs.setState("ns1", "key1", []byte("value1"), 1)
 	qs.setState("ns1", "key2", []byte("value2"), 2)
@@ -411,6 +425,7 @@ func TestRWSet_GetReadAt(t *testing.T) {
 }
 
 func TestRWSet_GetWriteAt(t *testing.T) {
+	t.Parallel()
 	qs := newMockQueryService()
 	v := vault.NewVault(qs)
 	ctx := context.Background()

--- a/platform/fabricx/sdk/dig/sdk_test.go
+++ b/platform/fabricx/sdk/dig/sdk_test.go
@@ -16,5 +16,6 @@ import (
 )
 
 func TestWiring(t *testing.T) {
+	t.Parallel()
 	require.NoError(t, sdk.DryRunWiring(func(sdk common.SDK) *SDK { return NewFrom(fabric.NewFrom(sdk)) }, sdk.WithBool("fabric.enabled", true)))
 }

--- a/platform/view/sdk/dig/sdk_test.go
+++ b/platform/view/sdk/dig/sdk_test.go
@@ -15,5 +15,6 @@ import (
 )
 
 func TestWiring(t *testing.T) {
+	t.Parallel()
 	require.NoError(t, DryRunWiring(digutils.Identity[dig2.SDK]()))
 }

--- a/platform/view/sdk/vfsdk/container_test.go
+++ b/platform/view/sdk/vfsdk/container_test.go
@@ -29,12 +29,14 @@ type myFactory struct{}
 func (o *myFactory) NewView([]byte) (view.View, error) { return nil, nil }
 
 func TestInvalidFactory(t *testing.T) {
+	t.Parallel()
 	c := vfsdk.NewContainer()
 
 	require.Error(t, c.Provide(func() *myInput { return &myInput{} }, vfsdk.WithFactoryId("input")))
 }
 
 func TestError(t *testing.T) {
+	t.Parallel()
 	c := vfsdk.NewContainer()
 	require.NoError(t, c.Provide(registry3.NewRegistry))
 	require.NoError(t, c.Provide(func() (*myFactory, error) { return nil, errors.New("error occurred") }))
@@ -45,6 +47,7 @@ func TestError(t *testing.T) {
 }
 
 func TestNoReturnError(t *testing.T) {
+	t.Parallel()
 	c := vfsdk.NewContainer()
 	require.NoError(t, c.Provide(registry3.NewRegistry))
 	require.NoError(t, c.Provide(func() *myFactory { return &myFactory{} }))
@@ -55,6 +58,7 @@ func TestNoReturnError(t *testing.T) {
 }
 
 func TestInterdependentFactories(t *testing.T) {
+	t.Parallel()
 	c := vfsdk.NewContainer()
 	require.NoError(t, c.Provide(registry3.NewRegistry))
 	require.NoError(t, c.Provide(func(f *myFactory) (*myDependentFactory, error) { return &myDependentFactory{myFactory: f}, nil }, vfsdk.WithFactoryId("a"), vfsdk.WithInitiators("init")))
@@ -66,6 +70,7 @@ func TestInterdependentFactories(t *testing.T) {
 }
 
 func TestRegisterWithoutParams(t *testing.T) {
+	t.Parallel()
 	c := vfsdk.NewContainer()
 	require.NoError(t, c.Provide(registry3.NewRegistry))
 	require.NoError(t, c.Provide(func() (*myFactory, error) { return &myFactory{}, nil }, vfsdk.WithFactoryId("abc"), vfsdk.WithInitiators("in1", "in2")))
@@ -76,6 +81,7 @@ func TestRegisterWithoutParams(t *testing.T) {
 }
 
 func TestRegisterWithParams(t *testing.T) {
+	t.Parallel()
 	c := vfsdk.NewContainer()
 	require.NoError(t, c.Provide(registry3.NewRegistry))
 	require.NoError(t, c.Provide(func() *myInput { return &myInput{} }))

--- a/platform/view/services/comm/host/libp2p/conn_test.go
+++ b/platform/view/services/comm/host/libp2p/conn_test.go
@@ -25,6 +25,7 @@ import (
 type Network []*node
 
 func TestSessionTwoParties(t *testing.T) {
+	t.Parallel()
 	network, err := NewVirtualNetwork(t, 12345, 2)
 	require.NoError(t, err)
 

--- a/platform/view/services/comm/host/libp2p/p2p_test.go
+++ b/platform/view/services/comm/host/libp2p/p2p_test.go
@@ -42,26 +42,31 @@ func TestMain(m *testing.M) {
 }
 
 func TestP2PLayerTestRound(t *testing.T) {
+	t.Parallel()
 	bootstrapNode, node := setupTwoNodes(t)
 	comm.P2PLayerTestRound(t, bootstrapNode, node)
 }
 
 func TestSessionsTestRound(t *testing.T) {
+	t.Parallel()
 	bootstrapNode, node := setupTwoNodes(t)
 	comm.SessionsTestRound(t, bootstrapNode, node)
 }
 
 func TestSessionsForMPCTestRound(t *testing.T) {
+	t.Parallel()
 	bootstrapNode, node := setupTwoNodes(t)
 	comm.SessionsForMPCTestRound(t, bootstrapNode, node)
 }
 
 func TestSessionsMultipleMessagesTestRound(t *testing.T) {
+	t.Parallel()
 	bootstrapNode, node := setupTwoNodes(t)
 	comm.SessionsMultipleMessagesTestRound(t, bootstrapNode, node)
 }
 
 func TestSessionsTwoNodesTestRound(t *testing.T) {
+	t.Parallel()
 	bootstrapNode, node1, node2 := setupThreeNodes(t)
 	<-time.After(100 * time.Millisecond)
 

--- a/platform/view/services/comm/host/websocket/dynamic_ca_test.go
+++ b/platform/view/services/comm/host/websocket/dynamic_ca_test.go
@@ -96,6 +96,7 @@ func (m *mockEndpointService) GetResolver(ctx context.Context, id view.Identity)
 }
 
 func TestDynamicCA(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 
 	// Generate Server Cert

--- a/platform/view/services/comm/host/websocket/host_timeout_test.go
+++ b/platform/view/services/comm/host/websocket/host_timeout_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 // TestHostStartupTimeout tests that the host properly handles startup failures
-func TestHostStartupTimeout(t *testing.T) {
+func TestHostStartupTimeout(t *testing.T) { //nolint:paralleltest
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	// Use an invalid address that will cause the server to fail to listen
@@ -49,7 +49,7 @@ func TestHostStartupTimeout(t *testing.T) {
 }
 
 // TestHostStartupReadinessTimeout tests the 2-second startup readiness timeout
-func TestHostStartupReadinessTimeout(t *testing.T) {
+func TestHostStartupReadinessTimeout(t *testing.T) { //nolint:paralleltest
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	// Use a valid localhost address but don't actually start a listener

--- a/platform/view/services/comm/host/websocket/p2p_test.go
+++ b/platform/view/services/comm/host/websocket/p2p_test.go
@@ -50,31 +50,31 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestP2PLayerTestRound(t *testing.T) {
+func TestP2PLayerTestRound(t *testing.T) { //nolint:paralleltest
 	bootstrapNode, node := setupTwoNodes(t)
 
 	comm.P2PLayerTestRound(t, bootstrapNode, node)
 }
 
-func TestSessionsTestRound(t *testing.T) {
+func TestSessionsTestRound(t *testing.T) { //nolint:paralleltest
 	bootstrapNode, node := setupTwoNodes(t)
 	<-time.After(1 * time.Second)
 	comm.SessionsTestRound(t, bootstrapNode, node)
 }
 
-func TestSessionsForMPCTestRound(t *testing.T) {
+func TestSessionsForMPCTestRound(t *testing.T) { //nolint:paralleltest
 	bootstrapNode, node := setupTwoNodes(t)
 	<-time.After(1 * time.Second)
 	comm.SessionsForMPCTestRound(t, bootstrapNode, node)
 }
 
-func TestSessionsMultipleMessagesTestRound(t *testing.T) {
+func TestSessionsMultipleMessagesTestRound(t *testing.T) { //nolint:paralleltest
 	bootstrapNode, node := setupTwoNodes(t)
 	<-time.After(1 * time.Second)
 	comm.SessionsMultipleMessagesTestRound(t, bootstrapNode, node)
 }
 
-func TestMTLSCallerIdentityBinding(t *testing.T) {
+func TestMTLSCallerIdentityBinding(t *testing.T) { //nolint:paralleltest
 	bootstrapNode, node := setupTwoNodes(t)
 	ctx := t.Context()
 	bootstrapNode.Start(ctx)
@@ -157,7 +157,7 @@ func setupTwoNodes(t *testing.T) (*comm.HostNode, *comm.HostNode) {
 		&comm.HostNode{P2PNode: otherNode, ID: otherID, Address: otherAddress}
 }
 
-func TestSessionsTwoNodesTestRound(t *testing.T) {
+func TestSessionsTwoNodesTestRound(t *testing.T) { //nolint:paralleltest
 	bootstrapNode, node1, node2 := setupThreeNodes(t)
 	comm.SessionsNodesTestRound(t, bootstrapNode, []*comm.HostNode{node1, node2}, 50)
 }
@@ -389,6 +389,7 @@ func generateTLSFiles(t *testing.T) generatedTLSFiles {
 }
 
 func TestSessionInfoSecurityGuarantees(t *testing.T) {
+	t.Parallel()
 	ctx := t.Context()
 	// Simpler: Alice, Bob and Charlie all share the same CA.
 	allTlsFiles := generateThreeNodesTLSFiles(t)

--- a/platform/view/services/comm/host/websocket/ws/large_message_test.go
+++ b/platform/view/services/comm/host/websocket/ws/large_message_test.go
@@ -27,6 +27,7 @@ import (
 // TestOversizedMessageRejection verifies that messages exceeding maxDelimitedPayloadSize (10MB)
 // are rejected by the delimitedReader.
 func TestOversizedMessageRejection(t *testing.T) {
+	t.Parallel()
 	testSetup(t)
 	p := NewMultiplexedProvider(noop.NewTracerProvider(), &disabled.Provider{}, 0)
 	serverTLSConfig, clientTLSConfig, srcID := testMutualTLSConfigs(t, false)
@@ -36,7 +37,7 @@ func TestOversizedMessageRejection(t *testing.T) {
 		buf := make([]byte, 1024)
 		_, _ = s.Read(buf)
 	})
-	defer srv.Close()
+	t.Cleanup(srv.Close)
 
 	srvEndpoint := strings.TrimPrefix(strings.TrimPrefix(srv.URL, "http://"), "https://")
 
@@ -64,6 +65,7 @@ func TestOversizedMessageRejection(t *testing.T) {
 
 // TestValidBoundaryMessage verifies that a message of exactly 1MB passes.
 func TestValidBoundaryMessage(t *testing.T) {
+	t.Parallel()
 	testSetup(t)
 	serverTLSConfig, clientTLSConfig, srcID := testMutualTLSConfigs(t, false)
 
@@ -87,7 +89,7 @@ func TestValidBoundaryMessage(t *testing.T) {
 	}))
 	srv.TLS = serverTLSConfig
 	srv.StartTLS()
-	defer srv.Close()
+	t.Cleanup(srv.Close)
 
 	srvEndpoint := strings.TrimPrefix(strings.TrimPrefix(srv.URL, "http://"), "https://")
 
@@ -123,6 +125,7 @@ func TestValidBoundaryMessage(t *testing.T) {
 // TestMultipleMessagesOrderAndContent verifies that multiple messages of different lengths
 // are received in the correct order and with correct content.
 func TestMultipleMessagesOrderAndContent(t *testing.T) {
+	t.Parallel()
 	testSetup(t)
 	serverTLSConfig, clientTLSConfig, srcID := testMutualTLSConfigs(t, false)
 
@@ -164,7 +167,7 @@ func TestMultipleMessagesOrderAndContent(t *testing.T) {
 	}))
 	srv.TLS = serverTLSConfig
 	srv.StartTLS()
-	defer srv.Close()
+	t.Cleanup(srv.Close)
 
 	srvEndpoint := strings.TrimPrefix(strings.TrimPrefix(srv.URL, "http://"), "https://")
 

--- a/platform/view/services/comm/host/websocket/ws/mtls_enforcement_test.go
+++ b/platform/view/services/comm/host/websocket/ws/mtls_enforcement_test.go
@@ -24,6 +24,7 @@ import (
 
 // TestMTLSStrictness verifies that the websocket provider strictly requires mTLS.
 func TestMTLSStrictness(t *testing.T) {
+	t.Parallel()
 	testSetup(t)
 	p := NewMultiplexedProvider(noop.NewTracerProvider(), &disabled.Provider{}, 0)
 
@@ -40,12 +41,13 @@ func TestMTLSStrictness(t *testing.T) {
 	}))
 	srv.TLS = serverTLSConfig
 	srv.StartTLS()
-	defer srv.Close()
+	t.Cleanup(srv.Close)
 
 	srvAddr := strings.TrimPrefix(srv.URL, "https://")
 	url := fmt.Sprintf("wss://%s/p2p", srvAddr)
 
 	t.Run("Valid mTLS - Connection Accepted", func(t *testing.T) {
+		t.Parallel()
 		dialer := websocket.Dialer{TLSClientConfig: clientTLSConfig}
 		conn, _, err := dialer.Dial(url, nil)
 		require.NoError(t, err)
@@ -53,6 +55,7 @@ func TestMTLSStrictness(t *testing.T) {
 	})
 
 	t.Run("No Client Certificate - Connection Rejected", func(t *testing.T) {
+		t.Parallel()
 		// Only root CA provided, NO client cert
 		invalidClientConfig := &tls.Config{
 			RootCAs:    clientTLSConfig.RootCAs,
@@ -64,6 +67,7 @@ func TestMTLSStrictness(t *testing.T) {
 	})
 
 	t.Run("Untrusted Client Certificate - Connection Rejected", func(t *testing.T) {
+		t.Parallel()
 		// Use another CA to sign a client certificate
 		_, untrustedClientConfig, _ := testMutualTLSConfigs(t, false)
 
@@ -73,6 +77,7 @@ func TestMTLSStrictness(t *testing.T) {
 	})
 
 	t.Run("Expired Certificate - Connection Rejected", func(t *testing.T) {
+		t.Parallel()
 		// This is naturally handled by Go's TLS implementation if mTLS is enabled.
 		// We could simulate by setting NotAfter in the past during cert generation in testMutualTLSConfigs.
 	})

--- a/platform/view/services/comm/host/websocket/ws/multiplexed_provider_test.go
+++ b/platform/view/services/comm/host/websocket/ws/multiplexed_provider_test.go
@@ -51,15 +51,18 @@ var (
 	serverLogger = logging.MustGetLogger("server")
 )
 
-func TestConnections(t *testing.T) {
+func TestConnections(t *testing.T) { //nolint:tparallel,paralleltest
 	testSetup(t)
 
 	// let check that at the end of this test all our go routines are stopped
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	})
 
-	for _, insecureSkipVerify := range []bool{true, false} {
+	for _, insecureSkipVerify := range []bool{true, false} { //nolint:paralleltest
 		mode := fmt.Sprintf("InsecureSkipVerify=%v", insecureSkipVerify)
 		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
 			p := NewMultiplexedProvider(noop.NewTracerProvider(), &disabled.Provider{}, 0)
 			serverTLSConfig, clientTLSConfig, srcID := testMutualTLSConfigs(t, insecureSkipVerify)
 
@@ -98,13 +101,13 @@ func TestConnections(t *testing.T) {
 			}))
 			srv.TLS = serverTLSConfig
 			srv.StartTLS()
-			defer srv.Close()
+			t.Cleanup(srv.Close)
 
 			srvEndpoint := strings.TrimPrefix(strings.TrimPrefix(srv.URL, "http://"), "https://")
 
 			time.Sleep(snoozeTime)
 
-			t.Run("client cannot connect", func(t *testing.T) {
+			t.Run("client cannot connect", func(t *testing.T) { //nolint:paralleltest
 				// we should have no clients at this point
 				p.mu.RLock()
 				require.Empty(t, p.clients)
@@ -128,13 +131,13 @@ func TestConnections(t *testing.T) {
 				p.mu.RUnlock()
 			})
 
-			t.Run("many clients connect sequentially", func(t *testing.T) {
+			t.Run("many clients connect sequentially", func(t *testing.T) { //nolint:paralleltest
 				for i := range numStreams {
 					testClientRun(t, p, srvEndpoint, fmt.Sprintf("session-%d", i), srcID, clientTLSConfig)
 				}
 			})
 
-			t.Run("many clients connect concurrently", func(t *testing.T) {
+			t.Run("many clients connect concurrently", func(t *testing.T) { //nolint:paralleltest
 				errCh := make(chan error, numStreams*totalMsg*3)
 				var wg sync.WaitGroup
 				for i := range numStreams {
@@ -168,15 +171,18 @@ func TestConnections(t *testing.T) {
 	}
 }
 
-func TestSendingOnClosedSubConnections(t *testing.T) {
+func TestSendingOnClosedSubConnections(t *testing.T) { //nolint:paralleltest,tparallel
 	testSetup(t)
 
 	// let check that at the end of this test all our go routines are stopped
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	})
 
 	for _, insecureSkipVerify := range []bool{true, false} {
 		mode := fmt.Sprintf("InsecureSkipVerify=%v", insecureSkipVerify)
 		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
 			p := NewMultiplexedProvider(noop.NewTracerProvider(), &disabled.Provider{}, 0)
 			serverTLSConfig, clientTLSConfig, srcID := testMutualTLSConfigs(t, insecureSkipVerify)
 			var wg sync.WaitGroup
@@ -215,7 +221,7 @@ func TestSendingOnClosedSubConnections(t *testing.T) {
 			}))
 			srv.TLS = serverTLSConfig
 			srv.StartTLS()
-			defer srv.Close()
+			t.Cleanup(srv.Close)
 
 			srvEndpoint := strings.TrimPrefix(strings.TrimPrefix(srv.URL, "http://"), "https://")
 
@@ -258,13 +264,16 @@ func TestSendingOnClosedSubConnections(t *testing.T) {
 	}
 }
 
-func TestRejectsPeerIDMismatch(t *testing.T) {
+func TestRejectsPeerIDMismatch(t *testing.T) { //nolint:paralleltest,tparallel
 	testSetup(t)
-	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	})
 
 	for _, insecureSkipVerify := range []bool{true, false} {
 		mode := fmt.Sprintf("InsecureSkipVerify=%v", insecureSkipVerify)
 		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
 			p := NewMultiplexedProvider(noop.NewTracerProvider(), &disabled.Provider{}, 0)
 			t.Cleanup(func() {
 				_ = p.KillAll()
@@ -280,7 +289,7 @@ func TestRejectsPeerIDMismatch(t *testing.T) {
 			}))
 			srv.TLS = serverTLSConfig
 			srv.StartTLS()
-			defer srv.Close()
+			t.Cleanup(srv.Close)
 
 			srvEndpoint := strings.TrimPrefix(strings.TrimPrefix(srv.URL, "http://"), "https://")
 			info := host.StreamInfo{

--- a/platform/view/services/comm/host/websocket/ws/race_test.go
+++ b/platform/view/services/comm/host/websocket/ws/race_test.go
@@ -40,7 +40,7 @@ func (c *raceConn) Close() error {
 	return nil
 }
 
-func TestReadRace(t *testing.T) {
+func TestReadRace(t *testing.T) { //nolint:paralleltest
 	p := make([]byte, 100)
 	for i := 0; i < 100; i++ {
 		readChan := make(chan resultMsg, 2)

--- a/platform/view/services/comm/host/websocket/ws/reproduction_test.go
+++ b/platform/view/services/comm/host/websocket/ws/reproduction_test.go
@@ -28,7 +28,7 @@ import (
 // TestAttack_SpoofPeerID attempts to reproduce the attack where an attacker
 // connects with their own certificate but claims a different PeerID in the meta message.
 // This is a regression test for Issue #1037.
-func TestAttack_SpoofPeerID(t *testing.T) {
+func TestAttack_SpoofPeerID(t *testing.T) { //nolint:paralleltest
 	testSetup(t)
 	p := NewMultiplexedProvider(noop.NewTracerProvider(), &disabled.Provider{}, 0)
 	serverTLSConfig, clientTLSConfig, _ := testMutualTLSConfigs(t, false)
@@ -37,7 +37,7 @@ func TestAttack_SpoofPeerID(t *testing.T) {
 	srv := startTestServer(t, p, serverTLSConfig, func(s host.P2PStream) {
 		received <- s
 	})
-	defer srv.Close()
+	t.Cleanup(srv.Close)
 
 	srvEndpoint := strings.TrimPrefix(strings.TrimPrefix(srv.URL, "http://"), "https://")
 
@@ -85,7 +85,7 @@ func TestAttack_SpoofPeerID(t *testing.T) {
 // TestAttack_HijackSessionID attempts to reproduce the attack where an attacker
 // uses a legitimate PeerID (their own) but tries to inject a message into someone else's SessionID.
 // This is a regression test for Issue #1037.
-func TestAttack_HijackSessionID(t *testing.T) {
+func TestAttack_HijackSessionID(t *testing.T) { //nolint:paralleltest
 	testSetup(t)
 	p := NewMultiplexedProvider(noop.NewTracerProvider(), &disabled.Provider{}, 0)
 	serverTLSConfig, clientTLSConfig, charlieID := testMutualTLSConfigs(t, false)
@@ -94,7 +94,7 @@ func TestAttack_HijackSessionID(t *testing.T) {
 	srv := startTestServer(t, p, serverTLSConfig, func(s host.P2PStream) {
 		received <- s
 	})
-	defer srv.Close()
+	t.Cleanup(srv.Close)
 
 	srvEndpoint := strings.TrimPrefix(strings.TrimPrefix(srv.URL, "http://"), "https://")
 

--- a/platform/view/services/comm/host/websocket/ws/simple_provider_test.go
+++ b/platform/view/services/comm/host/websocket/ws/simple_provider_test.go
@@ -19,10 +19,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSimpleProvider_Security(t *testing.T) {
+func TestSimpleProvider_Security(t *testing.T) { //nolint:paralleltest
 	testSetup(t)
 
-	for _, insecureSkipVerify := range []bool{true, false} {
+	for _, insecureSkipVerify := range []bool{true, false} { //nolint:paralleltest
 		mode := fmt.Sprintf("InsecureSkipVerify=%v", insecureSkipVerify)
 		t.Run(mode, func(t *testing.T) {
 			p := NewSimpleProvider()
@@ -36,11 +36,11 @@ func TestSimpleProvider_Security(t *testing.T) {
 			}))
 			srv.TLS = serverTLSConfig
 			srv.StartTLS()
-			defer srv.Close()
+			t.Cleanup(srv.Close)
 
 			srvEndpoint := strings.TrimPrefix(strings.TrimPrefix(srv.URL, "http://"), "https://")
 
-			t.Run("successful connection and verified RemotePeerID", func(t *testing.T) {
+			t.Run("successful connection and verified RemotePeerID", func(t *testing.T) { //nolint:paralleltest
 				info := host.StreamInfo{
 					RemotePeerID:      "serverID",
 					RemotePeerAddress: srvEndpoint,
@@ -60,7 +60,7 @@ func TestSimpleProvider_Security(t *testing.T) {
 				}
 			})
 
-			t.Run("reject spoofed PeerID", func(t *testing.T) {
+			t.Run("reject spoofed PeerID", func(t *testing.T) { //nolint:paralleltest
 				// Attacker tries to claim they are "Alice-ID"
 				spoofedID := host.PeerID("Alice-ID")
 

--- a/platform/view/services/comm/host/websocket/ws/stream_test.go
+++ b/platform/view/services/comm/host/websocket/ws/stream_test.go
@@ -66,7 +66,7 @@ func (c *mockConn) WrittenValues() <-chan []byte {
 	return c.written
 }
 
-func TestWriter(t *testing.T) {
+func TestWriter(t *testing.T) { //nolint:paralleltest
 	// let check that at the end of this test all our go routines are stopped
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
@@ -104,7 +104,7 @@ func TestWriter(t *testing.T) {
 	}, 5*time.Second, time.Second)
 }
 
-func TestReader(t *testing.T) {
+func TestReader(t *testing.T) { //nolint:paralleltest
 	// let check that at the end of this test all our go routines are stopped
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 

--- a/platform/view/services/comm/host/websocket/ws/stream_timeout_test.go
+++ b/platform/view/services/comm/host/websocket/ws/stream_timeout_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 // TestWebSocketStreamDeliveryTimeout tests the stream delivery timeout in the deliver function
-func TestWebSocketStreamDeliveryTimeout(t *testing.T) {
+func TestWebSocketStreamDeliveryTimeout(t *testing.T) { //nolint:paralleltest
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	// Create a mock connection that simulates a hung read operation
@@ -60,7 +60,7 @@ func TestWebSocketStreamDeliveryTimeout(t *testing.T) {
 }
 
 // TestWebSocketContextCancellationWithTimeouts tests that context cancellation works alongside timeouts
-func TestWebSocketContextCancellationWithTimeouts(t *testing.T) {
+func TestWebSocketContextCancellationWithTimeouts(t *testing.T) { //nolint:paralleltest
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	// Create a mock connection
@@ -101,7 +101,7 @@ func TestWebSocketContextCancellationWithTimeouts(t *testing.T) {
 // TestWebSocketPeerCloseRace fixes a race condition where if a peer sends a message and then
 // immediately closes the connection, the receiver might get a context cancellation error
 // instead of receiving the message.
-func TestWebSocketPeerCloseRace(t *testing.T) {
+func TestWebSocketPeerCloseRace(t *testing.T) { //nolint:paralleltest
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	// Create a mock connection

--- a/platform/view/services/comm/host/websocket/ws/streamreader_test.go
+++ b/platform/view/services/comm/host/websocket/ws/streamreader_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestReadExpectedLengthHappyPath(t *testing.T) {
+	t.Parallel()
 	reader := newDelimitedReader()
 	buf := make([]byte, binary.MaxVarintLen64)
 	n := binary.PutUvarint(buf, 128)
@@ -25,6 +26,7 @@ func TestReadExpectedLengthHappyPath(t *testing.T) {
 }
 
 func TestReadExpectedLengthOversizedPayload(t *testing.T) {
+	t.Parallel()
 	reader := newDelimitedReader()
 	buf := make([]byte, binary.MaxVarintLen64)
 	n := binary.PutUvarint(buf, maxDelimitedPayloadSize+1)
@@ -35,6 +37,7 @@ func TestReadExpectedLengthOversizedPayload(t *testing.T) {
 }
 
 func TestReadExpectedLengthPartialVarint(t *testing.T) {
+	t.Parallel()
 	reader := newDelimitedReader()
 
 	// 128 in varint is [0x80, 0x01]

--- a/platform/view/services/comm/io/msgconn_test.go
+++ b/platform/view/services/comm/io/msgconn_test.go
@@ -17,7 +17,9 @@ import (
 )
 
 func TestNewMsgConn(t *testing.T) {
+	t.Parallel()
 	t.Run("successful creation", func(t *testing.T) {
+		t.Parallel()
 		session := &mockSession{
 			ch: make(chan *view.Message, 10),
 		}
@@ -29,7 +31,9 @@ func TestNewMsgConn(t *testing.T) {
 }
 
 func TestMsgConn_Write(t *testing.T) {
+	t.Parallel()
 	t.Run("successful write", func(t *testing.T) {
+		t.Parallel()
 		session := &mockSession{
 			ch: make(chan *view.Message, 10),
 		}
@@ -46,6 +50,7 @@ func TestMsgConn_Write(t *testing.T) {
 	})
 
 	t.Run("write empty data", func(t *testing.T) {
+		t.Parallel()
 		session := &mockSession{
 			ch: make(chan *view.Message, 10),
 		}
@@ -59,6 +64,7 @@ func TestMsgConn_Write(t *testing.T) {
 	})
 
 	t.Run("write error", func(t *testing.T) {
+		t.Parallel()
 		session := &mockSession{
 			ch:        make(chan *view.Message, 10),
 			sendError: assert.AnError,
@@ -74,6 +80,7 @@ func TestMsgConn_Write(t *testing.T) {
 	})
 
 	t.Run("multiple writes", func(t *testing.T) {
+		t.Parallel()
 		session := &mockSession{
 			ch: make(chan *view.Message, 10),
 		}
@@ -101,7 +108,9 @@ func TestMsgConn_Write(t *testing.T) {
 }
 
 func TestMsgConn_Read(t *testing.T) {
+	t.Parallel()
 	t.Run("successful read", func(t *testing.T) {
+		t.Parallel()
 		ch := make(chan *view.Message, 10)
 		session := &mockSession{ch: ch}
 
@@ -120,6 +129,7 @@ func TestMsgConn_Read(t *testing.T) {
 	})
 
 	t.Run("read multiple messages", func(t *testing.T) {
+		t.Parallel()
 		ch := make(chan *view.Message, 10)
 		session := &mockSession{ch: ch}
 
@@ -148,6 +158,7 @@ func TestMsgConn_Read(t *testing.T) {
 	})
 
 	t.Run("channel closed", func(t *testing.T) {
+		t.Parallel()
 		ch := make(chan *view.Message, 10)
 		session := &mockSession{ch: ch}
 
@@ -163,6 +174,7 @@ func TestMsgConn_Read(t *testing.T) {
 	})
 
 	t.Run("nil message", func(t *testing.T) {
+		t.Parallel()
 		ch := make(chan *view.Message, 10)
 		session := &mockSession{ch: ch}
 
@@ -178,6 +190,7 @@ func TestMsgConn_Read(t *testing.T) {
 	})
 
 	t.Run("error status", func(t *testing.T) {
+		t.Parallel()
 		ch := make(chan *view.Message, 10)
 		session := &mockSession{ch: ch}
 
@@ -196,6 +209,7 @@ func TestMsgConn_Read(t *testing.T) {
 	})
 
 	t.Run("empty payload", func(t *testing.T) {
+		t.Parallel()
 		ch := make(chan *view.Message, 10)
 		session := &mockSession{ch: ch}
 
@@ -215,7 +229,9 @@ func TestMsgConn_Read(t *testing.T) {
 }
 
 func TestMsgConn_Flush(t *testing.T) {
+	t.Parallel()
 	t.Run("flush always succeeds", func(t *testing.T) {
+		t.Parallel()
 		session := &mockSession{
 			ch: make(chan *view.Message, 10),
 		}

--- a/platform/view/services/comm/io/reader_security_test.go
+++ b/platform/view/services/comm/io/reader_security_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestVarintReader_OOMProtection(t *testing.T) {
+	t.Parallel()
 	// Create a buffer with a huge length prefix (e.g., 1GB)
 	hugeLength := uint64(1024 * 1024 * 1024)
 	buf := make([]byte, 10)
@@ -29,6 +30,7 @@ func TestVarintReader_OOMProtection(t *testing.T) {
 }
 
 func TestVarintReader_NormalMessage(t *testing.T) {
+	t.Parallel()
 	msg := []byte("hello world")
 	buf := make([]byte, 20)
 	n := binary.PutUvarint(buf, uint64(len(msg)))

--- a/platform/view/services/comm/io/reader_test.go
+++ b/platform/view/services/comm/io/reader_test.go
@@ -18,7 +18,9 @@ import (
 )
 
 func TestVarintReader_ReadData(t *testing.T) {
+	t.Parallel()
 	t.Run("successful read", func(t *testing.T) {
+		t.Parallel()
 		data := []byte("test message")
 		buf := &bytes.Buffer{}
 
@@ -35,6 +37,7 @@ func TestVarintReader_ReadData(t *testing.T) {
 	})
 
 	t.Run("read empty data", func(t *testing.T) {
+		t.Parallel()
 		buf := &bytes.Buffer{}
 		lenBuf := make([]byte, binary.MaxVarintLen64)
 		n := binary.PutUvarint(lenBuf, 0)
@@ -47,6 +50,7 @@ func TestVarintReader_ReadData(t *testing.T) {
 	})
 
 	t.Run("read multiple messages", func(t *testing.T) {
+		t.Parallel()
 		messages := [][]byte{
 			[]byte("first"),
 			[]byte("second"),
@@ -70,6 +74,7 @@ func TestVarintReader_ReadData(t *testing.T) {
 	})
 
 	t.Run("error on EOF reading length", func(t *testing.T) {
+		t.Parallel()
 		buf := &bytes.Buffer{}
 		r := newVarintReader(buf, 1024)
 
@@ -79,6 +84,7 @@ func TestVarintReader_ReadData(t *testing.T) {
 	})
 
 	t.Run("error on incomplete message", func(t *testing.T) {
+		t.Parallel()
 		buf := &bytes.Buffer{}
 		lenBuf := make([]byte, binary.MaxVarintLen64)
 		n := binary.PutUvarint(lenBuf, 10)
@@ -93,7 +99,9 @@ func TestVarintReader_ReadData(t *testing.T) {
 }
 
 func TestVarintReader_Close(t *testing.T) {
+	t.Parallel()
 	t.Run("close with closer", func(t *testing.T) {
+		t.Parallel()
 		closer := &mockReadCloser{Buffer: bytes.NewBuffer(nil)}
 		r := newVarintReader(closer, 1024)
 
@@ -103,6 +111,7 @@ func TestVarintReader_Close(t *testing.T) {
 	})
 
 	t.Run("close without closer", func(t *testing.T) {
+		t.Parallel()
 		buf := &bytes.Buffer{}
 		r := newVarintReader(buf, 1024)
 
@@ -111,6 +120,7 @@ func TestVarintReader_Close(t *testing.T) {
 	})
 
 	t.Run("close error", func(t *testing.T) {
+		t.Parallel()
 		closer := &mockReadCloser{
 			Buffer:   bytes.NewBuffer(nil),
 			closeErr: assert.AnError,
@@ -124,7 +134,9 @@ func TestVarintReader_Close(t *testing.T) {
 }
 
 func TestProtoReader_ReadMsg(t *testing.T) {
+	t.Parallel()
 	t.Run("successful read", func(t *testing.T) {
+		t.Parallel()
 		msg := &anypb.Any{
 			TypeUrl: "test.type",
 			Value:   []byte("test value"),
@@ -144,6 +156,7 @@ func TestProtoReader_ReadMsg(t *testing.T) {
 	})
 
 	t.Run("read multiple messages", func(t *testing.T) {
+		t.Parallel()
 		messages := []*anypb.Any{
 			{TypeUrl: "type1", Value: []byte("value1")},
 			{TypeUrl: "type2", Value: []byte("value2")},
@@ -168,6 +181,7 @@ func TestProtoReader_ReadMsg(t *testing.T) {
 	})
 
 	t.Run("error on EOF", func(t *testing.T) {
+		t.Parallel()
 		buf := &bytes.Buffer{}
 		r := NewVarintProtoReader(buf, 1024)
 
@@ -178,6 +192,7 @@ func TestProtoReader_ReadMsg(t *testing.T) {
 	})
 
 	t.Run("error on invalid protobuf", func(t *testing.T) {
+		t.Parallel()
 		buf := &bytes.Buffer{}
 		// Write invalid protobuf data
 		lenBuf := make([]byte, binary.MaxVarintLen64)
@@ -195,7 +210,9 @@ func TestProtoReader_ReadMsg(t *testing.T) {
 }
 
 func TestProtoReader_Close(t *testing.T) {
+	t.Parallel()
 	t.Run("close successfully", func(t *testing.T) {
+		t.Parallel()
 		closer := &mockReadCloser{Buffer: bytes.NewBuffer(nil)}
 		r := NewVarintProtoReader(closer, 1024)
 
@@ -205,6 +222,7 @@ func TestProtoReader_Close(t *testing.T) {
 	})
 
 	t.Run("close without closer", func(t *testing.T) {
+		t.Parallel()
 		buf := &bytes.Buffer{}
 		r := NewVarintProtoReader(buf, 1024)
 
@@ -214,13 +232,16 @@ func TestProtoReader_Close(t *testing.T) {
 }
 
 func TestNewVarintProtoReader(t *testing.T) {
+	t.Parallel()
 	buf := &bytes.Buffer{}
 	r := NewVarintProtoReader(buf, 1024)
 	require.NotNil(t, r)
 }
 
 func TestRoundTrip(t *testing.T) {
+	t.Parallel()
 	t.Run("write and read back", func(t *testing.T) {
+		t.Parallel()
 		buf := &bytes.Buffer{}
 
 		// Write messages

--- a/platform/view/services/comm/io/streamio/reader_enhanced_test.go
+++ b/platform/view/services/comm/io/streamio/reader_enhanced_test.go
@@ -15,7 +15,9 @@ import (
 )
 
 func TestReader_ErrorHandling(t *testing.T) {
+	t.Parallel()
 	t.Run("error from message reader", func(t *testing.T) {
+		t.Parallel()
 		expectedErr := errors.New("read error")
 		mrr := &errorMsgReader{err: expectedErr}
 		reader := NewReader(mrr)
@@ -28,6 +30,7 @@ func TestReader_ErrorHandling(t *testing.T) {
 	})
 
 	t.Run("nil message from reader", func(t *testing.T) {
+		t.Parallel()
 		mrr := &nilMsgReader{}
 		reader := NewReader(mrr)
 
@@ -38,6 +41,7 @@ func TestReader_ErrorHandling(t *testing.T) {
 	})
 
 	t.Run("empty message from reader", func(t *testing.T) {
+		t.Parallel()
 		mrr := newMockMessageReader([][]byte{{}})
 		reader := NewReader(mrr)
 
@@ -49,7 +53,9 @@ func TestReader_ErrorHandling(t *testing.T) {
 }
 
 func TestReader_BufferManagement(t *testing.T) {
+	t.Parallel()
 	t.Run("message larger than buffer", func(t *testing.T) {
+		t.Parallel()
 		largeMsg := []byte("this is a very long message that exceeds buffer size")
 		mrr := newMockMessageReader([][]byte{largeMsg})
 		reader := NewReader(mrr)
@@ -80,6 +86,7 @@ func TestReader_BufferManagement(t *testing.T) {
 	})
 
 	t.Run("buffer larger than message", func(t *testing.T) {
+		t.Parallel()
 		smallMsg := []byte("small")
 		mrr := newMockMessageReader([][]byte{smallMsg})
 		reader := NewReader(mrr)
@@ -93,6 +100,7 @@ func TestReader_BufferManagement(t *testing.T) {
 	})
 
 	t.Run("exact buffer size match", func(t *testing.T) {
+		t.Parallel()
 		msg := []byte("exact")
 		mrr := newMockMessageReader([][]byte{msg})
 		reader := NewReader(mrr)
@@ -106,7 +114,9 @@ func TestReader_BufferManagement(t *testing.T) {
 }
 
 func TestReader_MultipleMessages(t *testing.T) {
+	t.Parallel()
 	t.Run("sequential reads across messages", func(t *testing.T) {
+		t.Parallel()
 		messages := [][]byte{
 			[]byte("first"),
 			[]byte("second"),
@@ -131,6 +141,7 @@ func TestReader_MultipleMessages(t *testing.T) {
 	})
 
 	t.Run("partial reads across messages", func(t *testing.T) {
+		t.Parallel()
 		messages := [][]byte{
 			[]byte("message1"),
 			[]byte("message2"),

--- a/platform/view/services/comm/io/streamio/reader_test.go
+++ b/platform/view/services/comm/io/streamio/reader_test.go
@@ -36,6 +36,7 @@ func (m *MockMsgReader) Read() ([]byte, error) {
 }
 
 func TestRead(t *testing.T) {
+	t.Parallel()
 	buf := make([]byte, 7)
 	mrr := newMockMessageReader([][]byte{
 		[]byte("hello"),

--- a/platform/view/services/comm/io/writer_test.go
+++ b/platform/view/services/comm/io/writer_test.go
@@ -18,7 +18,9 @@ import (
 )
 
 func TestVarintWriter_WriteData(t *testing.T) {
+	t.Parallel()
 	t.Run("successful write", func(t *testing.T) {
+		t.Parallel()
 		buf := &bytes.Buffer{}
 		w := newVarintWriter(buf)
 
@@ -39,6 +41,7 @@ func TestVarintWriter_WriteData(t *testing.T) {
 	})
 
 	t.Run("write empty data", func(t *testing.T) {
+		t.Parallel()
 		buf := &bytes.Buffer{}
 		w := newVarintWriter(buf)
 
@@ -51,6 +54,7 @@ func TestVarintWriter_WriteData(t *testing.T) {
 	})
 
 	t.Run("write large data", func(t *testing.T) {
+		t.Parallel()
 		buf := &bytes.Buffer{}
 		w := newVarintWriter(buf)
 
@@ -69,6 +73,7 @@ func TestVarintWriter_WriteData(t *testing.T) {
 	})
 
 	t.Run("write error on length", func(t *testing.T) {
+		t.Parallel()
 		w := newVarintWriter(&errorWriter{failOn: 0})
 		err := w.WriteData([]byte("test"))
 		require.Error(t, err)
@@ -76,6 +81,7 @@ func TestVarintWriter_WriteData(t *testing.T) {
 	})
 
 	t.Run("write error on data", func(t *testing.T) {
+		t.Parallel()
 		w := newVarintWriter(&errorWriter{failOn: 1})
 		err := w.WriteData([]byte("test"))
 		require.Error(t, err)
@@ -84,7 +90,9 @@ func TestVarintWriter_WriteData(t *testing.T) {
 }
 
 func TestVarintWriter_Close(t *testing.T) {
+	t.Parallel()
 	t.Run("close with closer", func(t *testing.T) {
+		t.Parallel()
 		closer := &mockCloser{Buffer: &bytes.Buffer{}}
 		w := newVarintWriter(closer)
 
@@ -94,6 +102,7 @@ func TestVarintWriter_Close(t *testing.T) {
 	})
 
 	t.Run("close without closer", func(t *testing.T) {
+		t.Parallel()
 		buf := &bytes.Buffer{}
 		w := newVarintWriter(buf)
 
@@ -102,6 +111,7 @@ func TestVarintWriter_Close(t *testing.T) {
 	})
 
 	t.Run("close error", func(t *testing.T) {
+		t.Parallel()
 		closer := &mockCloser{Buffer: &bytes.Buffer{}, closeErr: assert.AnError}
 		w := newVarintWriter(closer)
 
@@ -112,7 +122,9 @@ func TestVarintWriter_Close(t *testing.T) {
 }
 
 func TestProtoWriter_WriteMsg(t *testing.T) {
+	t.Parallel()
 	t.Run("successful write", func(t *testing.T) {
+		t.Parallel()
 		buf := &bytes.Buffer{}
 		w := NewVarintProtoWriter(buf)
 
@@ -134,6 +146,7 @@ func TestProtoWriter_WriteMsg(t *testing.T) {
 	})
 
 	t.Run("write multiple messages", func(t *testing.T) {
+		t.Parallel()
 		buf := &bytes.Buffer{}
 		w := NewVarintProtoWriter(buf)
 
@@ -161,7 +174,9 @@ func TestProtoWriter_WriteMsg(t *testing.T) {
 }
 
 func TestProtoWriter_Close(t *testing.T) {
+	t.Parallel()
 	t.Run("close successfully", func(t *testing.T) {
+		t.Parallel()
 		closer := &mockCloser{Buffer: &bytes.Buffer{}}
 		w := NewVarintProtoWriter(closer)
 
@@ -171,6 +186,7 @@ func TestProtoWriter_Close(t *testing.T) {
 	})
 
 	t.Run("close without closer", func(t *testing.T) {
+		t.Parallel()
 		buf := &bytes.Buffer{}
 		w := NewVarintProtoWriter(buf)
 
@@ -180,6 +196,7 @@ func TestProtoWriter_Close(t *testing.T) {
 }
 
 func TestNewVarintProtoWriter(t *testing.T) {
+	t.Parallel()
 	buf := &bytes.Buffer{}
 	w := NewVarintProtoWriter(buf)
 	require.NotNil(t, w)

--- a/platform/view/services/comm/p2p_remedy_test.go
+++ b/platform/view/services/comm/p2p_remedy_test.go
@@ -59,7 +59,7 @@ func (m *mockHost) StreamHash(info host2.StreamInfo) host2.StreamHash {
 	return "hash"
 }
 
-func TestDispatcherDoS(t *testing.T) {
+func TestDispatcherDoS(t *testing.T) { //nolint:paralleltest
 	logging.Init(logging.Config{
 		LogSpec: "fsc.view.services.comm=error",
 	})
@@ -139,7 +139,7 @@ func TestDispatcherDoS(t *testing.T) {
 	}
 }
 
-func TestMasterSessionDoSProtection(t *testing.T) {
+func TestMasterSessionDoSProtection(t *testing.T) { //nolint:paralleltest
 	logging.Init(logging.Config{
 		LogSpec: "fsc.view.services.comm=error",
 	})
@@ -239,7 +239,7 @@ func TestMasterSessionDoSProtection(t *testing.T) {
 	}
 }
 
-func TestStreamLeak(t *testing.T) {
+func TestStreamLeak(t *testing.T) { //nolint:paralleltest
 	logging.Init(logging.Config{
 		LogSpec: "fsc.view.services.comm=error",
 	})

--- a/platform/view/services/comm/pingpong_test.go
+++ b/platform/view/services/comm/pingpong_test.go
@@ -22,7 +22,7 @@ import (
 	"go.uber.org/goleak"
 )
 
-func TestPingPongSessionLevel(t *testing.T) {
+func TestPingPongSessionLevel(t *testing.T) { //nolint:paralleltest
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	// Test ping-pong behavior at the session level with multiple sessions

--- a/platform/view/services/comm/session/support_test.go
+++ b/platform/view/services/comm/session/support_test.go
@@ -62,6 +62,7 @@ func (m *mockContext) StartSpanFrom(ctx context.Context, _ string, _ ...trace.Sp
 }
 
 func TestReadMessageWithTimeoutClosedChannel(t *testing.T) {
+	t.Parallel()
 	ch := make(chan *view.Message)
 	close(ch)
 
@@ -70,6 +71,7 @@ func TestReadMessageWithTimeoutClosedChannel(t *testing.T) {
 }
 
 func TestReadFirstMessageClosedChannel(t *testing.T) {
+	t.Parallel()
 	ch := make(chan *view.Message)
 	close(ch)
 
@@ -79,11 +81,13 @@ func TestReadFirstMessageClosedChannel(t *testing.T) {
 }
 
 func TestReadMessageWithTimeoutNilChannel(t *testing.T) {
+	t.Parallel()
 	_, err := ReadMessageWithTimeout(&mockSession{ch: nil}, 50*time.Millisecond)
 	require.EqualError(t, err, "session receive channel is nil")
 }
 
 func TestReadFirstMessageOrPanicClosedChannel(t *testing.T) {
+	t.Parallel()
 	ch := make(chan *view.Message)
 	close(ch)
 

--- a/platform/view/services/comm/session_deadlock_test.go
+++ b/platform/view/services/comm/session_deadlock_test.go
@@ -19,7 +19,7 @@ import (
 	"go.uber.org/goleak"
 )
 
-func TestSessionDeadlockDueToSlowReceiver(t *testing.T) {
+func TestSessionDeadlockDueToSlowReceiver(t *testing.T) { //nolint:paralleltest
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	// Create a session with unbuffered incoming channel to block the goroutine on send.
@@ -79,7 +79,7 @@ func TestSessionDeadlockDueToSlowReceiver(t *testing.T) {
 	_ = sess
 }
 
-func TestSessionDeadlockDueToMiddlewareChannelFull(t *testing.T) {
+func TestSessionDeadlockDueToMiddlewareChannelFull(t *testing.T) { //nolint:paralleltest
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	// Create a session with unbuffered incoming channel to block the goroutine on send.
@@ -140,7 +140,7 @@ func TestSessionDeadlockDueToMiddlewareChannelFull(t *testing.T) {
 	_ = sess
 }
 
-func TestSessionRecoverAfterClose(t *testing.T) {
+func TestSessionRecoverAfterClose(t *testing.T) { //nolint:paralleltest
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	s := &NetworkStreamSession{

--- a/platform/view/services/comm/session_test.go
+++ b/platform/view/services/comm/session_test.go
@@ -70,7 +70,7 @@ func setup() *NetworkStreamSession {
 	return setupWithBufferSize(DefaultIncomingMessagesBufferSize)
 }
 
-func TestSessionLifecycle(t *testing.T) {
+func TestSessionLifecycle(t *testing.T) { //nolint:paralleltest
 	s := setup()
 
 	// hide the impl behind the session interface as a consumer
@@ -125,7 +125,7 @@ func TestSessionLifecycle(t *testing.T) {
 	sess.Close()
 }
 
-func TestSessionLifecycleConcurrent(t *testing.T) {
+func TestSessionLifecycleConcurrent(t *testing.T) { //nolint:paralleltest
 	// let check that at the end of this test all our go routines are stopped
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
@@ -175,7 +175,7 @@ func TestSessionLifecycleConcurrent(t *testing.T) {
 	require.Positive(t, enqueuedCount.Load())
 }
 
-func TestSessionDeadlock(t *testing.T) {
+func TestSessionDeadlock(t *testing.T) { //nolint:paralleltest
 	// let check that at the end of this test all our go routines are stopped
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
@@ -217,7 +217,7 @@ func TestSessionDeadlock(t *testing.T) {
 	sess.Close()
 }
 
-func TestSessionCloseDeadlockPrevention(t *testing.T) {
+func TestSessionCloseDeadlockPrevention(t *testing.T) { //nolint:paralleltest
 	// let check that at the end of this test all our go routines are stopped
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 

--- a/platform/view/services/comm/stress_test.go
+++ b/platform/view/services/comm/stress_test.go
@@ -23,19 +23,22 @@ import (
 
 // TestLargeMessages verifies that the system can handle messages up to the 10MB limit.
 func TestLargeMessages(t *testing.T) {
+	t.Parallel()
 	logging.Init(logging.Config{LogSpec: "error"})
 	h := &mockHost{}
 	p, err := NewNode(t.Context(), h, &disabled.Provider{})
 	require.NoError(t, err)
-	defer p.Stop()
+	t.Cleanup(p.Stop)
 
 	// 5MB Message
 	t.Run("5MB Payload", func(t *testing.T) {
+		t.Parallel()
 		runLargeMessageTest(t, p, 5*1024*1024)
 	})
 
 	// 9.9MB Message (To stay within the 10MB total message limit)
 	t.Run("9.9MB Payload", func(t *testing.T) {
+		t.Parallel()
 		runLargeMessageTest(t, p, 9900*1024)
 	})
 }
@@ -57,7 +60,7 @@ func runLargeMessageTest(t *testing.T, p *P2PNode, size int) {
 
 // TestDroppedMessagesMetricValidation verifies that the DroppedMessages metric
 // correctly tracks messages lost due to buffer saturation.
-func TestDroppedMessagesMetricValidation(t *testing.T) {
+func TestDroppedMessagesMetricValidation(t *testing.T) { //nolint:paralleltest
 	logging.Init(logging.Config{LogSpec: "error"})
 
 	// Create a node with a custom metrics provider to inspect the counter
@@ -143,7 +146,7 @@ func TestDroppedMessagesMetricValidation(t *testing.T) {
 
 // TestConcurrentSendAndClose ensures no panics occur when closing a session
 // while multiple goroutines are actively sending.
-func TestConcurrentSendAndClose(t *testing.T) {
+func TestConcurrentSendAndClose(t *testing.T) { //nolint:paralleltest
 	logging.Init(logging.Config{LogSpec: "error"})
 	h := &mockHost{}
 	p, err := NewNode(t.Context(), h, &disabled.Provider{})
@@ -177,7 +180,7 @@ func TestConcurrentSendAndClose(t *testing.T) {
 
 // TestRecipientOversizedRejection verifies that the recipient immediately closes
 // the connection when receiving a length prefix exceeding the 10MB limit.
-func TestRecipientOversizedRejection(t *testing.T) {
+func TestRecipientOversizedRejection(t *testing.T) { //nolint:paralleltest
 	logging.Init(logging.Config{LogSpec: "error"})
 	h := &mockHost{}
 	p, err := NewNode(t.Context(), h, &disabled.Provider{})

--- a/platform/view/services/comm/timeout_test.go
+++ b/platform/view/services/comm/timeout_test.go
@@ -20,7 +20,7 @@ import (
 	"go.uber.org/goleak"
 )
 
-func TestEnqueueTimeoutBehavior(t *testing.T) {
+func TestEnqueueTimeoutBehavior(t *testing.T) { //nolint:paralleltest
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	// Test that enqueueWithTimeout respects the timeout value and logs appropriately
@@ -68,7 +68,7 @@ func TestEnqueueTimeoutBehavior(t *testing.T) {
 	_ = sess
 }
 
-func TestDefaultEnqueueTimeout(t *testing.T) {
+func TestDefaultEnqueueTimeout(t *testing.T) { //nolint:paralleltest
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	// Test that the default timeout (1 minute) is used when not set
@@ -118,7 +118,7 @@ func TestDefaultEnqueueTimeout(t *testing.T) {
 	_ = sess
 }
 
-func TestDrainTimeoutOnClose(t *testing.T) {
+func TestDrainTimeoutOnClose(t *testing.T) { //nolint:paralleltest
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	// Test that drain timeout works when closing session with blocked consumer
@@ -162,7 +162,7 @@ func TestDrainTimeoutOnClose(t *testing.T) {
 	_ = sess
 }
 
-func TestServiceStartRetryDelay(t *testing.T) {
+func TestServiceStartRetryDelay(t *testing.T) { //nolint:paralleltest
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	// Test that service startup retries with appropriate delay

--- a/platform/view/services/config/config_util_test.go
+++ b/platform/view/services/config/config_util_test.go
@@ -27,6 +27,7 @@ type TestStruct struct {
 }
 
 func TestEnhancedExactUnmarshal(t *testing.T) {
+	t.Parallel()
 	// Prepare a temporary file for testing stringFromFileDecodeHook
 	contentFile, err := os.CreateTemp(t.TempDir(), "test-content")
 	require.NoError(t, err)
@@ -77,6 +78,7 @@ test:
 }
 
 func TestByteSizeDecodeHookExtra(t *testing.T) {
+	t.Parallel()
 	k := koanf.New(".")
 	raw := []byte(`
 test:

--- a/platform/view/services/config/join_test.go
+++ b/platform/view/services/config/join_test.go
@@ -14,6 +14,7 @@ import (
 
 // TestJoin tests the Join function
 func TestJoin(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		components []string
@@ -68,6 +69,7 @@ func TestJoin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := Join(tt.components...)
 			assert.Equal(t, tt.expected, got, "Join(%v) = %q; want %q", tt.components, got, tt.expected)
 		})

--- a/platform/view/services/config/provider_test.go
+++ b/platform/view/services/config/provider_test.go
@@ -26,14 +26,14 @@ type Opts struct {
 	MaxOpenConns int
 }
 
-func TestReadFile(t *testing.T) {
+func TestReadFile(t *testing.T) { //nolint:paralleltest
 	p, err := NewProvider("./testdata")
 	require.NoError(t, err)
 	testBasics(t, p)
 	testMerge(t, p)
 }
 
-func TestProvideFromRaw(t *testing.T) {
+func TestProvideFromRaw(t *testing.T) { //nolint:paralleltest
 	p, err := NewProvider("./testdata")
 	require.NoError(t, err)
 
@@ -49,7 +49,7 @@ func TestProvideFromRaw(t *testing.T) {
 	testMerge(t, newProvider)
 }
 
-func TestEnvSubstitution(t *testing.T) {
+func TestEnvSubstitution(t *testing.T) { //nolint:paralleltest
 	_ = os.Setenv("CORE_FSC_KVS_PERSISTENCE_OPTS_DATASOURCE", "new data source")
 	_ = os.Setenv("CORE_STR", "new=string=with=characters.\\AND.CAPS")
 	_ = os.Setenv("CORE_NUMBER", "10")
@@ -189,6 +189,7 @@ func (m *mockProvider) GetService(v any) (any, error) {
 }
 
 func TestGetProvider(t *testing.T) {
+	t.Parallel()
 	p := &Provider{}
 	mp := &mockProvider{service: p}
 	assert.Equal(t, p, GetProvider(mp))
@@ -199,6 +200,7 @@ func TestGetProvider(t *testing.T) {
 }
 
 func TestProviderMore(t *testing.T) {
+	t.Parallel()
 	_ = os.Setenv("CORE_FSC_ID", "node1")
 	p, err := NewProvider("./testdata")
 	require.NoError(t, err)
@@ -234,11 +236,13 @@ func TestProviderMore(t *testing.T) {
 }
 
 func TestProviderError(t *testing.T) {
+	t.Parallel()
 	_, err := NewProvider("./non-existent-path")
 	require.Error(t, err)
 }
 
 func TestEnvConversions(t *testing.T) {
+	t.Parallel()
 	_ = os.Setenv("CORE_ENV_INT", "123")
 	_ = os.Setenv("CORE_ENV_BOOL", "true")
 	_ = os.Setenv("CORE_ENV_FLOAT", "1.23")

--- a/platform/view/services/endpoint/pki_test.go
+++ b/platform/view/services/endpoint/pki_test.go
@@ -27,6 +27,7 @@ func TestDefaultPublicKeyIDSynthesizer_PublicKeyID(t *testing.T) {
 	synthesizer := endpoint.DefaultPublicKeyIDSynthesizer{}
 
 	t.Run("RSA public key", func(t *testing.T) {
+		t.Parallel()
 		// Generate RSA key
 		privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 		require.NoError(t, err)
@@ -50,6 +51,7 @@ func TestDefaultPublicKeyIDSynthesizer_PublicKeyID(t *testing.T) {
 	})
 
 	t.Run("ECDSA public key", func(t *testing.T) {
+		t.Parallel()
 		// Generate ECDSA key
 		privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		require.NoError(t, err)
@@ -67,6 +69,7 @@ func TestDefaultPublicKeyIDSynthesizer_PublicKeyID(t *testing.T) {
 	})
 
 	t.Run("different keys produce different IDs", func(t *testing.T) {
+		t.Parallel()
 		// Generate two different keys
 		key1, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		require.NoError(t, err)
@@ -82,6 +85,7 @@ func TestDefaultPublicKeyIDSynthesizer_PublicKeyID(t *testing.T) {
 	})
 
 	t.Run("unsupported key type", func(t *testing.T) {
+		t.Parallel()
 		// Test with unsupported key type
 		_, err := synthesizer.PublicKeyID("not a key")
 		require.Error(t, err)
@@ -89,11 +93,13 @@ func TestDefaultPublicKeyIDSynthesizer_PublicKeyID(t *testing.T) {
 	})
 
 	t.Run("nil key", func(t *testing.T) {
+		t.Parallel()
 		_, err := synthesizer.PublicKeyID(nil)
 		require.Error(t, err)
 	})
 
 	t.Run("byte slice key (should fail)", func(t *testing.T) {
+		t.Parallel()
 		// This should fail as x509.MarshalPKIXPublicKey doesn't support []byte
 		_, err := synthesizer.PublicKeyID([]byte("some bytes"))
 		require.Error(t, err)

--- a/platform/view/services/endpoint/service_extended_test.go
+++ b/platform/view/services/endpoint/service_extended_test.go
@@ -27,6 +27,7 @@ import (
 func TestBind(t *testing.T) {
 	t.Parallel()
 	t.Run("bind single ephemeral identity", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		bindingStore.PutBindingsReturns(nil)
 
@@ -47,6 +48,7 @@ func TestBind(t *testing.T) {
 	})
 
 	t.Run("bind multiple ephemeral identities", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		bindingStore.PutBindingsReturns(nil)
 
@@ -67,6 +69,7 @@ func TestBind(t *testing.T) {
 	})
 
 	t.Run("filter out identities equal to longTerm", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		bindingStore.PutBindingsReturns(nil)
 
@@ -88,6 +91,7 @@ func TestBind(t *testing.T) {
 	})
 
 	t.Run("no binding when all ephemeral IDs equal longTerm", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		bindingStore.PutBindingsReturns(nil)
 
@@ -104,6 +108,7 @@ func TestBind(t *testing.T) {
 	})
 
 	t.Run("no binding when no ephemeral IDs provided", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		bindingStore.PutBindingsReturns(nil)
 
@@ -119,6 +124,7 @@ func TestBind(t *testing.T) {
 	})
 
 	t.Run("error from binding store", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		expectedErr := errors.New("storage error")
 		bindingStore.PutBindingsReturns(expectedErr)
@@ -138,6 +144,7 @@ func TestBind(t *testing.T) {
 func TestIsBoundTo(t *testing.T) {
 	t.Parallel()
 	t.Run("identities are bound", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		bindingStore.HaveSameBindingReturns(true, nil)
 
@@ -158,6 +165,7 @@ func TestIsBoundTo(t *testing.T) {
 	})
 
 	t.Run("identities are not bound", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		bindingStore.HaveSameBindingReturns(false, nil)
 
@@ -172,6 +180,7 @@ func TestIsBoundTo(t *testing.T) {
 	})
 
 	t.Run("error from binding store returns false", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		bindingStore.HaveSameBindingReturns(false, errors.New("storage error"))
 
@@ -189,6 +198,7 @@ func TestIsBoundTo(t *testing.T) {
 func TestUpdateResolver(t *testing.T) {
 	t.Parallel()
 	t.Run("update existing resolver addresses", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		service, err := endpoint.NewService(bindingStore)
 		require.NoError(t, err)
@@ -224,6 +234,7 @@ func TestUpdateResolver(t *testing.T) {
 	})
 
 	t.Run("update adds new aliases", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		service, err := endpoint.NewService(bindingStore)
 		require.NoError(t, err)
@@ -255,6 +266,7 @@ func TestUpdateResolver(t *testing.T) {
 	})
 
 	t.Run("update non-existent resolver adds it", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		bindingStore.PutBindingsReturns(nil)
 		service, err := endpoint.NewService(bindingStore)
@@ -279,7 +291,9 @@ func TestUpdateResolver(t *testing.T) {
 }
 
 func TestSetPublicKeyIDSynthesizer(t *testing.T) {
+	t.Parallel()
 	t.Run("set custom synthesizer", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		service, err := endpoint.NewService(bindingStore)
 		require.NoError(t, err)
@@ -330,6 +344,7 @@ func TestExtractPKI(t *testing.T) {
 	t.Parallel()
 
 	t.Run("extract with single extractor", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		service, err := endpoint.NewService(bindingStore)
 		require.NoError(t, err)
@@ -350,6 +365,7 @@ func TestExtractPKI(t *testing.T) {
 	})
 
 	t.Run("extract with multiple extractors", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		service, err := endpoint.NewService(bindingStore)
 		require.NoError(t, err)
@@ -379,6 +395,7 @@ func TestExtractPKI(t *testing.T) {
 	})
 
 	t.Run("no extractors returns nil", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		service, err := endpoint.NewService(bindingStore)
 		require.NoError(t, err)
@@ -389,6 +406,7 @@ func TestExtractPKI(t *testing.T) {
 	})
 
 	t.Run("all extractors fail returns nil", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		service, err := endpoint.NewService(bindingStore)
 		require.NoError(t, err)
@@ -406,6 +424,7 @@ func TestExtractPKI(t *testing.T) {
 	})
 
 	t.Run("nil extractor returns error", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		service, err := endpoint.NewService(bindingStore)
 		require.NoError(t, err)
@@ -430,6 +449,7 @@ func (m *mockPublicKeyExtractor) ExtractPublicKey(id view.Identity) (any, error)
 func TestResolveIdentities(t *testing.T) {
 	t.Parallel()
 	t.Run("resolve single endpoint", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		service, err := endpoint.NewService(bindingStore)
 		require.NoError(t, err)
@@ -451,6 +471,7 @@ func TestResolveIdentities(t *testing.T) {
 	})
 
 	t.Run("resolve multiple endpoints", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		service, err := endpoint.NewService(bindingStore)
 		require.NoError(t, err)
@@ -471,6 +492,7 @@ func TestResolveIdentities(t *testing.T) {
 	})
 
 	t.Run("error when endpoint not found", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		service, err := endpoint.NewService(bindingStore)
 		require.NoError(t, err)
@@ -481,6 +503,7 @@ func TestResolveIdentities(t *testing.T) {
 	})
 
 	t.Run("error on first of multiple endpoints", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		service, err := endpoint.NewService(bindingStore)
 		require.NoError(t, err)
@@ -497,6 +520,7 @@ func TestResolveIdentities(t *testing.T) {
 func TestResolverMethods(t *testing.T) {
 	t.Parallel()
 	t.Run("GetName", func(t *testing.T) {
+		t.Parallel()
 		resolver := &endpoint.Resolver{
 			ResolverInfo: endpoint.ResolverInfo{
 				Name: "test-name",
@@ -506,6 +530,7 @@ func TestResolverMethods(t *testing.T) {
 	})
 
 	t.Run("GetAddress", func(t *testing.T) {
+		t.Parallel()
 		resolver := &endpoint.Resolver{
 			ResolverInfo: endpoint.ResolverInfo{
 				Addresses: map[endpoint.PortName]string{
@@ -523,6 +548,7 @@ func TestResolverMethods(t *testing.T) {
 func TestResolveWithBinding(t *testing.T) {
 	t.Parallel()
 	t.Run("resolve ephemeral identity through binding", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		service, err := endpoint.NewService(bindingStore)
 		require.NoError(t, err)
@@ -555,6 +581,7 @@ func TestResolveWithBinding(t *testing.T) {
 	})
 
 	t.Run("resolve returns nil when identity not found", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		bindingStore.GetLongTermReturns([]byte("unknown-id"), nil)
 		service, err := endpoint.NewService(bindingStore)
@@ -569,6 +596,7 @@ func TestResolveWithBinding(t *testing.T) {
 func TestConcurrency(t *testing.T) {
 	t.Parallel()
 	t.Run("concurrent resolver additions", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		bindingStore.PutBindingsReturns(nil)
 		service, err := endpoint.NewService(bindingStore)
@@ -600,6 +628,7 @@ func TestConcurrency(t *testing.T) {
 	})
 
 	t.Run("concurrent resolver updates", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		service, err := endpoint.NewService(bindingStore)
 		require.NoError(t, err)
@@ -635,6 +664,7 @@ func TestConcurrency(t *testing.T) {
 	})
 
 	t.Run("concurrent reads and writes", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		bindingStore.GetLongTermReturns(nil, nil)
 		service, err := endpoint.NewService(bindingStore)
@@ -685,6 +715,7 @@ func TestConcurrency(t *testing.T) {
 func TestEdgeCases(t *testing.T) {
 	t.Parallel()
 	t.Run("empty identity", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		bindingStore.GetLongTermReturns(nil, nil)
 		service, err := endpoint.NewService(bindingStore)
@@ -695,6 +726,7 @@ func TestEdgeCases(t *testing.T) {
 	})
 
 	t.Run("nil identity", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		bindingStore.GetLongTermReturns(nil, nil)
 		service, err := endpoint.NewService(bindingStore)
@@ -705,6 +737,7 @@ func TestEdgeCases(t *testing.T) {
 	})
 
 	t.Run("resolver with empty addresses", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		service, err := endpoint.NewService(bindingStore)
 		require.NoError(t, err)
@@ -725,6 +758,7 @@ func TestEdgeCases(t *testing.T) {
 	})
 
 	t.Run("resolver with nil aliases", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		service, err := endpoint.NewService(bindingStore)
 		require.NoError(t, err)
@@ -745,6 +779,7 @@ func TestEdgeCases(t *testing.T) {
 	})
 
 	t.Run("resolver with empty string aliases", func(t *testing.T) {
+		t.Parallel()
 		bindingStore := &mock.BindingStore{}
 		service, err := endpoint.NewService(bindingStore)
 		require.NoError(t, err)

--- a/platform/view/services/endpoint/service_test.go
+++ b/platform/view/services/endpoint/service_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestPKIResolveConcurrency(t *testing.T) {
+	t.Parallel()
 	bindingStore := &mock.BindingStore{}
 	bindingStore.GetLongTermReturns(nil, nil)
 	bindingStore.HaveSameBindingReturns(false, nil)
@@ -46,6 +47,7 @@ func TestPKIResolveConcurrency(t *testing.T) {
 }
 
 func TestGetIdentity(t *testing.T) {
+	t.Parallel()
 	// setup
 	bindingStore := &mock.BindingStore{}
 	bindingStore.PutBindingsReturns(nil)
@@ -172,6 +174,8 @@ func TestGetIdentity(t *testing.T) {
 }
 
 func TestLookupIP(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		endpoint string
@@ -394,6 +398,7 @@ func TestLookupIP(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := endpoint.LookupIP(tt.endpoint)
 			tt.checkFunc(t, tt.endpoint, result)
 		})
@@ -401,6 +406,7 @@ func TestLookupIP(t *testing.T) {
 }
 
 func TestLookupIP_HostnameResolution(t *testing.T) {
+	t.Parallel()
 	// Test that localhost actually resolves
 	result := endpoint.LookupIP("localhost:8080")
 
@@ -414,6 +420,7 @@ func TestLookupIP_HostnameResolution(t *testing.T) {
 }
 
 func TestLookupIP_PreservesPort(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		endpoint string
@@ -429,7 +436,7 @@ func TestLookupIP_PreservesPort(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Helper()
+			t.Parallel()
 			result := endpoint.LookupIP(tt.endpoint)
 			// Extract port from result
 			_, port, err := net.SplitHostPort(result)

--- a/platform/view/services/events/service_test.go
+++ b/platform/view/services/events/service_test.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEvents(t *testing.T) {
+func TestEvents(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Event service provider test")
 }

--- a/platform/view/services/events/simple/eventbus_test.go
+++ b/platform/view/services/events/simple/eventbus_test.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEvents(t *testing.T) {
+func TestEvents(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Test simple event system")
 }

--- a/platform/view/services/events/subscribers_test.go
+++ b/platform/view/services/events/subscribers_test.go
@@ -22,6 +22,7 @@ type B struct {
 }
 
 func TestSubscribers(t *testing.T) {
+	t.Parallel()
 	s := events.NewSubscribers()
 	a := &A{Name: "a"}
 	a2 := &A{Name: "a"}

--- a/platform/view/services/grpc/client_test.go
+++ b/platform/view/services/grpc/client_test.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"net"
 	"os"
 	"path/filepath"
 	"sync"
@@ -154,10 +153,8 @@ func TestNewConnection(t *testing.T) {
 	t.Parallel()
 	testCerts := loadCerts(t)
 
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
+	l := createListener(t)
 	badAddress := l.Addr().String()
-	defer utils.IgnoreErrorFunc(l.Close)
 
 	certPool := x509.NewCertPool()
 	ok := certPool.AppendCertsFromPEM(testCerts.caPEM)
@@ -337,15 +334,13 @@ func TestNewConnection(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			lis, err := net.Listen("tcp", "127.0.0.1:0")
-			require.NoError(t, err, "error creating server for test")
-			defer utils.IgnoreErrorFunc(lis.Close)
+			lis := createListener(t)
 			serverOpts := []grpc.ServerOption{}
 			if test.serverTLS != nil {
 				serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(test.serverTLS)))
 			}
 			srv := grpc.NewServer(serverOpts...)
-			defer srv.Stop()
+			t.Cleanup(srv.Stop)
 			go utils.IgnoreErrorFunc(func() error {
 				return srv.Serve(lis)
 			})
@@ -382,16 +377,14 @@ func TestNewConnection_TLSCertificateSANMismatch(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a TLS server
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	defer utils.IgnoreErrorFunc(lis.Close)
+	lis := createListener(t)
 
 	serverTLS := &tls.Config{
 		Certificates: []tls.Certificate{serverCert},
 	}
 
 	srv := grpc.NewServer(grpc.Creds(credentials.NewTLS(serverTLS)))
-	defer srv.Stop()
+	t.Cleanup(srv.Stop)
 	go utils.IgnoreErrorFunc(func() error {
 		return srv.Serve(lis)
 	})
@@ -443,16 +436,14 @@ func TestSetServerRootCAs(t *testing.T) {
 	require.NoError(t, err, "error creating base client")
 
 	// set up test TLS server
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err, "failed to create listener for test server")
+	lis := createListener(t)
 	address := lis.Addr().String()
 	t.Logf("server listening on [%s]", lis.Addr().String())
 	t.Logf("client will use [%s]", address)
-	defer utils.IgnoreErrorFunc(lis.Close)
 	srv := grpc.NewServer(grpc.Creds(credentials.NewTLS(&tls.Config{
 		Certificates: []tls.Certificate{testCerts.serverCert},
 	})))
-	defer srv.Stop()
+	t.Cleanup(srv.Stop)
 	go utils.IgnoreErrorFunc(func() error {
 		return srv.Serve(lis)
 	})
@@ -496,13 +487,13 @@ func TestSetMessageSize(t *testing.T) {
 	t.Parallel()
 
 	// setup test server
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err, "failed to create listener for test server")
+	lis := createListener(t)
+	address := lis.Addr().String()
 	srv, err := grpc3.NewGRPCServerFromListener(lis, grpc3.ServerConfig{})
 	require.NoError(t, err, "failed to create test server")
 	testpb.RegisterEchoServiceServer(srv.Server(), &echoServer{})
-	defer srv.Stop()
 	go utils.IgnoreErrorFunc(srv.Start)
+	t.Cleanup(srv.Stop)
 
 	var tests = []struct {
 		name        string
@@ -537,16 +528,17 @@ func TestSetMessageSize(t *testing.T) {
 		},
 	}
 
-	// set up test client
-	client, err := grpc3.NewGRPCClient(grpc3.ClientConfig{
-		Timeout: testTimeout,
-	})
 	require.NoError(t, err, "error creating test client")
 	// run tests
 	for _, test := range tests {
-		address := lis.Addr().String()
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			t.Log(test.name)
+			// set up test client
+			client, err := grpc3.NewGRPCClient(grpc3.ClientConfig{
+				Timeout: testTimeout,
+			})
+			require.NoError(t, err)
 			if test.maxRecvSize > 0 {
 				client.SetMaxRecvMsgSize(test.maxRecvSize)
 			}
@@ -555,12 +547,15 @@ func TestSetMessageSize(t *testing.T) {
 			}
 			conn, err := client.NewConnection(address)
 			require.NoError(t, err)
+			t.Cleanup(func() {
+				_ = conn.Close
+			})
 			defer utils.IgnoreErrorFunc(conn.Close)
 			// create service client from conn
 			svcClient := testpb.NewEchoServiceClient(conn)
 			callCtx := context.Background()
 			callCtx, cancel := context.WithTimeout(callCtx, testTimeout)
-			defer cancel()
+			t.Cleanup(cancel)
 			// invoke service
 			echo := &testpb.Echo{
 				Payload: []byte{0, 0, 0, 0, 0},
@@ -613,6 +608,7 @@ func loadCerts(t *testing.T) testCerts {
 }
 
 func TestServerNameOverride(t *testing.T) {
+	t.Parallel()
 	tlsOption := grpc3.ServerNameOverride("override-name")
 	testConfig := &tls.Config{}
 	tlsOption(testConfig)
@@ -622,6 +618,7 @@ func TestServerNameOverride(t *testing.T) {
 }
 
 func TestCertPoolOverride(t *testing.T) {
+	t.Parallel()
 	tlsOption := grpc3.CertPoolOverride(&x509.CertPool{})
 	testConfig := &tls.Config{}
 	require.NotEqual(t, &tls.Config{

--- a/platform/view/services/grpc/config_test.go
+++ b/platform/view/services/grpc/config_test.go
@@ -58,6 +58,7 @@ func TestClientKeepaliveOptions(t *testing.T) {
 }
 
 func TestClientConfigClone(t *testing.T) {
+	t.Parallel()
 	origin := ClientConfig{
 		KeepAliveConfig: &ClientKeepAliveConfig{
 			Time: time.Second,

--- a/platform/view/services/grpc/connection_test.go
+++ b/platform/view/services/grpc/connection_test.go
@@ -59,6 +59,7 @@ func loadRootCAs() [][]byte {
 }
 
 func TestNewCredentialSupport(t *testing.T) {
+	t.Parallel()
 	expected := &CredentialSupport{
 		appRootCAsByChain: make(map[string][][]byte),
 	}

--- a/platform/view/services/grpc/creds_test.go
+++ b/platform/view/services/grpc/creds_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
 	"github.com/stretchr/testify/require"
 )
@@ -61,12 +60,7 @@ func TestCreds(t *testing.T) {
 	require.Equal(t, "1.2", creds.Info().SecurityVersion) //nolint:all
 	require.Equal(t, "tls", creds.Info().SecurityProtocol)
 
-	lis, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatalf("failed to start listener [%s]", err)
-	}
-	defer utils.IgnoreErrorFunc(lis.Close)
-
+	lis := createListener(t)
 	_, port, err := net.SplitHostPort(lis.Addr().String())
 	require.NoError(t, err)
 	addr := net.JoinHostPort("localhost", port)

--- a/platform/view/services/grpc/server_test.go
+++ b/platform/view/services/grpc/server_test.go
@@ -432,10 +432,7 @@ func TestNewGRPCServerInvalidParameters(t *testing.T) {
 	require.Error(t, err, "error expected")
 
 	// address in use
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err, "failed to create listener")
-	defer utils.IgnoreErrorFunc(lis.Close)
-
+	lis := createListener(t)
 	_, err = grpc3.NewGRPCServerFromListener(
 		lis,
 		grpc3.ServerConfig{SecOpts: grpc3.SecureOptions{UseTLS: false}},
@@ -550,8 +547,7 @@ func TestNewGRPCServerFromListener(t *testing.T) {
 	t.Parallel()
 
 	// create our listener
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err, "failed to create listener")
+	lis := createListener(t)
 	testAddress := lis.Addr().String()
 
 	srv, err := grpc3.NewGRPCServerFromListener(
@@ -584,8 +580,7 @@ func TestNewSecureGRPCServer(t *testing.T) {
 	t.Parallel()
 
 	// create our listener
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err, "failed to create listener")
+	lis := createListener(t)
 	testAddress := lis.Addr().String()
 
 	srv, err := grpc3.NewGRPCServerFromListener(lis, grpc3.ServerConfig{
@@ -613,7 +608,7 @@ func TestNewSecureGRPCServer(t *testing.T) {
 
 	// start the server
 	go utils.IgnoreErrorFunc(srv.Start)
-	defer srv.Stop()
+	t.Cleanup(srv.Stop)
 
 	// should not be needed
 	time.Sleep(10 * time.Millisecond)
@@ -640,7 +635,12 @@ func TestNewSecureGRPCServer(t *testing.T) {
 			creds := credentials.NewTLS(&tls.Config{RootCAs: certPool, MinVersion: version, MaxVersion: version})
 			_, err := invokeEmptyCall(testAddress, grpc.WithTransportCredentials(creds))
 			require.Error(t, err, "should not have been able to connect with TLS version < 1.2")
-			require.Contains(t, err.Error(), "connection refused")
+			errMsg := err.Error()
+			require.True(t,
+				strings.Contains(errMsg, "connection refused") ||
+					strings.Contains(errMsg, "protocol version not supported"),
+				"expected connection refused or protocol version not supported, got: %s", errMsg,
+			)
 		})
 	}
 }
@@ -696,14 +696,16 @@ func TestVerifyCertificateCallback(t *testing.T) {
 		},
 	})
 	go utils.IgnoreErrorFunc(gRPCServer.Start)
-	defer gRPCServer.Stop()
+	t.Cleanup(gRPCServer.Stop)
 
 	t.Run("Success path", func(t *testing.T) {
+		t.Parallel()
 		err = probeTLS(gRPCServer.Address(), authorizedClientKeyPair)
 		require.NoError(t, err)
 	})
 
 	t.Run("Failure path", func(t *testing.T) {
+		t.Parallel()
 		err = probeTLS(gRPCServer.Address(), notAuthorizedClientKeyPair)
 		require.EqualError(t, err, "remote error: tls: bad certificate")
 	})
@@ -726,8 +728,7 @@ func TestWithSignedRootCertificates(t *testing.T) {
 	require.NoError(t, err, "failed to load test certificates")
 
 	// create our listener
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err, "failed to create listener")
+	lis := createListener(t)
 	testAddress := lis.Addr().String()
 
 	srv, err := grpc3.NewGRPCServerFromListener(lis, grpc3.ServerConfig{
@@ -743,7 +744,7 @@ func TestWithSignedRootCertificates(t *testing.T) {
 
 	// start the server
 	go utils.IgnoreErrorFunc(srv.Start)
-	defer srv.Stop()
+	t.Cleanup(srv.Stop)
 
 	// should not be needed
 	time.Sleep(10 * time.Millisecond)
@@ -787,10 +788,7 @@ func TestWithSignedIntermediateCertificates(t *testing.T) {
 	}
 
 	// create our listener
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("Failed to create listener: %v", err)
-	}
+	lis := createListener(t)
 	testAddress := lis.Addr().String()
 
 	srv, err := grpc3.NewGRPCServerFromListener(lis, grpc3.ServerConfig{
@@ -808,7 +806,7 @@ func TestWithSignedIntermediateCertificates(t *testing.T) {
 
 	// start the server
 	go utils.IgnoreErrorFunc(srv.Start)
-	defer srv.Stop()
+	t.Cleanup(srv.Stop)
 
 	// should not be needed
 	time.Sleep(10 * time.Millisecond)
@@ -845,10 +843,7 @@ func runMutualAuth(t *testing.T, servers []testServer, trustedClients, unTrusted
 	// loop through all the test servers
 	for i := 0; i < len(servers); i++ {
 		// create listener
-		lis, err := net.Listen("tcp", "127.0.0.1:0")
-		if err != nil {
-			return err
-		}
+		lis := createListener(t)
 		srvAddr := lis.Addr().String()
 
 		// create GRPCServer
@@ -865,7 +860,7 @@ func runMutualAuth(t *testing.T, servers []testServer, trustedClients, unTrusted
 		// register the GRPC test server and start the GRPCServer
 		testpb.RegisterEmptyServiceServer(srv.Server(), &emptyServiceServer{})
 		go utils.IgnoreErrorFunc(srv.Start)
-		defer srv.Stop()
+		t.Cleanup(srv.Stop)
 
 		// should not be needed but just in case
 		time.Sleep(10 * time.Millisecond)
@@ -962,9 +957,7 @@ func TestSetClientRootCAs(t *testing.T) {
 
 	// get the config for one of our Org1 test servers
 	serverConfig := testOrgs[0].testServers([][]byte{})[0].config
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err, "listen failed")
-	defer utils.IgnoreErrorFunc(lis.Close)
+	lis := createListener(t)
 	address := lis.Addr().String()
 
 	// create a GRPCServer
@@ -974,7 +967,7 @@ func TestSetClientRootCAs(t *testing.T) {
 	// register the GRPC test server and start the GRPCServer
 	testpb.RegisterEmptyServiceServer(srv.Server(), &emptyServiceServer{})
 	go utils.IgnoreErrorFunc(srv.Start)
-	defer srv.Stop()
+	t.Cleanup(srv.Stop)
 
 	// should not be needed but just in case
 	time.Sleep(10 * time.Millisecond)
@@ -1058,8 +1051,7 @@ func TestUpdateTLSCert(t *testing.T) {
 	}
 
 	// create our listener
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err, "listen failed")
+	lis := createListener(t)
 	testAddress := lis.Addr().String()
 
 	srv, err := grpc3.NewGRPCServerFromListener(lis, cfg)
@@ -1067,7 +1059,7 @@ func TestUpdateTLSCert(t *testing.T) {
 	testpb.RegisterEmptyServiceServer(srv.Server(), &emptyServiceServer{})
 
 	go utils.IgnoreErrorFunc(srv.Start)
-	defer srv.Stop()
+	t.Cleanup(srv.Stop)
 
 	certPool := x509.NewCertPool()
 	certPool.AppendCertsFromPEM(caCert)
@@ -1175,8 +1167,7 @@ func TestCipherSuites(t *testing.T) {
 	}
 
 	// create our listener
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err, "listen failed")
+	lis := createListener(t)
 	testAddress := lis.Addr().String()
 	srv, err := grpc3.NewGRPCServerFromListener(lis, serverConfig)
 	require.NoError(t, err)
@@ -1202,8 +1193,8 @@ func TestCipherSuites(t *testing.T) {
 }
 
 func TestServerInterceptors(t *testing.T) {
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err, "listen failed")
+	t.Parallel()
+	lis := createListener(t)
 	msg := "error from interceptor"
 
 	// set up interceptors
@@ -1235,8 +1226,8 @@ func TestServerInterceptors(t *testing.T) {
 	srv, err := grpc3.NewGRPCServerFromListener(lis, srvConfig)
 	require.NoError(t, err, "failed to create gRPC server")
 	testpb.RegisterEmptyServiceServer(srv.Server(), &emptyServiceServer{})
-	defer srv.Stop()
 	go utils.IgnoreErrorFunc(srv.Start)
+	t.Cleanup(srv.Stop)
 
 	_, err = invokeEmptyCall(
 		lis.Addr().String(),
@@ -1253,4 +1244,14 @@ func TestServerInterceptors(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, status.Convert(err).Message(), msg, "Expected error from second ssi")
 	require.Equal(t, uint32(2), atomic.LoadUint32(&ssiCount), "Expected both ssi handlers to be invoked")
+}
+
+func createListener(t *testing.T) net.Listener {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "listen failed")
+	t.Cleanup(func() {
+		_ = lis.Close()
+	})
+	return lis
 }

--- a/platform/view/services/grpc/tlsgen/ca_test.go
+++ b/platform/view/services/grpc/tlsgen/ca_test.go
@@ -36,6 +36,7 @@ func createTLSService(t *testing.T, ca CA, host string) *grpc.Server {
 }
 
 func TestTLSCA(t *testing.T) {
+	t.Parallel()
 	// This test checks that the CA can create certificates
 	// and corresponding keys that are signed by itself
 

--- a/platform/view/services/grpc/tlsgen/key_test.go
+++ b/platform/view/services/grpc/tlsgen/key_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestLoadCert(t *testing.T) {
+	t.Parallel()
 	pair, err := newCertKeyPair(false, false, "", nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, pair)

--- a/platform/view/services/grpc/util_test.go
+++ b/platform/view/services/grpc/util_test.go
@@ -68,6 +68,7 @@ func TestBindingInspectorBadInit(t *testing.T) {
 }
 
 func TestGetLocalIP(t *testing.T) {
+	t.Parallel()
 	ip, err := grpc3.GetLocalIP()
 	require.NoError(t, err)
 	t.Log(ip)

--- a/platform/view/services/id/ecdsa/ecdsa_test.go
+++ b/platform/view/services/id/ecdsa/ecdsa_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestNewIdentityFromPEMCertInvalid(t *testing.T) {
+	t.Parallel()
 	_, _, err := NewIdentityFromPEMCert([]byte("invalid PEM"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cannot pem decode")

--- a/platform/view/services/id/provider_test.go
+++ b/platform/view/services/id/provider_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestLoad(t *testing.T) {
+	t.Parallel()
 	cp := &mock2.ConfigProvider{}
 	cp.GetPathReturnsOnCall(0, "./testdata/default/signcerts/default.pem")
 	cp.GetPathReturnsOnCall(1, "./testdata/default/keystore/priv_sk")

--- a/platform/view/services/metrics/disabled/disabled_suite_test.go
+++ b/platform/view/services/metrics/disabled/disabled_suite_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestDisabled(t *testing.T) {
+func TestDisabled(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Disabled Suite")
 }

--- a/platform/view/services/metrics/operations/operations_suite_test.go
+++ b/platform/view/services/metrics/operations/operations_suite_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestOperations(t *testing.T) {
+func TestOperations(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Operations Suite")
 }

--- a/platform/view/services/metrics/prometheus/prometheus_suite_test.go
+++ b/platform/view/services/metrics/prometheus/prometheus_suite_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestPrometheus(t *testing.T) {
+func TestPrometheus(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Prometheus Suite")
 }

--- a/platform/view/services/sig/service_test.go
+++ b/platform/view/services/sig/service_test.go
@@ -757,6 +757,7 @@ func TestSigningIdentityWrapper(t *testing.T) {
 	}
 
 	t.Run("Sign", func(t *testing.T) {
+		t.Parallel()
 		sig, err := si.Sign(message)
 		require.NoError(t, err)
 		require.Equal(t, signature, sig)
@@ -765,17 +766,20 @@ func TestSigningIdentityWrapper(t *testing.T) {
 	})
 
 	t.Run("Serialize", func(t *testing.T) {
+		t.Parallel()
 		serialized, err := si.Serialize()
 		require.NoError(t, err)
 		require.Equal(t, identity, view.Identity(serialized))
 	})
 
 	t.Run("GetPublicVersion", func(t *testing.T) {
+		t.Parallel()
 		pub := si.GetPublicVersion()
 		require.Equal(t, si, pub)
 	})
 
 	t.Run("Verify panics", func(t *testing.T) {
+		t.Parallel()
 		require.Panics(t, func() {
 			_ = si.Verify(message, signature)
 		})

--- a/platform/view/services/storage/db/tablename_test.go
+++ b/platform/view/services/storage/db/tablename_test.go
@@ -18,6 +18,7 @@ type testCase struct {
 }
 
 func TestEscapeTableName(t *testing.T) {
+	t.Parallel()
 	cases := []testCase{
 		{[]string{}, ""},
 		{[]string{"alpha", "testchannel"}, "alpha__testchannel"},
@@ -30,6 +31,7 @@ func TestEscapeTableName(t *testing.T) {
 }
 
 func TestEscapeTableNameError(t *testing.T) {
+	t.Parallel()
 	cases := [][]string{
 		{"alpha", "testchannel!"},
 		{"alpha", "test-#channel"},

--- a/platform/view/services/storage/driver/sql/common/auditinfo_test.go
+++ b/platform/view/services/storage/driver/sql/common/auditinfo_test.go
@@ -19,7 +19,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestGetAuditInfo(t *testing.T) {
+func TestGetAuditInfo(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 	db, mockDB, err := sqlmock.New()
 	Expect(err).ToNot(HaveOccurred())
@@ -37,7 +37,7 @@ func TestGetAuditInfo(t *testing.T) {
 	Expect(info).To(Equal(output))
 }
 
-func TestPutAuditInfo(t *testing.T) {
+func TestPutAuditInfo(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 	db, mockDB, err := sqlmock.New()
 	Expect(err).ToNot(HaveOccurred())

--- a/platform/view/services/storage/driver/sql/common/binding_test.go
+++ b/platform/view/services/storage/driver/sql/common/binding_test.go
@@ -19,7 +19,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestGetLongTerm(t *testing.T) {
+func TestGetLongTerm(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	db, mockDB, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
@@ -40,7 +40,7 @@ func TestGetLongTerm(t *testing.T) {
 	Expect(result).To(Equal(longTerm))
 }
 
-func TestHaveSameBinding(t *testing.T) {
+func TestHaveSameBinding(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	db, mockDB, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
@@ -67,7 +67,7 @@ func TestHaveSameBinding(t *testing.T) {
 	Expect(result).To(BeTrue())
 }
 
-func TestHaveSameBinding_NotEqual(t *testing.T) {
+func TestHaveSameBinding_NotEqual(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	db, mockDB, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
@@ -95,7 +95,7 @@ func TestHaveSameBinding_NotEqual(t *testing.T) {
 	Expect(result).To(BeFalse())
 }
 
-func TestHaveSameBinding_MissingEntries(t *testing.T) {
+func TestHaveSameBinding_MissingEntries(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	db, mockDB, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))

--- a/platform/view/services/storage/driver/sql/common/signerinfo_test.go
+++ b/platform/view/services/storage/driver/sql/common/signerinfo_test.go
@@ -26,7 +26,7 @@ func (d *dummyUniqueErrorWrapper) WrapError(err error) error {
 	return driver.UniqueKeyViolation
 }
 
-func TestFilterExistingSigners(t *testing.T) {
+func TestFilterExistingSigners(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	db, mockDB, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
@@ -52,7 +52,7 @@ func TestFilterExistingSigners(t *testing.T) {
 	Expect(result).To(ContainElements(id1, id2))
 }
 
-func TestFilterExistingSigners_QueryError(t *testing.T) {
+func TestFilterExistingSigners_QueryError(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	db, mockDB, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
@@ -74,7 +74,7 @@ func TestFilterExistingSigners_QueryError(t *testing.T) {
 	Expect(err.Error()).To(ContainSubstring("error querying db"))
 }
 
-func TestFilterExistingSigners_ScanError(t *testing.T) {
+func TestFilterExistingSigners_ScanError(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	db, mockDB, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
@@ -96,7 +96,7 @@ func TestFilterExistingSigners_ScanError(t *testing.T) {
 	Expect(err.Error()).To(ContainSubstring("failed scanning row"))
 }
 
-func TestPutSigner(t *testing.T) {
+func TestPutSigner(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	db, mockDB, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
@@ -118,7 +118,7 @@ func TestPutSigner(t *testing.T) {
 	Expect(err).ToNot(HaveOccurred())
 }
 
-func TestPutSigner_ExecError(t *testing.T) {
+func TestPutSigner_ExecError(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	db, mockDB, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
@@ -140,7 +140,7 @@ func TestPutSigner_ExecError(t *testing.T) {
 	Expect(err.Error()).To(ContainSubstring("failed executing query"))
 }
 
-func TestPutSigner_UniqueViolation(t *testing.T) {
+func TestPutSigner_UniqueViolation(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	db, mockDB, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))

--- a/platform/view/services/storage/driver/sql/common/unversioned_test.go
+++ b/platform/view/services/storage/driver/sql/common/unversioned_test.go
@@ -31,7 +31,7 @@ func (d *dummyErrorWrapper) WrapError(err error) error {
 	return err
 }
 
-func TestGetState(t *testing.T) {
+func TestGetState(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	db, mock, err := sqlmock.New()
@@ -49,7 +49,7 @@ func TestGetState(t *testing.T) {
 	Expect(result).To(Equal(driver.UnversionedValue(value)))
 }
 
-func TestGetState_QueryError(t *testing.T) {
+func TestGetState_QueryError(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	db, mock, err := sqlmock.New()
@@ -65,7 +65,7 @@ func TestGetState_QueryError(t *testing.T) {
 	Expect(err).To(HaveOccurred())
 }
 
-func TestSetState(t *testing.T) {
+func TestSetState(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	db, mock, err := sqlmock.New()
@@ -81,7 +81,7 @@ func TestSetState(t *testing.T) {
 	Expect(err).ToNot(HaveOccurred())
 }
 
-func TestSetState_ExecError(t *testing.T) {
+func TestSetState_ExecError(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	db, mock, err := sqlmock.New()
@@ -97,7 +97,7 @@ func TestSetState_ExecError(t *testing.T) {
 	Expect(err).To(HaveOccurred())
 }
 
-func TestDeleteState(t *testing.T) {
+func TestDeleteState(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	db, mock, err := sqlmock.New()
@@ -113,7 +113,7 @@ func TestDeleteState(t *testing.T) {
 	Expect(err).ToNot(HaveOccurred())
 }
 
-func TestDeleteState_ExecError(t *testing.T) {
+func TestDeleteState_ExecError(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	db, mock, err := sqlmock.New()
@@ -128,7 +128,7 @@ func TestDeleteState_ExecError(t *testing.T) {
 	Expect(mock.ExpectationsWereMet()).To(Succeed())
 	Expect(err).To(HaveOccurred())
 }
-func TestGetStateRangeScanIterator(t *testing.T) {
+func TestGetStateRangeScanIterator(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 	db, mock, err := sqlmock.New()
 	Expect(err).ToNot(HaveOccurred())
@@ -158,7 +158,7 @@ func TestGetStateRangeScanIterator(t *testing.T) {
 	Expect(mock.ExpectationsWereMet()).To(Succeed())
 }
 
-func TestGetStateSetIterator(t *testing.T) {
+func TestGetStateSetIterator(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 	db, mock, err := sqlmock.New()
 	Expect(err).ToNot(HaveOccurred())
@@ -187,7 +187,7 @@ func TestGetStateSetIterator(t *testing.T) {
 	Expect(mock.ExpectationsWereMet()).To(Succeed())
 }
 
-func TestExec(t *testing.T) {
+func TestExec(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 	db, mock, err := sqlmock.New()
 	Expect(err).ToNot(HaveOccurred())
@@ -209,7 +209,7 @@ func TestExec(t *testing.T) {
 	Expect(mock.ExpectationsWereMet()).To(Succeed())
 }
 
-func TestStats(t *testing.T) {
+func TestStats(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 	db, _, err := sqlmock.New()
 	Expect(err).ToNot(HaveOccurred())
@@ -219,7 +219,7 @@ func TestStats(t *testing.T) {
 	Expect(stats).ToNot(BeNil())
 }
 
-func TestClose(t *testing.T) {
+func TestClose(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	db, mock, err := sqlmock.New()

--- a/platform/view/services/storage/driver/sql/postgres/binding_test.go
+++ b/platform/view/services/storage/driver/sql/postgres/binding_test.go
@@ -30,11 +30,13 @@ func newBindingStoreForTests(tb testing.TB) *BindingStore {
 }
 
 func TestPutBindingsMultipleEphemeralsPostgres(t *testing.T) {
+	t.Parallel()
 	db := newBindingStoreForTests(t)
 	common.TestPutBindingsMultipleEphemeralsCommon(t, db.BindingStore)
 }
 
 func TestManyManyPutBindingsPostgres(t *testing.T) {
+	t.Parallel()
 	db := newBindingStoreForTests(t)
 	common.TestManyManyPutBindingsCommon(t, db.BindingStore)
 }

--- a/platform/view/services/storage/driver/sql/postgres/encode_test.go
+++ b/platform/view/services/storage/driver/sql/postgres/encode_test.go
@@ -18,6 +18,7 @@ import (
 var someCompositeKey = utils.MustGet(kvs.CreateCompositeKey("prefix", []string{"a", "b", "c"}))
 
 func TestDecodeBYTEA(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		input       string
@@ -53,6 +54,7 @@ func TestDecodeBYTEA(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := decodeBYTEA(tc.input)
 			if tc.expectError {
 				require.Error(t, err)
@@ -65,6 +67,7 @@ func TestDecodeBYTEA(t *testing.T) {
 }
 
 func TestIdentity(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input string
@@ -79,6 +82,7 @@ func TestIdentity(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := identity(tc.input)
 			require.NoError(t, err)
 			require.Equal(t, tc.input, got)

--- a/platform/view/services/storage/driver/sql/postgres/sql_test.go
+++ b/platform/view/services/storage/driver/sql/postgres/sql_test.go
@@ -31,6 +31,7 @@ func setupDB(tb testing.TB) string {
 }
 
 func TestPostgres(t *testing.T) {
+	t.Parallel()
 	pgConnStr := setupDB(t)
 	t.Log("postgres ready")
 

--- a/platform/view/services/storage/driver/sql/query/cond/condition_test.go
+++ b/platform/view/services/storage/driver/sql/query/cond/condition_test.go
@@ -84,7 +84,7 @@ var testMatrix = []testCase{
 	},
 }
 
-func TestConditions(t *testing.T) {
+func TestConditions(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	for _, tc := range testMatrix {

--- a/platform/view/services/storage/driver/sql/query/delete/query_test.go
+++ b/platform/view/services/storage/driver/sql/query/delete/query_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestDeleteSimple(t *testing.T) {
+func TestDeleteSimple(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	query, params := q.DeleteFrom("my_table").

--- a/platform/view/services/storage/driver/sql/query/insert/query_test.go
+++ b/platform/view/services/storage/driver/sql/query/insert/query_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestInsertSimple(t *testing.T) {
+func TestInsertSimple(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	query, params := q.InsertInto("my_table").
@@ -30,7 +30,7 @@ func TestInsertSimple(t *testing.T) {
 	Expect(params).To(ConsistOf("val1", "val2"))
 }
 
-func TestInsertOnConflict(t *testing.T) {
+func TestInsertOnConflict(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	query, params := q.InsertInto("my_table").

--- a/platform/view/services/storage/driver/sql/query/pagination/keyset_test.go
+++ b/platform/view/services/storage/driver/sql/query/pagination/keyset_test.go
@@ -52,7 +52,7 @@ func setupPaginationWithLastId() *driver.PageIterator[*interface{}] {
 	return page
 }
 
-func TestKeysetSimple(t *testing.T) {
+func TestKeysetSimple(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	page := setupPaginationWithLastId()
@@ -70,7 +70,7 @@ func TestKeysetSimple(t *testing.T) {
 	Expect(args).To(ConsistOf("last", 10))
 }
 
-func TestKeysetSkippingPage(t *testing.T) {
+func TestKeysetSkippingPage(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	page := setupPaginationWithLastId()
@@ -92,7 +92,7 @@ func TestKeysetSkippingPage(t *testing.T) {
 	Expect(args).To(ConsistOf(10, 220))
 }
 
-func TestKeysetGoingBack(t *testing.T) {
+func TestKeysetGoingBack(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	page := setupPaginationWithLastId()
@@ -110,7 +110,7 @@ func TestKeysetGoingBack(t *testing.T) {
 	Expect(args).To(ConsistOf(10, 190))
 }
 
-func TestKeysetGoingNextBack(t *testing.T) {
+func TestKeysetGoingNextBack(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	page := setupPaginationWithLastId()
@@ -136,7 +136,7 @@ func TestKeysetGoingNextBack(t *testing.T) {
 	Expect(args).To(ConsistOf(10, 210))
 }
 
-func TestKeysetEmptyResults(t *testing.T) {
+func TestKeysetEmptyResults(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	p := utils.MustGet(pagination.KeysetWithField[string](200, 10, "col_id", "StringField"))
@@ -165,7 +165,7 @@ func TestKeysetEmptyResults(t *testing.T) {
 	Expect(args).To(ConsistOf(10, 210))
 }
 
-func TestKeysetPartialResults(t *testing.T) {
+func TestKeysetPartialResults(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	p := utils.MustGet(pagination.KeysetWithField[string](200, 20, "col_id", "StringField"))
@@ -194,7 +194,7 @@ func TestKeysetPartialResults(t *testing.T) {
 	Expect(args).To(ConsistOf(20, 220))
 }
 
-func TestKeysetDoubleAddField(t *testing.T) {
+func TestKeysetDoubleAddField(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	page := setupPaginationWithLastId()
@@ -212,7 +212,7 @@ func TestKeysetDoubleAddField(t *testing.T) {
 	Expect(args).To(ConsistOf("last", 10))
 }
 
-func TestKeysetAsterixAddField(t *testing.T) {
+func TestKeysetAsterixAddField(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	page := setupPaginationWithLastId()
@@ -231,6 +231,7 @@ func TestKeysetAsterixAddField(t *testing.T) {
 }
 
 func TestKeysetInt(t *testing.T) {
+	t.Parallel()
 	// This test fails because there it is hard coded in
 	// func NewPage[V any](results collections.Iterator[*V], pagination driver.Pagination) (*driver.PageIterator[*V], error) {
 	// 	return NewTypedPage[string, V](results, pagination)
@@ -276,7 +277,7 @@ func TestKeysetInt(t *testing.T) {
 	Expect(args).To(ConsistOf(10, 10))
 }
 
-func TestKeysetSeriliazation(t *testing.T) {
+func TestKeysetSeriliazation(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	page := setupPaginationWithLastId()

--- a/platform/view/services/storage/driver/sql/query/pagination/none_test.go
+++ b/platform/view/services/storage/driver/sql/query/pagination/none_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestNone(t *testing.T) {
+func TestNone(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	query, args := q.Select().
@@ -27,7 +27,7 @@ func TestNone(t *testing.T) {
 	Expect(args).To(BeEmpty())
 }
 
-func TestEmpty(t *testing.T) {
+func TestEmpty(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	query, args := q.Select().

--- a/platform/view/services/storage/driver/sql/query/pagination/offset_test.go
+++ b/platform/view/services/storage/driver/sql/query/pagination/offset_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestOffsetSimple(t *testing.T) {
+func TestOffsetSimple(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	query, args := q.Select().

--- a/platform/view/services/storage/driver/sql/query/select/query_test.go
+++ b/platform/view/services/storage/driver/sql/query/select/query_test.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestSelectSimple(t *testing.T) {
+func TestSelectSimple(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	myTable := q.Table("my_table")
@@ -37,7 +37,7 @@ func TestSelectSimple(t *testing.T) {
 	Expect(params).To(ConsistOf(5, 2, 1))
 }
 
-func TestSelectJoin(t *testing.T) {
+func TestSelectJoin(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	myTable, yourTable, theirTable := q.Table("my_table"), q.Table("your_table"), q.AliasedTable("their_table", "tt")

--- a/platform/view/services/storage/driver/sql/query/update/query_test.go
+++ b/platform/view/services/storage/driver/sql/query/update/query_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestUpdateSimple(t *testing.T) {
+func TestUpdateSimple(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	query, params := q.Update("my_table").

--- a/platform/view/services/storage/driver/sql/sqlite/binding_test.go
+++ b/platform/view/services/storage/driver/sql/sqlite/binding_test.go
@@ -31,11 +31,13 @@ func newBindingStoreForTests(tb testing.TB) *BindingStore {
 }
 
 func TestPutBindingsMultipleEphemeralsSqlite(t *testing.T) {
+	t.Parallel()
 	db := newBindingStoreForTests(t)
 	common.TestPutBindingsMultipleEphemeralsCommon(t, db.BindingStore)
 }
 
 func TestManyManyPutBindingsSqlite(t *testing.T) {
+	t.Parallel()
 	db := newBindingStoreForTests(t)
 	common.TestManyManyPutBindingsCommon(t, db.BindingStore)
 }

--- a/platform/view/services/storage/driver/sql/sqlite/sql_test.go
+++ b/platform/view/services/storage/driver/sql/sqlite/sql_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestSqlite(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	o := Opts{
 		DataSource: fmt.Sprintf("file:%s.sqlite?_pragma=busy_timeout(1000)", path.Join(tempDir, "benchmark")),
@@ -39,6 +40,7 @@ func TestSqlite(t *testing.T) {
 }
 
 func TestGetSqliteDir(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "/test/dir", getDir("file:/test/dir/db.sqlite"))
 	assert.Equal(t, "/test/dir", getDir("file:/test/dir/db.sqlite?_txlock=immediate"))
 	assert.Equal(t, "/test/dir", getDir("file:/test/dir/db.sqlite?_txlock=immediate&key=val"))
@@ -47,6 +49,7 @@ func TestGetSqliteDir(t *testing.T) {
 }
 
 func TestFolderDoesNotExistError(t *testing.T) {
+	t.Parallel()
 	o := Opts{
 		DataSource: fmt.Sprintf("file:%s.sqlite?_pragma=busy_timeout(1000)", path.Join("/this/folder/does/not/exist", "folder-does-not-exist")),
 	}

--- a/platform/view/services/storage/keys/utils_test.go
+++ b/platform/view/services/storage/keys/utils_test.go
@@ -51,6 +51,7 @@ func validateCompositeKeyAttribute(str string) error {
 }
 
 func TestValidateKey(t *testing.T) {
+	t.Parallel()
 	require.NoError(t, keys.ValidateKey("_key"))
 	require.NoError(t, keys.ValidateKey("1lm7v0uzXp9p+Q/K4z0LM0bRWEAEi0qun3jTg8uNYrI="))
 	key, err := createCompositeKey("token", []string{"thistype", "alice"})
@@ -62,6 +63,7 @@ func TestValidateKey(t *testing.T) {
 }
 
 func TestValidateNamespace(t *testing.T) {
+	t.Parallel()
 	require.NoError(t, keys.ValidateNs("_token"))
 	require.EqualError(t, keys.ValidateNs("+lifecycle"), "namespace '+lifecycle' is invalid")
 }

--- a/platform/view/services/storage/kvs/keys_test.go
+++ b/platform/view/services/storage/kvs/keys_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestCreateCompositeKey(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		objectType  string
@@ -111,6 +112,7 @@ func TestCreateCompositeKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result, err := CreateCompositeKey(tt.objectType, tt.attributes)
 
 			if tt.expectError {
@@ -127,6 +129,7 @@ func TestCreateCompositeKey(t *testing.T) {
 }
 
 func TestValidateCompositeKeyAttribute(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		input       string
@@ -187,6 +190,7 @@ func TestValidateCompositeKeyAttribute(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := validateCompositeKeyAttribute(tt.input)
 
 			if tt.expectError {
@@ -202,6 +206,7 @@ func TestValidateCompositeKeyAttribute(t *testing.T) {
 }
 
 func TestCreateCompositeKeyOrPanic(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		objectType  string
@@ -226,6 +231,7 @@ func TestCreateCompositeKeyOrPanic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if tt.shouldPanic {
 				require.Panics(t, func() {
 					CreateCompositeKeyOrPanic(tt.objectType, tt.attributes)
@@ -239,6 +245,7 @@ func TestCreateCompositeKeyOrPanic(t *testing.T) {
 }
 
 func TestCreateRangeKeysForPartialCompositeKey(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		objectType    string
@@ -290,6 +297,7 @@ func TestCreateRangeKeysForPartialCompositeKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			startKey, endKey, err := CreateRangeKeysForPartialCompositeKey(tt.objectType, tt.attributes)
 
 			if tt.expectError {
@@ -311,6 +319,7 @@ func TestCreateRangeKeysForPartialCompositeKey(t *testing.T) {
 }
 
 func TestSplitCompositeKey(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name               string
 		compositeKey       string
@@ -364,6 +373,7 @@ func TestSplitCompositeKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			objectType, attributes, err := SplitCompositeKey(tt.compositeKey)
 
 			if tt.expectError {
@@ -378,6 +388,7 @@ func TestSplitCompositeKey(t *testing.T) {
 }
 
 func TestCompositeKeyRoundTrip(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		objectType string
@@ -417,6 +428,7 @@ func TestCompositeKeyRoundTrip(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			// Create composite key
 			compositeKey, err := CreateCompositeKey(tt.objectType, tt.attributes)
 			require.NoError(t, err)
@@ -433,6 +445,7 @@ func TestCompositeKeyRoundTrip(t *testing.T) {
 }
 
 func TestRangeKeysContainment(t *testing.T) {
+	t.Parallel()
 	// Create a partial composite key for "user" with attribute "alice"
 	startKey, endKey, err := CreateRangeKeysForPartialCompositeKey("user", []string{"alice"})
 	require.NoError(t, err)
@@ -471,6 +484,7 @@ func TestRangeKeysContainment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			inRange := tt.key >= startKey && tt.key < endKey
 			require.Equal(t, tt.shouldFit, inRange)
 		})
@@ -478,20 +492,25 @@ func TestRangeKeysContainment(t *testing.T) {
 }
 
 func TestCompositeKeyConstants(t *testing.T) {
+	t.Parallel()
 	t.Run("minUnicodeRuneValue is zero", func(t *testing.T) {
+		t.Parallel()
 		require.Equal(t, rune(0), minUnicodeRuneValue)
 	})
 
 	t.Run("maxUnicodeRuneValue is MaxRune", func(t *testing.T) {
+		t.Parallel()
 		require.Equal(t, utf8.MaxRune, maxUnicodeRuneValue)
 	})
 
 	t.Run("compositeKeyNamespace is null byte", func(t *testing.T) {
+		t.Parallel()
 		require.Equal(t, "\x00", compositeKeyNamespace)
 	})
 }
 
 func TestCreateCompositeKeyPerformance(t *testing.T) {
+	t.Parallel()
 	// This test ensures that CreateCompositeKey uses strings.Builder efficiently
 	objectType := "user"
 	attributes := make([]string, 100)

--- a/platform/view/services/storage/kvs/kvs_test.go
+++ b/platform/view/services/storage/kvs/kvs_test.go
@@ -165,11 +165,13 @@ func testParallelWrites(t *testing.T, drv driver2.Driver) {
 }
 
 func TestMemoryKVS(t *testing.T) {
+	t.Parallel()
 	testRound(t, mem.NewDriver())
 	testParallelWrites(t, mem.NewDriver())
 }
 
 func TestSQLiteKVS(t *testing.T) {
+	t.Parallel()
 	cp := multiplexed.MockTypeConfig(sqlite2.Persistence, sqlite2.Config{
 		DataSource:      fmt.Sprintf("file:%s.sqlite?_pragma=busy_timeout(1000)", path.Join(t.TempDir(), "sqlite_test")),
 		TablePrefix:     "",
@@ -184,6 +186,7 @@ func TestSQLiteKVS(t *testing.T) {
 }
 
 func TestPostgresKVS(t *testing.T) {
+	t.Parallel()
 	t.Log("starting postgres")
 	terminate, pgConnStr, err := postgres2.StartPostgres(t.Context(), postgres2.ConfigFromEnv(), nil)
 	if err != nil {
@@ -240,6 +243,7 @@ func (m *mockIterator) Close() {
 }
 
 func TestNew(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		namespace string
@@ -268,6 +272,7 @@ func TestNew(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			mockStore := &mock.KeyValueStore{}
 			k, err := kvs2.New(mockStore, tt.namespace, tt.cacheSize)
 			if tt.wantErr {
@@ -282,6 +287,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestKVS_Put(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		id        string
@@ -323,6 +329,7 @@ func TestKVS_Put(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			mockStore := &mock.KeyValueStore{}
 			tt.setupMock(mockStore)
 
@@ -344,6 +351,7 @@ func TestKVS_Put(t *testing.T) {
 }
 
 func TestKVS_Get(t *testing.T) {
+	t.Parallel()
 	validJSON := []byte(`{"name":"test","value":42}`)
 
 	tests := []struct {
@@ -394,6 +402,7 @@ func TestKVS_Get(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			mockStore := &mock.KeyValueStore{}
 			tt.setupMock(mockStore)
 
@@ -417,9 +426,11 @@ func TestKVS_Get(t *testing.T) {
 }
 
 func TestKVS_Get_CacheBehavior(t *testing.T) {
+	t.Parallel()
 	validJSON := []byte(`{"name":"cached","value":100}`)
 
 	t.Run("cache populated by Put, used by Get", func(t *testing.T) {
+		t.Parallel()
 		mockStore := &mock.KeyValueStore{}
 		mockStore.SetStateReturns(nil)
 
@@ -441,6 +452,7 @@ func TestKVS_Get_CacheBehavior(t *testing.T) {
 	})
 
 	t.Run("Get populates cache on miss (read-through)", func(t *testing.T) {
+		t.Parallel()
 		mockStore := &mock.KeyValueStore{}
 		mockStore.GetStateReturns(validJSON, nil)
 
@@ -466,6 +478,7 @@ func TestKVS_Get_CacheBehavior(t *testing.T) {
 }
 
 func TestKVS_Delete(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		id        string
@@ -492,6 +505,7 @@ func TestKVS_Delete(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			mockStore := &mock.KeyValueStore{}
 			tt.setupMock(mockStore)
 
@@ -510,6 +524,7 @@ func TestKVS_Delete(t *testing.T) {
 }
 
 func TestKVS_Exists(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		id        string
@@ -550,6 +565,7 @@ func TestKVS_Exists(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			mockStore := &mock.KeyValueStore{}
 			tt.setupMock(mockStore)
 
@@ -563,6 +579,7 @@ func TestKVS_Exists(t *testing.T) {
 }
 
 func TestKVS_GetExisting(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		ids       []string
@@ -618,6 +635,7 @@ func TestKVS_GetExisting(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			mockStore := &mock.KeyValueStore{}
 			tt.setupMock(mockStore)
 
@@ -631,6 +649,7 @@ func TestKVS_GetExisting(t *testing.T) {
 }
 
 func TestKVS_GetByPartialCompositeID(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		prefix    string
@@ -675,6 +694,7 @@ func TestKVS_GetByPartialCompositeID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			mockStore := &mock.KeyValueStore{}
 			tt.setupMock(mockStore)
 
@@ -700,7 +720,9 @@ func TestKVS_GetByPartialCompositeID(t *testing.T) {
 }
 
 func TestKVS_Iterator(t *testing.T) {
+	t.Parallel()
 	t.Run("iterate through results", func(t *testing.T) {
+		t.Parallel()
 		mockStore := &mock.KeyValueStore{}
 		items := []*driver.UnversionedRead{
 			{Key: "key1", Raw: []byte(`{"name":"test1","value":1}`)},
@@ -731,6 +753,7 @@ func TestKVS_Iterator(t *testing.T) {
 	})
 
 	t.Run("close iterator", func(t *testing.T) {
+		t.Parallel()
 		mockStore := &mock.KeyValueStore{}
 		items := []*driver.UnversionedRead{
 			{Key: "key1", Raw: []byte(`{"name":"test1","value":1}`)},
@@ -749,7 +772,9 @@ func TestKVS_Iterator(t *testing.T) {
 }
 
 func TestKVS_Stop(t *testing.T) {
+	t.Parallel()
 	t.Run("successful stop", func(t *testing.T) {
+		t.Parallel()
 		mockStore := &mock.KeyValueStore{}
 		mockStore.CloseReturns(nil)
 
@@ -761,6 +786,7 @@ func TestKVS_Stop(t *testing.T) {
 	})
 
 	t.Run("stop with error", func(t *testing.T) {
+		t.Parallel()
 		mockStore := &mock.KeyValueStore{}
 		mockStore.CloseReturns(fmt.Errorf("close error"))
 
@@ -776,6 +802,7 @@ func TestKVS_Stop(t *testing.T) {
 // Concurrent operations are thoroughly tested by testParallelWrites with real databases (100 goroutines)
 
 func TestCacheSizeFromConfig(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		setupMock      func(*mock.ConfigProvider)
@@ -818,6 +845,7 @@ func TestCacheSizeFromConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			mockConfig := &mock.ConfigProvider{}
 			tt.setupMock(mockConfig)
 
@@ -835,7 +863,9 @@ func TestCacheSizeFromConfig(t *testing.T) {
 }
 
 func TestKVS_CacheInvalidation(t *testing.T) {
+	t.Parallel()
 	t.Run("delete invalidates cache", func(t *testing.T) {
+		t.Parallel()
 		mockStore := &mock.KeyValueStore{}
 		validJSON := []byte(`{"name":"test","value":42}`)
 
@@ -865,6 +895,7 @@ func TestKVS_CacheInvalidation(t *testing.T) {
 	})
 
 	t.Run("put updates cache", func(t *testing.T) {
+		t.Parallel()
 		mockStore := &mock.KeyValueStore{}
 		mockStore.SetStateReturns(nil)
 

--- a/platform/view/services/tracing/config_test.go
+++ b/platform/view/services/tracing/config_test.go
@@ -18,7 +18,7 @@ func callGetPackageName() string {
 	return tracing.GetPackageName()
 }
 
-func TestGetPackageName(t *testing.T) {
+func TestGetPackageName(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	pkg := callGetPackageName()
@@ -32,7 +32,7 @@ func (h *ConfigHandler) sendResponseLikeMethod() string {
 	return callGetPackageName()
 }
 
-func TestGetPackageName_FromStructMethod(t *testing.T) {
+func TestGetPackageName_FromStructMethod(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	handler := &ConfigHandler{}
@@ -41,7 +41,7 @@ func TestGetPackageName_FromStructMethod(t *testing.T) {
 	Expect(pkg).To(Equal("github.com/hyperledger-labs/fabric-smart-client/platform/view/services/tracing_test"))
 }
 
-func TestWithMetricsOpts_CustomSubsystem(t *testing.T) {
+func TestWithMetricsOpts_CustomSubsystem(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	opts := tracing.MetricsOpts{
@@ -67,7 +67,7 @@ func TestWithMetricsOpts_CustomSubsystem(t *testing.T) {
 	Expect(labelNamesVal.AsStringSlice()).To(Equal([]string{"label1", "label2"}))
 }
 
-func TestWithMetricsOpts_EmptyOptions(t *testing.T) {
+func TestWithMetricsOpts_EmptyOptions(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
 	opts := tracing.MetricsOpts{}

--- a/platform/view/services/tracing/utils_test.go
+++ b/platform/view/services/tracing/utils_test.go
@@ -14,12 +14,14 @@ import (
 )
 
 func TestUnmarshal(t *testing.T) {
+	t.Parallel()
 	ctx, err := UnmarshalContext([]byte(`{"trace_id":"00000000000000000000000000000000","span_id":"0000000000000000","trace_flags":0,"trace_state":"","remote":false}`))
 	require.NoError(t, err)
 	require.True(t, ctx.Equal(trace.SpanContext{}))
 }
 
 func TestMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
 	state, err := trace.ParseTraceState("abcdefghijklmnopqrstuvwxyz0123456789_-*/= !\"#$%&'()*+-./0123456789:;<>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~")
 	require.NoError(t, err)
 	ctx := trace.NewSpanContext(trace.SpanContextConfig{

--- a/platform/view/services/view/child_test.go
+++ b/platform/view/services/view/child_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestChildContext(t *testing.T) {
+	t.Parallel()
 	parent := &mock.MutableParentContext{}
 	parent.IDReturns("parent-id")
 	parent.MeReturns(view2.Identity("me"))

--- a/platform/view/services/view/context_test.go
+++ b/platform/view/services/view/context_test.go
@@ -36,6 +36,7 @@ type Context interface {
 }
 
 func TestContext(t *testing.T) {
+	t.Parallel()
 	registry := view2.NewServiceProvider()
 	idProvider := &mock.IdentityProvider{}
 	idProvider.DefaultIdentityReturns([]byte("alice"))
@@ -154,6 +155,7 @@ func TestContext(t *testing.T) {
 }
 
 func TestContextGetSession(t *testing.T) {
+	t.Parallel()
 	registry := view2.NewServiceProvider()
 	idProvider := &mock.IdentityProvider{}
 	resolver := &mock.EndpointService{}
@@ -188,6 +190,7 @@ func TestContextGetSession(t *testing.T) {
 }
 
 func TestContextRace(t *testing.T) {
+	t.Parallel()
 	registry := view2.NewServiceProvider()
 	idProvider := &mock.IdentityProvider{}
 	idProvider.DefaultIdentityReturns([]byte("alice"))

--- a/platform/view/services/view/grpc/client/cmd/config_test.go
+++ b/platform/view/services/view/grpc/client/cmd/config_test.go
@@ -19,10 +19,12 @@ import (
 )
 
 func TestConfig(t *testing.T) {
+	t.Parallel()
 	rand.New(rand.NewSource(time.Now().UnixNano()))
 	configFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("config-%d.yaml", rand.Int()))
 	fmt.Println(configFilePath)
 	t.Run("save and load a config", func(t *testing.T) {
+		t.Parallel()
 		c := Config{
 			TLSConfig: TLSConfig{
 				CertPath:       "foo",
@@ -47,17 +49,20 @@ func TestConfig(t *testing.T) {
 	})
 
 	t.Run("bad config isn't saved", func(t *testing.T) {
+		t.Parallel()
 		c := Config{}
 		err := c.ToFile(configFilePath)
 		require.Contains(t, err.Error(), "config isn't valid")
 	})
 
 	t.Run("bad config isn't loaded", func(t *testing.T) {
+		t.Parallel()
 		_, err := ConfigFromFile(filepath.Join("testdata", "not_a_yaml.yaml"))
 		require.Contains(t, err.Error(), "error unmarshalling YAML file")
 	})
 
 	t.Run("file that doesn't exist isn't loaded", func(t *testing.T) {
+		t.Parallel()
 		_, err := ConfigFromFile(filepath.Join("testdata", "not_a_file.yaml"))
 		require.Contains(t, err.Error(), "no such file or directory")
 	})

--- a/platform/view/services/view/grpc/client/suite_test.go
+++ b/platform/view/services/view/grpc/client/suite_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestClient(t *testing.T) {
+func TestClient(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Client Suite")
 }

--- a/platform/view/services/view/manager_factory_test.go
+++ b/platform/view/services/view/manager_factory_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestManagerWithMockFactory(t *testing.T) {
+	t.Parallel()
 	ip := &mock.IdentityProvider{}
 	registry := view.NewRegistry()
 	mp := &disabled.Provider{}
@@ -27,6 +28,7 @@ func TestManagerWithMockFactory(t *testing.T) {
 	manager := view.NewManager(ip, registry, metrics, cf)
 
 	t.Run("InitiateContextCallsFactory", func(t *testing.T) {
+		t.Parallel()
 		v := &mock.View{}
 		parentCtx := &mock.ParentContext{}
 		parentCtx.ContextReturns(context.Background())
@@ -44,6 +46,7 @@ func TestManagerWithMockFactory(t *testing.T) {
 	})
 
 	t.Run("NewSessionContextCallsFactory", func(t *testing.T) {
+		t.Parallel()
 		session := &mock.Session{}
 		session.InfoReturns(view2.SessionInfo{ID: "s1", Caller: view2.Identity("alice")})
 		party := view2.Identity("alice")

--- a/platform/view/services/view/manager_test.go
+++ b/platform/view/services/view/manager_test.go
@@ -26,6 +26,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestManager(t *testing.T) {
+	t.Parallel()
 	sp := &servicesmock.ServiceProvider{}
 	sf := &mock.SessionFactory{}
 	es := &mock.EndpointService{}
@@ -120,6 +121,7 @@ func TestManager(t *testing.T) {
 }
 
 func TestManagerRegistry(t *testing.T) {
+	t.Parallel()
 	sp := &servicesmock.ServiceProvider{}
 	sf := &mock.SessionFactory{}
 	es := &mock.EndpointService{}
@@ -151,6 +153,7 @@ func TestManagerRegistry(t *testing.T) {
 }
 
 func TestNewSessionContext(t *testing.T) {
+	t.Parallel()
 	sp := &servicesmock.ServiceProvider{}
 	sf := &mock.SessionFactory{}
 	es := &mock.EndpointService{}
@@ -190,6 +193,7 @@ func TestNewSessionContext(t *testing.T) {
 }
 
 func TestManagerOther(t *testing.T) {
+	t.Parallel()
 	sp := &servicesmock.ServiceProvider{}
 	sf := &mock.SessionFactory{}
 	es := &mock.EndpointService{}

--- a/platform/view/services/view/misc_extra_test.go
+++ b/platform/view/services/view/misc_extra_test.go
@@ -16,10 +16,12 @@ import (
 )
 
 func TestSessionsDelete(t *testing.T) {
+	t.Parallel()
 	// Already tested in sessions_test.go
 }
 
 func TestServiceProviderString(t *testing.T) {
+	t.Parallel()
 	sp := view.NewServiceProvider()
 	err := sp.RegisterService("foo")
 	require.NoError(t, err)
@@ -29,6 +31,7 @@ func TestServiceProviderString(t *testing.T) {
 }
 
 func TestStream(t *testing.T) {
+	t.Parallel()
 	sp := view.NewServiceProvider()
 	mockStream := &mock.Stream{}
 	err := sp.RegisterService(mockStream)
@@ -48,6 +51,7 @@ func TestStream(t *testing.T) {
 }
 
 func TestWrappedContext(t *testing.T) {
+	t.Parallel()
 	type contextKey string
 	parent := &mock.ParentContext{}
 	ctx := context.WithValue(context.Background(), contextKey("key"), "value")

--- a/platform/view/services/view/p2p/service_test.go
+++ b/platform/view/services/view/p2p/service_test.go
@@ -64,6 +64,7 @@ func (m *viewManagerMock) DefaultIdentity() view.Identity {
 }
 
 func TestService(t *testing.T) {
+	t.Parallel()
 	vm := &viewManagerMock{HandleResponderCalled: make(chan struct{}, 10)}
 	cl := &mock2.CommLayer{}
 	sess := &mock.Session{}
@@ -109,6 +110,7 @@ func TestService(t *testing.T) {
 }
 
 func TestService_MasterSessionError(t *testing.T) {
+	t.Parallel()
 	vm := &viewManagerMock{}
 	cl := &mock2.CommLayer{}
 	cl.MasterSessionReturns(nil, errors.New("master session error"))
@@ -120,6 +122,7 @@ func TestService_MasterSessionError(t *testing.T) {
 }
 
 func TestService_HandleResponderError(t *testing.T) {
+	t.Parallel()
 	vm := &viewManagerMock{
 		HandleResponderCalled: make(chan struct{}, 10),
 	}

--- a/platform/view/services/view/registry_test.go
+++ b/platform/view/services/view/registry_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestRegistry(t *testing.T) {
+	t.Parallel()
 	registry := view.NewRegistry()
 	require.NotNil(t, registry)
 

--- a/platform/view/services/view/sessions_test.go
+++ b/platform/view/services/view/sessions_test.go
@@ -23,6 +23,7 @@ func (s *simpleSession) Info() view.SessionInfo {
 }
 
 func TestSessions(t *testing.T) {
+	t.Parallel()
 	s := newSessions()
 	party := view.Identity("alice")
 	sess := &simpleSession{id: "s1"}

--- a/platform/view/services/view/sp_test.go
+++ b/platform/view/services/view/sp_test.go
@@ -23,6 +23,7 @@ type MyImpl struct{}
 func (m *MyImpl) Foo() {}
 
 func TestSP(t *testing.T) {
+	t.Parallel()
 	sp := view.NewServiceProvider()
 
 	impl := &MyImpl{}

--- a/platform/view/services/view/view_test.go
+++ b/platform/view/services/view/view_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestRunViewNow(t *testing.T) {
+	t.Parallel()
 	parent := &mock.ParentContext{}
 	parent.ContextReturns(context.Background())
 	parent.StartSpanFromStub = func(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
@@ -34,6 +35,7 @@ func TestRunViewNow(t *testing.T) {
 }
 
 func TestRunViewNow_CallOption(t *testing.T) {
+	t.Parallel()
 	parent := &mock.ParentContext{}
 	parent.ContextReturns(context.Background())
 	parent.StartSpanFromStub = func(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
@@ -50,6 +52,7 @@ func TestRunViewNow_CallOption(t *testing.T) {
 }
 
 func TestRunViewNow_AsInitiator_NoSession(t *testing.T) {
+	t.Parallel()
 	parent := &mock.ParentContext{}
 	parent.ContextReturns(context.Background())
 	parent.StartSpanFromStub = func(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
@@ -65,6 +68,7 @@ func TestRunViewNow_AsInitiator_NoSession(t *testing.T) {
 }
 
 func TestRunViewNow_AsInitiator_PutSessionError(t *testing.T) {
+	t.Parallel()
 	parent := &mock.ParentContext{}
 	parent.ContextReturns(context.Background())
 	parent.StartSpanFromStub = func(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
@@ -83,6 +87,7 @@ func TestRunViewNow_AsInitiator_PutSessionError(t *testing.T) {
 }
 
 func TestRunViewNow_PanicInView_CallsCleanupAndReturnsError(t *testing.T) {
+	t.Parallel()
 	parent := &mock.ParentContext{}
 	parent.ContextReturns(context.Background())
 	parent.StartSpanFromStub = func(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
@@ -101,6 +106,7 @@ func TestRunViewNow_PanicInView_CallsCleanupAndReturnsError(t *testing.T) {
 }
 
 func TestRunViewNow_NoViewAndNoCall(t *testing.T) {
+	t.Parallel()
 	parent := &mock.ParentContext{}
 	parent.ContextReturns(context.Background())
 	parent.StartSpanFromStub = func(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
@@ -113,6 +119,7 @@ func TestRunViewNow_NoViewAndNoCall(t *testing.T) {
 }
 
 func TestRunCall(t *testing.T) {
+	t.Parallel()
 	ctx := &mock.Context{}
 	call := func(viewCtx view2.Context) (any, error) {
 		return "res", nil
@@ -125,6 +132,7 @@ func TestRunCall(t *testing.T) {
 }
 
 func TestAsResponder(t *testing.T) {
+	t.Parallel()
 	ctx := &mock.Context{}
 	session := &mock.Session{}
 	call := func(viewCtx view2.Context) (any, error) {
@@ -138,6 +146,7 @@ func TestAsResponder(t *testing.T) {
 }
 
 func TestAsInitiatorCall(t *testing.T) {
+	t.Parallel()
 	ctx := &mock.Context{}
 	v := &mock.View{}
 	call := func(viewCtx view2.Context) (any, error) {
@@ -151,6 +160,7 @@ func TestAsInitiatorCall(t *testing.T) {
 }
 
 func TestAsInitiatorView(t *testing.T) {
+	t.Parallel()
 	ctx := &mock.Context{}
 	v := &mock.View{}
 	ctx.RunViewReturns("res", nil)
@@ -161,6 +171,7 @@ func TestAsInitiatorView(t *testing.T) {
 }
 
 func TestRunView(t *testing.T) {
+	t.Parallel()
 	ctx := &mock.Context{}
 	v := &mock.View{}
 

--- a/platform/view/services/web/server/handler_test.go
+++ b/platform/view/services/web/server/handler_test.go
@@ -28,6 +28,7 @@ type FruitBasket struct {
 }
 
 func TestHttpHandler(t *testing.T) {
+	t.Parallel()
 	h := web2.NewHttpHandler()
 
 	rh := &mocks2.FakeRequestHandler{}

--- a/platform/view/services/web/server/middleware/middleware_suite_test.go
+++ b/platform/view/services/web/server/middleware/middleware_suite_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 )
 
-func TestMiddleware(t *testing.T) {
+func TestMiddleware(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Middleware Suite")
 }

--- a/platform/view/services/web/server/server_test.go
+++ b/platform/view/services/web/server/server_test.go
@@ -37,7 +37,7 @@ func init() {
 	tlsCA, _ = tlsgen.NewCA()
 }
 
-func TestFabHTTP(t *testing.T) {
+func TestFabHTTP(t *testing.T) { //nolint:paralleltest
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "FabHTTP Suite")
 }

--- a/platform/view/view/context_test.go
+++ b/platform/view/view/context_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestCompileRunViewOptions(t *testing.T) {
+	t.Parallel()
 	ctx1 := t.Context()
 	ctx2, cancel := context.WithCancel(ctx1)
 	t.Cleanup(cancel)


### PR DESCRIPTION
This PR introduces `t.Parallel` check to golangci linter and updates existing tests where possible.