### PR TITLE
Preserve SigningIdentity Interface in MSP Cache

### DIFF
--- a/platform/fabric/core/msp/cache/cache.go
+++ b/platform/fabric/core/msp/cache/cache.go
@@ -69,24 +69,57 @@ func (id *cachedIdentity) Validate() error {
 	return id.cache.Validate(id.Identity)
 }
 
+type cachedSigningIdentity struct {
+	cachedIdentity
+	msp.SigningIdentity
+}
+
+func (id *cachedSigningIdentity) SatisfiesPrincipal(principal *pmsp.MSPPrincipal) error {
+	return id.cachedIdentity.SatisfiesPrincipal(principal)
+}
+
+func (id *cachedSigningIdentity) Validate() error {
+	return id.cachedIdentity.Validate()
+}
+
+func (id *cachedSigningIdentity) Sign(msg []byte) ([]byte, error) {
+	return id.SigningIdentity.Sign(msg)
+}
+
+func (id *cachedSigningIdentity) GetPublicVersion() msp.Identity {
+	return id.cache.wrap(id.SigningIdentity.GetPublicVersion())
+}
+
 func (c *cachedMSP) DeserializeIdentity(serializedIdentity []byte) (msp.Identity, error) {
 	id, ok := c.deserializeIdentityCache.Get(string(serializedIdentity))
 	if ok {
-		return &cachedIdentity{
-			cache:    c,
-			Identity: id.(msp.Identity),
-		}, nil
+		return c.wrap(id.(msp.Identity)), nil
 	}
 
 	id, err := c.MSP.DeserializeIdentity(serializedIdentity)
 	if err == nil {
 		c.deserializeIdentityCache.Add(string(serializedIdentity), id)
-		return &cachedIdentity{
-			cache:    c,
-			Identity: id.(msp.Identity),
-		}, nil
+		return c.wrap(id.(msp.Identity)), nil
 	}
 	return nil, err
+}
+
+// wrap returns a cached identity wrapper that preserves the SigningIdentity
+// interface if the underlying identity supports signing operations.
+func (c *cachedMSP) wrap(id msp.Identity) msp.Identity {
+	if sid, ok := id.(msp.SigningIdentity); ok {
+		return &cachedSigningIdentity{
+			cachedIdentity: cachedIdentity{
+				Identity: id,
+				cache:    c,
+			},
+			SigningIdentity: sid,
+		}
+	}
+	return &cachedIdentity{
+		Identity: id,
+		cache:    c,
+	}
 }
 
 func (c *cachedMSP) Setup(config *pmsp.MSPConfig) error {

--- a/platform/fabric/core/msp/cache/cache_test.go
+++ b/platform/fabric/core/msp/cache/cache_test.go
@@ -322,3 +322,117 @@ func TestSatisfiesPrincipal(t *testing.T) {
 	require.NotNil(t, v)
 	require.Contains(t, "Invalid", v.(error).Error())
 }
+
+func TestDeserializeSigningIdentity(t *testing.T) {
+	t.Parallel()
+	mockMSP := &mocks.MockMSP{}
+	wrappedMSP, err := New(mockMSP)
+	require.NoError(t, err)
+
+	// Mock a signing identity
+	mockIdentity := &mocks.MockSigningIdentity{}
+	serializedIdentity := []byte{1, 2, 3}
+	mockMSP.On("DeserializeIdentity", serializedIdentity).Return(mockIdentity, nil)
+
+	// Deserialize identity
+	id, err := wrappedMSP.DeserializeIdentity(serializedIdentity)
+	require.NoError(t, err)
+
+	// Verify that the cached identity still implements msp.SigningIdentity
+	_, ok := id.(msp.SigningIdentity)
+	require.True(t, ok, "cached identity should implement msp.SigningIdentity")
+}
+
+func TestCachedSigningIdentity_GetPublicVersion(t *testing.T) {
+	t.Parallel()
+	mockMSP := &mocks.MockMSP{}
+	wrappedMSP, err := New(mockMSP)
+	require.NoError(t, err)
+
+	mockPublicIdentity := &mocks.MockIdentity{ID: "Alice-Public"}
+	mockSigningIdentity := &mocks.MockSigningIdentity{MockIdentity: &mocks.MockIdentity{ID: "Alice"}}
+	mockSigningIdentity.On("GetPublicVersion").Return(mockPublicIdentity)
+
+	serializedIdentity := []byte("Alice-Serialized")
+	mockMSP.On("DeserializeIdentity", serializedIdentity).Return(mockSigningIdentity, nil)
+
+	id, err := wrappedMSP.DeserializeIdentity(serializedIdentity)
+	require.NoError(t, err)
+
+	signingId, ok := id.(msp.SigningIdentity)
+	require.True(t, ok)
+
+	publicId := signingId.GetPublicVersion()
+	require.NotNil(t, publicId)
+
+	// Verify it's a cached identity
+	_, ok = publicId.(*cachedIdentity)
+	require.True(t, ok)
+	require.Equal(t, mockPublicIdentity, publicId.(*cachedIdentity).Identity)
+
+	mockSigningIdentity.AssertExpectations(t)
+}
+
+func TestCachedSigningIdentity_Sign(t *testing.T) {
+	t.Parallel()
+	mockMSP := &mocks.MockMSP{}
+	wrappedMSP, err := New(mockMSP)
+	require.NoError(t, err)
+
+	mockSigningIdentity := &mocks.MockSigningIdentity{MockIdentity: &mocks.MockIdentity{ID: "Alice"}}
+	msg := []byte("hello")
+	sig := []byte("signature")
+	mockSigningIdentity.On("Sign", msg).Return(sig, nil)
+
+	serializedIdentity := []byte("Alice-Serialized")
+	mockMSP.On("DeserializeIdentity", serializedIdentity).Return(mockSigningIdentity, nil)
+
+	id, err := wrappedMSP.DeserializeIdentity(serializedIdentity)
+	require.NoError(t, err)
+
+	signingId, ok := id.(msp.SigningIdentity)
+	require.True(t, ok)
+
+	res, err := signingId.Sign(msg)
+	require.NoError(t, err)
+	require.Equal(t, sig, res)
+
+	mockSigningIdentity.AssertExpectations(t)
+}
+
+func TestCachedIdentity_DirectCalls(t *testing.T) {
+	t.Parallel()
+	mockMSP := &mocks.MockMSP{}
+	wrappedMSP, err := New(mockMSP)
+	require.NoError(t, err)
+
+	mockIdentity := &mocks.MockIdentity{ID: "Alice"}
+	mockIdentity.On("GetIdentifier").Return(&msp.IdentityIdentifier{Mspid: "MSP", Id: "Alice"})
+
+	serializedIdentity := []byte("Alice-Serialized")
+	mockMSP.On("DeserializeIdentity", serializedIdentity).Return(mockIdentity, nil)
+
+	id, err := wrappedMSP.DeserializeIdentity(serializedIdentity)
+	require.NoError(t, err)
+
+	// Test Validate
+	mockMSP.On("Validate", mockIdentity).Return(nil).Once()
+	err = id.Validate()
+	require.NoError(t, err)
+
+	// Second call should be cached
+	err = id.Validate()
+	require.NoError(t, err)
+
+	// Test SatisfiesPrincipal
+	principal := &msp2.MSPPrincipal{PrincipalClassification: msp2.MSPPrincipal_IDENTITY, Principal: []byte("Alice")}
+	mockMSP.On("SatisfiesPrincipal", mockIdentity, principal).Return(nil).Once()
+	err = id.SatisfiesPrincipal(principal)
+	require.NoError(t, err)
+
+	// Second call should be cached
+	err = id.SatisfiesPrincipal(principal)
+	require.NoError(t, err)
+
+	mockMSP.AssertExpectations(t)
+}

--- a/platform/fabric/core/msp/mocks/mocks.go
+++ b/platform/fabric/core/msp/mocks/mocks.go
@@ -121,10 +121,12 @@ type MockSigningIdentity struct {
 	*MockIdentity
 }
 
-func (*MockSigningIdentity) Sign(msg []byte) ([]byte, error) {
-	panic("implement me")
+func (m *MockSigningIdentity) Sign(msg []byte) ([]byte, error) {
+	args := m.Called(msg)
+	return args.Get(0).([]byte), args.Error(1)
 }
 
-func (*MockSigningIdentity) GetPublicVersion() msp.Identity {
-	panic("implement me")
+func (m *MockSigningIdentity) GetPublicVersion() msp.Identity {
+	args := m.Called()
+	return args.Get(0).(msp.Identity)
 }


### PR DESCRIPTION
The `cachedIdentity` wrapper in `platform/fabric/core/msp/cache/cache.go` only implemented the base `msp.Identity` interface. This caused identities retrieved from the cache to lose their `Sign()` capability, breaking transaction envelope creation when using cached identities.

### Solution
- Introduced `cachedSigningIdentity` to preserve both `Identity` and `SigningIdentity` interfaces.
- Implemented explicit delegation for `SatisfiesPrincipal` and `Validate` to resolve interface ambiguity.
- Updated `DeserializeIdentity` to automatically upgrade signers to the new cached signing type.


### Verification
- Added a regression test `TestDeserializeSigningIdentity` to `cache_test.go`.
- Verified that all package tests pass.