### PR TITLE
fabricx: use idemix with new curves to sign transactions

### DIFF
--- a/platform/fabric/core/generic/config/ds.go
+++ b/platform/fabric/core/generic/config/ds.go
@@ -50,12 +50,16 @@ type MSPOpts struct {
 }
 
 type MSP struct {
-	ID        string                      `yaml:"id"`
-	MSPType   string                      `yaml:"mspType"`
-	MSPID     string                      `yaml:"mspID"`
-	Path      string                      `yaml:"path"`
-	CacheSize int                         `yaml:"cacheSize"`
-	Opts      map[interface{}]interface{} `yaml:"opts, omitempty"`
+	ID        string `yaml:"id"`
+	MSPType   string `yaml:"mspType"`
+	MSPID     string `yaml:"mspID"`
+	Path      string `yaml:"path"`
+	CacheSize int    `yaml:"cacheSize"`
+	// CurveID specifies the elliptic curve to use for idemix identities.
+	// Supported values: "BN254", "FP256BN_AMCL", "FP256BN_AMCL_MIRACL", "BLS12_377_GURVY", "BLS12_381_BBS".
+	// Defaults to "FP256BN_AMCL" if empty.
+	CurveID string                      `yaml:"curveID,omitempty"`
+	Opts    map[interface{}]interface{} `yaml:"opts, omitempty"`
 }
 
 type File struct {

--- a/platform/fabric/core/generic/ledger/mock/fake_local_membership.go
+++ b/platform/fabric/core/generic/ledger/mock/fake_local_membership.go
@@ -114,6 +114,20 @@ type FakeLocalMembership struct {
 	registerIdemixMSPReturnsOnCall map[int]struct {
 		result1 error
 	}
+	RegisterIdemixMSPWithCurveStub        func(string, string, string, string) error
+	registerIdemixMSPWithCurveMutex       sync.RWMutex
+	registerIdemixMSPWithCurveArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 string
+	}
+	registerIdemixMSPWithCurveReturns struct {
+		result1 error
+	}
+	registerIdemixMSPWithCurveReturnsOnCall map[int]struct {
+		result1 error
+	}
 	RegisterX509MSPStub        func(string, string, string) error
 	registerX509MSPMutex       sync.RWMutex
 	registerX509MSPArgsForCall []struct {
@@ -655,6 +669,70 @@ func (fake *FakeLocalMembership) RegisterIdemixMSPReturnsOnCall(i int, result1 e
 		})
 	}
 	fake.registerIdemixMSPReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeLocalMembership) RegisterIdemixMSPWithCurve(arg1 string, arg2 string, arg3 string, arg4 string) error {
+	fake.registerIdemixMSPWithCurveMutex.Lock()
+	ret, specificReturn := fake.registerIdemixMSPWithCurveReturnsOnCall[len(fake.registerIdemixMSPWithCurveArgsForCall)]
+	fake.registerIdemixMSPWithCurveArgsForCall = append(fake.registerIdemixMSPWithCurveArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.RegisterIdemixMSPWithCurveStub
+	fakeReturns := fake.registerIdemixMSPWithCurveReturns
+	fake.recordInvocation("RegisterIdemixMSPWithCurve", []interface{}{arg1, arg2, arg3, arg4})
+	fake.registerIdemixMSPWithCurveMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeLocalMembership) RegisterIdemixMSPWithCurveCallCount() int {
+	fake.registerIdemixMSPWithCurveMutex.RLock()
+	defer fake.registerIdemixMSPWithCurveMutex.RUnlock()
+	return len(fake.registerIdemixMSPWithCurveArgsForCall)
+}
+
+func (fake *FakeLocalMembership) RegisterIdemixMSPWithCurveCalls(stub func(string, string, string, string) error) {
+	fake.registerIdemixMSPWithCurveMutex.Lock()
+	defer fake.registerIdemixMSPWithCurveMutex.Unlock()
+	fake.RegisterIdemixMSPWithCurveStub = stub
+}
+
+func (fake *FakeLocalMembership) RegisterIdemixMSPWithCurveArgsForCall(i int) (string, string, string, string) {
+	fake.registerIdemixMSPWithCurveMutex.RLock()
+	defer fake.registerIdemixMSPWithCurveMutex.RUnlock()
+	argsForCall := fake.registerIdemixMSPWithCurveArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeLocalMembership) RegisterIdemixMSPWithCurveReturns(result1 error) {
+	fake.registerIdemixMSPWithCurveMutex.Lock()
+	defer fake.registerIdemixMSPWithCurveMutex.Unlock()
+	fake.RegisterIdemixMSPWithCurveStub = nil
+	fake.registerIdemixMSPWithCurveReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeLocalMembership) RegisterIdemixMSPWithCurveReturnsOnCall(i int, result1 error) {
+	fake.registerIdemixMSPWithCurveMutex.Lock()
+	defer fake.registerIdemixMSPWithCurveMutex.Unlock()
+	fake.RegisterIdemixMSPWithCurveStub = nil
+	if fake.registerIdemixMSPWithCurveReturnsOnCall == nil {
+		fake.registerIdemixMSPWithCurveReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.registerIdemixMSPWithCurveReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }

--- a/platform/fabric/core/generic/msp/idemix/config.go
+++ b/platform/fabric/core/generic/msp/idemix/config.go
@@ -106,8 +106,10 @@ func GetFabricCAIdemixMspConfig(dir, ID string) (*m.MSPConfig, error) {
 			EnrollmentId:                    si.EnrollmentID,
 			CredentialRevocationInformation: si.CredentialRevocationInformation,
 			RevocationHandle:                si.RevocationHandle,
+			CurveId:                         si.CurveID,
 		}
 		idemixConfig.Signer = signerConfig
+		idemixConfig.CurveId = si.CurveID
 	} else {
 		if !os.IsNotExist(errors.Cause(err)) {
 			return nil, errors.Wrapf(err, "failed to read the content of signer config at [%s]", path)

--- a/platform/fabric/core/generic/msp/idemix/config_test.go
+++ b/platform/fabric/core/generic/msp/idemix/config_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package idemix_test
+
+import (
+	"testing"
+
+	"github.com/IBM/idemix/idemixmsp"
+	math "github.com/IBM/mathlib"
+	m "github.com/hyperledger/fabric-protos-go-apiv2/msp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	idemix2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/idemix"
+)
+
+func TestGetFabricCAIdemixMspConfigPreservesCurveID(t *testing.T) {
+	t.Parallel()
+
+	conf, err := idemix2.GetFabricCAIdemixMspConfig("./testdata/charlie.ExtraId2", "charlie.ExtraId2")
+	require.NoError(t, err)
+
+	var idemixConf idemixmsp.IdemixMSPConfig
+	err = proto.UnmarshalV1(conf.Config, &idemixConf)
+	require.NoError(t, err)
+
+	require.Equal(t, "gurvy.Bn254", idemixConf.CurveId)
+	require.NotNil(t, idemixConf.Signer)
+	require.Equal(t, "gurvy.Bn254", idemixConf.Signer.CurveId)
+}
+
+func TestCurveIDFromString(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		input    string
+		expected math.CurveID
+	}{
+		{name: "default empty", input: "", expected: math.FP256BN_AMCL},
+		{name: "trimmed amcl", input: "  amcl.Fp256bn ", expected: math.FP256BN_AMCL},
+		{name: "bn254 short alias", input: "bn254", expected: math.BN254},
+		{name: "bn254 gurvy alias", input: "gurvy.Bn254", expected: math.BN254},
+		{name: "miracl alias", input: "fp256bn_amcl_miracl", expected: math.FP256BN_AMCL_MIRACL},
+		{name: "bls12_381", input: "bls12_381", expected: math.BLS12_381},
+		{name: "bls12_377 gurvy alias", input: "gurvy.bls12_377", expected: math.BLS12_377_GURVY},
+		{name: "bls12_381 gurvy alias", input: "BLS12_381_GURVY", expected: math.BLS12_381_GURVY},
+		{name: "bls12_381 bbs", input: "bls12_381_bbs", expected: math.BLS12_381_BBS},
+		{name: "bls12_381 bbs gurvy", input: "bls12_381_bbs_gurvy", expected: math.BLS12_381_BBS_GURVY},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			curveID, err := idemix2.CurveIDFromString(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, curveID)
+		})
+	}
+}
+
+func TestCurveIDFromStringInvalid(t *testing.T) {
+	t.Parallel()
+
+	_, err := idemix2.CurveIDFromString("not-a-curve")
+	require.EqualError(t, err, "unsupported curve id [not-a-curve]")
+}
+
+func TestCurveIDFromMSPConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil config", func(t *testing.T) {
+		t.Parallel()
+
+		curveID, err := idemix2.CurveIDFromMSPConfig(nil)
+		require.Equal(t, math.FP256BN_AMCL, curveID)
+		require.EqualError(t, err, "setup error: nil conf reference")
+	})
+
+	t.Run("invalid protobuf", func(t *testing.T) {
+		t.Parallel()
+
+		curveID, err := idemix2.CurveIDFromMSPConfig(&m.MSPConfig{Config: []byte("garbage")})
+		require.Equal(t, math.FP256BN_AMCL, curveID)
+		require.ErrorContains(t, err, "failed unmarshalling idemix provider config")
+	})
+
+	t.Run("top-level curve id", func(t *testing.T) {
+		t.Parallel()
+
+		conf := &idemixmsp.IdemixMSPConfig{CurveId: "BLS12_381"}
+		raw, err := proto.MarshalV1(conf)
+		require.NoError(t, err)
+
+		curveID, err := idemix2.CurveIDFromMSPConfig(&m.MSPConfig{Config: raw})
+		require.NoError(t, err)
+		require.Equal(t, math.BLS12_381, curveID)
+	})
+
+	t.Run("signer curve id fallback", func(t *testing.T) {
+		t.Parallel()
+
+		conf := &idemixmsp.IdemixMSPConfig{
+			Signer: &idemixmsp.IdemixMSPSignerConfig{CurveId: "gurvy.Bn254"},
+		}
+		raw, err := proto.MarshalV1(conf)
+		require.NoError(t, err)
+
+		curveID, err := idemix2.CurveIDFromMSPConfig(&m.MSPConfig{Config: raw})
+		require.NoError(t, err)
+		require.Equal(t, math.BN254, curveID)
+	})
+
+	t.Run("default curve when missing", func(t *testing.T) {
+		t.Parallel()
+
+		conf := &idemixmsp.IdemixMSPConfig{}
+		raw, err := proto.MarshalV1(conf)
+		require.NoError(t, err)
+
+		curveID, err := idemix2.CurveIDFromMSPConfig(&m.MSPConfig{Config: raw})
+		require.NoError(t, err)
+		require.Equal(t, math.FP256BN_AMCL, curveID)
+	})
+}

