### PR TITLE
Split Fabric-x client and endorser wiring

### DIFF
--- a/platform/fabricx/sdk/dig/client/providers.go
+++ b/platform/fabricx/sdk/dig/client/providers.go
@@ -4,23 +4,28 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package sdk
+package client
 
 import (
+	"context"
+	"errors"
+
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/dig"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core"
+	commondig "github.com/hyperledger-labs/fabric-smart-client/platform/common/sdk/dig"
+	digutils "github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/dig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/delivery"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/driver/config"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/driver/identity"
 	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver/multiplexed"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/channel"
+	committerconfig "github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/config"
+	committergrpc "github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/grpc"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/finality"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/ledger"
@@ -32,43 +37,45 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/kvs"
 )
 
-type P2PCommunicationType = string
-
-const (
-	WebSocket P2PCommunicationType = "websocket"
-)
-
-func NewDriver(in struct {
-	dig.In
-	ConfigProvider  config.Provider
-	MetricsProvider metrics.Provider
-	EndpointService identity.EndpointService
-	IdProvider      identity.ViewIdentityProvider
-	KVS             *kvs.KVS
-	SignerInfoStore driver.SignerInfoStore
-	AuditInfoStore  driver.AuditInfoStore
-	ChannelProvider ChannelProvider
-	IdentityLoaders []identity.NamedIdentityLoader `group:"identity-loaders"`
-},
-) core.NamedDriver {
-	d := core.NamedDriver{
-		Name: fabricx.DriverName,
-		Driver: fabricx.NewProvider(
-			in.ConfigProvider,
-			in.MetricsProvider,
-			in.EndpointService,
-			in.ChannelProvider,
-			in.IdProvider,
-			in.IdentityLoaders,
-			in.KVS,
-			in.SignerInfoStore,
-			in.AuditInfoStore,
-		),
-	}
-	return d
+func Install(sdk commondig.SDK) error {
+	return errors.Join(
+		sdk.Container().Provide(committerconfig.NewProvider, dig.As(
+			new(committergrpc.ServiceConfigProvider),
+			new(finality.ServiceConfigProvider),
+			new(queryservice.ServiceConfigProvider),
+		)),
+		sdk.Container().Provide(committergrpc.NewClientProvider, dig.As(
+			new(ledger.GRPCClientProvider),
+			new(queryservice.GRPCClientProvider),
+			new(finality.GRPCClientProvider),
+		)),
+		sdk.Container().Provide(ledger.NewProvider),
+		sdk.Container().Provide(finality.NewListenerManagerProvider),
+		sdk.Container().Provide(digutils.Identity[*finality.Provider](), dig.As(new(finality.ListenerManagerProvider))),
+		sdk.Container().Provide(queryservice.NewProvider, dig.As(new(queryservice.Provider))),
+		sdk.Container().Provide(NewChannelProvider, dig.As(new(generic.ChannelProvider))),
+	)
 }
 
-type ChannelProvider generic.ChannelProvider
+func RegisterLegacy(sdk commondig.SDK) error {
+	return errors.Join(
+		digutils.Register[finality.ListenerManagerProvider](sdk.Container()),
+		digutils.Register[queryservice.Provider](sdk.Container()),
+		digutils.Register[*ledger.Provider](sdk.Container()),
+	)
+}
+
+func InitializeProviders(sdk commondig.SDK, ctx context.Context) error {
+	return sdk.Container().Invoke(func(in struct {
+		dig.In
+		FinalityProvider *finality.Provider
+		LedgerProvider   *ledger.Provider
+	}) error {
+		in.FinalityProvider.Initialize(ctx)
+		in.LedgerProvider.Initialize(ctx)
+		return nil
+	})
+}
 
 func NewChannelProvider(in struct {
 	dig.In
@@ -87,8 +94,7 @@ func NewChannelProvider(in struct {
 	MetadataStore           fdriver.MetadataStore
 	EndorseTxStore          fdriver.EndorseTxStore
 	Drivers                 multiplexed.Driver
-},
-) generic.ChannelProvider {
+}) generic.ChannelProvider {
 	channelConfigProvider := generic.NewChannelConfigProvider(in.ConfigProvider)
 	return channel.NewProvider(
 		in.ConfigProvider,
@@ -106,7 +112,6 @@ func NewChannelProvider(in struct {
 		func(channel string, nw fdriver.FabricNetworkService, envelopeService fdriver.EnvelopeService, transactionService fdriver.EndorserTransactionService, vault fdriver.RWSetInspector) (fdriver.RWSetLoader, error) {
 			return NewRWSetLoader(channel, nw, envelopeService, transactionService, vault), nil
 		},
-		// delivery service constructor
 		func(
 			nw fdriver.FabricNetworkService,
 			channel string,
@@ -135,7 +140,6 @@ func NewChannelProvider(in struct {
 				[]cb.HeaderType{cb.HeaderType_MESSAGE},
 			)
 		},
-		// membership service
 		func(channelName string) fdriver.MembershipService {
 			return membership.NewService(channelName)
 		},

--- a/platform/fabricx/sdk/dig/endorser/providers.go
+++ b/platform/fabricx/sdk/dig/endorser/providers.go
@@ -1,0 +1,55 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package endorser
+
+import (
+	"go.uber.org/dig"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+	commondig "github.com/hyperledger-labs/fabric-smart-client/platform/common/sdk/dig"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/driver/config"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/driver/identity"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver/multiplexed"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/kvs"
+)
+
+func Install(sdk commondig.SDK) error {
+	return sdk.Container().Provide(NewDriver, dig.Group("fabric-platform-drivers"))
+}
+
+func NewDriver(in struct {
+	dig.In
+	ConfigProvider  config.Provider
+	MetricsProvider metrics.Provider
+	EndpointService identity.EndpointService
+	IdProvider      identity.ViewIdentityProvider
+	KVS             *kvs.KVS
+	SignerInfoStore driver.SignerInfoStore
+	AuditInfoStore  driver.AuditInfoStore
+	ChannelProvider generic.ChannelProvider
+	IdentityLoaders []identity.NamedIdentityLoader `group:"identity-loaders"`
+	Drivers         multiplexed.Driver
+}) core.NamedDriver {
+	return core.NamedDriver{
+		Name: fabricx.DriverName,
+		Driver: fabricx.NewProvider(
+			in.ConfigProvider,
+			in.MetricsProvider,
+			in.EndpointService,
+			in.ChannelProvider,
+			in.IdProvider,
+			in.IdentityLoaders,
+			in.KVS,
+			in.SignerInfoStore,
+			in.AuditInfoStore,
+		),
+	}
+}

--- a/platform/fabricx/sdk/dig/sdk.go
+++ b/platform/fabricx/sdk/dig/sdk.go
@@ -9,17 +9,11 @@ package sdk
 import (
 	"context"
 
-	"go.uber.org/dig"
-
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	common "github.com/hyperledger-labs/fabric-smart-client/platform/common/sdk/dig"
-	digutils "github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/dig"
 	fabric "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk/dig"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/config"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/grpc"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/finality"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/ledger"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/sdk/dig/client"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/sdk/dig/endorser"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services"
 )
 
@@ -45,23 +39,8 @@ func (p *SDK) Install() error {
 		return p.SDK.Install()
 	}
 	err := errors.Join(
-		// Register the new fabricx platform driver
-		p.Container().Provide(NewDriver, dig.Group("fabric-platform-drivers")),
-		p.Container().Provide(NewChannelProvider, dig.As(new(ChannelProvider))),
-		p.Container().Provide(config.NewProvider, dig.As(
-			new(grpc.ServiceConfigProvider),
-			new(finality.ServiceConfigProvider),
-			new(queryservice.ServiceConfigProvider),
-		)),
-		p.Container().Provide(grpc.NewClientProvider, dig.As(
-			new(ledger.GRPCClientProvider),
-			new(queryservice.GRPCClientProvider),
-			new(finality.GRPCClientProvider),
-		)),
-		p.Container().Provide(ledger.NewProvider),
-		p.Container().Provide(finality.NewListenerManagerProvider),
-		p.Container().Provide(digutils.Identity[*finality.Provider](), dig.As(new(finality.ListenerManagerProvider))),
-		p.Container().Provide(queryservice.NewProvider, dig.As(new(queryservice.Provider))),
+		endorser.Install(p.SDK),
+		client.Install(p.SDK),
 	)
 	if err != nil {
 		return err
@@ -72,11 +51,7 @@ func (p *SDK) Install() error {
 	}
 
 	// Backward compatibility with SP
-	return errors.Join(
-		digutils.Register[finality.ListenerManagerProvider](p.Container()),
-		digutils.Register[queryservice.Provider](p.Container()),
-		digutils.Register[*ledger.Provider](p.Container()),
-	)
+	return client.RegisterLegacy(p.SDK)
 }
 
 func (p *SDK) Start(ctx context.Context) error {
@@ -84,19 +59,8 @@ func (p *SDK) Start(ctx context.Context) error {
 		return p.SDK.Start(ctx)
 	}
 
-	// Wire the finality Listener Manager Provider and Ledger Provider with the application's root context.
-	// This context is cancelled when the FSC application shuts down.
-	err := p.Container().Invoke(func(in struct {
-		dig.In
-		FinalityProvider *finality.Provider
-		LedgerProvider   *ledger.Provider
-	},
-	) error {
-		in.FinalityProvider.Initialize(ctx)
-		in.LedgerProvider.Initialize(ctx)
-		return nil
-	})
-	if err != nil {
+	// Wire the client-side providers with the application's root context.
+	if err := client.InitializeProviders(p.SDK, ctx); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary
- split the Fabric-x dig wiring into dedicated client-side and endorser-side packages
- keep the public `platform/fabricx/sdk/dig` entrypoint unchanged while isolating the two concerns
- make the current Fabric-x SDK layout easier to extract into a separate client SDK in follow-up work

## Testing
- `go test ./platform/fabricx/sdk/dig/... ./platform/fabricx/...`

## Issue
Refs #1150

## Notes
This is a preparatory refactor toward the extraction described in #1150 rather than the full move to a standalone `fabric-x-client-sdk`.
