### PR TITLE
fix(storage): migrate SimpleKeyDataStore and KeyValueStore to squirrel

### DIFF
--- a/platform/fabric/services/db/driver/sql/common/data_test.go
+++ b/platform/fabric/services/db/driver/sql/common/data_test.go
@@ -120,7 +120,7 @@ func PutData_Success(t *testing.T, put putFunc) {
 
 	key := "key1"
 	data := []byte("value1")
-	query := regexp.QuoteMeta("INSERT INTO test_table (key, data) VALUES ($1, $2) ON CONFLICT DO NOTHING")
+	query := regexp.QuoteMeta("INSERT INTO test_table (key,data) VALUES ($1,$2) ON CONFLICT DO NOTHING")
 
 	mockDB.
 		ExpectExec(query).
@@ -142,7 +142,7 @@ func PutData_Conflict(t *testing.T, put putFunc) {
 
 	key := "key1"
 	data := []byte("value1")
-	query := regexp.QuoteMeta("INSERT INTO test_table (key, data) VALUES ($1, $2) ON CONFLICT DO NOTHING")
+	query := regexp.QuoteMeta("INSERT INTO test_table (key,data) VALUES ($1,$2) ON CONFLICT DO NOTHING")
 
 	mockDB.
 		ExpectExec(query).

--- a/platform/fabric/services/db/driver/sql/common/endorsetx.go
+++ b/platform/fabric/services/db/driver/sql/common/endorsetx.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
 	common3 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
-	
 )
 
 func NewEndorseTxStore(writeDB common3.WriteDB, readDB *sql.DB, table string, errorWrapper driver.SQLErrorWrapper, ph sq.PlaceholderFormat) *EndorseTxStore {

--- a/platform/fabric/services/db/driver/sql/common/endorsetx.go
+++ b/platform/fabric/services/db/driver/sql/common/endorsetx.go
@@ -10,13 +10,15 @@ import (
 	"context"
 	"database/sql"
 
+	sq "github.com/Masterminds/squirrel"
+
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
 	common3 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/common"
+	
 )
 
-func NewEndorseTxStore(writeDB common3.WriteDB, readDB *sql.DB, table string, errorWrapper driver.SQLErrorWrapper, ci common.CondInterpreter) *EndorseTxStore {
-	return &EndorseTxStore{p: common3.NewSimpleKeyDataStore(writeDB, readDB, table, errorWrapper, ci)}
+func NewEndorseTxStore(writeDB common3.WriteDB, readDB *sql.DB, table string, errorWrapper driver.SQLErrorWrapper, ph sq.PlaceholderFormat) *EndorseTxStore {
+	return &EndorseTxStore{p: common3.NewSimpleKeyDataStore(writeDB, readDB, table, errorWrapper, ph)}
 }
 
 type EndorseTxStore struct {

--- a/platform/fabric/services/db/driver/sql/common/endorsetx_test.go
+++ b/platform/fabric/services/db/driver/sql/common/endorsetx_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"database/sql"
 
-	sq "github.com/Masterminds/squirrel"
 	"testing"
+
+	sq "github.com/Masterminds/squirrel"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver/sql/common"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/common/mock"

--- a/platform/fabric/services/db/driver/sql/common/endorsetx_test.go
+++ b/platform/fabric/services/db/driver/sql/common/endorsetx_test.go
@@ -8,11 +8,12 @@ package common_test
 import (
 	"context"
 	"database/sql"
+
+	sq "github.com/Masterminds/squirrel"
 	"testing"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver/sql/common"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/common/mock"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/sqlite"
 )
 
 func TestEnvelope_GetData(t *testing.T) { //nolint:paralleltest
@@ -52,5 +53,5 @@ func TestEnvelope_PutData_Conflict(t *testing.T) { //nolint:paralleltest
 }
 
 func mockEnvelopeStore(db *sql.DB) *common.EnvelopeStore {
-	return common.NewEnvelopeStore(db, db, "test_table", &mock.SQLErrorWrapper{}, sqlite.NewConditionInterpreter())
+	return common.NewEnvelopeStore(db, db, "test_table", &mock.SQLErrorWrapper{}, sq.Dollar)
 }

--- a/platform/fabric/services/db/driver/sql/common/endorsetx_test.go
+++ b/platform/fabric/services/db/driver/sql/common/endorsetx_test.go
@@ -8,7 +8,6 @@ package common_test
 import (
 	"context"
 	"database/sql"
-
 	"testing"
 
 	sq "github.com/Masterminds/squirrel"

--- a/platform/fabric/services/db/driver/sql/common/envelope.go
+++ b/platform/fabric/services/db/driver/sql/common/envelope.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
 	common3 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
-	
 )
 
 func NewEnvelopeStore(writeDB common3.WriteDB, readDB *sql.DB, table string, errorWrapper driver.SQLErrorWrapper, ph sq.PlaceholderFormat) *EnvelopeStore {

--- a/platform/fabric/services/db/driver/sql/common/envelope.go
+++ b/platform/fabric/services/db/driver/sql/common/envelope.go
@@ -10,13 +10,15 @@ import (
 	"context"
 	"database/sql"
 
+	sq "github.com/Masterminds/squirrel"
+
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
 	common3 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/common"
+	
 )
 
-func NewEnvelopeStore(writeDB common3.WriteDB, readDB *sql.DB, table string, errorWrapper driver.SQLErrorWrapper, ci common.CondInterpreter) *EnvelopeStore {
-	return &EnvelopeStore{p: common3.NewSimpleKeyDataStore(writeDB, readDB, table, errorWrapper, ci)}
+func NewEnvelopeStore(writeDB common3.WriteDB, readDB *sql.DB, table string, errorWrapper driver.SQLErrorWrapper, ph sq.PlaceholderFormat) *EnvelopeStore {
+	return &EnvelopeStore{p: common3.NewSimpleKeyDataStore(writeDB, readDB, table, errorWrapper, ph)}
 }
 
 type EnvelopeStore struct {

--- a/platform/fabric/services/db/driver/sql/common/envelope_test.go
+++ b/platform/fabric/services/db/driver/sql/common/envelope_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"database/sql"
 
-	sq "github.com/Masterminds/squirrel"
 	"testing"
+
+	sq "github.com/Masterminds/squirrel"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver/sql/common"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/common/mock"

--- a/platform/fabric/services/db/driver/sql/common/envelope_test.go
+++ b/platform/fabric/services/db/driver/sql/common/envelope_test.go
@@ -8,11 +8,12 @@ package common_test
 import (
 	"context"
 	"database/sql"
+
+	sq "github.com/Masterminds/squirrel"
 	"testing"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver/sql/common"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/common/mock"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/sqlite"
 )
 
 func TestEndorseTX_GetData(t *testing.T) { //nolint:paralleltest
@@ -52,5 +53,5 @@ func TestEndorseTX_PutData_Conflict(t *testing.T) { //nolint:paralleltest
 }
 
 func mockEndorseTXStore(db *sql.DB) *common.EndorseTxStore {
-	return common.NewEndorseTxStore(db, db, "test_table", &mock.SQLErrorWrapper{}, sqlite.NewConditionInterpreter())
+	return common.NewEndorseTxStore(db, db, "test_table", &mock.SQLErrorWrapper{}, sq.Dollar)
 }

--- a/platform/fabric/services/db/driver/sql/common/envelope_test.go
+++ b/platform/fabric/services/db/driver/sql/common/envelope_test.go
@@ -8,7 +8,6 @@ package common_test
 import (
 	"context"
 	"database/sql"
-
 	"testing"
 
 	sq "github.com/Masterminds/squirrel"

--- a/platform/fabric/services/db/driver/sql/common/metadata.go
+++ b/platform/fabric/services/db/driver/sql/common/metadata.go
@@ -10,13 +10,15 @@ import (
 	"context"
 	"database/sql"
 
+	sq "github.com/Masterminds/squirrel"
+
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
 	common3 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/common"
+	
 )
 
-func NewMetadataStore(writeDB common3.WriteDB, readDB *sql.DB, table string, errorWrapper driver.SQLErrorWrapper, ci common.CondInterpreter) *MetadataStore {
-	return &MetadataStore{p: common3.NewSimpleKeyDataStore(writeDB, readDB, table, errorWrapper, ci)}
+func NewMetadataStore(writeDB common3.WriteDB, readDB *sql.DB, table string, errorWrapper driver.SQLErrorWrapper, ph sq.PlaceholderFormat) *MetadataStore {
+	return &MetadataStore{p: common3.NewSimpleKeyDataStore(writeDB, readDB, table, errorWrapper, ph)}
 }
 
 type MetadataStore struct {

--- a/platform/fabric/services/db/driver/sql/common/metadata.go
+++ b/platform/fabric/services/db/driver/sql/common/metadata.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
 	common3 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
-	
 )
 
 func NewMetadataStore(writeDB common3.WriteDB, readDB *sql.DB, table string, errorWrapper driver.SQLErrorWrapper, ph sq.PlaceholderFormat) *MetadataStore {

--- a/platform/fabric/services/db/driver/sql/common/metadata_test.go
+++ b/platform/fabric/services/db/driver/sql/common/metadata_test.go
@@ -9,8 +9,9 @@ import (
 	"context"
 	"database/sql"
 
-	sq "github.com/Masterminds/squirrel"
 	"testing"
+
+	sq "github.com/Masterminds/squirrel"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver/sql/common"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/common/mock"

--- a/platform/fabric/services/db/driver/sql/common/metadata_test.go
+++ b/platform/fabric/services/db/driver/sql/common/metadata_test.go
@@ -8,11 +8,12 @@ package common_test
 import (
 	"context"
 	"database/sql"
+
+	sq "github.com/Masterminds/squirrel"
 	"testing"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver/sql/common"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/common/mock"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/sqlite"
 )
 
 func TestMetadata_GetData(t *testing.T) { //nolint:paralleltest
@@ -52,5 +53,5 @@ func TestMetadata_PutData_Conflict(t *testing.T) { //nolint:paralleltest
 }
 
 func mockMetadataStore(db *sql.DB) *common.MetadataStore {
-	return common.NewMetadataStore(db, db, "test_table", &mock.SQLErrorWrapper{}, sqlite.NewConditionInterpreter())
+	return common.NewMetadataStore(db, db, "test_table", &mock.SQLErrorWrapper{}, sq.Dollar)
 }

--- a/platform/fabric/services/db/driver/sql/common/metadata_test.go
+++ b/platform/fabric/services/db/driver/sql/common/metadata_test.go
@@ -8,7 +8,6 @@ package common_test
 import (
 	"context"
 	"database/sql"
-
 	"testing"
 
 	sq "github.com/Masterminds/squirrel"

--- a/platform/fabric/services/db/driver/sql/postgres/endorsetx.go
+++ b/platform/fabric/services/db/driver/sql/postgres/endorsetx.go
@@ -9,6 +9,8 @@ package postgres
 import (
 	"database/sql"
 
+	sq "github.com/Masterminds/squirrel"
+
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver/sql/common"
 	common2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
 	postgres2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/postgres"
@@ -23,5 +25,5 @@ func NewEndorseTxStore(dbs *common2.RWDB, tables common.TableNames) (*EndorseTxS
 }
 
 func newEndorseTxStore(readDB, writeDB *sql.DB, table string) *EndorseTxStore {
-	return &EndorseTxStore{EndorseTxStore: common.NewEndorseTxStore(readDB, writeDB, table, &postgres2.ErrorMapper{}, postgres2.NewConditionInterpreter())}
+	return &EndorseTxStore{EndorseTxStore: common.NewEndorseTxStore(readDB, writeDB, table, &postgres2.ErrorMapper{}, sq.Dollar)}
 }

--- a/platform/fabric/services/db/driver/sql/postgres/envelope.go
+++ b/platform/fabric/services/db/driver/sql/postgres/envelope.go
@@ -9,6 +9,8 @@ package postgres
 import (
 	"database/sql"
 
+	sq "github.com/Masterminds/squirrel"
+
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver/sql/common"
 	common2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
 	postgres2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/postgres"
@@ -23,5 +25,5 @@ func NewEnvelopeStore(dbs *common2.RWDB, tables common.TableNames) (*EnvelopeSto
 }
 
 func newEnvelopeStore(readDB, writeDB *sql.DB, table string) *EnvelopeStore {
-	return &EnvelopeStore{EnvelopeStore: common.NewEnvelopeStore(readDB, writeDB, table, &postgres2.ErrorMapper{}, postgres2.NewConditionInterpreter())}
+	return &EnvelopeStore{EnvelopeStore: common.NewEnvelopeStore(readDB, writeDB, table, &postgres2.ErrorMapper{}, sq.Dollar)}
 }

--- a/platform/fabric/services/db/driver/sql/postgres/metadata.go
+++ b/platform/fabric/services/db/driver/sql/postgres/metadata.go
@@ -9,6 +9,8 @@ package postgres
 import (
 	"database/sql"
 
+	sq "github.com/Masterminds/squirrel"
+
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver/sql/common"
 	common2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
 	postgres2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/postgres"
@@ -23,5 +25,5 @@ func NewMetadataStore(dbs *common2.RWDB, tables common.TableNames) (*MetadataSto
 }
 
 func newMetadataStore(readDB, writeDB *sql.DB, table string) *MetadataStore {
-	return &MetadataStore{MetadataStore: common.NewMetadataStore(readDB, writeDB, table, &postgres2.ErrorMapper{}, postgres2.NewConditionInterpreter())}
+	return &MetadataStore{MetadataStore: common.NewMetadataStore(readDB, writeDB, table, &postgres2.ErrorMapper{}, sq.Dollar)}
 }

--- a/platform/fabric/services/db/driver/sql/sqlite/endorsetx.go
+++ b/platform/fabric/services/db/driver/sql/sqlite/endorsetx.go
@@ -9,6 +9,8 @@ package sqlite
 import (
 	"database/sql"
 
+	sq "github.com/Masterminds/squirrel"
+
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver/sql/common"
 	common3 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
 	common4 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
@@ -24,5 +26,5 @@ func NewEndorseTxStore(dbs *common3.RWDB, tables common.TableNames) (*EndorseTxS
 }
 
 func newEndorseTxStore(readDB *sql.DB, writeDB common4.WriteDB, table string) *EndorseTxStore {
-	return &EndorseTxStore{EndorseTxStore: common.NewEndorseTxStore(writeDB, readDB, table, &sqlite2.ErrorMapper{}, sqlite2.NewConditionInterpreter())}
+	return &EndorseTxStore{EndorseTxStore: common.NewEndorseTxStore(writeDB, readDB, table, &sqlite2.ErrorMapper{}, sq.Question)}
 }

--- a/platform/fabric/services/db/driver/sql/sqlite/envelope.go
+++ b/platform/fabric/services/db/driver/sql/sqlite/envelope.go
@@ -9,6 +9,8 @@ package sqlite
 import (
 	"database/sql"
 
+	sq "github.com/Masterminds/squirrel"
+
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver/sql/common"
 	common3 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
 	common2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
@@ -24,5 +26,5 @@ func NewEnvelopeStore(dbs *common3.RWDB, tables common.TableNames) (*EnvelopeSto
 }
 
 func newEnvelopeStore(readDB *sql.DB, writeDB common2.WriteDB, table string) *EnvelopeStore {
-	return &EnvelopeStore{EnvelopeStore: common.NewEnvelopeStore(writeDB, readDB, table, &sqlite2.ErrorMapper{}, sqlite2.NewConditionInterpreter())}
+	return &EnvelopeStore{EnvelopeStore: common.NewEnvelopeStore(writeDB, readDB, table, &sqlite2.ErrorMapper{}, sq.Question)}
 }

--- a/platform/fabric/services/db/driver/sql/sqlite/metadata.go
+++ b/platform/fabric/services/db/driver/sql/sqlite/metadata.go
@@ -9,6 +9,8 @@ package sqlite
 import (
 	"database/sql"
 
+	sq "github.com/Masterminds/squirrel"
+
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver/sql/common"
 	common3 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
 	common2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
@@ -24,5 +26,5 @@ func NewMetadataStore(dbs *common3.RWDB, tables common.TableNames) (*MetadataSto
 }
 
 func newMetadataStore(readDB *sql.DB, writeDB common2.WriteDB, table string) *MetadataStore {
-	return &MetadataStore{MetadataStore: common.NewMetadataStore(writeDB, readDB, table, &sqlite2.ErrorMapper{}, sqlite2.NewConditionInterpreter())}
+	return &MetadataStore{MetadataStore: common.NewMetadataStore(writeDB, readDB, table, &sqlite2.ErrorMapper{}, sq.Question)}
 }

--- a/platform/view/services/storage/driver/sql/common/simplekeydata.go
+++ b/platform/view/services/storage/driver/sql/common/simplekeydata.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	sq "github.com/Masterminds/squirrel"
+
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
 )

--- a/platform/view/services/storage/driver/sql/common/simplekeydata.go
+++ b/platform/view/services/storage/driver/sql/common/simplekeydata.go
@@ -40,7 +40,7 @@ func (db *SimpleKeyDataStore) GetData(ctx context.Context, key string) ([]byte, 
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to build query")
 	}
-	logger.Debug(query, params)
+	logger.Debug(query)
 	return QueryUniqueContext[[]byte](ctx, db.readDB, query, params...)
 }
 

--- a/platform/view/services/storage/driver/sql/common/simplekeydata.go
+++ b/platform/view/services/storage/driver/sql/common/simplekeydata.go
@@ -11,20 +11,18 @@ import (
 	"database/sql"
 	"fmt"
 
+	sq "github.com/Masterminds/squirrel"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
-	q "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query"
-	common2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/common"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/cond"
 )
 
-func NewSimpleKeyDataStore(writeDB WriteDB, readDB *sql.DB, table string, errorWrapper driver.SQLErrorWrapper, ci common2.CondInterpreter) *SimpleKeyDataStore {
+func NewSimpleKeyDataStore(writeDB WriteDB, readDB *sql.DB, table string, errorWrapper driver.SQLErrorWrapper, ph sq.PlaceholderFormat) *SimpleKeyDataStore {
 	return &SimpleKeyDataStore{
 		table:        table,
 		errorWrapper: errorWrapper,
 		readDB:       readDB,
 		writeDB:      writeDB,
-		ci:           ci,
+		sb:           sq.StatementBuilder.PlaceholderFormat(ph),
 	}
 }
 
@@ -33,15 +31,15 @@ type SimpleKeyDataStore struct {
 	errorWrapper driver.SQLErrorWrapper
 	readDB       *sql.DB
 	writeDB      WriteDB
-	ci           common2.CondInterpreter
+	sb           sq.StatementBuilderType
 }
 
 func (db *SimpleKeyDataStore) GetData(ctx context.Context, key string) ([]byte, error) {
-	query, params := q.Select().FieldsByName("data").
-		From(q.Table(db.table)).
-		Where(cond.Eq("key", key)).
-		Format(db.ci)
-
+	query, params, err := db.sb.Select("data").From(db.table).Where(sq.Eq{"key": key}).ToSql()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to build query")
+	}
+	logger.Debug(query, params)
 	return QueryUniqueContext[[]byte](ctx, db.readDB, query, params...)
 }
 
@@ -51,11 +49,14 @@ func (db *SimpleKeyDataStore) ExistData(ctx context.Context, key string) (bool, 
 }
 
 func (db *SimpleKeyDataStore) PutData(ctx context.Context, key string, data []byte) error {
-	query, params := q.InsertInto(db.table).
-		Fields("key", "data").
-		Row(key, data).
-		OnConflictDoNothing().
-		Format()
+	query, params, err := db.sb.Insert(db.table).
+		Columns("key", "data").
+		Values(key, data).
+		Suffix("ON CONFLICT DO NOTHING").
+		ToSql()
+	if err != nil {
+		return errors.Wrapf(err, "failed to build query")
+	}
 	logger.Debug(query, string(data))
 	result, err := db.writeDB.ExecContext(ctx, query, params...)
 	if err != nil {

--- a/platform/view/services/storage/driver/sql/common/unversioned.go
+++ b/platform/view/services/storage/driver/sql/common/unversioned.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	sq "github.com/Masterminds/squirrel"
+
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"

--- a/platform/view/services/storage/driver/sql/common/unversioned.go
+++ b/platform/view/services/storage/driver/sql/common/unversioned.go
@@ -109,7 +109,7 @@ func (db *KeyValueStore) GetStateSetIterator(ctx context.Context, ns driver2.Nam
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to build query")
 	}
-	logger.Debug(query[:30] + "...")
+	logger.Debug(query[:min(30, len(query))] + "...")
 
 	rows, err := db.readDB.QueryContext(ctx, query, params...)
 	if err != nil {

--- a/platform/view/services/storage/driver/sql/common/unversioned.go
+++ b/platform/view/services/storage/driver/sql/common/unversioned.go
@@ -11,6 +11,7 @@ import (
 	"database/sql"
 	"fmt"
 
+	sq "github.com/Masterminds/squirrel"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
@@ -18,9 +19,6 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections/iterators"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
-	q "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query"
-	common2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/common"
-	cond2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/cond"
 )
 
 var logger = logging.MustGetLogger()
@@ -37,27 +35,47 @@ type KeyValueStore struct {
 	table   string
 
 	errorWrapper driver.SQLErrorWrapper
-	ci           common2.CondInterpreter
+	sb           sq.StatementBuilderType
 }
 
-func NewKeyValueStore(writeDB WriteDB, readDB *sql.DB, table string, errorWrapper driver.SQLErrorWrapper, ci common2.CondInterpreter) *KeyValueStore {
+func NewKeyValueStore(writeDB WriteDB, readDB *sql.DB, table string, errorWrapper driver.SQLErrorWrapper, ph sq.PlaceholderFormat) *KeyValueStore {
 	return &KeyValueStore{
 		BaseDB:       common.NewBaseDB(func() (*sql.Tx, error) { return writeDB.Begin() }),
 		readDB:       readDB,
 		writeDB:      writeDB,
 		table:        table,
 		errorWrapper: errorWrapper,
-		ci:           ci,
+		sb:           sq.StatementBuilder.PlaceholderFormat(ph),
 	}
 }
 
-func (db *KeyValueStore) GetStateRangeScanIterator(ctx context.Context, ns driver2.Namespace, startKey, endKey driver2.PKey) (iterators.Iterator[*driver.UnversionedRead], error) {
-	query, params := q.Select().FieldsByName("pkey", "val").
-		From(q.Table(db.table)).
-		Where(cond2.And(cond2.Eq("ns", ns), cond2.BetweenBytes("pkey", []byte(startKey), []byte(endKey)))).
-		OrderBy(q.Asc(common2.FieldName("pkey"))).
-		Format(db.ci)
+func hasKeysCondition(ns driver2.Namespace, keys ...driver2.PKey) sq.Sqlizer {
+	if len(keys) == 1 {
+		return sq.And{sq.Eq{"ns": ns}, sq.Eq{"pkey": []byte(keys[0])}}
+	}
+	pkeys := make([][]byte, len(keys))
+	for i, k := range keys {
+		pkeys[i] = []byte(k)
+	}
+	return sq.And{sq.Eq{"ns": ns}, sq.Eq{"pkey": pkeys}}
+}
 
+func (db *KeyValueStore) GetStateRangeScanIterator(ctx context.Context, ns driver2.Namespace, startKey, endKey driver2.PKey) (iterators.Iterator[*driver.UnversionedRead], error) {
+	conds := sq.And{sq.Eq{"ns": ns}}
+	if len(startKey) != 0 {
+		conds = append(conds, sq.GtOrEq{"pkey": []byte(startKey)})
+	}
+	if len(endKey) != 0 {
+		conds = append(conds, sq.Lt{"pkey": []byte(endKey)})
+	}
+	query, params, err := db.sb.Select("pkey", "val").
+		From(db.table).
+		Where(conds).
+		OrderBy("pkey ASC").
+		ToSql()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to build query")
+	}
 	logger.Debug(query, params)
 
 	rows, err := db.readDB.QueryContext(ctx, query, params...)
@@ -69,11 +87,13 @@ func (db *KeyValueStore) GetStateRangeScanIterator(ctx context.Context, ns drive
 }
 
 func (db *KeyValueStore) GetState(ctx context.Context, namespace driver2.Namespace, key driver2.PKey) (driver.UnversionedValue, error) {
-	query, params := q.Select().FieldsByName("val").
-		From(q.Table(db.table)).
-		Where(HasKeys(namespace, key)).
-		Format(db.ci)
-
+	query, params, err := db.sb.Select("val").
+		From(db.table).
+		Where(hasKeysCondition(namespace, key)).
+		ToSql()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to build query")
+	}
 	return QueryUniqueContext[driver.UnversionedValue](ctx, db.readDB, query, params...)
 }
 
@@ -81,11 +101,13 @@ func (db *KeyValueStore) GetStateSetIterator(ctx context.Context, ns driver2.Nam
 	if len(keys) == 0 {
 		return collections.NewEmptyIterator[*driver.UnversionedRead](), nil
 	}
-	query, params := q.Select().FieldsByName("pkey", "val").
-		From(q.Table(db.table)).
-		Where(HasKeys(ns, keys...)).
-		Format(db.ci)
-
+	query, params, err := db.sb.Select("pkey", "val").
+		From(db.table).
+		Where(hasKeysCondition(ns, keys...)).
+		ToSql()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to build query")
+	}
 	logger.Debug(query[:30] + "...")
 
 	rows, err := db.readDB.QueryContext(ctx, query, params...)
@@ -96,21 +118,12 @@ func (db *KeyValueStore) GetStateSetIterator(ctx context.Context, ns driver2.Nam
 	return NewIterator(rows, func(r *driver.UnversionedRead) error { return rows.Scan(&r.Key, &r.Raw) }), nil
 }
 
-func HasKeys(ns driver2.Namespace, keys ...driver2.PKey) cond2.Condition {
-	kbytes := make([][]byte, len(keys))
-	for i, k := range keys {
-		kbytes[i] = []byte(k)
-	}
-	return cond2.And(cond2.Eq("ns", ns), cond2.In("pkey", kbytes...))
-}
-
 func (db *KeyValueStore) Close() error {
 	logger.Info("closing database")
 	err := db.writeDB.Close()
 	if err != nil {
 		return errors.Wrapf(err, "could not close DB")
 	}
-
 	return nil
 }
 
@@ -138,20 +151,22 @@ func (db *KeyValueStore) DeleteStatesWithTx(ctx context.Context, tx dbTransactio
 	if len(namespace) == 0 {
 		return collections.RepeatValue(keys, errors.New("ns or key is empty"))
 	}
-	query, params := q.DeleteFrom(db.table).
-		Where(HasKeys(namespace, keys...)).
-		Format(db.ci)
+	query, params, err := db.sb.Delete(db.table).
+		Where(hasKeysCondition(namespace, keys...)).
+		ToSql()
+	if err != nil {
+		return collections.RepeatValue(keys, errors.Wrapf(err, "failed to build query"))
+	}
 
 	logger.Debug(query, params)
-	_, err := tx.ExecContext(ctx, query, params...)
-	if err != nil {
+	_, execErr := tx.ExecContext(ctx, query, params...)
+	if execErr != nil {
 		errs := make(map[driver2.PKey]error)
 		for _, key := range keys {
-			errs[key] = errors.Wrapf(db.errorWrapper.WrapError(err), "could not deleteOp val for key [%s]", key)
+			errs[key] = errors.Wrapf(db.errorWrapper.WrapError(execErr), "could not deleteOp val for key [%s]", key)
 		}
 		return errs
 	}
-
 	return nil
 }
 
@@ -179,13 +194,11 @@ func (db *KeyValueStore) SetStatesWithTx(ctx context.Context, tx dbTransaction, 
 	upserted := make(map[driver2.PKey]driver.UnversionedValue, len(kvs))
 	deleted := make([]driver2.PKey, 0, len(kvs))
 	for pkey, val := range kvs {
-		// Get rawVal
 		if len(val) == 0 {
 			logger.DebugfContext(ctx, "set key [%s:%s] to nil value, will be deleted instead", ns, pkey)
 			deleted = append(deleted, pkey)
 		} else {
 			logger.DebugfContext(ctx, "set state [%s,%s]", ns, pkey)
-			// Overwrite rawVal
 			upserted[pkey] = append([]byte(nil), val...)
 		}
 	}
@@ -201,19 +214,20 @@ func (db *KeyValueStore) SetStatesWithTx(ctx context.Context, tx dbTransaction, 
 }
 
 func (db *KeyValueStore) upsertStatesWithTx(ctx context.Context, tx dbTransaction, ns driver2.Namespace, vals map[driver2.PKey]driver.UnversionedValue) map[driver2.PKey]error {
-	rows := make([]common2.Tuple, 0, len(vals))
+	insert := db.sb.Insert(db.table).Columns("ns", "pkey", "val")
 	for pkey, val := range vals {
-		rows = append(rows, common2.Tuple{ns, []byte(pkey), val})
+		insert = insert.Values(ns, []byte(pkey), val)
 	}
-	query, params := q.InsertInto(db.table).
-		Fields("ns", "pkey", "val").
-		Rows(rows).
-		OnConflict([]common2.FieldName{"ns", "pkey"}, q.OverwriteValue("val")).
-		Format()
+	query, params, err := insert.
+		Suffix("ON CONFLICT (ns, pkey) DO UPDATE SET val = EXCLUDED.val").
+		ToSql()
+	if err != nil {
+		return collections.RepeatValue(collections.Keys(vals), errors.Wrapf(err, "failed to build query"))
+	}
 
 	logger.Debug(query, params)
-	if _, err := tx.ExecContext(ctx, query, params...); err != nil {
-		return collections.RepeatValue(collections.Keys(vals), errors.Wrapf(db.errorWrapper.WrapError(err), "could not upsert"))
+	if _, execErr := tx.ExecContext(ctx, query, params...); execErr != nil {
+		return collections.RepeatValue(collections.Keys(vals), errors.Wrapf(db.errorWrapper.WrapError(execErr), "could not upsert"))
 	}
 	return nil
 }

--- a/platform/view/services/storage/driver/sql/common/unversioned_test.go
+++ b/platform/view/services/storage/driver/sql/common/unversioned_test.go
@@ -10,9 +10,10 @@ import (
 	"context"
 	"database/sql"
 
-	sq "github.com/Masterminds/squirrel"
 	"regexp"
 	"testing"
+
+	sq "github.com/Masterminds/squirrel"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	. "github.com/onsi/gomega"

--- a/platform/view/services/storage/driver/sql/common/unversioned_test.go
+++ b/platform/view/services/storage/driver/sql/common/unversioned_test.go
@@ -9,13 +9,11 @@ package common_test
 import (
 	"context"
 	"database/sql"
-
 	"regexp"
 	"testing"
 
-	sq "github.com/Masterminds/squirrel"
-
 	"github.com/DATA-DOG/go-sqlmock"
+	sq "github.com/Masterminds/squirrel"
 	. "github.com/onsi/gomega"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
@@ -238,6 +236,6 @@ func TestClose(t *testing.T) { //nolint:paralleltest
 	Expect(mock.ExpectationsWereMet()).To(Succeed())
 }
 
-func mockKeyValueStore(write *sql.DB, read *sql.DB) *common2.KeyValueStore {
+func mockKeyValueStore(write, read *sql.DB) *common2.KeyValueStore {
 	return common2.NewKeyValueStore(write, read, "kv_table", &dummyErrorWrapper{}, sq.Dollar)
 }

--- a/platform/view/services/storage/driver/sql/common/unversioned_test.go
+++ b/platform/view/services/storage/driver/sql/common/unversioned_test.go
@@ -9,6 +9,8 @@ package common_test
 import (
 	"context"
 	"database/sql"
+
+	sq "github.com/Masterminds/squirrel"
 	"regexp"
 	"testing"
 
@@ -17,7 +19,6 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
 	common2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/sqlite"
 )
 
 var (
@@ -38,7 +39,7 @@ func TestGetState(t *testing.T) { //nolint:paralleltest
 	db, mock, err := sqlmock.New()
 	Expect(err).ToNot(HaveOccurred())
 
-	query := regexp.QuoteMeta("SELECT val FROM kv_table WHERE (ns = $1) AND (pkey = $2)")
+	query := regexp.QuoteMeta("SELECT val FROM kv_table WHERE (ns = $1 AND pkey = $2)")
 	mock.ExpectQuery(query).WithArgs(ns, key).
 		WillReturnRows(mock.NewRows([]string{"val"}).AddRow(value))
 
@@ -56,7 +57,7 @@ func TestGetState_QueryError(t *testing.T) { //nolint:paralleltest
 	db, mock, err := sqlmock.New()
 	Expect(err).ToNot(HaveOccurred())
 
-	query := regexp.QuoteMeta("SELECT val FROM kv_table WHERE (ns = $1) AND (pkey = $2)")
+	query := regexp.QuoteMeta("SELECT val FROM kv_table WHERE (ns = $1 AND pkey = $2)")
 	mock.ExpectQuery(query).WithArgs(ns, key).WillReturnError(sql.ErrConnDone)
 
 	store := mockKeyValueStore(db, db)
@@ -72,7 +73,7 @@ func TestSetState(t *testing.T) { //nolint:paralleltest
 	db, mock, err := sqlmock.New()
 	Expect(err).ToNot(HaveOccurred())
 
-	query := regexp.QuoteMeta("INSERT INTO kv_table (ns, pkey, val) VALUES ($1, $2, $3)")
+	query := regexp.QuoteMeta("INSERT INTO kv_table (ns,pkey,val) VALUES ($1,$2,$3) ON CONFLICT (ns, pkey) DO UPDATE SET val = EXCLUDED.val")
 	mock.ExpectExec(query).WithArgs(ns, key, value).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	store := mockKeyValueStore(db, db)
@@ -88,7 +89,7 @@ func TestSetState_ExecError(t *testing.T) { //nolint:paralleltest
 	db, mock, err := sqlmock.New()
 	Expect(err).ToNot(HaveOccurred())
 
-	query := regexp.QuoteMeta("INSERT INTO kv_table (ns, pkey, val) VALUES ($1, $2, $3)")
+	query := regexp.QuoteMeta("INSERT INTO kv_table (ns,pkey,val) VALUES ($1,$2,$3) ON CONFLICT (ns, pkey) DO UPDATE SET val = EXCLUDED.val")
 	mock.ExpectExec(query).WithArgs(ns, key, value).WillReturnError(sql.ErrConnDone)
 
 	store := mockKeyValueStore(db, db)
@@ -104,7 +105,7 @@ func TestDeleteState(t *testing.T) { //nolint:paralleltest
 	db, mock, err := sqlmock.New()
 	Expect(err).ToNot(HaveOccurred())
 
-	query := regexp.QuoteMeta("DELETE FROM kv_table WHERE (ns = $1) AND (pkey = $2)")
+	query := regexp.QuoteMeta("DELETE FROM kv_table WHERE (ns = $1 AND pkey = $2)")
 	mock.ExpectExec(query).WithArgs(ns, key).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	store := mockKeyValueStore(db, db)
@@ -120,7 +121,7 @@ func TestDeleteState_ExecError(t *testing.T) { //nolint:paralleltest
 	db, mock, err := sqlmock.New()
 	Expect(err).ToNot(HaveOccurred())
 
-	query := regexp.QuoteMeta("DELETE FROM kv_table WHERE (ns = $1) AND (pkey = $2)")
+	query := regexp.QuoteMeta("DELETE FROM kv_table WHERE (ns = $1 AND pkey = $2)")
 	mock.ExpectExec(query).WithArgs(ns, key).WillReturnError(sql.ErrConnDone)
 
 	store := mockKeyValueStore(db, db)
@@ -138,7 +139,7 @@ func TestGetStateRangeScanIterator(t *testing.T) { //nolint:paralleltest
 	startKey := []byte("a")
 	endKey := []byte("z")
 
-	query := regexp.QuoteMeta("SELECT pkey, val FROM kv_table WHERE (ns = $1) AND ((pkey >= $2) AND (pkey < $3)) ORDER BY pkey ASC")
+	query := regexp.QuoteMeta("SELECT pkey, val FROM kv_table WHERE (ns = $1 AND pkey >= $2 AND pkey < $3) ORDER BY pkey ASC")
 	mock.ExpectQuery(query).
 		WithArgs(ns, startKey, endKey).
 		WillReturnRows(sqlmock.NewRows([]string{"pkey", "val"}).AddRow("a", []byte("val1")).AddRow("b", []byte("val2")))
@@ -167,7 +168,7 @@ func TestGetStateSetIterator(t *testing.T) { //nolint:paralleltest
 
 	keys := []string{"a", "b"}
 
-	query := regexp.QuoteMeta("SELECT pkey, val FROM kv_table WHERE (ns = $1) AND ((pkey) IN (($2), ($3)))")
+	query := regexp.QuoteMeta("SELECT pkey, val FROM kv_table WHERE (ns = $1 AND pkey IN ($2,$3))")
 	mock.ExpectQuery(query).
 		WithArgs(ns, []byte("a"), []byte("b")).
 		WillReturnRows(sqlmock.NewRows([]string{"pkey", "val"}).AddRow("a", []byte("val1")).AddRow("b", []byte("val2")))
@@ -236,6 +237,6 @@ func TestClose(t *testing.T) { //nolint:paralleltest
 	Expect(mock.ExpectationsWereMet()).To(Succeed())
 }
 
-func mockKeyValueStore(write, read *sql.DB) *common2.KeyValueStore {
-	return common2.NewKeyValueStore(write, read, "kv_table", &dummyErrorWrapper{}, sqlite.NewConditionInterpreter())
+func mockKeyValueStore(write *sql.DB, read *sql.DB) *common2.KeyValueStore {
+	return common2.NewKeyValueStore(write, read, "kv_table", &dummyErrorWrapper{}, sq.Dollar)
 }

--- a/platform/view/services/storage/driver/sql/postgres/keyvalue.go
+++ b/platform/view/services/storage/driver/sql/postgres/keyvalue.go
@@ -39,7 +39,7 @@ func (db *KeyValueStoreNotifier) CreateSchema() error {
 }
 
 func newKeyValueStore(readDB, writeDB *sql.DB, table string) *common4.KeyValueStore {
-	
+
 	errorWrapper := &ErrorMapper{}
 
 	return common4.NewKeyValueStore(readDB, writeDB, table, errorWrapper, sq.Dollar)

--- a/platform/view/services/storage/driver/sql/postgres/keyvalue.go
+++ b/platform/view/services/storage/driver/sql/postgres/keyvalue.go
@@ -9,6 +9,7 @@ package postgres
 import (
 	"database/sql"
 
+	sq "github.com/Masterminds/squirrel"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	common3 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
 	common4 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
@@ -38,8 +39,8 @@ func (db *KeyValueStoreNotifier) CreateSchema() error {
 }
 
 func newKeyValueStore(readDB, writeDB *sql.DB, table string) *common4.KeyValueStore {
-	ci := NewConditionInterpreter()
+	
 	errorWrapper := &ErrorMapper{}
 
-	return common4.NewKeyValueStore(readDB, writeDB, table, errorWrapper, ci)
+	return common4.NewKeyValueStore(readDB, writeDB, table, errorWrapper, sq.Dollar)
 }

--- a/platform/view/services/storage/driver/sql/postgres/keyvalue.go
+++ b/platform/view/services/storage/driver/sql/postgres/keyvalue.go
@@ -10,6 +10,7 @@ import (
 	"database/sql"
 
 	sq "github.com/Masterminds/squirrel"
+
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	common3 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
 	common4 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
@@ -39,7 +40,6 @@ func (db *KeyValueStoreNotifier) CreateSchema() error {
 }
 
 func newKeyValueStore(readDB, writeDB *sql.DB, table string) *common4.KeyValueStore {
-
 	errorWrapper := &ErrorMapper{}
 
 	return common4.NewKeyValueStore(readDB, writeDB, table, errorWrapper, sq.Dollar)

--- a/platform/view/services/storage/driver/sql/sqlite/unversioned.go
+++ b/platform/view/services/storage/driver/sql/sqlite/unversioned.go
@@ -9,6 +9,8 @@ package sqlite
 import (
 	"database/sql"
 
+	sq "github.com/Masterminds/squirrel"
+
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
 	common3 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/notifier"
@@ -30,6 +32,6 @@ func NewKeyValueStoreNotifier(dbs *common3.RWDB, table string) (*notifier.Unvers
 func newKeyValueStore(readDB *sql.DB, writeDB common2.WriteDB, table string) *KeyValueStore {
 	var wrapper driver.SQLErrorWrapper = &ErrorMapper{}
 	return &KeyValueStore{
-		KeyValueStore: common2.NewKeyValueStore(writeDB, readDB, table, wrapper, NewConditionInterpreter()),
+		KeyValueStore: common2.NewKeyValueStore(writeDB, readDB, table, wrapper, sq.Question),
 	}
 }


### PR DESCRIPTION
Part of #1159

Migrates `SimpleKeyDataStore` and `KeyValueStore` from the deprecated `CondInterpreter` query builder to squirrel's `PlaceholderFormat`, following the same pattern established for `SignerInfoStore` (#1199) and `BindingStore`.

## Changes
- `common/simplekeydata.go` : replace `CondInterpreter` with `sq.PlaceholderFormat`
- `common/unversioned.go` : replace `CondInterpreter` with `sq.PlaceholderFormat`
- `sqlite/unversioned.go` : pass `sq.Question`
- `postgres/keyvalue.go` : pass `sq.Dollar`
- `fabric/sql/common` : update `MetadataStore`, `EndorseTxStore`, `EnvelopeStore` constructors
- Update all affected test files to match squirrel SQL format

## Test results
All locally runnable tests pass:
- `platform/fabric/services/db/driver/sql/common` 
- `platform/view/services/storage/driver/sql/common` 
- `platform/view/services/storage/driver/sql/sqlite` 
- All query builder tests 

Postgres failures are pre-existing (require Docker daemon).