--- a/platform/fabric/core/generic/msp/idemix/deserializer.go
+++ b/platform/fabric/core/generic/msp/idemix/deserializer.go
@@ -23,11 +23,16 @@ type Deserializer struct {
 	*Idemix
 }
 
-// NewDeserializer returns a new deserializer for the best effort strategy
+// NewDeserializer returns a new deserializer for the best effort strategy using the default FP256BN_AMCL curve
 func NewDeserializer(ipk []byte) (*Deserializer, error) {
-	bccsp, err := NewBCCSP(math.FP256BN_AMCL)
+	return NewDeserializerWithCurve(ipk, math.FP256BN_AMCL)
+}
+
+// NewDeserializerWithCurve returns a new deserializer for the best effort strategy using the specified curve
+func NewDeserializerWithCurve(ipk []byte, curveID math.CurveID) (*Deserializer, error) {
+	bccsp, err := NewBCCSP(curveID)
 	if err != nil {
-		return nil, errors.WithMessagef(err, "failed to instantiate bccsp")
+		return nil, errors.WithMessagef(err, "failed to instantiate bccsp for curve %d", curveID)
 	}
 	return NewDeserializerWithBCCSP(ipk, csp.BestEffort, nil, bccsp)
 }

--- a/platform/fabric/core/generic/msp/idemix/loader.go
+++ b/platform/fabric/core/generic/msp/idemix/loader.go
@@ -30,6 +30,7 @@ func (i *IdentityLoader) Load(manager driver.Manager, c config.MSP) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed reading idemix msp configuration from [%s]", manager.Config().TranslatePath(c.Path))
 	}
