### PR TITLE
fix(fabricx): restore endpoint parser for id=<group>,<type>,<host:port>

### DIFF
--- a/platform/fabricx/core/membership/endpoint.go
+++ b/platform/fabricx/core/membership/endpoint.go
@@ -1,0 +1,51 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package membership
+
+import (
+	"regexp"
+	"strconv"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+const (
+	OrdererBroadcastType = "broadcast"
+	OrdererDeliverType   = "deliver"
+)
+
+var (
+	endpointRegex            = regexp.MustCompile(`id=(\d+),(` + OrdererBroadcastType + `|` + OrdererDeliverType + `),(.*)`)
+	ErrInvalidEndpointFormat = errors.New("invalid endpoint format")
+)
+
+type endpoint struct {
+	ID       int
+	Type     string
+	Endpoint string
+}
+
+// parseEndpoint parses the fabric-x channel-config endpoint format
+// `id=<group>,(broadcast|deliver),<host>:<port>` as emitted by the official
+// fabric-x ansible collection and fabric-x-tool config-builder. A plain
+// `<host>:<port>` value is accepted and treated as broadcast with ID=0 for
+// backward compatibility.
+func parseEndpoint(str string) (*endpoint, error) {
+	match := endpointRegex.FindStringSubmatch(str)
+	if len(match) == 4 {
+		id, err := strconv.Atoi(match[1])
+		if err != nil {
+			return nil, errors.Wrap(err, "invalid endpoint id")
+		}
+		return &endpoint{ID: id, Type: match[2], Endpoint: match[3]}, nil
+	}
+	// Fallback: plain host:port. Treat as broadcast.
+	if str != "" {
+		return &endpoint{ID: 0, Type: OrdererBroadcastType, Endpoint: str}, nil
+	}
+	return nil, ErrInvalidEndpointFormat
+}

--- a/platform/fabricx/core/membership/endpoint_test.go
+++ b/platform/fabricx/core/membership/endpoint_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package membership
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseEndpoint(t *testing.T) {
+	t.Parallel()
+
+	t.Run("formatted broadcast endpoint", func(t *testing.T) {
+		t.Parallel()
+		ep, err := parseEndpoint("id=0,broadcast,orderer.example.com:7050")
+		require.NoError(t, err)
+		require.Equal(t, &endpoint{ID: 0, Type: OrdererBroadcastType, Endpoint: "orderer.example.com:7050"}, ep)
+	})
+
+	t.Run("formatted deliver endpoint", func(t *testing.T) {
+		t.Parallel()
+		ep, err := parseEndpoint("id=1,deliver,orderer.example.com:7051")
+		require.NoError(t, err)
+		require.Equal(t, &endpoint{ID: 1, Type: OrdererDeliverType, Endpoint: "orderer.example.com:7051"}, ep)
+	})
+
+	t.Run("multi-digit id parses", func(t *testing.T) {
+		t.Parallel()
+		ep, err := parseEndpoint("id=42,broadcast,orderer:7050")
+		require.NoError(t, err)
+		require.Equal(t, 42, ep.ID)
+		require.Equal(t, OrdererBroadcastType, ep.Type)
+		require.Equal(t, "orderer:7050", ep.Endpoint)
+	})
+
+	t.Run("endpoint with extra colons is captured fully", func(t *testing.T) {
+		t.Parallel()
+		// The regex uses `.*` for the endpoint group, so IPv6-style
+		// literals with embedded colons round-trip unchanged.
+		ep, err := parseEndpoint("id=0,broadcast,[::1]:7050")
+		require.NoError(t, err)
+		require.Equal(t, "[::1]:7050", ep.Endpoint)
+	})
+
+	t.Run("plain host:port falls back to broadcast with id=0", func(t *testing.T) {
+		t.Parallel()
+		ep, err := parseEndpoint("orderer:7050")
+		require.NoError(t, err)
+		require.Equal(t, &endpoint{ID: 0, Type: OrdererBroadcastType, Endpoint: "orderer:7050"}, ep)
+	})
+
+	t.Run("empty string returns ErrInvalidEndpointFormat", func(t *testing.T) {
+		t.Parallel()
+		ep, err := parseEndpoint("")
+		require.Nil(t, ep)
+		require.ErrorIs(t, err, ErrInvalidEndpointFormat)
+	})
+
+	t.Run("id overflowing int returns wrapped parse error", func(t *testing.T) {
+		t.Parallel()
+		ep, err := parseEndpoint("id=99999999999999999999999999,broadcast,orderer:7050")
+		require.Nil(t, ep)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid endpoint id")
+	})
+}

--- a/platform/fabricx/core/membership/membership.go
+++ b/platform/fabricx/core/membership/membership.go
@@ -240,13 +240,24 @@ func (s *Service) OrdererConfig(cs driver.ConfigService) (string, []*grpc.Connec
 				continue
 			}
 
+			ep, err := parseEndpoint(epStr)
+			if err != nil {
+				return "", nil, errors.Wrapf(err, "parse orderer endpoint [%s]", epStr)
+			}
+
+			// Skip deliver-typed endpoints; FSC clients only broadcast here.
+			// Deliver is sourced from the local sidecar / committer.
+			if ep.Type != OrdererBroadcastType {
+				continue
+			}
+
 			newOrderers = append(newOrderers, &grpc.ConnectionConfig{
-				Address:           epStr,
+				Address:           ep.Endpoint,
 				ConnectionTimeout: connectionTimeout,
 				TLSEnabled:        tlsEnabled,
 				TLSClientSideAuth: tlsClientSideAuth,
 				TLSRootCertBytes:  tlsRootCerts,
-				Usage:             "broadcast",
+				Usage:             ep.Type,
 			})
 		}
 	}


