### PR TITLE
fix: consistent use of TLS12/TLS13

### DIFF
--- a/platform/fabricx/core/committer/grpc/grpc.go
+++ b/platform/fabricx/core/committer/grpc/grpc.go
@@ -118,7 +118,8 @@ func TransportCredentials(tlsConfig *config.TLSConfig) (credentials.TransportCre
 	}
 
 	t := &tls.Config{
-		MinVersion: tls.VersionTLS13,
+		MinVersion: tls.VersionTLS12,
+		MaxVersion: tls.VersionTLS13,
 		ServerName: tlsConfig.ServerNameOverride,
 	}
 

--- a/platform/view/services/grpc/creds.go
+++ b/platform/view/services/grpc/creds.go
@@ -39,7 +39,7 @@ func NewServerTransportCredentials(
 	serverConfig.config.NextProtos = alpnProtoStr
 	// override TLS version and ensure it is 1.2
 	serverConfig.config.MinVersion = tls.VersionTLS12
-	serverConfig.config.MaxVersion = tls.VersionTLS12
+	serverConfig.config.MaxVersion = tls.VersionTLS13
 	return &serverCreds{
 		serverConfig: serverConfig,
 		logger:       logger,


### PR DESCRIPTION
This PR fixes inconsistent use of min/max tls version in TLS configurations which may cause handshake failures.

As aligned with go [current defaults](https://github.com/golang/go/blob/master/src/crypto/tls/common.go#L791) we use the following TLS configuration.

```go
MinVersion: tls.VersionTLS12,
MaxVersion: tls.VersionTLS13,
```

Closes #1297