+
 	provider, err := NewProviderWithAnyPolicy(conf, i.KVS, i.SignerService)
 	if err != nil {
 		return errors.Wrapf(err, "failed instantiating idemix msp provider from [%s]", manager.Config().TranslatePath(c.Path))
@@ -68,6 +69,7 @@ func (f *FolderIdentityLoader) Load(manager driver.Manager, c config.MSP) error 
 			MSPType: MSPType,
 			MSPID:   id,
 			Path:    filepath.Join(manager.Config().TranslatePath(c.Path), id),
+			CurveID: c.CurveID,
 		}); err != nil {
 			return errors.WithMessagef(err, "failed to load Idemix MSP configuration [%s]", id)
 		}

--- a/platform/fabric/core/generic/msp/idemix/loader.go
+++ b/platform/fabric/core/generic/msp/idemix/loader.go
@@ -9,6 +9,9 @@ package idemix
 import (
 	"os"
 	"path/filepath"
+	"strings"
+
+	math "github.com/IBM/mathlib"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
@@ -30,7 +33,13 @@ func (i *IdentityLoader) Load(manager driver.Manager, c config.MSP) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed reading idemix msp configuration from [%s]", manager.Config().TranslatePath(c.Path))
 	}
-	provider, err := NewProviderWithAnyPolicy(conf, i.KVS, i.SignerService)
+
+	curveID, err := ParseCurveID(c.CurveID)
+	if err != nil {
+		return errors.Wrapf(err, "invalid curve ID [%s] for idemix msp [%s]", c.CurveID, c.ID)
+	}
+
+	provider, err := NewProviderWithAnyPolicyAndCurve(conf, i.KVS, i.SignerService, curveID)
 	if err != nil {
 		return errors.Wrapf(err, "failed instantiating idemix msp provider from [%s]", manager.Config().TranslatePath(c.Path))
 	}