### PR DESCRIPTION
## Problem

The fabric-x official ansible collection (`LF-Decentralized-Trust-labs/fabric-x-ansible-collection`) and the fabric-x-tool `config-builder` emit orderer endpoints in channel config as:

- `id=<group>,broadcast,<host>:<port>` for routers
- `id=<group>,deliver,<host>:<port>` for assemblers

See [ansible collection configtx template](https://github.com/LF-Decentralized-Trust-labs/fabric-x-ansible-collection/blob/main/roles/configtxgen/templates/configtx.yaml.j2).

FSC v0.8.2 parsed this format in `platform/fabricx/core/membership/endpoint.go` and filtered to broadcast-only endpoints in `Service.OrdererConfig` (https://github.com/hyperledger-labs/fabric-smart-client/blob/v0.8.2/platform/fabricx/core/membership/membership.go#L170-L207). The parser was removed during the v0.9/v0.10 membership refactor, which now treats every endpoint (including deliver-typed assembler ports) as broadcast.

## Impact

With the official configtx template, FSC clients attempt to `Broadcast` to assemblers (which only serve `Deliver`) and get:

```
failed to get status after broadcast to [host:7x53]: rpc error: code = Unknown desc = should not be used
```

Any FSC-based token-sdk / fabricx application deployed on top of the ansible-provisioned fabric-x infrastructure hits this regression on v0.9+.

## Fix

This PR ports the v0.8.2 `endpoint.go` and reintroduces the filter in `OrdererConfig`:

1. Parses `id=<group>,<type>,<host:port>` when present
2. Skips `deliver`-typed endpoints (clients only broadcast here; deliver is sourced from the local sidecar / committer)
3. Falls back to treating plain `<host:port>` as broadcast for backward compatibility with non-fabric-x callers

## Sibling PR

Related upstream regression patch: #1249 (arma -> BFT broadcaster alias, also from the same v0.9/v0.10 membership refactor).

## Testing

Verified end-to-end on a fabric-x v0.1.9 / orderer v0.0.24 deployment using the ansible collection configtx format:
- TMS deploy finality succeeds
- IssueToken / Transfer / Redeem full token lifecycle passes
- No more "should not be used" broadcast errors on assembler ports