### PR TITLE
fix(fabricx): restore arma -> BFT broadcaster alias

### DIFF
--- a/platform/fabricx/core/channel/wrappers.go
+++ b/platform/fabricx/core/channel/wrappers.go
@@ -187,6 +187,12 @@ func (a *orderingServiceAdapter) Configure(consensusType string, orderers []*grp
 	if !ok {
 		return errors.New("ordering service is not an *ordering.ChannelConfigMonitor")
 	}
+	// [CBDC-ARMA] FSC v0.9+ dropped the arma -> BFT broadcaster alias that v0.8.2 had
+	// in NewCommitter. fabric-x-orderer writes ConsensusType="arma" to genesis, so
+	// translate it to FSC's BFT broadcaster here. Tracking upstream PR.
+	if consensusType == "arma" {
+		consensusType = ordering.BFT
+	}
 	return orderingService.Configure(consensusType, orderers)
 }
 

--- a/platform/fabricx/core/channel/wrappers.go
+++ b/platform/fabricx/core/channel/wrappers.go
@@ -54,6 +54,8 @@ type DeliveryConstructor func(
 
 type MembershipConstructor func(channelName string) fdriver.MembershipService
 
+const armaConsensusType = "arma"
+
 // finalityServiceAdapter adapts finality.ListenerManager to implement driver.Finality
 type finalityServiceAdapter struct {
 	manager finality.ListenerManager
@@ -187,10 +189,9 @@ func (a *orderingServiceAdapter) Configure(consensusType string, orderers []*grp
 	if !ok {
 		return errors.New("ordering service is not an *ordering.ChannelConfigMonitor")
 	}
-	// [CBDC-ARMA] FSC v0.9+ dropped the arma -> BFT broadcaster alias that v0.8.2 had
-	// in NewCommitter. fabric-x-orderer writes ConsensusType="arma" to genesis, so
-	// translate it to FSC's BFT broadcaster here. Tracking upstream PR.
-	if consensusType == "arma" {
+	// Translate "arma" to BFT for backward compatibility with fabric-x-orderer,
+	// which uses "arma" as the consensus type in genesis blocks.
+	if consensusType == armaConsensusType {
 		consensusType = ordering.BFT
 	}
 	return orderingService.Configure(consensusType, orderers)


### PR DESCRIPTION
## Summary

Commit dfdcbba6 (PR #1206 "support for GetConfigTransaction") refactored the fabricx channel/committer initialization and removed the `NewCommitter` function. That function used to contain the line:

```go
os.Broadcasters[\"arma\"] = os.Broadcasters[ordering.BFT]
```

which registered \"arma\" as an alias for the BFT broadcaster. The alias was not carried over to the new architecture, so **v0.9.0+ fabricx can no longer talk to deployments that use fabric-x-orderer / fabric-x-common**, where \`ConsensusType=\"arma\"\` is the standard (see the \`SampleFabricX\` profile in \`fabric-x-common/sampleconfig/configtx.yaml\` and the \`ConsensusTypeArma\` constant in \`fabric-x-common/tools/configtxgen/encoder.go\`).

## Symptom

FSC v0.10.0 + fabric-x-orderer v0.0.24 + fabric-x-committer v0.1.9 biz service fails to initialize:

\`\`\`
failed to apply config update: failed to update ordering service:
failed to set consensus type from channel config: no broadcaster found
for consensus [arma]
\`\`\`

The retry loop then re-invokes \`membershipService.Update\` with the same genesis envelope and trips the sequence-0 config validator, which masks the root cause:

\`\`\`
failed validating config for channel [arma]: config currently at sequence 0,
cannot validate config at sequence 0
\`\`\`

## Fix

Translate \`consensusType == \"arma\"\` to \`ordering.BFT\` inside the fabricx channel wrapper's \`Configure\` adapter. This:

- **Keeps the alias localized to fabricx** — the fabric generic ordering service is untouched.
- **Matches the intent** of the original registration in the removed \`NewCommitter\` (v0.8.2 \`platform/fabricx/sdk/dig/providers.go:178\`).
- **Preserves the \"arma IS fabric-x's BFT\" semantic** — fabric-x-orderer uses SmartBFT under the hood, and \`arma\` is the shard-aware label fabric-x-common emits in genesis blocks.

## Reproduction

1. Deploy \`fabric-x-orderer v0.0.24\` and \`fabric-x-committer v0.1.9\` using their default SampleFabricX profile (emits \`ConsensusType=\"arma\"\`).
2. Start an FSC v0.10.0 application with \`fabric.default.driver: fabricx\`.
3. Observe the errors above in the application log.

## Changes

- \`platform/fabricx/core/channel/wrappers.go\`: 6 lines added (inside \`orderingServiceAdapter.Configure\`).