### PR TITLE
Add utility coverage tests and testing docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -94,12 +94,37 @@ make unit-tests-postgres
 make unit-tests-sdk
 ```
 
+Use `make unit-tests` for the default unit-test suite.
+Use `make unit-tests-postgres` only for tests that explicitly exercise the PostgreSQL-backed storage implementations.
+Use `make unit-tests-sdk` when validating dependency-injection wiring in SDK packages.
+
+To keep the feedback loop fast while working on a single package, scope the test run with `TEST_PKGS`:
+
+```bash
+TEST_PKGS=./platform/common/utils/... make unit-tests
+TEST_PKGS=./platform/common/utils/dig go test -race -cover ./platform/common/utils/dig
+```
+
 For coverage analysis:
 ```bash
 GO_TEST_PARAMS="-coverprofile=cov.out" make unit-tests
 go tool cover -func=cov.out
 go tool cover -html=cov.out
 ```
+
+To reproduce the filtered local coverage used in CI:
+
+```bash
+make coverage-local
+```
+
+The CI workflow runs:
+- `make checks`
+- `make unit-tests`
+- `make unit-tests-postgres`
+- `make integration-tests-*`
+
+If you are preparing a pull request that only touches unit-tested code, running `make checks` together with a targeted `make unit-tests` command is usually the fastest high-signal validation pass before pushing.
 
 ### Integration Tests
 
@@ -130,6 +155,31 @@ Enable coverage profiling:
 mkdir -p covdata
 GOCOVERDIR=covdata make integration-tests
 go tool covdata textfmt -i=covdata -o profile.txt
+```
+
+## Troubleshooting Test Setup
+
+### Missing `FAB_BINS`
+
+If integration tests fail early because Fabric binaries cannot be found, confirm that `FAB_BINS` points to the directory created by `make install-fabric-bins`:
+
+```bash
+echo $FAB_BINS
+ls $FAB_BINS
+```
+
+### PostgreSQL unit tests
+
+The PostgreSQL-specific unit tests expect the container image pulled by `make testing-docker-images`.
+Run that target once before `make unit-tests-postgres` on a new machine.
+
+### Coverage for a single package
+
+When you are improving unit-test coverage for one package, it is often easier to generate coverage for just that package first:
+
+```bash
+go test -race -coverprofile=cov.out ./platform/common/utils/dig
+go tool cover -func=cov.out
 ```
 
 ## Write your own integration test

--- a/platform/common/utils/assert/assert_test.go
+++ b/platform/common/utils/assert/assert_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package assert
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
+
+func TestNoErrorDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	require.NotPanics(t, func() {
+		NoError(nil)
+	})
+}
+
+func TestNoErrorPanicsAndReleases(t *testing.T) {
+	t.Parallel()
+
+	released := false
+	require.Panics(t, func() {
+		NoError(errors.New("boom"), func() { released = true })
+	})
+	require.True(t, released)
+}
+
+func TestValidIdentityReturnsIdentity(t *testing.T) {
+	t.Parallel()
+
+	id := view.Identity("alice")
+	require.Equal(t, id, ValidIdentity(id, nil))
+}
+
+func TestValidIdentityPanicsOnEmptyIdentity(t *testing.T) {
+	t.Parallel()
+
+	released := false
+	require.Panics(t, func() {
+		ValidIdentity(nil, nil, func() { released = true })
+	})
+	require.True(t, released)
+}
+
+func TestExtractReleasersSeparatesFunctions(t *testing.T) {
+	t.Parallel()
+
+	releaser := func() {}
+	msgs, releasers := extractReleasers("hello", 42, releaser)
+	require.Equal(t, []interface{}{"hello", 42}, msgs)
+	require.Len(t, releasers, 1)
+}

--- a/platform/common/utils/assert/retry_test.go
+++ b/platform/common/utils/assert/retry_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package assert
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	pkgerrors "github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+func TestRetrySucceedsImmediately(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	err := Retry(3, 0, func() error {
+		calls++
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+}
+
+func TestRetryEventuallySucceeds(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	err := Retry(4, 0, func() error {
+		calls++
+		if calls < 3 {
+			return pkgerrors.New("not yet")
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 3, calls)
+}
+
+func TestRetryReturnsWrappedLastError(t *testing.T) {
+	t.Parallel()
+
+	sentinelErr := pkgerrors.New("still failing")
+	err := Retry(2, 0, func() error {
+		return sentinelErr
+	})
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "no luck after 2 attempts"))
+	require.True(t, strings.Contains(err.Error(), sentinelErr.Error()))
+}
+
+func TestEventuallyWithRetry(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	EventuallyWithRetry(t, 3, time.Nanosecond, func() error {
+		calls++
+		if calls < 2 {
+			return pkgerrors.New("retry")
+		}
+		return nil
+	})
+	require.Equal(t, 2, calls)
+}

--- a/platform/common/utils/collections/maps/utils_test.go
+++ b/platform/common/utils/collections/maps/utils_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package maps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyCopiesSourceEntries(t *testing.T) {
+	t.Parallel()
+
+	target := map[string]int{"existing": 1}
+	Copy(target, map[string]int{"existing": 2, "new": 3})
+	require.Equal(t, map[string]int{"existing": 2, "new": 3}, target)
+}
+
+func TestCopyIgnoresNilSource(t *testing.T) {
+	t.Parallel()
+
+	target := map[string]int{"existing": 1}
+	Copy(target, nil)
+	require.Equal(t, map[string]int{"existing": 1}, target)
+}
+
+func TestInverseContainsValueAndKeysAndValues(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]int{"alice": 1, "bob": 2}
+	require.Equal(t, map[int]string{1: "alice", 2: "bob"}, Inverse(input))
+	require.True(t, ContainsValue(input, 2))
+	require.False(t, ContainsValue(input, 3))
+	require.ElementsMatch(t, []string{"alice", "bob"}, Keys(input))
+	require.ElementsMatch(t, []int{1, 2}, Values(input))
+}
+
+func TestSubMapAndRepeatValue(t *testing.T) {
+	t.Parallel()
+
+	found, missing := SubMap(map[string]int{"alice": 1, "bob": 2}, "bob", "carol")
+	require.Equal(t, map[string]int{"bob": 2}, found)
+	require.Equal(t, []string{"carol"}, missing)
+	require.Equal(t, map[string]bool{"alice": true, "bob": true}, RepeatValue([]string{"alice", "bob"}, true))
+}

