### PR TITLE
Resolve flaky unit tests caused by parallelization

### DIFF
--- a/platform/view/services/comm/host/libp2p/p2p_test.go
+++ b/platform/view/services/comm/host/libp2p/p2p_test.go
@@ -42,32 +42,27 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestP2PLayerTestRound(t *testing.T) {
-	t.Parallel()
+func TestP2PLayerTestRound(t *testing.T) { //nolint:paralleltest
 	bootstrapNode, node := setupTwoNodes(t)
 	comm.P2PLayerTestRound(t, bootstrapNode, node)
 }
 
-func TestSessionsTestRound(t *testing.T) {
-	t.Parallel()
+func TestSessionsTestRound(t *testing.T) { //nolint:paralleltest
 	bootstrapNode, node := setupTwoNodes(t)
 	comm.SessionsTestRound(t, bootstrapNode, node)
 }
 
-func TestSessionsForMPCTestRound(t *testing.T) {
-	t.Parallel()
+func TestSessionsForMPCTestRound(t *testing.T) { //nolint:paralleltest
 	bootstrapNode, node := setupTwoNodes(t)
 	comm.SessionsForMPCTestRound(t, bootstrapNode, node)
 }
 
-func TestSessionsMultipleMessagesTestRound(t *testing.T) {
-	t.Parallel()
+func TestSessionsMultipleMessagesTestRound(t *testing.T) { //nolint:paralleltest
 	bootstrapNode, node := setupTwoNodes(t)
 	comm.SessionsMultipleMessagesTestRound(t, bootstrapNode, node)
 }
 
-func TestSessionsTwoNodesTestRound(t *testing.T) {
-	t.Parallel()
+func TestSessionsTwoNodesTestRound(t *testing.T) { //nolint:paralleltest
 	bootstrapNode, node1, node2 := setupThreeNodes(t)
 	<-time.After(100 * time.Millisecond)
 

--- a/platform/view/services/comm/host/websocket/p2p_test.go
+++ b/platform/view/services/comm/host/websocket/p2p_test.go
@@ -389,8 +389,7 @@ func generateTLSFiles(t *testing.T) generatedTLSFiles {
 	}
 }
 
-func TestSessionInfoSecurityGuarantees(t *testing.T) {
-	t.Parallel()
+func TestSessionInfoSecurityGuarantees(t *testing.T) { //nolint:paralleltest
 	ctx := t.Context()
 	// Simpler: Alice, Bob and Charlie all share the same CA.
 	allTlsFiles := generateThreeNodesTLSFiles(t)

--- a/platform/view/services/config/provider_test.go
+++ b/platform/view/services/config/provider_test.go
@@ -199,8 +199,7 @@ func TestGetProvider(t *testing.T) {
 	})
 }
 
-func TestProviderMore(t *testing.T) {
-	t.Parallel()
+func TestProviderMore(t *testing.T) { //nolint:paralleltest
 	_ = os.Setenv("CORE_FSC_ID", "node1")
 	p, err := NewProvider("./testdata")
 	require.NoError(t, err)
@@ -241,8 +240,7 @@ func TestProviderError(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestEnvConversions(t *testing.T) {
-	t.Parallel()
+func TestEnvConversions(t *testing.T) { //nolint:paralleltest
 	_ = os.Setenv("CORE_ENV_INT", "123")
 	_ = os.Setenv("CORE_ENV_BOOL", "true")
 	_ = os.Setenv("CORE_ENV_FLOAT", "1.23")

--- a/platform/view/services/grpc/server_test.go
+++ b/platform/view/services/grpc/server_test.go
@@ -446,7 +446,18 @@ func TestNewGRPCServerInvalidParameters(t *testing.T) {
 		grpc3.ServerConfig{SecOpts: grpc3.SecureOptions{UseTLS: false}},
 	)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "address already in use")
+	msgs = []string{
+		"address already in use",
+		"Only one usage of each socket address",
+	}
+	require.Condition(t, func() bool {
+		for _, msg := range msgs {
+			if strings.Contains(err.Error(), msg) {
+				return true
+			}
+		}
+		return false
+	}, "unexpected error: %v", err)
 
 	// missing server Certificate
 	_, err = grpc3.NewGRPCServerFromListener(
@@ -516,12 +527,12 @@ func TestNewGRPCServerInvalidParameters(t *testing.T) {
 func TestNewGRPCServer(t *testing.T) {
 	t.Parallel()
 
-	testAddress := "127.0.0.1:9053"
 	srv, err := grpc3.NewGRPCServer(
-		testAddress,
+		"127.0.0.1:0",
 		grpc3.ServerConfig{SecOpts: grpc3.SecureOptions{UseTLS: false}},
 	)
 	require.NoError(t, err, "failed to create new GRPC server")
+	testAddress := srv.Address()
 
 	// resolve the address
 	addr, err := net.ResolveTCPAddr("tcp", testAddress)


### PR DESCRIPTION
Closes: #1250

### Description
This PR addresses critical test flakiness introduced by over-eager parallelization in commit `5e3fe55`. It restores CI stability by resolving resource contention, environment leaks, and platform-specific discrepancies.

### Key Changes
- **Dynamic Port Selection**: Refactored `server_test.go` to use dynamic ports (`:0`), eliminating port collisions in the GRPC layer.
- **Environment Isolation**: Removed `t.Parallel()` from configuration tests that mutate shared environment variables using `os.Setenv`.
- **Sequenced Networking**: Disabled parallel execution for P2P networking tests that use a "port-probing" strategy incompatible with concurrency.
- **Cross-Platform Compatibility**: Updated GRPC server tests to support Windows-specific socket error messages.

### Verification
- **Stress Tested**: Verified with `go test -count=10` on formerly flaky packages.
- **Zero Regressions**: Confirmed stable passes for the `grpc`, `comm/host`, and `config` components.