@@ -42,7 +51,7 @@ func (i *IdentityLoader) Load(manager driver.Manager, c config.MSP) error {
 	if err := manager.AddMSP(c.ID, c.MSPType, provider.EnrollmentID(), NewIdentityCache(provider.Identity, cacheSize, nil).Identity); err != nil {
 		return errors.Wrapf(err, "failed adding idemix msp [%s]", manager.Config().TranslatePath(c.Path))
 	}
-	logger.Debugf("added %s msp for id %s with cache of size %d", c.MSPType, c.ID+"@"+provider.EnrollmentID(), cacheSize)
+	logger.Debugf("added %s msp for id %s with curve %d and cache of size %d", c.MSPType, c.ID+"@"+provider.EnrollmentID(), curveID, cacheSize)
 
 	return nil
 }
@@ -68,9 +77,33 @@ func (f *FolderIdentityLoader) Load(manager driver.Manager, c config.MSP) error 
 			MSPType: MSPType,
 			MSPID:   id,
 			Path:    filepath.Join(manager.Config().TranslatePath(c.Path), id),
+			CurveID: c.CurveID,
 		}); err != nil {
 			return errors.WithMessagef(err, "failed to load Idemix MSP configuration [%s]", id)
 		}
 	}
 	return nil
+}
+
+// ParseCurveID maps a curve name string to its math.CurveID constant.
+// If name is empty, it defaults to math.FP256BN_AMCL for backward compatibility.
+func ParseCurveID(name string) (math.CurveID, error) {
+	if name == "" {
+		return math.FP256BN_AMCL, nil
+	}
+
+	switch strings.ToUpper(name) {
+	case "BN254":
+		return math.BN254, nil
+	case "FP256BN_AMCL":
+		return math.FP256BN_AMCL, nil
+	case "FP256BN_AMCL_MIRACL":
+		return math.FP256BN_AMCL_MIRACL, nil
+	case "BLS12_377_GURVY":
+		return math.BLS12_377_GURVY, nil
+	case "BLS12_381_BBS":
+		return math.BLS12_381_BBS, nil
+	default:
+		return 0, errors.Errorf("unsupported idemix curve: %s", name)
+	}
 }

