### PR TITLE
node/start/profile coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,19 +113,20 @@ include $(TOP)/checks.mk
 GO_PACKAGES = $$(go list ./... | grep -Ev '/(integration/)'; go list ./integration/nwo/...)
 GO_PACKAGES_SDK = $$(go list ./... | grep '/sdk/dig$$')
 GO_TEST_PARAMS ?= -race -cover
+TEST_PKGS ?= $(GO_PACKAGES)
 
 .PHONY: unit-tests
 unit-tests: ## Run unit tests
 	@echo "Running unit tests..."
 	export FABRIC_LOGGING_SPEC=error; \
 	export FAB_BINS=$(FAB_BINS); \
-	go test $(GO_TEST_PARAMS) --skip '(Postgres)' $(GO_PACKAGES)
+	go test $(GO_TEST_PARAMS) --skip '(Postgres)' $(TEST_PKGS)
 
 .PHONY: unit-tests-postgres
 unit-tests-postgres: ## Run unit tests for postgres (requires container images as defined in testing-docker-images)
 	@echo "Running unit tests..."
 	export FABRIC_LOGGING_SPEC=error; \
-	go test $(GO_TEST_PARAMS) --run '(Postgres)' $(GO_PACKAGES)
+	go test $(GO_TEST_PARAMS) --run '(Postgres)' $(TEST_PKGS)
 
 .PHONY: unit-tests-sdk
 unit-tests-sdk: ## Run sdk wiring tests
@@ -205,7 +206,7 @@ clean-fabric-peer-images:
 .PHONY: coverage-local
 coverage-local: ## Run unit tests and show filtered coverage
 	@echo "Running unit tests with coverage..."
-	@env FABRIC_LOGGING_SPEC=error FAB_BINS=$(FAB_BINS) go test -coverprofile=coverage.tmp $(GO_PACKAGES)
+	@env FABRIC_LOGGING_SPEC=error FAB_BINS=$(FAB_BINS) go test $(GO_TEST_PARAMS) -coverprofile=coverage.tmp $(TEST_PKGS)
 	@./scripts/filter-coverage.sh coverage.tmp coverage.out
 	@go tool cover -func=coverage.out | tail -n 1
 	@rm coverage.tmp

--- a/Makefile
+++ b/Makefile
@@ -201,3 +201,11 @@ fmt: ## Run gofmt on the entire project
 .PHONY: clean-fabric-peer-images
 clean-fabric-peer-images:
 	docker images -a | grep "_peer_" | awk '{print $3}' | xargs docker rmi
+
+.PHONY: coverage-local
+coverage-local: ## Run unit tests and show filtered coverage
+	@echo "Running unit tests with coverage..."
+	@env FABRIC_LOGGING_SPEC=error FAB_BINS=$(FAB_BINS) go test -coverprofile=coverage.tmp $(GO_PACKAGES)
+	@./scripts/filter-coverage.sh coverage.tmp coverage.out
+	@go tool cover -func=coverage.out | tail -n 1
+	@rm coverage.tmp