--- a/platform/common/utils/collections/sets/sets_test.go
+++ b/platform/common/utils/collections/sets/sets_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package sets
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetOperations(t *testing.T) {
+	t.Parallel()
+
+	s := New("alice", "bob")
+	require.True(t, s.Contains("alice"))
+	require.False(t, s.Empty())
+	require.Equal(t, 2, s.Length())
+
+	s.Add("carol", "alice")
+	require.True(t, s.Contains("carol"))
+	require.Equal(t, 3, s.Length())
+
+	s.Remove("bob")
+	require.False(t, s.Contains("bob"))
+	require.ElementsMatch(t, []string{"alice", "carol"}, s.ToSlice())
+}
+
+func TestMinus(t *testing.T) {
+	t.Parallel()
+
+	diff := New("alice", "bob", "carol").Minus(New("bob"))
+	require.ElementsMatch(t, []string{"alice", "carol"}, diff.ToSlice())
+}

--- a/platform/common/utils/collections/slices/utils_test.go
+++ b/platform/common/utils/collections/slices/utils_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package slices
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemove(t *testing.T) {
+	t.Parallel()
+
+	items, removed := Remove([]string{"a", "b", "c"}, "b")
+	require.True(t, removed)
+	require.Equal(t, []string{"a", "c"}, items)
+
+	items, removed = Remove([]string{"a", "b"}, "z")
+	require.False(t, removed)
+	require.Equal(t, []string{"a", "b"}, items)
+
+	items, removed = Remove[string](nil, "z")
+	require.False(t, removed)
+	require.Nil(t, items)
+}
+
+func TestDifferenceAndIntersection(t *testing.T) {
+	t.Parallel()
+
+	require.ElementsMatch(t, []string{"alice", "carol"}, Difference([]string{"alice", "bob", "carol"}, []string{"bob"}))
+	require.Equal(t, []string{"carol", "alice"}, Intersection([]string{"alice", "carol"}, []string{"carol", "bob", "alice"}))
+}
+
+func TestRepeatAndSortedSliceAdd(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, []int{7, 7, 7}, Repeat(7, 3))
+
+	sorted := SortedSlice[int]{1, 3}
+	sorted.Add(2)
+	sorted.Add(3)
+	require.Equal(t, SortedSlice[int]{1, 2, 3}, sorted)
+}

--- a/platform/common/utils/dig/dig_test.go
+++ b/platform/common/utils/dig/dig_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"go.uber.org/dig"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/mock"
+)
+
+type sampleService struct {
+	Name string
+}
+
+func TestVisualize(t *testing.T) {
+	t.Parallel()
+
+	container := dig.New()
+	require.NoError(t, container.Provide(func() string { return "hello" }))
+
+	visualization := Visualize(container)
+	require.Contains(t, visualization, "digraph")
+}
+
+func TestProvideAll(t *testing.T) {
+	t.Parallel()
+
+	container := dig.New()
+	err := ProvideAll(
+		container,
+		func() string { return "hello" },
+		func(s string) int { return len(s) },
+	)
+	require.NoError(t, err)
+
+	err = container.Invoke(func(length int) {
+		require.Equal(t, 5, length)
+	})
+	require.NoError(t, err)
+}
+
+func TestProvideAllReturnsJoinedErrors(t *testing.T) {
+	t.Parallel()
+
+	container := dig.New()
+	err := ProvideAll(container, 42, "invalid")
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "must provide constructor function"))
+}
+
+func TestRegister(t *testing.T) {
+	t.Parallel()
+
+	registry := &mock.ServiceRegistry{}
+	container := dig.New()
+	require.NoError(t, container.Provide(func() services.Registry {
+		return registry
+	}))
+	require.NoError(t, container.Provide(func() sampleService {
+		return sampleService{Name: "alpha"}
+	}))
+
+	require.NoError(t, Register[sampleService](container))
+	require.Equal(t, 1, registry.RegisterServiceCallCount())
+	require.Equal(t, sampleService{Name: "alpha"}, registry.RegisterServiceArgsForCall(0))
+}
+
+func TestRegisterReturnsHelpfulError(t *testing.T) {
+	t.Parallel()
+
+	container := dig.New()
+	err := Register[sampleService](container)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed registering type utils.sampleService")
+}
+
+func TestIdentity(t *testing.T) {
+	t.Parallel()
+
+	fn := Identity[int]()
+	require.Equal(t, 42, fn(42))
+}


### PR DESCRIPTION
## Summary
- add unit tests for previously untested utility helpers in `assert`, `collections`, and `dig`
- document faster local test workflows, CI-aligned coverage commands, and common test setup troubleshooting
- improve contributor guidance for package-scoped coverage work

## Testing
- `go test ./platform/common/utils/...`

## Issue Context
This PR is a scoped contribution toward:
- #1233 Test coverage (Stage 2)
- #1116 Documentation

It improves utility-package coverage and expands developer/testing documentation without claiming to complete either umbrella issue in full.