--- a/platform/fabric/core/generic/msp/idemix/provider.go
+++ b/platform/fabric/core/generic/msp/idemix/provider.go
@@ -73,7 +73,7 @@ func NewProviderWithStandardPolicy(conf1 *m.MSPConfig, KVS KVS, sp mspdriver.Sig
 }
 
 func NewProviderWithAnyPolicy(conf1 *m.MSPConfig, KVS KVS, sp mspdriver.SignerService) (*Provider, error) {
-	return NewProviderWithSigType(conf1, KVS, sp, Any)
+	return NewProviderWithAnyPolicyAndCurve(conf1, KVS, sp, math.FP256BN_AMCL)
 }
 
 func NewProviderWithAnyPolicyAndCurve(conf1 *m.MSPConfig, KVS KVS, sp mspdriver.SignerService, curveID math.CurveID) (*Provider, error) {
@@ -85,11 +85,7 @@ func NewProviderWithAnyPolicyAndCurve(conf1 *m.MSPConfig, KVS KVS, sp mspdriver.
 }
 
 func NewProviderWithSigType(conf1 *m.MSPConfig, KVS KVS, sp mspdriver.SignerService, sigType bccsp.SignatureType) (*Provider, error) {
-	cryptoProvider, err := NewKSVBCCSP(&kvsAdapter{KVS}, math.FP256BN_AMCL, false)
-	if err != nil {
-		return nil, err
-	}
-	return NewProvider(conf1, sp, sigType, cryptoProvider)
+	return NewProviderWithSigTypeAncCurve(conf1, KVS, sp, sigType, math.FP256BN_AMCL)
 }
 
 func NewProviderWithSigTypeAncCurve(conf1 *m.MSPConfig, KVS KVS, sp mspdriver.SignerService, sigType bccsp.SignatureType, curveID math.CurveID) (*Provider, error) {

--- a/platform/fabric/core/generic/msp/idemix/provider.go
+++ b/platform/fabric/core/generic/msp/idemix/provider.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/IBM/idemix"
 	bccsp "github.com/IBM/idemix/bccsp/types"
@@ -85,7 +86,11 @@ func NewProviderWithAnyPolicyAndCurve(conf1 *m.MSPConfig, KVS KVS, sp mspdriver.
 }
 
 func NewProviderWithSigType(conf1 *m.MSPConfig, KVS KVS, sp mspdriver.SignerService, sigType bccsp.SignatureType) (*Provider, error) {
-	cryptoProvider, err := NewKSVBCCSP(&kvsAdapter{KVS}, math.FP256BN_AMCL, false)
+	curveID, err := CurveIDFromMSPConfig(conf1)
+	if err != nil {
+		return nil, err
+	}
+	cryptoProvider, err := NewKSVBCCSP(&kvsAdapter{KVS}, curveID, false)
 	if err != nil {
 		return nil, err
 	}
@@ -98,6 +103,46 @@ func NewProviderWithSigTypeAncCurve(conf1 *m.MSPConfig, KVS KVS, sp mspdriver.Si
 		return nil, err
 	}
 	return NewProvider(conf1, sp, sigType, cryptoProvider)
+}
+
+func CurveIDFromMSPConfig(conf1 *m.MSPConfig) (math.CurveID, error) {
+	if conf1 == nil {
+		return math.FP256BN_AMCL, errors.Errorf("setup error: nil conf reference")
+	}
+
+	var conf idemixmsp.IdemixMSPConfig
+	if err := proto.UnmarshalV1(conf1.Config, &conf); err != nil {
+		return math.FP256BN_AMCL, errors.Wrap(err, "failed unmarshalling idemix provider config")
+	}
+
+	curveLabel := conf.CurveId
+	if len(curveLabel) == 0 && conf.Signer != nil {
+		curveLabel = conf.Signer.CurveId
+	}
+	return CurveIDFromString(curveLabel)
+}
+
+func CurveIDFromString(curveLabel string) (math.CurveID, error) {
+	switch strings.TrimSpace(strings.ToUpper(curveLabel)) {
+	case "", "AMCL.FP256BN", "FP256BN_AMCL":
+		return math.FP256BN_AMCL, nil
+	case "GURVY.BN254", "BN254":
+		return math.BN254, nil
+	case "AMCL.FP256BNMIRACL", "FP256BN_AMCL_MIRACL":
+		return math.FP256BN_AMCL_MIRACL, nil
+	case "BLS12_381":
+		return math.BLS12_381, nil
+	case "GURVY.BLS12_377", "BLS12_377_GURVY":
+		return math.BLS12_377_GURVY, nil
+	case "GURVY.BLS12_381", "BLS12_381_GURVY":
+		return math.BLS12_381_GURVY, nil
+	case "BLS12_381_BBS":
+		return math.BLS12_381_BBS, nil
+	case "BLS12_381_BBS_GURVY":
+		return math.BLS12_381_BBS_GURVY, nil
+	default:
+		return math.FP256BN_AMCL, errors.Errorf("unsupported curve id [%s]", curveLabel)
+	}
 }
 
 func NewProvider(conf1 *m.MSPConfig, signerService mspdriver.SignerService, sigType bccsp.SignatureType, cryptoProvider bccsp.BCCSP) (*Provider, error) {

--- a/platform/fabric/core/generic/msp/service.go
+++ b/platform/fabric/core/generic/msp/service.go
@@ -242,14 +242,23 @@ func (s *service) GetIdentityByID(id string) (view.Identity, error) {
 }
 
 func (s *service) RegisterIdemixMSP(id, path, mspID string) error {
+	return s.RegisterIdemixMSPWithCurve(id, path, mspID, "")
+}
+
+func (s *service) RegisterIdemixMSPWithCurve(id, path, mspID, curveIDName string) error {
 	s.mspsMutex.Lock()
 	defer s.mspsMutex.Unlock()
+
+	curveID, err := idemix.ParseCurveID(curveIDName)
+	if err != nil {
+		return errors.Wrapf(err, "invalid curve ID [%s] for idemix msp [%s]", curveIDName, id)
+	}
 
 	conf, err := msp.GetLocalMspConfigWithType(path, nil, mspID, IdemixMSP)
 	if err != nil {
 		return errors.Wrapf(err, "failed reading idemix msp configuration from [%s]", path)
 	}
-	provider, err := idemix.NewProviderWithAnyPolicy(conf, s.KVS, s.signerService)
+	provider, err := idemix.NewProviderWithAnyPolicyAndCurve(conf, s.KVS, s.signerService, curveID)
 	if err != nil {
 		return errors.Wrapf(err, "failed instantiating idemix msp provider from [%s]", path)
 	}
@@ -258,7 +267,7 @@ func (s *service) RegisterIdemixMSP(id, path, mspID string) error {
 	if err := s.AddMSP(id, IdemixMSP, provider.EnrollmentID(), idemix.NewIdentityCache(provider.Identity, s.cacheSize, nil).Identity); err != nil {
 		return errors.Wrapf(err, "failed adding idemix msp [%s] to [%s]", id, path)
 	}
-	logger.Debugf("added IdemixMSP msp for id %s with cache of size %d", id+"@"+provider.EnrollmentID(), s.cacheSize)
+	logger.Debugf("added IdemixMSP msp for id %s with curve %d and cache of size %d", id+"@"+provider.EnrollmentID(), curveID, s.cacheSize)
 	return nil
 }
 

--- a/platform/fabric/core/generic/msp/service.go
+++ b/platform/fabric/core/generic/msp/service.go
@@ -250,14 +250,23 @@ func (s *service) GetIdentityByID(id string) (view.Identity, error) {
 }
 
 func (s *service) RegisterIdemixMSP(id, path, mspID string) error {
+	return s.RegisterIdemixMSPWithCurve(id, path, mspID, "")
+}
+
+func (s *service) RegisterIdemixMSPWithCurve(id, path, mspID, curveIDName string) error {
 	s.mspsMutex.Lock()
 	defer s.mspsMutex.Unlock()
+
+	curveID, err := idemix.CurveIDFromString(curveIDName)
+	if err != nil {
+		return errors.Wrapf(err, "invalid curve ID [%s] for idemix msp [%s]", curveIDName, id)
+	}
 
 	conf, err := msp.GetLocalMspConfigWithType(path, nil, mspID, IdemixMSP)
 	if err != nil {
 		return errors.Wrapf(err, "failed reading idemix msp configuration from [%s]", path)
 	}
-	provider, err := idemix.NewProviderWithAnyPolicy(conf, s.KVS, s.signerService)
+	provider, err := idemix.NewProviderWithAnyPolicyAndCurve(conf, s.KVS, s.signerService, curveID)
 	if err != nil {
 		return errors.Wrapf(err, "failed instantiating idemix msp provider from [%s]", path)
 	}
@@ -266,7 +275,7 @@ func (s *service) RegisterIdemixMSP(id, path, mspID string) error {
 	if err := s.AddMSP(id, IdemixMSP, provider.EnrollmentID(), idemix.NewIdentityCache(provider.Identity, s.cacheSize, nil).Identity); err != nil {
 		return errors.Wrapf(err, "failed adding idemix msp [%s] to [%s]", id, path)
 	}
-	logger.Debugf("added IdemixMSP msp for id %s with cache of size %d", id+"@"+provider.EnrollmentID(), s.cacheSize)
+	logger.Debugf("added IdemixMSP msp for id %s with curve %d and cache of size %d", id+"@"+provider.EnrollmentID(), curveID, s.cacheSize)
 	return nil
 }
 

--- a/platform/fabric/driver/membership.go
+++ b/platform/fabric/driver/membership.go
@@ -35,6 +35,7 @@ type LocalMembership interface {
 	DefaultSigningIdentity() SigningIdentity
 	RegisterX509MSP(id, path, mspID string) error
 	RegisterIdemixMSP(id, path, mspID string) error
+	RegisterIdemixMSPWithCurve(id, path, mspID, curveID string) error
 	GetIdentityByID(id string) (view.Identity, error)
 	GetIdentityInfoByLabel(mspType, label string) *IdentityInfo
 	GetIdentityInfoByIdentity(mspType string, id view.Identity) *IdentityInfo

--- a/platform/fabric/membership.go
+++ b/platform/fabric/membership.go
@@ -66,6 +66,10 @@ func (s *LocalMembership) RegisterIdemixMSP(id, path, mspID string) error {
 	return s.network.LocalMembership().RegisterIdemixMSP(id, path, mspID)
 }
 
+func (s *LocalMembership) RegisterIdemixMSPWithCurve(id, path, mspID, curveID string) error {
+	return s.network.LocalMembership().RegisterIdemixMSPWithCurve(id, path, mspID, curveID)
+}
+
 func (s *LocalMembership) RegisterX509MSP(id, path, mspID string) error {
 	return s.network.LocalMembership().RegisterX509MSP(id, path, mspID)
 }


### PR DESCRIPTION
Closes : #1093 

## Description
This PR addresses the hardcoded `FP256BN_AMCL` curve in the Idemix implementation. The existing logic made it difficult to adopt newer, more efficient elliptic curves like `BN254` (via `mathlib`/`gnark-crypto`), which offer better performance and avoid known race conditions in the older AMCL library.
I've refactored the identity loading pipeline to make the elliptic curve configurable while maintaining strict backward compatibility.
## Changes
- **Config**: Added an optional `curveID` field to the `MSP` configuration struct.
- **Loader**: Updated the identity loader to parse the `curveID` string and pass the corresponding `math.CurveID` to the providers.
- **Deserializer**: Added a curve-configurable constructor for the deserializer to ensure consistent verification of remote identities.
- **Membership Interface**: Extended `LocalMembership` with `RegisterIdemixMSPWithCurve` to allow programmatic curve selection.
- **Backward Compatibility**: All existing methods (`RegisterIdemixMSP`, `NewProviderWithAnyPolicy`, `NewDeserializer`) now delegate to the new curve-aware variants using the legacy `FP256BN_AMCL` as the default.
## Testing
Verified the changes with the following steps:
- Ran all Idemix provider unit tests (`platform/fabric/core/generic/msp/idemix`): **Passed**.
- Ran full platform build: **Succeeded**.
- Verified linting with `golangci-lint run --fix`: **0 issues**.
## Manual Configuration
You can now specify the curve in your network configuration:
```yaml
fabric:
  msps:
    - id: idemix
      mspType: idemix
      mspID: IdemixOrgMSP
      path: ./crypto/idemix
      curveID: BN254  # Supported: BN254, FP256BN_AMCL, BLS12_381_BBS, etc.