### PR TITLE
Restructure documentation entry points

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We appreciate your contributions to the Fabric Smart Client project. Any help is
 
 Please go to the issues page to create a bug report or suggest a new feature. Feel free to create a pull request (PR) and link it to the corresponding issue.
 
-More info on how to test your contribution you can find in [`docs/development.md`](docs/development.md).
+More info on how to test your contribution you can find in [`docs/development.md`](docs/development.md). The documentation index is available at [`docs/README.md`](docs/README.md).
 
 Note that we follow the [LFDT Charter](https://www.lfdecentralizedtrust.org/about/charter), particularly, all new inbound code contributions to the Fabric Smart Client project shall be made under the Apache License, Version 2.0. All outbound code will be made available under the Apache License, Version 2.0.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ FSC abstracts away the complexity of a DLT network, enabling developers to build
 - **Token SDK** as an example of building distributed ledger applications on top of FSC.
 
 ## Quick links
-- **Documentation:** [docs/](docs/)
+- **Documentation:** [docs/README.md](docs/README.md)
 - **Examples and integration tests:** [`integration/fabric/`](integration/fabric/) and [`integration/fabricx/`](integration/fabricx/)  
 - **Token SDK:** https://github.com/hyperledger-labs/fabric-token-sdk
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,27 @@
+# Fabric Smart Client Documentation
+
+Welcome to the Fabric Smart Client (FSC) documentation.
+
+## Core Concepts
+
+- [Overview and architecture](core-concepts.md)
+- [Shared node configuration](configuration.md)
+
+## Platforms
+
+- [View platform](platform/view/README.md)
+- [Fabric platform](platform/fabric/README.md)
+- [Fabric-x platform](platform/fabric-x/README.md)
+
+Each platform section includes a local `README.md` plus a `configuration.md` page as a starting point.
+
+## Development
+
+- [Development guide](development.md)
+- [Contributor guide](../CONTRIBUTING.md)
+
+## Guides and Tutorials
+
+- [Integration examples](../integration/README.md)
+- [FSC CLI reference](reference/fsc-cli.md)
+- [Benchmark examples](../integration/benchmark/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,5 @@ Each platform section includes a local `README.md` plus a `configuration.md` pag
 
 ## Guides and Tutorials
 
-- [Integration examples](../integration/README.md)
 - [FSC CLI reference](reference/fsc-cli.md)
 - [Benchmark examples](../integration/benchmark/README.md)

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -110,11 +110,11 @@ Currently, FSC comes with the following SDKs:
 
 ![stack.png](imgs/stack.png)
 
-- The [`View SDK`](platform/view/view-sdk.md) is the core of the FSC. It offers API and services to allow FSC nodes:
+- The [`View platform`](platform/view/README.md) is the core of the FSC. It offers API and services to allow FSC nodes:
     - To connect to each other in a peer to peer fashion.
     - To manage and execute business views.
     - To handle node identities.
-- The [`Fabric SDK`](platform/fabric/fabric-sdk.md) builds on top of the `View` platform and offers API and services to allow FSC nodes to communicate
+- The [`Fabric platform`](platform/fabric/README.md) builds on top of the `View` platform and offers API and services to allow FSC nodes to communicate
   with Fabric. The Fabric module is not just the usual Fabric Client SDK, it is more.
   Indeed, we can identify the following components that make the Fabric module different from the current Fabric Client SDKs:
   - **Chaincode API**: These are APIs that allow the developer to invoke any chaincode and assemble Fabric transactions
@@ -130,7 +130,7 @@ Currently, FSC comes with the following SDKs:
     the node is interested about or helped to assemble. An FSC node does not need to store the entire ledger but
     only what is relevant. This storage space allows the FSC nodes to keep temporary version of the transactions
     they are assembling before they get submitted for ordering.
-  - The [`Fabric-x SDK`](platform/fabric-x/readme.md) builds on top of the Fabric platform to communicate with Fabric-x.
+  - The [`Fabric-x platform`](platform/fabric-x/README.md) builds on top of the Fabric platform to communicate with Fabric-x.
 
 For the developers, more information about how SDKs are handles can be found [here](platform/sdk.md).
 

--- a/docs/platform/fabric-x/README.md
+++ b/docs/platform/fabric-x/README.md
@@ -37,7 +37,7 @@ func main() {
 
 ### Configuration
 
-> TODO: Configuration details for Fabric-x platform here soon.
+Start with the [Fabric-x platform configuration](configuration.md) page for the documented `notificationService` and `queryService` settings, then layer those on top of the shared FSC [node configuration](../../configuration.md).
 
 ## Notification Service (Transaction Finality)
 

--- a/docs/platform/fabric-x/configuration.md
+++ b/docs/platform/fabric-x/configuration.md
@@ -1,0 +1,21 @@
+# Fabric-x Platform Configuration
+
+The Fabric-x platform builds on the shared FSC configuration plus additional `fabric.<network>` service settings for Fabric-x-specific integrations.
+
+## Shared Node Configuration
+
+Start with the common FSC node settings documented in the [shared node configuration](../../configuration.md) guide.
+
+## Fabric-x Services
+
+The Fabric-x platform currently documents configuration for these services:
+
+- `fabric.<network>.notificationService`
+- `fabric.<network>.queryService`
+
+Both services support endpoint-based gRPC connectivity and optional TLS or mutual TLS settings.
+
+## Related Documentation
+
+- [Fabric-x platform overview](README.md)
+- [Fabric platform configuration](../fabric/configuration.md)

--- a/docs/platform/fabric/README.md
+++ b/docs/platform/fabric/README.md
@@ -1,0 +1,21 @@
+# Fabric Platform
+
+The Fabric platform extends the FSC view runtime with services and APIs for communicating with Hyperledger Fabric networks.
+
+## Start Here
+
+- [Fabric SDK architecture](fabric-sdk.md)
+- [Fabric platform driver architecture](drivers.md)
+- [Fabric platform configuration](configuration.md)
+
+## What This Platform Adds
+
+- Fabric-aware APIs layered on top of the View platform
+- Transaction endorsement and submission flows
+- Identity providers and finality handlers
+- Vault and state-oriented services used by Fabric applications
+
+## Related Documentation
+
+- [View platform](../view/README.md)
+- [Shared node configuration](../../configuration.md)

--- a/docs/platform/fabric/configuration.md
+++ b/docs/platform/fabric/configuration.md
@@ -1,0 +1,33 @@
+# Fabric Platform Configuration
+
+The Fabric platform configuration lives inside the shared FSC `core.yaml` described in the [shared node configuration](../../configuration.md) guide.
+
+## Start with the Shared Configuration
+
+Before adding Fabric-specific sections, configure the common FSC node settings:
+
+- `logging`
+- `fsc`
+- `grpc`
+- `p2p`
+- `persistences`
+- `web`
+- `tracing`
+- `metrics`
+
+## Fabric-Specific Settings
+
+When a node uses the Fabric platform, the `core.yaml` also includes `fabric` network definitions and related services such as:
+
+- network connection settings
+- identities and MSP material
+- finality handling
+- vault and persistence wiring
+- channel and chaincode access configuration
+
+Use the full [example configuration](../../configuration.md) as the starting point for a Fabric-enabled FSC node.
+
+## Related Documentation
+
+- [Fabric SDK architecture](fabric-sdk.md)
+- [Fabric platform driver architecture](drivers.md)

--- a/docs/platform/fabric/fabric-sdk.md
+++ b/docs/platform/fabric/fabric-sdk.md
@@ -12,4 +12,4 @@ It consists of the following layers:
 
 ## Configuration
 
-You can find an example of the configuration required for the Fabric SDK in [Example Core File for Fabric](../../configuration.md)
+Start with the [Fabric platform configuration](configuration.md) page and then use the shared [example configuration](../../configuration.md) as the concrete `core.yaml` reference.

--- a/docs/platform/view/README.md
+++ b/docs/platform/view/README.md
@@ -1,0 +1,22 @@
+# View Platform
+
+The View platform is the core runtime of the Fabric Smart Client. It provides the communication, orchestration, identity, and service model that higher-level platforms build on.
+
+## Start Here
+
+- [View SDK architecture](view-sdk.md)
+- [View platform configuration](configuration.md)
+- [View runtime security model](security-model.md)
+
+## Services
+
+- [View service](services/view-service.md)
+- [Configuration service](services/config-service.md)
+- [Database drivers](services/db-driver.md)
+- [Monitoring](services/monitoring.md)
+- [Communication services](services/comm/readme.md)
+
+## Related Documentation
+
+- [Shared node configuration](../../configuration.md)
+- [Fabric platform](../fabric/README.md)

--- a/docs/platform/view/configuration.md
+++ b/docs/platform/view/configuration.md
@@ -1,0 +1,24 @@
+# View Platform Configuration
+
+The View platform uses the shared FSC node configuration described in [shared node configuration](../../configuration.md).
+
+## Core Sections
+
+For a node using only the View platform, the most relevant `core.yaml` sections are:
+
+- `logging`
+- `fsc`
+- `grpc`
+- `p2p`
+- `kvs`
+- `persistences`
+- `web`
+- `tracing`
+- `metrics`
+
+These sections configure node identity, transport, persistence, observability, and runtime services used by the View SDK.
+
+## Related Documentation
+
+- [View SDK architecture](view-sdk.md)
+- [View runtime security model](security-model.md)

--- a/docs/platform/view/view-sdk.md
+++ b/docs/platform/view/view-sdk.md
@@ -10,3 +10,7 @@ This is the architecture of the View SDK:
 - [Configuration Service](services/config-service.md)
 - [DB Drivers](services/db-driver.md)
 - [Monitoring](services/monitoring.md)
+
+## Configuration
+
+See [View platform configuration](configuration.md) for the runtime sections that back the View SDK.

--- a/integration/fabric/atsa/README.md
+++ b/integration/fabric/atsa/README.md
@@ -56,7 +56,7 @@ However, we will change paradigm: The `asset_transfer` chaincode will not mediat
 between business parties (issuers and asset owners). 
 The business parties will interact directly to achieve the business goals.
 
-We have already learned, when exploring the ['Fabric's hidden gems'](./../../../docs/readme.md#fabric-and-its-hidden-gems), 
+We have already learned, when exploring the ['Fabric's hidden gems'](./../../../docs/core-concepts.md#fabric-and-its-hidden-gems),
 that an endorser is just a network node that executes `some code` and possesses a signing key compatible with an endorsement policy. 
 The node produces a signature to signal its approval. Therefore, if we equip an FSC node with 
 a signing secret key accepted by our endorsement policy, that FSC node can endorse Fabric transactions.
@@ -215,5 +215,3 @@ func (f *IssueView) Call(viewCtx view.Context) (interface{}, error) {
 ### Agree to Spend an Asset
 
 ### Transfer an Asset
-
-


### PR DESCRIPTION
## Summary
- restructure the docs entry point around `docs/README.md` with clearer sections for core concepts, platforms, development, and guides
- move the long-form FSC overview into `docs/core-concepts.md`
- add `README.md` and `configuration.md` landing pages for the `view`, `fabric`, and `fabric-x` platform docs
- update repository links to point to the new documentation layout

## Testing
- `git diff --check`

## Issue
Closes #1277