--- a/node/start/profile/profile.go
+++ b/node/start/profile/profile.go
@@ -161,7 +161,11 @@ func (p *Profile) startMemProfile(memProfileType string) error {
 	runtime.MemProfileRate = p.memProfileRate
 	p.appendCloser(func() {
 		logger.Infof("Stopping memory profile")
-		defer f.Close()
+		defer func() {
+			if err := f.Close(); err != nil {
+				logger.Errorf("failed to close memory profile file: %s", err)
+			}
+		}()
 		mp := pprof.Lookup(memProfileType)
 		if mp == nil {
 			logger.Errorf("failed to find memory profile: %s", memProfileType)

--- a/node/start/profile/profile.go
+++ b/node/start/profile/profile.go
@@ -161,14 +161,17 @@ func (p *Profile) startMemProfile(memProfileType string) error {
 	runtime.MemProfileRate = p.memProfileRate
 	p.appendCloser(func() {
 		logger.Infof("Stopping memory profile")
-		if err := pprof.Lookup(memProfileType).WriteTo(f, 0); err != nil {
+		defer f.Close()
+		mp := pprof.Lookup(memProfileType)
+		if mp == nil {
+			logger.Errorf("failed to find memory profile: %s", memProfileType)
+			return
+		}
+		if err := mp.WriteTo(f, 0); err != nil {
 			logger.Errorf("failed to write memory profile: %s", err)
 		}
 		if err := f.Sync(); err != nil {
 			logger.Errorf("failed to flush memory profile data to disk: %s", err)
-		}
-		if err := f.Close(); err != nil {
-			logger.Errorf("failed to close memory profile file: %s", err)
 		}
 		runtime.MemProfileRate = old
 	})

--- a/node/start/profile/profile_test.go
+++ b/node/start/profile/profile_test.go
@@ -54,11 +54,11 @@ func TestNew(t *testing.T) {
 	require.True(t, p.cpu) // Default is true
 }
 
+//nolint:paralleltest
 func TestLifecycle(t *testing.T) {
-	// nolint:paralleltest
 	// We run these sequentially because they interact with global runtime state
 
-	t.Run("Start and Stop CPU and Memory", func(t *testing.T) {
+	t.Run("Start and Stop CPU and Memory", func(t *testing.T) { //nolint:paralleltest
 		tempDir := t.TempDir()
 		p, err := New(WithPath(tempDir), WithAll())
 		require.NoError(t, err)
@@ -76,10 +76,10 @@ func TestLifecycle(t *testing.T) {
 		p.Stop()
 	})
 
-	t.Run("Start Error - Path is a file", func(t *testing.T) {
+	t.Run("Start Error - Path is a file", func(t *testing.T) { //nolint:paralleltest
 		tempDir := t.TempDir()
 		filePath := filepath.Join(tempDir, "a-file")
-		err := os.WriteFile(filePath, []byte("hello"), 0644)
+		err := os.WriteFile(filePath, []byte("hello"), 0o644)
 		require.NoError(t, err)
 
 		p := &Profile{
@@ -90,7 +90,7 @@ func TestLifecycle(t *testing.T) {
 		require.Contains(t, err.Error(), "failed to create profile directory")
 	})
 
-	t.Run("Unknown Memory Profile", func(t *testing.T) {
+	t.Run("Unknown Memory Profile", func(t *testing.T) { //nolint:paralleltest
 		tempDir := t.TempDir()
 		p := &Profile{path: tempDir}
 		err := p.startMemProfile("unknown-type")
@@ -98,7 +98,7 @@ func TestLifecycle(t *testing.T) {
 		p.Stop() // Should log error instead of panicking
 	})
 
-	t.Run("Partial Profiling", func(t *testing.T) {
+	t.Run("Partial Profiling", func(t *testing.T) { //nolint:paralleltest
 		tempDir := t.TempDir()
 		p, err := New(WithPath(tempDir)) // Default is cpu=true, others=false
 		require.NoError(t, err)
@@ -115,9 +115,9 @@ func TestLifecycle(t *testing.T) {
 	})
 }
 
+//nolint:paralleltest
 func TestInternalHelpers(t *testing.T) {
-	// nolint:paralleltest
-	t.Run("appendCloser", func(t *testing.T) {
+	t.Run("appendCloser", func(t *testing.T) { //nolint:paralleltest
 		p := &Profile{}
 		called := false
 		p.appendCloser(func() {
@@ -128,7 +128,7 @@ func TestInternalHelpers(t *testing.T) {
 		require.True(t, called)
 	})
 
-	t.Run("MemProfileRate restoration", func(t *testing.T) {
+	t.Run("MemProfileRate restoration", func(t *testing.T) { //nolint:paralleltest
 		oldRate := runtime.MemProfileRate
 		tempDir := t.TempDir()
 		p := &Profile{

--- a/node/start/profile/profile_test.go
+++ b/node/start/profile/profile_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package profile
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptions(t *testing.T) {
+	t.Parallel()
+	t.Run("WithPath", func(t *testing.T) {
+		t.Parallel()
+		p := &Profile{}
+		opt := WithPath("test-path")
+		err := opt(p)
+		require.NoError(t, err)
+		require.Equal(t, "test-path", p.path)
+
+		optEmpty := WithPath("")
+		err = optEmpty(p)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "path is required")
+	})
+
+	t.Run("WithAll", func(t *testing.T) {
+		t.Parallel()
+		p := &Profile{}
+		opt := WithAll()
+		err := opt(p)
+		require.NoError(t, err)
+		require.True(t, p.cpu)
+		require.True(t, p.memoryAllocs)
+		require.True(t, p.memoryHeap)
+		require.True(t, p.mutex)
+		require.True(t, p.blocker)
+	})
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+	p, err := New(WithPath("test-path"))
+	require.NoError(t, err)
+	require.Equal(t, "test-path", p.path)
+	require.Equal(t, DefaultMemProfileRate, p.memProfileRate)
+	require.True(t, p.cpu) // Default is true
+}
+
+func TestLifecycle(t *testing.T) {
+	// nolint:paralleltest
+	// We run these sequentially because they interact with global runtime state
+
+	t.Run("Start and Stop CPU and Memory", func(t *testing.T) {
+		tempDir := t.TempDir()
+		p, err := New(WithPath(tempDir), WithAll())
+		require.NoError(t, err)
+
+		err = p.Start()
+		require.NoError(t, err)
+
+		// Check if files are created
+		require.FileExists(t, filepath.Join(tempDir, "cpu.pprof"))
+		require.FileExists(t, filepath.Join(tempDir, "mem-heap.pprof"))
+		require.FileExists(t, filepath.Join(tempDir, "mem-allocs.pprof"))
+		require.FileExists(t, filepath.Join(tempDir, "mutex.pprof"))
+		require.FileExists(t, filepath.Join(tempDir, "block.pprof"))
+
+		p.Stop()
+	})
+
+	t.Run("Start Error - Path is a file", func(t *testing.T) {
+		tempDir := t.TempDir()
+		filePath := filepath.Join(tempDir, "a-file")
+		err := os.WriteFile(filePath, []byte("hello"), 0644)
+		require.NoError(t, err)
+
+		p := &Profile{
+			path: filePath,
+		}
+		err = p.Start()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to create profile directory")
+	})
+
+	t.Run("Unknown Memory Profile", func(t *testing.T) {
+		tempDir := t.TempDir()
+		p := &Profile{path: tempDir}
+		err := p.startMemProfile("unknown-type")
+		require.NoError(t, err)
+		p.Stop() // Should log error instead of panicking
+	})
+
+	t.Run("Partial Profiling", func(t *testing.T) {
+		tempDir := t.TempDir()
+		p, err := New(WithPath(tempDir)) // Default is cpu=true, others=false
+		require.NoError(t, err)
+		p.cpu = false // Disable CPU for this test to hit branches where nothing happens
+
+		err = p.Start()
+		require.NoError(t, err)
+		p.Stop()
+
+		// Verify no files created except maybe the dir
+		entries, err := os.ReadDir(tempDir)
+		require.NoError(t, err)
+		require.Empty(t, entries)
+	})
+}
+
+func TestInternalHelpers(t *testing.T) {
+	// nolint:paralleltest
+	t.Run("appendCloser", func(t *testing.T) {
+		p := &Profile{}
+		called := false
+		p.appendCloser(func() {
+			called = true
+		})
+		require.Len(t, p.closers, 1)
+		p.Stop()
+		require.True(t, called)
+	})
+
+	t.Run("MemProfileRate restoration", func(t *testing.T) {
+		oldRate := runtime.MemProfileRate
+		tempDir := t.TempDir()
+		p := &Profile{
+			path:           tempDir,
+			memoryHeap:     true,
+			memProfileRate: 1234,
+		}
+
+		err := p.startMemProfile("heap")
+		require.NoError(t, err)
+		require.Equal(t, 1234, runtime.MemProfileRate)
+
+		p.Stop()
+		require.Equal(t, oldRate, runtime.MemProfileRate)
+	})
+}


### PR DESCRIPTION
## Description
This PR increases the unit test coverage for the `node/start/profile` package to ensure robust handling of node profiling lifecycles.

### Key Changes
- **Expanded Lifecycle Tests**: Added comprehensive test cases for starting and stopping CPU, Memory, Block, and Mutex profiles.
- **Edge Case Coverage**: Implemented tests for error scenarios, including:
    - Invalid or unauthorized output paths.
    - Unknown or unsupported profiling types.
    - Partial profiling configurations.
- **State Restoration Verification**: Added tests to ensure that global state, such as `runtime.MemProfileRate`, is correctly restored after profiling sessions.
- **Internal Helper Tests**: Increased coverage for internal utility functions used for closer management and resource cleanup.

### Verification
- All unit tests in `node/start/profile` pass.
- Branch has been rebased on the latest `upstream/main`.

Closes #1257
