### PR TITLE
fix(storage): migrate AuditInfoStore to squirrel PlaceholderFormat

### DIFF
--- a/platform/view/services/storage/driver/sql/common/auditinfo.go
+++ b/platform/view/services/storage/driver/sql/common/auditinfo.go
@@ -11,21 +11,20 @@ import (
 	"database/sql"
 	"fmt"
 
+	sq "github.com/Masterminds/squirrel"
+
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
-	q "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/common"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/cond"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
-func NewAuditInfoStore(writeDB WriteDB, readDB *sql.DB, table string, errorWrapper driver.SQLErrorWrapper, ci common.CondInterpreter) *AuditInfoStore {
+func NewAuditInfoStore(writeDB WriteDB, readDB *sql.DB, table string, errorWrapper driver.SQLErrorWrapper, ph sq.PlaceholderFormat) *AuditInfoStore {
 	return &AuditInfoStore{
 		table:        table,
 		errorWrapper: errorWrapper,
 		readDB:       readDB,
 		writeDB:      writeDB,
-		ci:           ci,
+		sb:           sq.StatementBuilder.PlaceholderFormat(ph),
 	}
 }
 
@@ -34,33 +33,40 @@ type AuditInfoStore struct {
 	errorWrapper driver.SQLErrorWrapper
 	readDB       *sql.DB
 	writeDB      WriteDB
-	ci           common.CondInterpreter
+	sb           sq.StatementBuilderType
 }
 
 func (db *AuditInfoStore) GetAuditInfo(ctx context.Context, id view.Identity) ([]byte, error) {
-	query, params := q.Select().FieldsByName("audit_info").
-		From(q.Table(db.table)).
-		Where(cond.Eq("id", id.UniqueID())).
-		Format(db.ci)
+	query, params, err := db.sb.Select("audit_info").
+		From(db.table).
+		Where(sq.Eq{"id": id.UniqueID()}).
+		ToSql()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to build query")
+	}
+
 	logger.Debug(query, params)
 
 	return QueryUniqueContext[[]byte](ctx, db.readDB, query, params...)
 }
 
 func (db *AuditInfoStore) PutAuditInfo(ctx context.Context, id view.Identity, info []byte) error {
-	query, params := q.InsertInto(db.table).
-		Fields("id", "audit_info").
-		Row(id.UniqueID(), info).
-		Format()
+	query, params, err := db.sb.Insert(db.table).
+		Columns("id", "audit_info").
+		Values(id.UniqueID(), info).
+		ToSql()
+	if err != nil {
+		return errors.Wrapf(err, "failed to build query")
+	}
 
 	logger.Debug(query, params)
-	_, err := db.writeDB.ExecContext(ctx, query, params...)
-	if err != nil && errors.Is(db.errorWrapper.WrapError(err), driver.UniqueKeyViolation) {
+	_, execErr := db.writeDB.ExecContext(ctx, query, params...)
+	if execErr != nil && errors.Is(db.errorWrapper.WrapError(execErr), driver.UniqueKeyViolation) {
 		logger.Infof("Audit info [%s] already in db. Skipping...", id)
 		return nil
 	}
-	if err != nil {
-		return errors.Wrapf(err, "failed executing query [%s]", query)
+	if execErr != nil {
+		return errors.Wrapf(execErr, "failed executing query [%s]", query)
 	}
 	logger.DebugfContext(ctx, "signer [%s] registered", id)
 	return nil

--- a/platform/view/services/storage/driver/sql/common/auditinfo_test.go
+++ b/platform/view/services/storage/driver/sql/common/auditinfo_test.go
@@ -12,22 +12,22 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	sq "github.com/Masterminds/squirrel"
 	. "github.com/onsi/gomega"
 
 	common2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/common/mock"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/sqlite"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
 func TestGetAuditInfo(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
-	db, mockDB, err := sqlmock.New()
+	db, mockDB, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 	Expect(err).ToNot(HaveOccurred())
 
 	input, output := view.Identity("an_id"), []byte("some_result")
 	mockDB.
-		ExpectQuery("SELECT audit_info FROM audit_info WHERE id = \\$1").
+		ExpectQuery("SELECT audit_info FROM audit_info WHERE id = $1").
 		WithArgs(input.UniqueID()).
 		WillReturnRows(mockDB.NewRows([]string{"audit_info"}).AddRow(output))
 
@@ -40,12 +40,12 @@ func TestGetAuditInfo(t *testing.T) { //nolint:paralleltest
 
 func TestPutAuditInfo(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
-	db, mockDB, err := sqlmock.New()
+	db, mockDB, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 	Expect(err).ToNot(HaveOccurred())
 
 	input, output := view.Identity("an_id"), []byte("some_result")
 	mockDB.
-		ExpectExec("INSERT INTO audit_info \\(id, audit_info\\) VALUES \\(\\$1, \\$2\\)").
+		ExpectExec("INSERT INTO audit_info (id,audit_info) VALUES ($1,$2)").
 		WithArgs(input.UniqueID(), output).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
@@ -56,5 +56,5 @@ func TestPutAuditInfo(t *testing.T) { //nolint:paralleltest
 }
 
 func mockAuditInfoStore(db *sql.DB) *common2.AuditInfoStore {
-	return common2.NewAuditInfoStore(db, db, "audit_info", &mock.SQLErrorWrapper{}, sqlite.NewConditionInterpreter())
+	return common2.NewAuditInfoStore(db, db, "audit_info", &mock.SQLErrorWrapper{}, sq.Dollar)
 }

--- a/platform/view/services/storage/driver/sql/postgres/auditinfo.go
+++ b/platform/view/services/storage/driver/sql/postgres/auditinfo.go
@@ -9,6 +9,8 @@ package postgres
 import (
 	"database/sql"
 
+	sq "github.com/Masterminds/squirrel"
+
 	common2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
 	common3 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
 )
@@ -22,5 +24,5 @@ func NewAuditInfoStore(dbs *common2.RWDB, tables common3.TableNames) (*AuditInfo
 }
 
 func newAuditInfoStore(readDB, writeDB *sql.DB, table string) *AuditInfoStore {
-	return &AuditInfoStore{AuditInfoStore: common3.NewAuditInfoStore(readDB, writeDB, table, &ErrorMapper{}, NewConditionInterpreter())}
+	return &AuditInfoStore{AuditInfoStore: common3.NewAuditInfoStore(writeDB, readDB, table, &ErrorMapper{}, sq.Dollar)}
 }

--- a/platform/view/services/storage/driver/sql/sqlite/auditinfo.go
+++ b/platform/view/services/storage/driver/sql/sqlite/auditinfo.go
@@ -9,6 +9,8 @@ package sqlite
 import (
 	"database/sql"
 
+	sq "github.com/Masterminds/squirrel"
+
 	common3 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
 	common2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
 )
@@ -18,9 +20,9 @@ type AuditInfoStore struct {
 }
 
 func NewAuditInfoStore(dbs *common3.RWDB, tables common2.TableNames) (*AuditInfoStore, error) {
-	return newAuditInfoStore(dbs.ReadDB, dbs.WriteDB, tables.AuditInfo), nil
+	return newAuditInfoStore(dbs.ReadDB, NewRetryWriteDB(dbs.WriteDB), tables.AuditInfo), nil
 }
 
-func newAuditInfoStore(readDB, writeDB *sql.DB, table string) *AuditInfoStore {
-	return &AuditInfoStore{AuditInfoStore: common2.NewAuditInfoStore(readDB, writeDB, table, &ErrorMapper{}, NewConditionInterpreter())}
+func newAuditInfoStore(readDB *sql.DB, writeDB common2.WriteDB, table string) *AuditInfoStore {
+	return &AuditInfoStore{AuditInfoStore: common2.NewAuditInfoStore(writeDB, readDB, table, &ErrorMapper{}, sq.Question)}
 }


### PR DESCRIPTION
Migrates AuditInfoStore from the deprecated CondInterpreter query builder 
to squirrel's PlaceholderFormat, following the same pattern established 
for SignerInfoStore and BindingStore (PR #1199) and SimpleKeyDataStore (PR #1235).

Changes:
- common/auditinfo.go: replace ci CondInterpreter with sq.PlaceholderFormat
- sqlite/auditinfo.go: pass sq.Question to NewAuditInfoStore, add RetryWriteDB
- postgres/auditinfo.go: pass sq.Dollar to NewAuditInfoStore
- auditinfo_test.go: update mock to use sq.Dollar and exact query matching

All tests pass locally:
- go test ./platform/view/services/storage/driver/sql/common/... 
- go test ./platform/view/services/storage/driver/sql/sqlite/... 

Part of #1159