### PR TITLE
Add utility coverage tests

### DIFF
--- a/platform/common/utils/assert/assert_test.go
+++ b/platform/common/utils/assert/assert_test.go
@@ -26,11 +26,129 @@ func TestNoErrorDoesNotPanic(t *testing.T) {
 func TestNoErrorPanicsAndReleases(t *testing.T) {
 	t.Parallel()
 
-	released := false
-	require.Panics(t, func() {
-		NoError(errors.New("boom"), func() { released = true })
+	assertPanicsAndReleases(t, func(release func()) {
+		NoError(errors.New("boom"), release)
 	})
-	require.True(t, released)
+}
+
+func TestErrorDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	require.NotPanics(t, func() {
+		Error(errors.New("boom"))
+	})
+}
+
+func TestErrorPanicsAndReleases(t *testing.T) {
+	t.Parallel()
+
+	assertPanicsAndReleases(t, func(release func()) {
+		Error(nil, release)
+	})
+}
+
+func TestNotNilDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	require.NotPanics(t, func() {
+		NotNil("value")
+	})
+}
+
+func TestNotNilPanicsAndReleases(t *testing.T) {
+	t.Parallel()
+
+	assertPanicsAndReleases(t, func(release func()) {
+		NotNil(nil, release)
+	})
+}
+
+func TestNotEmptyDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	require.NotPanics(t, func() {
+		NotEmpty("value")
+	})
+}
+
+func TestNotEmptyPanicsAndReleases(t *testing.T) {
+	t.Parallel()
+
+	assertPanicsAndReleases(t, func(release func()) {
+		NotEmpty("", release)
+	})
+}
+
+func TestEqualDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	require.NotPanics(t, func() {
+		Equal("alice", "alice")
+	})
+}
+
+func TestEqualPanicsAndReleases(t *testing.T) {
+	t.Parallel()
+
+	assertPanicsAndReleases(t, func(release func()) {
+		Equal("alice", "bob", release)
+	})
+}
+
+func TestNotEqualDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	require.NotPanics(t, func() {
+		NotEqual("alice", "bob")
+	})
+}
+
+func TestNotEqualPanicsAndReleases(t *testing.T) {
+	t.Parallel()
+
+	assertPanicsAndReleases(t, func(release func()) {
+		NotEqual("alice", "alice", release)
+	})
+}
+
+func TestTrueDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	require.NotPanics(t, func() {
+		True(true)
+	})
+}
+
+func TestTruePanicsAndReleases(t *testing.T) {
+	t.Parallel()
+
+	assertPanicsAndReleases(t, func(release func()) {
+		True(false, release)
+	})
+}
+
+func TestFalseDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	require.NotPanics(t, func() {
+		False(false)
+	})
+}
+
+func TestFalsePanicsAndReleases(t *testing.T) {
+	t.Parallel()
+
+	assertPanicsAndReleases(t, func(release func()) {
+		False(true, release)
+	})
+}
+
+func TestFailPanicsAndReleases(t *testing.T) {
+	t.Parallel()
+
+	assertPanicsAndReleases(t, func(release func()) {
+		Fail("boom", release)
+	})
 }
 
 func TestValidIdentityReturnsIdentity(t *testing.T) {
@@ -43,23 +161,17 @@ func TestValidIdentityReturnsIdentity(t *testing.T) {
 func TestValidIdentityPanicsWhenIdentityIsNil(t *testing.T) {
 	t.Parallel()
 
-	released := false
-
-	require.Panics(t, func() {
-		ValidIdentity(nil, nil, func() { released = true })
+	assertPanicsAndReleases(t, func(release func()) {
+		ValidIdentity(nil, nil, release)
 	})
-	require.True(t, released)
 }
 
 func TestValidIdentityPanicsWhenErrorIsNotNil(t *testing.T) {
 	t.Parallel()
 
-	released := false
-
-	require.Panics(t, func() {
-		ValidIdentity(view.Identity([]byte("alice")), errors.New("boom"), func() { released = true })
+	assertPanicsAndReleases(t, func(release func()) {
+		ValidIdentity(view.Identity([]byte("alice")), errors.New("boom"), release)
 	})
-	require.True(t, released)
 }
 
 func TestExtractReleasersSeparatesFunctions(t *testing.T) {
@@ -69,4 +181,14 @@ func TestExtractReleasersSeparatesFunctions(t *testing.T) {
 	msgs, releasers := extractReleasers("hello", 42, releaser)
 	require.Equal(t, []interface{}{"hello", 42}, msgs)
 	require.Len(t, releasers, 1)
+}
+
+func assertPanicsAndReleases(t *testing.T, f func(release func())) {
+	t.Helper()
+
+	released := false
+	require.Panics(t, func() {
+		f(func() { released = true })
+	})
+	require.True(t, released)
 }

--- a/platform/common/utils/assert/assert_test.go
+++ b/platform/common/utils/assert/assert_test.go
@@ -40,12 +40,24 @@ func TestValidIdentityReturnsIdentity(t *testing.T) {
 	require.Equal(t, id, ValidIdentity(id, nil))
 }
 
-func TestValidIdentityPanicsOnEmptyIdentity(t *testing.T) {
+func TestValidIdentityPanicsWhenIdentityIsNil(t *testing.T) {
 	t.Parallel()
 
 	released := false
+
 	require.Panics(t, func() {
 		ValidIdentity(nil, nil, func() { released = true })
+	})
+	require.True(t, released)
+}
+
+func TestValidIdentityPanicsWhenErrorIsNotNil(t *testing.T) {
+	t.Parallel()
+
+	released := false
+
+	require.Panics(t, func() {
+		ValidIdentity(view.Identity([]byte("alice")), errors.New("boom"), func() { released = true })
 	})
 	require.True(t, released)
 }

--- a/platform/common/utils/assert/assert_test.go
+++ b/platform/common/utils/assert/assert_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package assert
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
+
+func TestNoErrorDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	require.NotPanics(t, func() {
+		NoError(nil)
+	})
+}
+
+func TestNoErrorPanicsAndReleases(t *testing.T) {
+	t.Parallel()
+
+	released := false
+	require.Panics(t, func() {
+		NoError(errors.New("boom"), func() { released = true })
+	})
+	require.True(t, released)
+}
+
+func TestValidIdentityReturnsIdentity(t *testing.T) {
+	t.Parallel()
+
+	id := view.Identity("alice")
+	require.Equal(t, id, ValidIdentity(id, nil))
+}
+
+func TestValidIdentityPanicsOnEmptyIdentity(t *testing.T) {
+	t.Parallel()
+
+	released := false
+	require.Panics(t, func() {
+		ValidIdentity(nil, nil, func() { released = true })
+	})
+	require.True(t, released)
+}
+
+func TestExtractReleasersSeparatesFunctions(t *testing.T) {
+	t.Parallel()
+
+	releaser := func() {}
+	msgs, releasers := extractReleasers("hello", 42, releaser)
+	require.Equal(t, []interface{}{"hello", 42}, msgs)
+	require.Len(t, releasers, 1)
+}

--- a/platform/common/utils/assert/retry_test.go
+++ b/platform/common/utils/assert/retry_test.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package assert
 
 import (
-	"strings"
+	"errors"
 	"testing"
 	"time"
 
@@ -20,10 +20,11 @@ func TestRetrySucceedsImmediately(t *testing.T) {
 	t.Parallel()
 
 	calls := 0
-	err := Retry(3, 0, func() error {
+	err := Retry(2, 0, func() error {
 		calls++
 		return nil
 	})
+
 	require.NoError(t, err)
 	require.Equal(t, 1, calls)
 }
@@ -43,16 +44,17 @@ func TestRetryEventuallySucceeds(t *testing.T) {
 	require.Equal(t, 3, calls)
 }
 
-func TestRetryReturnsWrappedLastError(t *testing.T) {
+func TestRetryReturnsLastErrorAfterAttempts(t *testing.T) {
 	t.Parallel()
 
-	sentinelErr := pkgerrors.New("still failing")
-	err := Retry(2, 0, func() error {
+	sentinelErr := errors.New("still no luck")
+	err := Retry(2, time.Nanosecond, func() error {
 		return sentinelErr
 	})
+
 	require.Error(t, err)
-	require.True(t, strings.Contains(err.Error(), "no luck after 2 attempts"))
-	require.True(t, strings.Contains(err.Error(), sentinelErr.Error()))
+	require.ErrorContains(t, err, "no luck after 2 attempts")
+	require.ErrorContains(t, err, sentinelErr.Error())
 }
 
 func TestEventuallyWithRetry(t *testing.T) {

--- a/platform/common/utils/assert/retry_test.go
+++ b/platform/common/utils/assert/retry_test.go
@@ -12,8 +12,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
-	pkgerrors "github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
 
 func TestRetrySucceedsImmediately(t *testing.T) {
@@ -33,10 +31,10 @@ func TestRetryEventuallySucceeds(t *testing.T) {
 	t.Parallel()
 
 	calls := 0
-	err := Retry(4, 0, func() error {
+	err := Retry(4, time.Microsecond, func() error {
 		calls++
 		if calls < 3 {
-			return pkgerrors.New("not yet")
+			return errors.New("not yet")
 		}
 		return nil
 	})
@@ -61,10 +59,10 @@ func TestEventuallyWithRetry(t *testing.T) {
 	t.Parallel()
 
 	calls := 0
-	EventuallyWithRetry(t, 3, time.Nanosecond, func() error {
+	EventuallyWithRetry(t, 3, time.Microsecond, func() error {
 		calls++
 		if calls < 2 {
-			return pkgerrors.New("retry")
+			return errors.New("retry")
 		}
 		return nil
 	})

--- a/platform/common/utils/assert/retry_test.go
+++ b/platform/common/utils/assert/retry_test.go
@@ -18,7 +18,7 @@ func TestRetrySucceedsImmediately(t *testing.T) {
 	t.Parallel()
 
 	calls := 0
-	err := Retry(2, 0, func() error {
+	err := Retry(2, time.Microsecond, func() error {
 		calls++
 		return nil
 	})
@@ -46,7 +46,7 @@ func TestRetryReturnsLastErrorAfterAttempts(t *testing.T) {
 	t.Parallel()
 
 	sentinelErr := errors.New("still no luck")
-	err := Retry(2, time.Nanosecond, func() error {
+	err := Retry(2, time.Microsecond, func() error {
 		return sentinelErr
 	})
 

--- a/platform/common/utils/assert/retry_test.go
+++ b/platform/common/utils/assert/retry_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package assert
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	pkgerrors "github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+func TestRetrySucceedsImmediately(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	err := Retry(3, 0, func() error {
+		calls++
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, calls)
+}
+
+func TestRetryEventuallySucceeds(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	err := Retry(4, 0, func() error {
+		calls++
+		if calls < 3 {
+			return pkgerrors.New("not yet")
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 3, calls)
+}
+
+func TestRetryReturnsWrappedLastError(t *testing.T) {
+	t.Parallel()
+
+	sentinelErr := pkgerrors.New("still failing")
+	err := Retry(2, 0, func() error {
+		return sentinelErr
+	})
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "no luck after 2 attempts"))
+	require.True(t, strings.Contains(err.Error(), sentinelErr.Error()))
+}
+
+func TestEventuallyWithRetry(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	EventuallyWithRetry(t, 3, time.Nanosecond, func() error {
+		calls++
+		if calls < 2 {
+			return pkgerrors.New("retry")
+		}
+		return nil
+	})
+	require.Equal(t, 2, calls)
+}

--- a/platform/common/utils/collections/maps/utils_test.go
+++ b/platform/common/utils/collections/maps/utils_test.go
@@ -28,22 +28,50 @@ func TestCopyIgnoresNilSource(t *testing.T) {
 	require.Equal(t, map[string]int{"existing": 1}, target)
 }
 
-func TestInverseContainsValueAndKeysAndValues(t *testing.T) {
+func TestInverse(t *testing.T) {
 	t.Parallel()
 
 	input := map[string]int{"alice": 1, "bob": 2}
+
 	require.Equal(t, map[int]string{1: "alice", 2: "bob"}, Inverse(input))
+}
+
+func TestContainsValue(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]int{"alice": 1, "bob": 2}
+
 	require.True(t, ContainsValue(input, 2))
 	require.False(t, ContainsValue(input, 3))
+}
+
+func TestKeys(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]int{"alice": 1, "bob": 2}
+
 	require.ElementsMatch(t, []string{"alice", "bob"}, Keys(input))
+}
+
+func TestValues(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]int{"alice": 1, "bob": 2}
+
 	require.ElementsMatch(t, []int{1, 2}, Values(input))
 }
 
-func TestSubMapAndRepeatValue(t *testing.T) {
+func TestSubMap(t *testing.T) {
 	t.Parallel()
 
 	found, missing := SubMap(map[string]int{"alice": 1, "bob": 2}, "bob", "carol")
+
 	require.Equal(t, map[string]int{"bob": 2}, found)
 	require.Equal(t, []string{"carol"}, missing)
+}
+
+func TestRepeatValue(t *testing.T) {
+	t.Parallel()
+
 	require.Equal(t, map[string]bool{"alice": true, "bob": true}, RepeatValue([]string{"alice", "bob"}, true))
 }

--- a/platform/common/utils/collections/maps/utils_test.go
+++ b/platform/common/utils/collections/maps/utils_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package maps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopyCopiesSourceEntries(t *testing.T) {
+	t.Parallel()
+
+	target := map[string]int{"existing": 1}
+	Copy(target, map[string]int{"existing": 2, "new": 3})
+	require.Equal(t, map[string]int{"existing": 2, "new": 3}, target)
+}
+
+func TestCopyIgnoresNilSource(t *testing.T) {
+	t.Parallel()
+
+	target := map[string]int{"existing": 1}
+	Copy(target, nil)
+	require.Equal(t, map[string]int{"existing": 1}, target)
+}
+
+func TestInverseContainsValueAndKeysAndValues(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]int{"alice": 1, "bob": 2}
+	require.Equal(t, map[int]string{1: "alice", 2: "bob"}, Inverse(input))
+	require.True(t, ContainsValue(input, 2))
+	require.False(t, ContainsValue(input, 3))
+	require.ElementsMatch(t, []string{"alice", "bob"}, Keys(input))
+	require.ElementsMatch(t, []int{1, 2}, Values(input))
+}
+
+func TestSubMapAndRepeatValue(t *testing.T) {
+	t.Parallel()
+
+	found, missing := SubMap(map[string]int{"alice": 1, "bob": 2}, "bob", "carol")
+	require.Equal(t, map[string]int{"bob": 2}, found)
+	require.Equal(t, []string{"carol"}, missing)
+	require.Equal(t, map[string]bool{"alice": true, "bob": true}, RepeatValue([]string{"alice", "bob"}, true))
+}

--- a/platform/common/utils/collections/maps/utils_test.go
+++ b/platform/common/utils/collections/maps/utils_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCopyCopiesSourceEntries(t *testing.T) {
+func TestCopyOverwritesExistingKeys(t *testing.T) {
 	t.Parallel()
 
 	target := map[string]int{"existing": 1}

--- a/platform/common/utils/collections/sets/sets_test.go
+++ b/platform/common/utils/collections/sets/sets_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package sets
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetOperations(t *testing.T) {
+	t.Parallel()
+
+	s := New("alice", "bob")
+	require.True(t, s.Contains("alice"))
+	require.False(t, s.Empty())
+	require.Equal(t, 2, s.Length())
+
+	s.Add("carol", "alice")
+	require.True(t, s.Contains("carol"))
+	require.Equal(t, 3, s.Length())
+
+	s.Remove("bob")
+	require.False(t, s.Contains("bob"))
+	require.ElementsMatch(t, []string{"alice", "carol"}, s.ToSlice())
+}
+
+func TestMinus(t *testing.T) {
+	t.Parallel()
+
+	diff := New("alice", "bob", "carol").Minus(New("bob"))
+	require.ElementsMatch(t, []string{"alice", "carol"}, diff.ToSlice())
+}

--- a/platform/common/utils/collections/sets/sets_test.go
+++ b/platform/common/utils/collections/sets/sets_test.go
@@ -12,19 +12,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSetOperations(t *testing.T) {
+func TestNewContainsAndLength(t *testing.T) {
 	t.Parallel()
 
 	s := New("alice", "bob")
-	require.True(t, s.Contains("alice"))
-	require.False(t, s.Empty())
-	require.Equal(t, 2, s.Length())
 
+	require.True(t, s.Contains("alice"))
+	require.Equal(t, 2, s.Length())
+}
+
+func TestEmpty(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, New[string]().Empty())
+	require.False(t, New("alice").Empty())
+}
+
+func TestAdd(t *testing.T) {
+	t.Parallel()
+
+	s := New("alice", "bob")
 	s.Add("carol", "alice")
+
 	require.True(t, s.Contains("carol"))
 	require.Equal(t, 3, s.Length())
+}
 
+func TestRemove(t *testing.T) {
+	t.Parallel()
+
+	s := New("alice", "bob", "carol")
 	s.Remove("bob")
+
 	require.False(t, s.Contains("bob"))
 	require.ElementsMatch(t, []string{"alice", "carol"}, s.ToSlice())
 }

--- a/platform/common/utils/collections/slices/utils_test.go
+++ b/platform/common/utils/collections/slices/utils_test.go
@@ -46,12 +46,13 @@ func TestRepeat(t *testing.T) {
 	require.Equal(t, []int{7, 7, 7}, Repeat(7, 3))
 }
 
-func TestSortedSliceAdd(t *testing.T) {
+func TestSortedSliceAddDeduplicates(t *testing.T) {
 	t.Parallel()
 
 	sorted := SortedSlice[int]{1, 3}
 	sorted.Add(2)
 	sorted.Add(3)
+	sorted.Add(3) // ensure de-duplication
 
 	require.Equal(t, SortedSlice[int]{1, 2, 3}, sorted)
 }

--- a/platform/common/utils/collections/slices/utils_test.go
+++ b/platform/common/utils/collections/slices/utils_test.go
@@ -51,7 +51,7 @@ func TestSortedSliceAddDeduplicates(t *testing.T) {
 
 	sorted := SortedSlice[int]{1, 3}
 	sorted.Add(2)
-	sorted.Add(3)
+	sorted.Add(3) // ensure de-duplication
 	sorted.Add(3) // ensure de-duplication
 
 	require.Equal(t, SortedSlice[int]{1, 2, 3}, sorted)

--- a/platform/common/utils/collections/slices/utils_test.go
+++ b/platform/common/utils/collections/slices/utils_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package slices
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemove(t *testing.T) {
+	t.Parallel()
+
+	items, removed := Remove([]string{"a", "b", "c"}, "b")
+	require.True(t, removed)
+	require.Equal(t, []string{"a", "c"}, items)
+
+	items, removed = Remove([]string{"a", "b"}, "z")
+	require.False(t, removed)
+	require.Equal(t, []string{"a", "b"}, items)
+
+	items, removed = Remove[string](nil, "z")
+	require.False(t, removed)
+	require.Nil(t, items)
+}
+
+func TestDifferenceAndIntersection(t *testing.T) {
+	t.Parallel()
+
+	require.ElementsMatch(t, []string{"alice", "carol"}, Difference([]string{"alice", "bob", "carol"}, []string{"bob"}))
+	require.Equal(t, []string{"carol", "alice"}, Intersection([]string{"alice", "carol"}, []string{"carol", "bob", "alice"}))
+}
+
+func TestRepeatAndSortedSliceAdd(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, []int{7, 7, 7}, Repeat(7, 3))
+
+	sorted := SortedSlice[int]{1, 3}
+	sorted.Add(2)
+	sorted.Add(3)
+	require.Equal(t, SortedSlice[int]{1, 2, 3}, sorted)
+}

--- a/platform/common/utils/collections/slices/utils_test.go
+++ b/platform/common/utils/collections/slices/utils_test.go
@@ -28,20 +28,30 @@ func TestRemove(t *testing.T) {
 	require.Nil(t, items)
 }
 
-func TestDifferenceAndIntersection(t *testing.T) {
+func TestDifference(t *testing.T) {
 	t.Parallel()
 
 	require.ElementsMatch(t, []string{"alice", "carol"}, Difference([]string{"alice", "bob", "carol"}, []string{"bob"}))
-	require.Equal(t, []string{"carol", "alice"}, Intersection([]string{"alice", "carol"}, []string{"carol", "bob", "alice"}))
 }
 
-func TestRepeatAndSortedSliceAdd(t *testing.T) {
+func TestIntersection(t *testing.T) {
+	t.Parallel()
+
+	require.ElementsMatch(t, []string{"alice", "carol"}, Intersection([]string{"alice", "carol"}, []string{"carol", "bob", "alice"}))
+}
+
+func TestRepeat(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, []int{7, 7, 7}, Repeat(7, 3))
+}
+
+func TestSortedSliceAdd(t *testing.T) {
+	t.Parallel()
 
 	sorted := SortedSlice[int]{1, 3}
 	sorted.Add(2)
 	sorted.Add(3)
+
 	require.Equal(t, SortedSlice[int]{1, 2, 3}, sorted)
 }

--- a/platform/common/utils/dig/dig_test.go
+++ b/platform/common/utils/dig/dig_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"go.uber.org/dig"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/mock"
+)
+
+type sampleService struct {
+	Name string
+}
+
+func TestVisualize(t *testing.T) {
+	t.Parallel()
+
+	container := dig.New()
+	require.NoError(t, container.Provide(func() string { return "hello" }))
+
+	visualization := Visualize(container)
+	require.Contains(t, visualization, "digraph")
+}
+
+func TestProvideAll(t *testing.T) {
+	t.Parallel()
+
+	container := dig.New()
+	err := ProvideAll(
+		container,
+		func() string { return "hello" },
+		func(s string) int { return len(s) },
+	)
+	require.NoError(t, err)
+
+	err = container.Invoke(func(length int) {
+		require.Equal(t, 5, length)
+	})
+	require.NoError(t, err)
+}
+
+func TestProvideAllReturnsJoinedErrors(t *testing.T) {
+	t.Parallel()
+
+	container := dig.New()
+	err := ProvideAll(container, 42, "invalid")
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "must provide constructor function"))
+}
+
+func TestRegister(t *testing.T) {
+	t.Parallel()
+
+	registry := &mock.ServiceRegistry{}
+	container := dig.New()
+	require.NoError(t, container.Provide(func() services.Registry {
+		return registry
+	}))
+	require.NoError(t, container.Provide(func() sampleService {
+		return sampleService{Name: "alpha"}
+	}))
+
+	require.NoError(t, Register[sampleService](container))
+	require.Equal(t, 1, registry.RegisterServiceCallCount())
+	require.Equal(t, sampleService{Name: "alpha"}, registry.RegisterServiceArgsForCall(0))
+}
+
+func TestRegisterReturnsHelpfulError(t *testing.T) {
+	t.Parallel()
+
+	container := dig.New()
+	err := Register[sampleService](container)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed registering type utils.sampleService")
+}
+
+func TestIdentity(t *testing.T) {
+	t.Parallel()
+
+	fn := Identity[int]()
+	require.Equal(t, 42, fn(42))
+}

--- a/platform/common/utils/dig/dig_test.go
+++ b/platform/common/utils/dig/dig_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package utils
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -54,7 +53,7 @@ func TestProvideAllReturnsJoinedErrors(t *testing.T) {
 	container := dig.New()
 	err := ProvideAll(container, 42, "invalid")
 	require.Error(t, err)
-	require.True(t, strings.Contains(err.Error(), "must provide constructor function"))
+	require.ErrorContains(t, err, "must provide constructor function")
 }
 
 func TestRegister(t *testing.T) {
@@ -80,7 +79,7 @@ func TestRegisterReturnsHelpfulError(t *testing.T) {
 	container := dig.New()
 	err := Register[sampleService](container)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed registering type utils.sampleService")
+	require.ErrorContains(t, err, "failed registering type utils.sampleService")
 }
 
 func TestIdentity(t *testing.T) {

--- a/platform/common/utils/dig/dig_test.go
+++ b/platform/common/utils/dig/dig_test.go
@@ -10,9 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"go.uber.org/dig"
-
 	"github.com/stretchr/testify/require"
+	"go.uber.org/dig"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/mock"


### PR DESCRIPTION
## Summary
- add unit tests for previously untested utility helpers in `assert`, `collections`, and `dig`
- keep the scope focused on coverage improvements for common utility packages

## Testing
- `go test ./platform/common/utils/...`

## Issue
Closes #1289

## Context
- split out of #1282 per review feedback requesting separate issue/PR tracking for tests and documentation
