### PR TITLE
Update golangci v2.11.4

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,5 +21,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.10.1
+          version: v2.11.4
           args: --timeout=5m

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ install-tools: ## Install all tools
 .PHONY: install-linter-tool
 install-linter-tool: ## Install linter in $(go env GOPATH)/bin
 	@echo "Installing golangci Linter"
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.4
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $$(go env GOPATH)/bin v2.11.4
 
 .PHONY: install-fxconfig
 install-fxconfig: ## Install fxconfig in $(FAB_BINS)

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ install-tools: ## Install all tools
 .PHONY: install-linter-tool
 install-linter-tool: ## Install linter in $(go env GOPATH)/bin
 	@echo "Installing golangci Linter"
-	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $$(go env GOPATH)/bin v2.10.1
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.4
 
 .PHONY: install-fxconfig
 install-fxconfig: ## Install fxconfig in $(FAB_BINS)


### PR DESCRIPTION
### Description
This PR updates the `golangci-lint` version to `v2.11.4` as requested in #1238. 


### Changes
- Updated `Makefile` and `golangci-lint.yml` to `v2.11.4`.

Fixes #1238
