### PR TITLE
testing: Add unit tests for platform/fabric/core/msp/mgmt/testtools

### DIFF
--- a/platform/fabric/core/msp/mgmt/testtools/config.go
+++ b/platform/fabric/core/msp/mgmt/testtools/config.go
@@ -23,6 +23,12 @@ func LoadMSPSetupForTesting() error {
 		return err
 	}
 
+	return LoadMSPSetupForTestingFromDir(dir)
+}
+
+// LoadMSPSetupForTestingFromDir sets up the local MSP
+// and a chain MSP for the default chain using the given directory
+func LoadMSPSetupForTestingFromDir(dir string) error {
 	conf, err := msp.GetLocalMspConfig(dir, nil, "SampleOrg")
 	if err != nil {
 		return err

--- a/platform/fabric/core/msp/mgmt/testtools/config_test.go
+++ b/platform/fabric/core/msp/mgmt/testtools/config_test.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package msptesttools
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/hyperledger/fabric-lib-go/bccsp/sw"
@@ -37,4 +39,31 @@ func TestFakeSetup(t *testing.T) {
 	if len(msps) == 0 {
 		t.Fatalf("There are no MSPS in the manager for chain %s", "testchannelid")
 	}
+}
+
+func TestLoadMSPSetupForTestingFromDir_InvalidPath(t *testing.T) {
+	t.Parallel()
+	err := LoadMSPSetupForTestingFromDir("/nonexistent/path/to/msp")
+	require.Error(t, err, "expected error for non-existent MSP directory")
+}
+
+func TestLoadMSPSetupForTestingFromDir_InvalidCerts(t *testing.T) {
+	t.Parallel()
+	// Create a fake MSP directory with valid PEM structure but invalid cert content.
+	// This should pass GetLocalMspConfig (which only reads PEM bytes) but fail on Setup
+	// (which actually parses the certificates).
+	dir := t.TempDir()
+
+	// Create required subdirectories
+	for _, sub := range []string{"cacerts", "signcerts", "keystore"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, sub), 0o755))
+	}
+
+	// Write a valid PEM block with garbage certificate data
+	fakePEM := []byte("-----BEGIN CERTIFICATE-----\nZmFrZWNlcnQ=\n-----END CERTIFICATE-----\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cacerts", "ca.pem"), fakePEM, 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "signcerts", "sign.pem"), fakePEM, 0o644))
+
+	err := LoadMSPSetupForTestingFromDir(dir)
+	require.Error(t, err, "expected error when setting up MSP with invalid certificates")
 }

--- a/platform/fabric/core/msp/mgmt/testtools/config_test.go
+++ b/platform/fabric/core/msp/mgmt/testtools/config_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/msp/mgmt"
 )
 
+//nolint:paralleltest
 func TestFakeSetup(t *testing.T) {
-	t.Parallel()
 	err := LoadMSPSetupForTesting()
 	if err != nil {
 		t.Fatalf("LoadLocalMsp failed, err %s", err)
@@ -41,14 +41,14 @@ func TestFakeSetup(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest
 func TestLoadMSPSetupForTestingFromDir_InvalidPath(t *testing.T) {
-	t.Parallel()
 	err := LoadMSPSetupForTestingFromDir("/nonexistent/path/to/msp")
 	require.Error(t, err, "expected error for non-existent MSP directory")
 }
 
+//nolint:paralleltest
 func TestLoadMSPSetupForTestingFromDir_InvalidCerts(t *testing.T) {
-	t.Parallel()
 	// Create a fake MSP directory with valid PEM structure but invalid cert content.
 	// This should pass GetLocalMspConfig (which only reads PEM bytes) but fail on Setup
 	// (which actually parses the certificates).


### PR DESCRIPTION
Closes #1279

This PR increases the statement coverage for the `platform/fabric/core/msp/mgmt/testtools` package from **69.2% to 85.7%**, as part of the Stage 2 initiative (#1233).

### Changes:
- **Refactored `LoadMSPSetupForTesting`**: Extracted the core logic into `LoadMSPSetupForTestingFromDir(dir string)` to allow testing with custom/invalid directories.
- **Added Error Path Tests**: 
    - `TestLoadMSPSetupForTestingFromDir_InvalidPath`: Verifies handling of non-existent directories.
    - `TestLoadMSPSetupForTestingFromDir_InvalidCerts`: Verifies handling of directories with invalid certificate content (valid PEM structure but garbage data), triggering the `Setup` error path.

### Verification:
Ran `go test -v -cover ./platform/fabric/core/msp/mgmt/testtools/...`
**Result**: `coverage: 85.7% of statements`
