### PR TITLE
feat(vault): migrate VaultStore SELECT queries to squirrel (#1272)

### DIFF
--- a/platform/fabric/services/db/driver/sql/common/vault.go
+++ b/platform/fabric/services/db/driver/sql/common/vault.go
@@ -215,6 +215,7 @@ func (db *VaultStore) convertStateRows(writes driver.Writes, metaWrites driver.M
 				return nil, errors.Wrapf(err, "failed to marshal metadata for [%s:%s]", ns, pkey)
 			}
 			if len(val.Raw) == 0 {
+				// Deleting value
 				logger.Debugf("setting version of [%s] to nil", pkey)
 				val.Version = nil
 			}
@@ -456,7 +457,7 @@ func (db *vaultReader) GetStateMetadata(ctx context.Context, namespace driver.Na
 func (db *vaultReader) GetLast(ctx context.Context) (*driver.TxStatus, error) {
 	// Select the row with the highest pos that is not Busy
 	it, err := db.queryStatus(ctx,
-		sq.Expr("pos=(SELECT max(pos) FROM "+db.tables.StatusTable+" WHERE code!=?)", driver.Busy),
+		sq.Expr(fmt.Sprintf("pos=(SELECT max(pos) FROM %s WHERE code!=?)", db.tables.StatusTable), driver.Busy),
 		pagination.None())
 	if err != nil {
 		return nil, err

--- a/platform/fabric/services/db/driver/sql/common/vault.go
+++ b/platform/fabric/services/db/driver/sql/common/vault.go
@@ -160,6 +160,10 @@ func (db *VaultStore) SetStatuses(ctx context.Context, code driver.TxStatusCode,
 	return nil
 }
 
+// SetStatusesBusy builds an INSERT ... ON CONFLICT DO UPDATE statement that marks all
+// transactions in txIDs as Busy in the status table. It returns the SQL query string
+// and the corresponding argument slice ready for execution, or an error if the query
+// cannot be built.
 func (db *VaultStore) SetStatusesBusy(txIDs []driver.TxID) (string, []any, error) {
 	ib := db.sb.Insert(db.tables.StatusTable).
 		Columns("tx_id", "code")

--- a/platform/fabric/services/db/driver/sql/common/vault.go
+++ b/platform/fabric/services/db/driver/sql/common/vault.go
@@ -145,6 +145,7 @@ func (db *VaultStore) SetStatuses(ctx context.Context, code driver.TxStatusCode,
 	for _, txID := range txIDs {
 		ib = ib.Values(txID, code, message)
 	}
+
 	query, params, err := ib.
 		Suffix("ON CONFLICT (tx_id) DO UPDATE SET code = EXCLUDED.code, message = EXCLUDED.message").
 		ToSql()
@@ -170,6 +171,7 @@ func (db *VaultStore) SetStatusesBusy(txIDs []driver.TxID) (string, []any, error
 	for _, txID := range txIDs {
 		ib = ib.Values(txID, driver.Busy)
 	}
+
 	return ib.
 		Suffix("ON CONFLICT (tx_id) DO UPDATE SET code = EXCLUDED.code").
 		ToSql()
@@ -242,6 +244,7 @@ func (db *VaultStore) convertStateRows(writes driver.Writes, metaWrites driver.M
 		}
 		for pkey, metaVal := range metaWrite {
 			if _, ok = write[pkey]; ok {
+				// MetaWrites already written in the previous section
 				continue
 			}
 			metadata, err := marshallMetadata(metaVal.Metadata)
@@ -257,6 +260,7 @@ func (db *VaultStore) convertStateRows(writes driver.Writes, metaWrites driver.M
 				return nil, err
 			}
 			states = append(states, common4.Tuple{ns, pkey, []byte{}, metaVal.Version, metadata})
+
 		}
 	}
 	return states, nil
@@ -455,6 +459,7 @@ func (db *vaultReader) GetStateMetadata(ctx context.Context, namespace driver.Na
 	if err != nil {
 		return meta, nil, fmt.Errorf("error decoding metadata: %w", err)
 	}
+
 	return meta, kversion, err
 }
 
@@ -488,6 +493,7 @@ func (db *vaultReader) GetAllTxStatuses(ctx context.Context, p driver.Pagination
 	if p == nil {
 		return nil, fmt.Errorf("invalid input pagination: %+v", p)
 	}
+
 	txStatusIterator, err := db.queryStatus(ctx, nil, p)
 	if err != nil {
 		return nil, err

--- a/platform/fabric/services/db/driver/sql/common/vault.go
+++ b/platform/fabric/services/db/driver/sql/common/vault.go
@@ -111,7 +111,7 @@ func (db *VaultStore) newTxLockVaultReader(ctx context.Context, isolationLevel d
 	}
 	return &vaultReader{
 		readDB:    tx,
-		sb:        db.vaultReader.sb,
+		sb:        db.sb,
 		sanitizer: db.sanitizer,
 		tables:    db.tables,
 	}, tx.Commit, nil
@@ -131,7 +131,7 @@ func (db *VaultStore) newGlobalLockVaultReader() (*vaultReader, releaseFunc, err
 	}
 	return &vaultReader{
 		readDB:    db.readDB,
-		sb:        db.vaultReader.sb,
+		sb:        db.sb,
 		sanitizer: db.sanitizer,
 		tables:    db.tables,
 	}, release, nil

--- a/platform/fabric/services/db/driver/sql/common/vault.go
+++ b/platform/fabric/services/db/driver/sql/common/vault.go
@@ -15,6 +15,8 @@ import (
 	"fmt"
 	"sync"
 
+	sq "github.com/Masterminds/squirrel"
+
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
@@ -41,13 +43,15 @@ type Sanitizer interface {
 	Decode(string) (string, error)
 }
 
-func NewVaultStore(writeDB common3.WriteDB, readDB *sql.DB, tables VaultTables, errorWrapper driver2.SQLErrorWrapper, ci common4.CondInterpreter, pi common4.PagInterpreter, sanitizer sql2.Sanitizer, il common3.IsolationLevelMapper) *VaultStore {
+// NewVaultStore creates a VaultStore. ph is the squirrel PlaceholderFormat (sq.Dollar or sq.Question)
+// used for all SELECT queries; write queries continue to use the legacy builder with $N placeholders.
+func NewVaultStore(writeDB common3.WriteDB, readDB *sql.DB, tables VaultTables, errorWrapper driver2.SQLErrorWrapper, ci common4.CondInterpreter, ph sq.PlaceholderFormat, sanitizer sql2.Sanitizer, il common3.IsolationLevelMapper) *VaultStore {
+	sb := sq.StatementBuilder.PlaceholderFormat(ph)
 	vaultSanitizer := common3.NewSanitizer(sanitizer)
 	return &VaultStore{
 		vaultReader: &vaultReader{
 			readDB:    readDB,
-			ci:        ci,
-			pi:        pi,
+			sb:        sb,
 			sanitizer: vaultSanitizer,
 			tables:    tables,
 		},
@@ -67,8 +71,7 @@ type VaultStore struct {
 	errorWrapper driver2.SQLErrorWrapper
 	readDB       *sql.DB
 	writeDB      common3.WriteDB
-	ci           common4.CondInterpreter
-	pi           common4.PagInterpreter
+	ci           common4.CondInterpreter // kept for legacy write-path methods
 	GlobalLock   sync.RWMutex
 	sanitizer    Sanitizer
 	il           common3.IsolationLevelMapper
@@ -108,8 +111,7 @@ func (db *VaultStore) newTxLockVaultReader(ctx context.Context, isolationLevel d
 	}
 	return &vaultReader{
 		readDB:    tx,
-		ci:        db.ci,
-		pi:        db.pi,
+		sb:        db.vaultReader.sb,
 		sanitizer: db.sanitizer,
 		tables:    db.tables,
 	}, tx.Commit, nil
@@ -129,8 +131,7 @@ func (db *VaultStore) newGlobalLockVaultReader() (*vaultReader, releaseFunc, err
 	}
 	return &vaultReader{
 		readDB:    db.readDB,
-		ci:        db.ci,
-		pi:        db.pi,
+		sb:        db.vaultReader.sb,
 		sanitizer: db.sanitizer,
 		tables:    db.tables,
 	}, release, nil
@@ -221,7 +222,6 @@ func (db *VaultStore) convertStateRows(writes driver.Writes, metaWrites driver.M
 				return nil, errors.Wrapf(err, "failed to marshal metadata for [%s:%s]", ns, pkey)
 			}
 			if len(val.Raw) == 0 {
-				// Deleting value
 				logger.Debugf("setting version of [%s] to nil", pkey)
 				val.Version = nil
 			}
@@ -244,7 +244,6 @@ func (db *VaultStore) convertStateRows(writes driver.Writes, metaWrites driver.M
 		}
 		for pkey, metaVal := range metaWrite {
 			if _, ok = write[pkey]; ok {
-				// MetaWrites already written in the previous section
 				continue
 			}
 			metadata, err := marshallMetadata(metaVal.Metadata)
@@ -260,7 +259,6 @@ func (db *VaultStore) convertStateRows(writes driver.Writes, metaWrites driver.M
 				return nil, err
 			}
 			states = append(states, common4.Tuple{ns, pkey, []byte{}, metaVal.Version, metadata})
-
 		}
 	}
 	return states, nil
@@ -348,21 +346,21 @@ func (db *txVaultReader) GetTxStatuses(ctx context.Context, txIDs ...driver.TxID
 	return db.vr.GetTxStatuses(ctx, txIDs...)
 }
 
-func (db *txVaultReader) GetAllTxStatuses(ctx context.Context, pagination driver.Pagination) (*driver.PageIterator[*driver.TxStatus], error) {
+func (db *txVaultReader) GetAllTxStatuses(ctx context.Context, p driver.Pagination) (*driver.PageIterator[*driver.TxStatus], error) {
 	if err := db.setVaultReader(); err != nil {
 		return nil, err
 	}
-	return db.vr.GetAllTxStatuses(ctx, pagination)
+	return db.vr.GetAllTxStatuses(ctx, p)
 }
 
 func (db *txVaultReader) Done() error {
 	return db.release()
 }
 
+// vaultReader handles all read queries using squirrel for SELECT statements.
 type vaultReader struct {
 	readDB    dbReader
-	ci        common4.CondInterpreter
-	pi        common4.PagInterpreter
+	sb        sq.StatementBuilderType
 	sanitizer Sanitizer
 	tables    VaultTables
 }
@@ -376,29 +374,44 @@ func (db *vaultReader) GetState(ctx context.Context, namespace driver.Namespace,
 }
 
 func (db *vaultReader) GetStates(ctx context.Context, namespace driver.Namespace, keys ...driver.PKey) (driver.TxStateIterator, error) {
-	return db.queryState(ctx, cond2.And(cond2.Eq("ns", namespace), cond2.In("pkey", keys...)))
+	return db.queryState(ctx, sq.And{sq.Eq{"ns": namespace}, sq.Eq{"pkey": keys}})
 }
 
 func (db *vaultReader) GetStateRange(ctx context.Context, namespace driver.Namespace, startKey, endKey driver.PKey) (driver.TxStateIterator, error) {
-	return db.queryState(ctx, cond2.And(cond2.Eq("ns", namespace), cond2.BetweenStrings("pkey", startKey, endKey)))
+	return db.queryState(ctx, sq.And{sq.Eq{"ns": namespace}, betweenStrings("pkey", startKey, endKey)})
 }
 
 func (db *vaultReader) GetAllStates(ctx context.Context, namespace driver.Namespace) (driver.TxStateIterator, error) {
-	return db.queryState(ctx, cond2.Eq("ns", namespace))
+	return db.queryState(ctx, sq.Eq{"ns": namespace})
 }
 
-func (db *vaultReader) queryState(ctx context.Context, where cond2.Condition) (driver.TxStateIterator, error) {
-	query, params := q.Select().FieldsByName("pkey", "kversion", "val").
-		From(q.Table(db.tables.StateTable)).
+// betweenStrings returns a half-open [start, end) range condition, omitting a bound when it is empty.
+func betweenStrings(col, start, end string) sq.Sqlizer {
+	var parts sq.And
+	if start != "" {
+		parts = append(parts, sq.GtOrEq{col: start})
+	}
+	if end != "" {
+		parts = append(parts, sq.Lt{col: end})
+	}
+	return parts
+}
+
+func (db *vaultReader) queryState(ctx context.Context, where sq.Sqlizer) (driver.TxStateIterator, error) {
+	query, params, err := db.sb.Select("pkey", "kversion", "val").
+		From(db.tables.StateTable).
 		Where(where).
-		Format(db.ci)
-	params, err := db.sanitizer.EncodeAll(params)
+		ToSql()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to build query")
+	}
+	encodedParams, err := db.sanitizer.EncodeAll(params)
 	if err != nil {
 		return nil, err
 	}
 
-	logger.Debug(query, params)
-	rows, err := db.readDB.QueryContext(ctx, query, params...)
+	logger.Debug(query, encodedParams)
+	rows, err := db.readDB.QueryContext(ctx, query, encodedParams...)
 	if err != nil {
 		return nil, err
 	}
@@ -421,10 +434,13 @@ func (db *vaultReader) GetStateMetadata(ctx context.Context, namespace driver.Na
 		return nil, nil, err
 	}
 
-	query, params := q.Select().FieldsByName("metadata", "kversion").
-		From(q.Table(db.tables.StateTable)).
-		Where(cond2.And(cond2.Eq("ns", namespace), cond2.Eq("pkey", key))).
-		Format(db.ci)
+	query, params, err := db.sb.Select("metadata", "kversion").
+		From(db.tables.StateTable).
+		Where(sq.And{sq.Eq{"ns": namespace}, sq.Eq{"pkey": key}}).
+		ToSql()
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "failed to build query")
+	}
 	logger.Debug(query, params)
 
 	row := db.readDB.QueryRowContext(ctx, query, params...)
@@ -441,35 +457,22 @@ func (db *vaultReader) GetStateMetadata(ctx context.Context, namespace driver.Na
 	if err != nil {
 		return meta, nil, fmt.Errorf("error decoding metadata: %w", err)
 	}
-
 	return meta, kversion, err
 }
 
 func (db *vaultReader) GetLast(ctx context.Context) (*driver.TxStatus, error) {
-	it, err := db.queryStatus(ctx, IsLast(common4.TableName(db.tables.StatusTable)), pagination.None())
+	// Select the row with the highest pos that is not Busy
+	it, err := db.queryStatus(ctx,
+		sq.Expr("pos=(SELECT max(pos) FROM "+db.tables.StatusTable+" WHERE code!=?)", driver.Busy),
+		pagination.None())
 	if err != nil {
 		return nil, err
 	}
 	return collections.GetUnique(it)
 }
 
-func IsLast(tableName common4.TableName) *isLast {
-	return &isLast{tableName: tableName}
-}
-
-type isLast struct {
-	tableName common4.TableName
-}
-
-func (c *isLast) WriteString(_ common4.CondInterpreter, sb common4.Builder) {
-	sb.WriteString("pos=(SELECT max(pos) FROM ").
-		WriteString(string(c.tableName)).WriteString(" WHERE code!=").
-		WriteParam(driver.Busy).
-		WriteRune(')')
-}
-
 func (db *vaultReader) GetTxStatus(ctx context.Context, txID driver.TxID) (*driver.TxStatus, error) {
-	it, err := db.queryStatus(ctx, cond2.Eq("tx_id", txID), pagination.None())
+	it, err := db.queryStatus(ctx, sq.Eq{"tx_id": txID}, pagination.None())
 	if err != nil {
 		return nil, err
 	}
@@ -480,15 +483,13 @@ func (db *vaultReader) GetTxStatuses(ctx context.Context, txIDs ...driver.TxID) 
 	if len(txIDs) == 0 {
 		return collections.NewEmptyIterator[*driver.TxStatus](), nil
 	}
-
-	return db.queryStatus(ctx, cond2.In("tx_id", txIDs...), pagination.None())
+	return db.queryStatus(ctx, sq.Eq{"tx_id": txIDs}, pagination.None())
 }
 
 func (db *vaultReader) GetAllTxStatuses(ctx context.Context, p driver.Pagination) (*driver.PageIterator[*driver.TxStatus], error) {
 	if p == nil {
 		return nil, fmt.Errorf("invalid input pagination: %+v", p)
 	}
-
 	txStatusIterator, err := db.queryStatus(ctx, nil, p)
 	if err != nil {
 		return nil, err
@@ -496,12 +497,17 @@ func (db *vaultReader) GetAllTxStatuses(ctx context.Context, p driver.Pagination
 	return pagination.NewPage[driver.TxStatus](txStatusIterator, p)
 }
 
-func (db *vaultReader) queryStatus(ctx context.Context, where cond2.Condition, pagination driver.Pagination) (driver.TxStatusIterator, error) {
-	query, params := q.Select().FieldsByName("tx_id", "code", "message").
-		From(q.Table(db.tables.StatusTable)).
-		Where(where).
-		Paginated(pagination).
-		FormatPaginated(db.ci, db.pi)
+func (db *vaultReader) queryStatus(ctx context.Context, where sq.Sqlizer, p driver.Pagination) (driver.TxStatusIterator, error) {
+	sb := db.sb.Select("tx_id", "code", "message").From(db.tables.StatusTable)
+	if where != nil {
+		sb = sb.Where(where)
+	}
+	sb = pagination.ApplyToSquirrel(p, sb)
+
+	query, params, err := sb.ToSql()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to build query")
+	}
 	logger.Debug(query, params)
 
 	rows, err := db.readDB.QueryContext(ctx, query, params...)

--- a/platform/fabric/services/db/driver/sql/common/vault.go
+++ b/platform/fabric/services/db/driver/sql/common/vault.go
@@ -24,9 +24,7 @@ import (
 	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
 	sql2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql"
 	common3 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
-	q "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query"
 	common4 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/common"
-	cond2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/cond"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/pagination"
 )
 
@@ -44,8 +42,8 @@ type Sanitizer interface {
 }
 
 // NewVaultStore creates a VaultStore. ph is the squirrel PlaceholderFormat (sq.Dollar or sq.Question)
-// used for all SELECT queries; write queries continue to use the legacy builder with $N placeholders.
-func NewVaultStore(writeDB common3.WriteDB, readDB *sql.DB, tables VaultTables, errorWrapper driver2.SQLErrorWrapper, ci common4.CondInterpreter, ph sq.PlaceholderFormat, sanitizer sql2.Sanitizer, il common3.IsolationLevelMapper) *VaultStore {
+// used for all read and write queries.
+func NewVaultStore(writeDB common3.WriteDB, readDB *sql.DB, tables VaultTables, errorWrapper driver2.SQLErrorWrapper, ph sq.PlaceholderFormat, sanitizer sql2.Sanitizer, il common3.IsolationLevelMapper) *VaultStore {
 	sb := sq.StatementBuilder.PlaceholderFormat(ph)
 	vaultSanitizer := common3.NewSanitizer(sanitizer)
 	return &VaultStore{
@@ -59,7 +57,6 @@ func NewVaultStore(writeDB common3.WriteDB, readDB *sql.DB, tables VaultTables, 
 		errorWrapper: errorWrapper,
 		readDB:       readDB,
 		writeDB:      writeDB,
-		ci:           ci,
 		sanitizer:    vaultSanitizer,
 		il:           il,
 	}
@@ -71,7 +68,6 @@ type VaultStore struct {
 	errorWrapper driver2.SQLErrorWrapper
 	readDB       *sql.DB
 	writeDB      common3.WriteDB
-	ci           common4.CondInterpreter // kept for legacy write-path methods
 	GlobalLock   sync.RWMutex
 	sanitizer    Sanitizer
 	il           common3.IsolationLevelMapper
@@ -81,11 +77,14 @@ func (db *VaultStore) NewTxLockVaultReader(ctx context.Context, txID driver.TxID
 	logger.DebugfContext(ctx, "acquire tx id lock for [%s]", txID)
 
 	// Ignore conflicts in case replicas create the same entry when receiving the envelope
-	query, params := q.InsertInto(db.tables.StatusTable).
-		Fields("tx_id", "code").
-		Row(txID, driver.Busy).
-		OnConflictDoNothing().
-		Format()
+	query, params, err := db.sb.Insert(db.tables.StatusTable).
+		Columns("tx_id", "code").
+		Values(txID, driver.Busy).
+		Suffix("ON CONFLICT DO NOTHING").
+		ToSql()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to build query")
+	}
 	logger.Debug(query, params)
 
 	if _, err := db.writeDB.ExecContext(ctx, query, params...); err != nil {
@@ -141,19 +140,17 @@ func (db *VaultStore) SetStatuses(ctx context.Context, code driver.TxStatusCode,
 	db.GlobalLock.RLock()
 	defer db.GlobalLock.RUnlock()
 
-	rows := make([]common4.Tuple, len(txIDs))
-	for i, txID := range txIDs {
-		rows[i] = common4.Tuple{txID, code, message}
+	ib := db.sb.Insert(db.tables.StatusTable).
+		Columns("tx_id", "code", "message")
+	for _, txID := range txIDs {
+		ib = ib.Values(txID, code, message)
 	}
-
-	query, params := q.InsertInto(db.tables.StatusTable).
-		Fields("tx_id", "code", "message").
-		Rows(rows).
-		OnConflict([]common4.FieldName{"tx_id"},
-			q.SetValue("code", code),
-			q.SetValue("message", message),
-		).
-		Format()
+	query, params, err := ib.
+		Suffix("ON CONFLICT (tx_id) DO UPDATE SET code = EXCLUDED.code, message = EXCLUDED.message").
+		ToSql()
+	if err != nil {
+		return errors.Wrapf(err, "failed to build query")
+	}
 
 	logger.Debug(query, params)
 
@@ -163,41 +160,37 @@ func (db *VaultStore) SetStatuses(ctx context.Context, code driver.TxStatusCode,
 	return nil
 }
 
-func (db *VaultStore) SetStatusesBusy(txIDs []driver.TxID, sb common4.Builder) {
-	rows := make([]common4.Tuple, len(txIDs))
-	for i, txID := range txIDs {
-		rows[i] = common4.Tuple{txID, driver.Busy}
+func (db *VaultStore) SetStatusesBusy(txIDs []driver.TxID) (string, []any, error) {
+	ib := db.sb.Insert(db.tables.StatusTable).
+		Columns("tx_id", "code")
+	for _, txID := range txIDs {
+		ib = ib.Values(txID, driver.Busy)
 	}
-
-	q.InsertInto(db.tables.StatusTable).
-		Fields("tx_id", "code").
-		Rows(rows).
-		OnConflict([]common4.FieldName{"tx_id"}, q.SetValue("code", driver.Busy)).
-		FormatTo(sb)
+	return ib.
+		Suffix("ON CONFLICT (tx_id) DO UPDATE SET code = EXCLUDED.code").
+		ToSql()
 }
 
-func (db *VaultStore) UpsertStates(writes driver.Writes, metaWrites driver.MetaWrites, sb common4.Builder) error {
+func (db *VaultStore) UpsertStates(writes driver.Writes, metaWrites driver.MetaWrites) (string, []any, error) {
 	states, err := db.convertStateRows(writes, metaWrites)
 	if err != nil {
-		return err
+		return "", nil, err
 	}
-	q.InsertInto(db.tables.StateTable).
-		Fields("ns", "pkey", "val", "kversion", "metadata").
-		Rows(states).
-		OnConflict([]common4.FieldName{"ns", "pkey"},
-			q.OverwriteValue("val"),
-			q.OverwriteValue("kversion"),
-			q.OverwriteValue("metadata"),
-		).
-		FormatTo(sb)
-	return nil
+	ib := db.sb.Insert(db.tables.StateTable).
+		Columns("ns", "pkey", "val", "kversion", "metadata")
+	for _, s := range states {
+		ib = ib.Values(s...)
+	}
+	return ib.
+		Suffix("ON CONFLICT (ns,pkey) DO UPDATE SET val = EXCLUDED.val, kversion = EXCLUDED.kversion, metadata = EXCLUDED.metadata").
+		ToSql()
 }
 
-func (db *VaultStore) SetStatusesValid(txIDs []driver.TxID, sb common4.Builder) {
-	q.Update(db.tables.StatusTable).
+func (db *VaultStore) SetStatusesValid(txIDs []driver.TxID) (string, []any, error) {
+	return db.sb.Update(db.tables.StatusTable).
 		Set("code", driver.Valid).
-		Where(cond2.In("tx_id", txIDs...)).
-		FormatTo(db.ci, sb)
+		Where(sq.Eq{"tx_id": txIDs}).
+		ToSql()
 }
 
 func (db *VaultStore) convertStateRows(writes driver.Writes, metaWrites driver.MetaWrites) ([]common4.Tuple, error) {

--- a/platform/fabric/services/db/driver/sql/common/vault.go
+++ b/platform/fabric/services/db/driver/sql/common/vault.go
@@ -387,7 +387,8 @@ func (db *vaultReader) GetAllStates(ctx context.Context, namespace driver.Namesp
 	return db.queryState(ctx, sq.Eq{"ns": namespace})
 }
 
-// betweenStrings returns a half-open [start, end) range condition, omitting a bound when it is empty.
+// betweenStrings returns a squirrel condition matching rows where col falls
+// in the half-open range [start, end). Empty start or end omits that bound.
 func betweenStrings(col, start, end string) sq.Sqlizer {
 	var parts sq.And
 	if start != "" {
@@ -399,6 +400,8 @@ func betweenStrings(col, start, end string) sq.Sqlizer {
 	return parts
 }
 
+// queryState runs a SELECT on the state table filtered by where and returns
+// an iterator over the matching rows.
 func (db *vaultReader) queryState(ctx context.Context, where sq.Sqlizer) (driver.TxStateIterator, error) {
 	query, params, err := db.sb.Select("pkey", "kversion", "val").
 		From(db.tables.StateTable).
@@ -501,6 +504,8 @@ func (db *vaultReader) GetAllTxStatuses(ctx context.Context, p driver.Pagination
 	return pagination.NewPage[driver.TxStatus](txStatusIterator, p)
 }
 
+// queryStatus runs a SELECT on the status table filtered by the optional
+// where condition, applies pagination, and returns an iterator over the results.
 func (db *vaultReader) queryStatus(ctx context.Context, where sq.Sqlizer, p driver.Pagination) (driver.TxStatusIterator, error) {
 	sb := db.sb.Select("tx_id", "code", "message").From(db.tables.StatusTable)
 	if where != nil {

--- a/platform/fabric/services/db/driver/sql/common/vault_test.go
+++ b/platform/fabric/services/db/driver/sql/common/vault_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBetweenStrings_BothBounds(t *testing.T) { //nolint:paralleltest
+	sql, args, err := betweenStrings("pkey", "a", "z").ToSql()
+	require.NoError(t, err)
+	require.Equal(t, "(pkey >= ? AND pkey < ?)", sql)
+	require.Equal(t, []any{"a", "z"}, args)
+}
+
+func TestBetweenStrings_OnlyStart(t *testing.T) { //nolint:paralleltest
+	sql, args, err := betweenStrings("pkey", "a", "").ToSql()
+	require.NoError(t, err)
+	require.Equal(t, "(pkey >= ?)", sql)
+	require.Equal(t, []any{"a"}, args)
+}
+
+func TestBetweenStrings_OnlyEnd(t *testing.T) { //nolint:paralleltest
+	sql, args, err := betweenStrings("pkey", "", "z").ToSql()
+	require.NoError(t, err)
+	require.Equal(t, "(pkey < ?)", sql)
+	require.Equal(t, []any{"z"}, args)
+}

--- a/platform/fabric/services/db/driver/sql/postgres/vault.go
+++ b/platform/fabric/services/db/driver/sql/postgres/vault.go
@@ -20,7 +20,6 @@ import (
 	common3 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
 	postgres2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/postgres"
-	common5 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/common"
 )
 
 type VaultStore struct {
@@ -28,7 +27,6 @@ type VaultStore struct {
 
 	tables  common4.VaultTables
 	writeDB *sql.DB
-	ci      common5.CondInterpreter
 }
 
 func NewVaultStore(dbs *common3.RWDB, tables common4.TableNames) (*VaultStore, error) {
@@ -39,12 +37,10 @@ func NewVaultStore(dbs *common3.RWDB, tables common4.TableNames) (*VaultStore, e
 }
 
 func newVaultStore(readDB, writeDB *sql.DB, tables common4.VaultTables) *VaultStore {
-	ci := postgres2.NewConditionInterpreter()
 	return &VaultStore{
-		VaultStore: common4.NewVaultStore(writeDB, readDB, tables, &postgres2.ErrorMapper{}, ci, sq.Dollar, postgres2.NewSanitizer(), postgres2.IsolationLevels),
+		VaultStore: common4.NewVaultStore(writeDB, readDB, tables, &postgres2.ErrorMapper{}, sq.Dollar, postgres2.NewSanitizer(), postgres2.IsolationLevels),
 		tables:     tables,
 		writeDB:    writeDB,
-		ci:         ci,
 	}
 }
 
@@ -58,28 +54,32 @@ func (db *VaultStore) Store(ctx context.Context, txIDs []driver.TxID, writes dri
 	}
 
 	if len(txIDs) > 0 {
-		sb := common5.NewBuilder()
-		db.SetStatusesBusy(txIDs, sb)
-		query, args := sb.Build()
-		if err := execOrRollback(ctx, tx, query, args); err != nil {
+		query, params, err := db.SetStatusesBusy(txIDs)
+		if err != nil {
+			_ = tx.Rollback()
+			return errors.Wrapf(err, "failed building busy query")
+		}
+		if err := execOrRollback(ctx, tx, query, params); err != nil {
 			return errors.Wrapf(err, "failed setting tx to busy")
 		}
 	}
 	if len(writes) > 0 || len(metaWrites) > 0 {
-		sb := common5.NewBuilder()
-		if err := db.UpsertStates(writes, metaWrites, sb); err != nil {
-			return err
+		query, params, err := db.UpsertStates(writes, metaWrites)
+		if err != nil {
+			_ = tx.Rollback()
+			return errors.Wrapf(err, "failed building upsert states query")
 		}
-		query, args := sb.Build()
-		if err := execOrRollback(ctx, tx, query, args); err != nil {
+		if err := execOrRollback(ctx, tx, query, params); err != nil {
 			return errors.Wrapf(err, "failed writing state")
 		}
 	}
 	if len(txIDs) > 0 {
-		sb := common5.NewBuilder()
-		db.SetStatusesValid(txIDs, sb)
-		query, args := sb.Build()
-		if err := execOrRollback(ctx, tx, query, args); err != nil {
+		query, params, err := db.SetStatusesValid(txIDs)
+		if err != nil {
+			_ = tx.Rollback()
+			return errors.Wrapf(err, "failed building valid query")
+		}
+		if err := execOrRollback(ctx, tx, query, params); err != nil {
 			return errors.Wrapf(err, "failed setting tx to valid")
 		}
 	}

--- a/platform/fabric/services/db/driver/sql/postgres/vault.go
+++ b/platform/fabric/services/db/driver/sql/postgres/vault.go
@@ -9,7 +9,6 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	errors2 "errors"
 	"fmt"
 
 	sq "github.com/Masterminds/squirrel"
@@ -52,58 +51,40 @@ func (db *VaultStore) Store(ctx context.Context, txIDs []driver.TxID, writes dri
 	if err != nil {
 		return errors.Wrapf(err, "failed to initiate db transaction")
 	}
+	defer func() { _ = tx.Rollback() }()
 
 	if len(txIDs) > 0 {
 		query, params, err := db.SetStatusesBusy(txIDs)
 		if err != nil {
-			_ = tx.Rollback()
 			return errors.Wrapf(err, "failed building busy query")
 		}
-		if err := execOrRollback(ctx, tx, query, params); err != nil {
+		logger.Debug(query, len(params), params)
+		if _, err := tx.ExecContext(ctx, query, params...); err != nil {
 			return errors.Wrapf(err, "failed setting tx to busy")
 		}
 	}
 	if len(writes) > 0 || len(metaWrites) > 0 {
 		query, params, err := db.UpsertStates(writes, metaWrites)
 		if err != nil {
-			_ = tx.Rollback()
 			return errors.Wrapf(err, "failed building upsert states query")
 		}
-		if err := execOrRollback(ctx, tx, query, params); err != nil {
+		logger.Debug(query, len(params), params)
+		if _, err := tx.ExecContext(ctx, query, params...); err != nil {
 			return errors.Wrapf(err, "failed writing state")
 		}
 	}
 	if len(txIDs) > 0 {
 		query, params, err := db.SetStatusesValid(txIDs)
 		if err != nil {
-			_ = tx.Rollback()
 			return errors.Wrapf(err, "failed building valid query")
 		}
-		if err := execOrRollback(ctx, tx, query, params); err != nil {
+		logger.Debug(query, len(params), params)
+		if _, err := tx.ExecContext(ctx, query, params...); err != nil {
 			return errors.Wrapf(err, "failed setting tx to valid")
 		}
 	}
 
-	if err := tx.Commit(); err != nil {
-		if err2 := tx.Rollback(); err2 != nil {
-			return errors2.Join(err, err2)
-		}
-		return err
-	}
-
-	return nil
-}
-
-func execOrRollback(ctx context.Context, tx *sql.Tx, query string, params []any) error {
-	logger.Debug(query, len(params), params)
-
-	if _, err := tx.ExecContext(ctx, query, params...); err != nil {
-		if err2 := tx.Rollback(); err2 != nil {
-			return errors2.Join(err, err2)
-		}
-		return err
-	}
-	return nil
+	return tx.Commit()
 }
 
 func (db *VaultStore) CreateSchema() error {

--- a/platform/fabric/services/db/driver/sql/postgres/vault.go
+++ b/platform/fabric/services/db/driver/sql/postgres/vault.go
@@ -28,6 +28,8 @@ type VaultStore struct {
 	writeDB *sql.DB
 }
 
+// NewVaultStore creates a postgres-backed VaultStore for the given
+// read/write database and table names.
 func NewVaultStore(dbs *common3.RWDB, tables common4.TableNames) (*VaultStore, error) {
 	return newVaultStore(dbs.ReadDB, dbs.WriteDB, common4.VaultTables{
 		StateTable:  tables.State,
@@ -35,6 +37,8 @@ func NewVaultStore(dbs *common3.RWDB, tables common4.TableNames) (*VaultStore, e
 	}), nil
 }
 
+// newVaultStore is the internal constructor. It uses sq.Dollar as the
+// squirrel placeholder format for all PostgreSQL queries.
 func newVaultStore(readDB, writeDB *sql.DB, tables common4.VaultTables) *VaultStore {
 	return &VaultStore{
 		VaultStore: common4.NewVaultStore(writeDB, readDB, tables, &postgres2.ErrorMapper{}, sq.Dollar, postgres2.NewSanitizer(), postgres2.IsolationLevels),

--- a/platform/fabric/services/db/driver/sql/postgres/vault.go
+++ b/platform/fabric/services/db/driver/sql/postgres/vault.go
@@ -12,6 +12,8 @@ import (
 	errors2 "errors"
 	"fmt"
 
+	sq "github.com/Masterminds/squirrel"
+
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	common4 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver/sql/common"
@@ -27,7 +29,6 @@ type VaultStore struct {
 	tables  common4.VaultTables
 	writeDB *sql.DB
 	ci      common5.CondInterpreter
-	pi      common5.PagInterpreter
 }
 
 func NewVaultStore(dbs *common3.RWDB, tables common4.TableNames) (*VaultStore, error) {
@@ -39,13 +40,11 @@ func NewVaultStore(dbs *common3.RWDB, tables common4.TableNames) (*VaultStore, e
 
 func newVaultStore(readDB, writeDB *sql.DB, tables common4.VaultTables) *VaultStore {
 	ci := postgres2.NewConditionInterpreter()
-	pi := postgres2.NewPaginationInterpreter()
 	return &VaultStore{
-		VaultStore: common4.NewVaultStore(writeDB, readDB, tables, &postgres2.ErrorMapper{}, ci, pi, postgres2.NewSanitizer(), postgres2.IsolationLevels),
+		VaultStore: common4.NewVaultStore(writeDB, readDB, tables, &postgres2.ErrorMapper{}, ci, sq.Dollar, postgres2.NewSanitizer(), postgres2.IsolationLevels),
 		tables:     tables,
 		writeDB:    writeDB,
 		ci:         ci,
-		pi:         pi,
 	}
 }
 

--- a/platform/fabric/services/db/driver/sql/sqlite/vault.go
+++ b/platform/fabric/services/db/driver/sql/sqlite/vault.go
@@ -9,7 +9,6 @@ package sqlite
 import (
 	"context"
 	"database/sql"
-	errors2 "errors"
 	"fmt"
 
 	sq "github.com/Masterminds/squirrel"
@@ -58,16 +57,15 @@ func (db *VaultStore) Store(ctx context.Context, txIDs []driver.TxID, writes dri
 	if err != nil {
 		return errors.Wrapf(err, "failed to initiate db transaction")
 	}
+	defer func() { _ = tx.Rollback() }()
 
 	if len(txIDs) > 0 {
 		query, params, err := db.SetStatusesBusy(txIDs)
 		if err != nil {
-			_ = tx.Rollback()
 			return errors.Wrapf(err, "failed building busy query")
 		}
 		logger.Debug(query, txIDs)
 		if _, err := tx.ExecContext(ctx, query, params...); err != nil {
-			_ = tx.Rollback()
 			return errors.Wrapf(err, "failed setting tx to busy")
 		}
 	}
@@ -75,12 +73,10 @@ func (db *VaultStore) Store(ctx context.Context, txIDs []driver.TxID, writes dri
 	if len(writes) > 0 || len(metaWrites) > 0 {
 		query, params, err := db.UpsertStates(writes, metaWrites)
 		if err != nil {
-			_ = tx.Rollback()
 			return errors.Wrapf(err, "failed building upsert states query")
 		}
 		logger.Debug(query, logging.Keys(writes))
 		if _, err := tx.ExecContext(ctx, query, params...); err != nil {
-			_ = tx.Rollback()
 			return errors.Wrapf(err, "failed writing state")
 		}
 	}
@@ -88,23 +84,15 @@ func (db *VaultStore) Store(ctx context.Context, txIDs []driver.TxID, writes dri
 	if len(txIDs) > 0 {
 		query, params, err := db.SetStatusesValid(txIDs)
 		if err != nil {
-			_ = tx.Rollback()
 			return errors.Wrapf(err, "failed building valid query")
 		}
 		logger.Debug(query, txIDs)
 		if _, err := tx.ExecContext(ctx, query, params...); err != nil {
-			_ = tx.Rollback()
 			return errors.Wrapf(err, "failed setting tx to valid")
 		}
 	}
 
-	if err := tx.Commit(); err != nil {
-		if err2 := tx.Rollback(); err2 != nil {
-			return errors2.Join(err, err2)
-		}
-		return err
-	}
-	return nil
+	return tx.Commit()
 }
 
 func (db *VaultStore) CreateSchema() error {

--- a/platform/fabric/services/db/driver/sql/sqlite/vault.go
+++ b/platform/fabric/services/db/driver/sql/sqlite/vault.go
@@ -9,6 +9,7 @@ package sqlite
 import (
 	"context"
 	"database/sql"
+	errors2 "errors"
 	"fmt"
 
 	sq "github.com/Masterminds/squirrel"
@@ -19,7 +20,6 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver/sql/common"
 	common3 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
 	common5 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
-	common4 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/common"
 	sqlite2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/sqlite"
 )
 
@@ -28,8 +28,6 @@ type VaultStore struct {
 
 	tables  common.VaultTables
 	writeDB common5.WriteDB
-
-	ci common4.CondInterpreter
 }
 
 func NewVaultStore(dbs *common3.RWDB, tables common.TableNames) (*VaultStore, error) {
@@ -40,12 +38,10 @@ func NewVaultStore(dbs *common3.RWDB, tables common.TableNames) (*VaultStore, er
 }
 
 func newVaultStore(readDB *sql.DB, writeDB common5.WriteDB, tables common.VaultTables) *VaultStore {
-	ci := sqlite2.NewConditionInterpreter()
 	return &VaultStore{
-		VaultStore: common.NewVaultStore(writeDB, readDB, tables, &sqlite2.ErrorMapper{}, ci, sq.Question, sqlite2.NewSanitizer(), sqlite2.IsolationLevels),
+		VaultStore: common.NewVaultStore(writeDB, readDB, tables, &sqlite2.ErrorMapper{}, sq.Question, sqlite2.NewSanitizer(), sqlite2.IsolationLevels),
 		tables:     tables,
 		writeDB:    writeDB,
-		ci:         ci,
 	}
 }
 
@@ -55,39 +51,58 @@ func (db *VaultStore) Store(ctx context.Context, txIDs []driver.TxID, writes dri
 		return nil
 	}
 
-	sb := common4.NewBuilder().
-		WriteString(`
-		BEGIN;
-`)
+	db.GlobalLock.RLock()
+	defer db.GlobalLock.RUnlock()
+
+	tx, err := db.writeDB.Begin()
+	if err != nil {
+		return errors.Wrapf(err, "failed to initiate db transaction")
+	}
 
 	if len(txIDs) > 0 {
-		db.SetStatusesBusy(txIDs, sb)
-		sb.WriteRune(';')
+		query, params, err := db.SetStatusesBusy(txIDs)
+		if err != nil {
+			_ = tx.Rollback()
+			return errors.Wrapf(err, "failed building busy query")
+		}
+		logger.Debug(query, txIDs)
+		if _, err := tx.ExecContext(ctx, query, params...); err != nil {
+			_ = tx.Rollback()
+			return errors.Wrapf(err, "failed setting tx to busy")
+		}
 	}
 
 	if len(writes) > 0 || len(metaWrites) > 0 {
-		if err := db.UpsertStates(writes, metaWrites, sb); err != nil {
-			return err
+		query, params, err := db.UpsertStates(writes, metaWrites)
+		if err != nil {
+			_ = tx.Rollback()
+			return errors.Wrapf(err, "failed building upsert states query")
 		}
-		sb.WriteRune(';')
+		logger.Debug(query, logging.Keys(writes))
+		if _, err := tx.ExecContext(ctx, query, params...); err != nil {
+			_ = tx.Rollback()
+			return errors.Wrapf(err, "failed writing state")
+		}
 	}
 
 	if len(txIDs) > 0 {
-		db.SetStatusesValid(txIDs, sb)
-		sb.WriteRune(';')
+		query, params, err := db.SetStatusesValid(txIDs)
+		if err != nil {
+			_ = tx.Rollback()
+			return errors.Wrapf(err, "failed building valid query")
+		}
+		logger.Debug(query, txIDs)
+		if _, err := tx.ExecContext(ctx, query, params...); err != nil {
+			_ = tx.Rollback()
+			return errors.Wrapf(err, "failed setting tx to valid")
+		}
 	}
 
-	sb.WriteString(`
-		COMMIT;
-`)
-
-	query, args := sb.Build()
-
-	logger.Debug(query, txIDs, logging.Keys(writes))
-	db.GlobalLock.RLock()
-	defer db.GlobalLock.RUnlock()
-	if _, err := db.writeDB.ExecContext(ctx, query, args...); err != nil {
-		return errors.Wrapf(err, "failed to store writes and metawrites for %d txs", len(txIDs))
+	if err := tx.Commit(); err != nil {
+		if err2 := tx.Rollback(); err2 != nil {
+			return errors2.Join(err, err2)
+		}
+		return err
 	}
 	return nil
 }

--- a/platform/fabric/services/db/driver/sql/sqlite/vault.go
+++ b/platform/fabric/services/db/driver/sql/sqlite/vault.go
@@ -11,6 +11,8 @@ import (
 	"database/sql"
 	"fmt"
 
+	sq "github.com/Masterminds/squirrel"
+
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
@@ -28,7 +30,6 @@ type VaultStore struct {
 	writeDB common5.WriteDB
 
 	ci common4.CondInterpreter
-	pi common4.PagInterpreter
 }
 
 func NewVaultStore(dbs *common3.RWDB, tables common.TableNames) (*VaultStore, error) {
@@ -40,13 +41,11 @@ func NewVaultStore(dbs *common3.RWDB, tables common.TableNames) (*VaultStore, er
 
 func newVaultStore(readDB *sql.DB, writeDB common5.WriteDB, tables common.VaultTables) *VaultStore {
 	ci := sqlite2.NewConditionInterpreter()
-	pi := sqlite2.NewPaginationInterpreter()
 	return &VaultStore{
-		VaultStore: common.NewVaultStore(writeDB, readDB, tables, &sqlite2.ErrorMapper{}, ci, pi, sqlite2.NewSanitizer(), sqlite2.IsolationLevels),
+		VaultStore: common.NewVaultStore(writeDB, readDB, tables, &sqlite2.ErrorMapper{}, ci, sq.Question, sqlite2.NewSanitizer(), sqlite2.IsolationLevels),
 		tables:     tables,
 		writeDB:    writeDB,
 		ci:         ci,
-		pi:         pi,
 	}
 }
 

--- a/platform/view/services/storage/driver/sql/query/pagination/squirrel.go
+++ b/platform/view/services/storage/driver/sql/query/pagination/squirrel.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 )
 
+// ApplyToSquirrel translates a driver.Pagination into squirrel limit/offset
+// clauses applied to sb and returns the modified SelectBuilder.
 // ApplyToSquirrel applies a driver.Pagination to a squirrel SelectBuilder by adding
 // the appropriate LIMIT, OFFSET, ORDER BY, and WHERE clauses.
 // It lives in this package because it needs access to the unexported pagination types.

--- a/platform/view/services/storage/driver/sql/query/pagination/squirrel.go
+++ b/platform/view/services/storage/driver/sql/query/pagination/squirrel.go
@@ -19,6 +19,9 @@ import (
 // It lives in this package because it needs access to the unexported pagination types.
 func ApplyToSquirrel(p driver.Pagination, sb sq.SelectBuilder) sq.SelectBuilder {
 	switch pg := p.(type) {
+	case nil:
+		return sb
+
 	case *none:
 		return sb
 

--- a/platform/view/services/storage/driver/sql/query/pagination/squirrel.go
+++ b/platform/view/services/storage/driver/sql/query/pagination/squirrel.go
@@ -14,8 +14,6 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 )
 
-// ApplyToSquirrel translates a driver.Pagination into squirrel limit/offset
-// clauses applied to sb and returns the modified SelectBuilder.
 // ApplyToSquirrel applies a driver.Pagination to a squirrel SelectBuilder by adding
 // the appropriate LIMIT, OFFSET, ORDER BY, and WHERE clauses.
 // It lives in this package because it needs access to the unexported pagination types.

--- a/platform/view/services/storage/driver/sql/query/pagination/squirrel.go
+++ b/platform/view/services/storage/driver/sql/query/pagination/squirrel.go
@@ -1,0 +1,55 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pagination
+
+import (
+	"fmt"
+
+	sq "github.com/Masterminds/squirrel"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+)
+
+// ApplyToSquirrel applies a driver.Pagination to a squirrel SelectBuilder by adding
+// the appropriate LIMIT, OFFSET, ORDER BY, and WHERE clauses.
+// It lives in this package because it needs access to the unexported pagination types.
+func ApplyToSquirrel(p driver.Pagination, sb sq.SelectBuilder) sq.SelectBuilder {
+	switch pg := p.(type) {
+	case *none:
+		return sb
+
+	case *offset:
+		sb = sb.Limit(uint64(pg.PageSize))
+		if pg.Offset > 0 {
+			sb = sb.Offset(uint64(pg.Offset))
+		}
+		return sb
+
+	case *keyset[string, any]:
+		return applyKeysetSquirrel(pg, sb)
+
+	case *keyset[int, any]:
+		return applyKeysetSquirrel(pg, sb)
+
+	case *empty:
+		return sb.Limit(0)
+
+	default:
+		panic(fmt.Sprintf("invalid pagination option %+v", p))
+	}
+}
+
+func applyKeysetSquirrel[T comparable](pg *keyset[T, any], sb sq.SelectBuilder) sq.SelectBuilder {
+	col := string(pg.SQLIDName)
+	sb = sb.OrderBy(col + " ASC").Limit(uint64(pg.PageSize))
+	if pg.FirstID != pg.nilElement() {
+		sb = sb.Where(sq.Gt{col: pg.FirstID})
+	} else if pg.Offset > 0 {
+		sb = sb.Offset(uint64(pg.Offset))
+	}
+	return sb
+}

--- a/platform/view/services/storage/driver/sql/query/pagination/squirrel_test.go
+++ b/platform/view/services/storage/driver/sql/query/pagination/squirrel_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	sq "github.com/Masterminds/squirrel"
-	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/pagination"
 )
@@ -19,44 +19,85 @@ func baseQuery() sq.SelectBuilder {
 	return sq.Select("tx_id", "code").From("status")
 }
 
-func TestApplyToSquirrel_None(t *testing.T) { //nolint:paralleltest
-	RegisterTestingT(t)
-
-	q, args, err := pagination.ApplyToSquirrel(pagination.None(), baseQuery()).ToSql()
-	Expect(err).ToNot(HaveOccurred())
-	Expect(q).To(Equal("SELECT tx_id, code FROM status"))
-	Expect(args).To(BeEmpty())
-}
-
-func TestApplyToSquirrel_PageSizeOnly(t *testing.T) { //nolint:paralleltest
-	RegisterTestingT(t)
-
-	p, err := pagination.Offset(0, 10)
-	Expect(err).ToNot(HaveOccurred())
-
-	q, args, err := pagination.ApplyToSquirrel(p, baseQuery()).ToSql()
-	Expect(err).ToNot(HaveOccurred())
-	Expect(q).To(Equal("SELECT tx_id, code FROM status LIMIT 10"))
-	Expect(args).To(BeEmpty())
-}
-
-func TestApplyToSquirrel_PageSizeAndOffset(t *testing.T) { //nolint:paralleltest
-	RegisterTestingT(t)
-
-	p, err := pagination.Offset(5, 10)
-	Expect(err).ToNot(HaveOccurred())
-
-	q, args, err := pagination.ApplyToSquirrel(p, baseQuery()).ToSql()
-	Expect(err).ToNot(HaveOccurred())
-	Expect(q).To(Equal("SELECT tx_id, code FROM status LIMIT 10 OFFSET 5"))
-	Expect(args).To(BeEmpty())
-}
-
 func TestApplyToSquirrel_Nil(t *testing.T) { //nolint:paralleltest
-	RegisterTestingT(t)
-
 	q, args, err := pagination.ApplyToSquirrel(nil, baseQuery()).ToSql()
-	Expect(err).ToNot(HaveOccurred())
-	Expect(q).To(Equal("SELECT tx_id, code FROM status"))
-	Expect(args).To(BeEmpty())
+	require.NoError(t, err)
+	require.Equal(t, "SELECT tx_id, code FROM status", q)
+	require.Empty(t, args)
+}
+
+func TestApplyToSquirrel_None(t *testing.T) { //nolint:paralleltest
+	q, args, err := pagination.ApplyToSquirrel(pagination.None(), baseQuery()).ToSql()
+	require.NoError(t, err)
+	require.Equal(t, "SELECT tx_id, code FROM status", q)
+	require.Empty(t, args)
+}
+
+func TestApplyToSquirrel_Empty(t *testing.T) { //nolint:paralleltest
+	q, args, err := pagination.ApplyToSquirrel(pagination.Empty(), baseQuery()).ToSql()
+	require.NoError(t, err)
+	require.Equal(t, "SELECT tx_id, code FROM status LIMIT 0", q)
+	require.Empty(t, args)
+}
+
+func TestApplyToSquirrel_OffsetPageSizeOnly(t *testing.T) { //nolint:paralleltest
+	p, err := pagination.Offset(0, 10)
+	require.NoError(t, err)
+
+	q, args, err := pagination.ApplyToSquirrel(p, baseQuery()).ToSql()
+	require.NoError(t, err)
+	require.Equal(t, "SELECT tx_id, code FROM status LIMIT 10", q)
+	require.Empty(t, args)
+}
+
+func TestApplyToSquirrel_OffsetAndPageSize(t *testing.T) { //nolint:paralleltest
+	p, err := pagination.Offset(5, 10)
+	require.NoError(t, err)
+
+	q, args, err := pagination.ApplyToSquirrel(p, baseQuery()).ToSql()
+	require.NoError(t, err)
+	require.Equal(t, "SELECT tx_id, code FROM status LIMIT 10 OFFSET 5", q)
+	require.Empty(t, args)
+}
+
+func TestApplyToSquirrel_KeysetString_NoFirstID(t *testing.T) { //nolint:paralleltest
+	p, err := pagination.Keyset[string, any](0, 10, "tx_id", nil)
+	require.NoError(t, err)
+
+	q, args, err := pagination.ApplyToSquirrel(p, baseQuery()).ToSql()
+	require.NoError(t, err)
+	require.Equal(t, "SELECT tx_id, code FROM status ORDER BY tx_id ASC LIMIT 10", q)
+	require.Empty(t, args)
+}
+
+func TestApplyToSquirrel_KeysetString_WithFirstID(t *testing.T) { //nolint:paralleltest
+	raw := []byte(`{"offset":0,"page_size":10,"sqlid_name":"tx_id","first_id":"abc","last_id":""}`)
+	p, err := pagination.KeysetFromRaw[string](raw, "TxID")
+	require.NoError(t, err)
+
+	q, args, err := pagination.ApplyToSquirrel(p, baseQuery()).ToSql()
+	require.NoError(t, err)
+	require.Equal(t, "SELECT tx_id, code FROM status WHERE tx_id > ? ORDER BY tx_id ASC LIMIT 10", q)
+	require.Equal(t, []any{"abc"}, args)
+}
+
+func TestApplyToSquirrel_KeysetString_WithOffset(t *testing.T) { //nolint:paralleltest
+	p, err := pagination.Keyset[string, any](5, 10, "tx_id", nil)
+	require.NoError(t, err)
+
+	q, args, err := pagination.ApplyToSquirrel(p, baseQuery()).ToSql()
+	require.NoError(t, err)
+	require.Equal(t, "SELECT tx_id, code FROM status ORDER BY tx_id ASC LIMIT 10 OFFSET 5", q)
+	require.Empty(t, args)
+}
+
+func TestApplyToSquirrel_KeysetInt_NoFirstID(t *testing.T) { //nolint:paralleltest
+	raw := []byte(`{"offset":0,"page_size":10,"sqlid_name":"pos","first_id":-1,"last_id":-1}`)
+	p, err := pagination.KeysetFromRaw[int](raw, "Pos")
+	require.NoError(t, err)
+
+	q, args, err := pagination.ApplyToSquirrel(p, baseQuery()).ToSql()
+	require.NoError(t, err)
+	require.Equal(t, "SELECT tx_id, code FROM status ORDER BY pos ASC LIMIT 10", q)
+	require.Empty(t, args)
 }

--- a/platform/view/services/storage/driver/sql/query/pagination/squirrel_test.go
+++ b/platform/view/services/storage/driver/sql/query/pagination/squirrel_test.go
@@ -19,28 +19,31 @@ func baseQuery() sq.SelectBuilder {
 	return sq.Select("tx_id", "code").From("status")
 }
 
-func TestApplyToSquirrel_Nil(t *testing.T) { //nolint:paralleltest
+func TestApplyToSquirrel_Nil(t *testing.T) {
+	t.Parallel()
 	q, args, err := pagination.ApplyToSquirrel(nil, baseQuery()).ToSql()
 	require.NoError(t, err)
 	require.Equal(t, "SELECT tx_id, code FROM status", q)
 	require.Empty(t, args)
 }
 
-func TestApplyToSquirrel_None(t *testing.T) { //nolint:paralleltest
+func TestApplyToSquirrel_None(t *testing.T) {
+	t.Parallel()
 	q, args, err := pagination.ApplyToSquirrel(pagination.None(), baseQuery()).ToSql()
 	require.NoError(t, err)
 	require.Equal(t, "SELECT tx_id, code FROM status", q)
 	require.Empty(t, args)
 }
 
-func TestApplyToSquirrel_Empty(t *testing.T) { //nolint:paralleltest
+func TestApplyToSquirrel_Empty(t *testing.T) {
+	t.Parallel()
 	q, args, err := pagination.ApplyToSquirrel(pagination.Empty(), baseQuery()).ToSql()
 	require.NoError(t, err)
 	require.Equal(t, "SELECT tx_id, code FROM status LIMIT 0", q)
 	require.Empty(t, args)
 }
 
-func TestApplyToSquirrel_OffsetPageSizeOnly(t *testing.T) { //nolint:paralleltest
+func TestApplyToSquirrel_OffsetPageSizeOnly(t *testing.T) {
 	p, err := pagination.Offset(0, 10)
 	require.NoError(t, err)
 
@@ -50,7 +53,8 @@ func TestApplyToSquirrel_OffsetPageSizeOnly(t *testing.T) { //nolint:paralleltes
 	require.Empty(t, args)
 }
 
-func TestApplyToSquirrel_OffsetAndPageSize(t *testing.T) { //nolint:paralleltest
+func TestApplyToSquirrel_OffsetAndPageSize(t *testing.T) {
+	t.Parallel()
 	p, err := pagination.Offset(5, 10)
 	require.NoError(t, err)
 
@@ -60,7 +64,8 @@ func TestApplyToSquirrel_OffsetAndPageSize(t *testing.T) { //nolint:paralleltest
 	require.Empty(t, args)
 }
 
-func TestApplyToSquirrel_KeysetString_NoFirstID(t *testing.T) { //nolint:paralleltest
+func TestApplyToSquirrel_KeysetString_NoFirstID(t *testing.T) {
+	t.Parallel()
 	p, err := pagination.Keyset[string, any](0, 10, "tx_id", nil)
 	require.NoError(t, err)
 
@@ -70,7 +75,8 @@ func TestApplyToSquirrel_KeysetString_NoFirstID(t *testing.T) { //nolint:paralle
 	require.Empty(t, args)
 }
 
-func TestApplyToSquirrel_KeysetString_WithFirstID(t *testing.T) { //nolint:paralleltest
+func TestApplyToSquirrel_KeysetString_WithFirstID(t *testing.T) {
+	t.Parallel()
 	raw := []byte(`{"offset":0,"page_size":10,"sqlid_name":"tx_id","first_id":"abc","last_id":""}`)
 	p, err := pagination.KeysetFromRaw[string](raw, "TxID")
 	require.NoError(t, err)
@@ -81,7 +87,8 @@ func TestApplyToSquirrel_KeysetString_WithFirstID(t *testing.T) { //nolint:paral
 	require.Equal(t, []any{"abc"}, args)
 }
 
-func TestApplyToSquirrel_KeysetString_WithOffset(t *testing.T) { //nolint:paralleltest
+func TestApplyToSquirrel_KeysetString_WithOffset(t *testing.T) {
+	t.Parallel()
 	p, err := pagination.Keyset[string, any](5, 10, "tx_id", nil)
 	require.NoError(t, err)
 
@@ -91,7 +98,8 @@ func TestApplyToSquirrel_KeysetString_WithOffset(t *testing.T) { //nolint:parall
 	require.Empty(t, args)
 }
 
-func TestApplyToSquirrel_KeysetInt_NoFirstID(t *testing.T) { //nolint:paralleltest
+func TestApplyToSquirrel_KeysetInt_NoFirstID(t *testing.T) {
+	t.Parallel()
 	raw := []byte(`{"offset":0,"page_size":10,"sqlid_name":"pos","first_id":-1,"last_id":-1}`)
 	p, err := pagination.KeysetFromRaw[int](raw, "Pos")
 	require.NoError(t, err)

--- a/platform/view/services/storage/driver/sql/query/pagination/squirrel_test.go
+++ b/platform/view/services/storage/driver/sql/query/pagination/squirrel_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pagination_test
+
+import (
+	"testing"
+
+	sq "github.com/Masterminds/squirrel"
+	. "github.com/onsi/gomega"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/query/pagination"
+)
+
+func baseQuery() sq.SelectBuilder {
+	return sq.Select("tx_id", "code").From("status")
+}
+
+func TestApplyToSquirrel_None(t *testing.T) { //nolint:paralleltest
+	RegisterTestingT(t)
+
+	q, args, err := pagination.ApplyToSquirrel(pagination.None(), baseQuery()).ToSql()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(q).To(Equal("SELECT tx_id, code FROM status"))
+	Expect(args).To(BeEmpty())
+}
+
+func TestApplyToSquirrel_PageSizeOnly(t *testing.T) { //nolint:paralleltest
+	RegisterTestingT(t)
+
+	p, err := pagination.Offset(0, 10)
+	Expect(err).ToNot(HaveOccurred())
+
+	q, args, err := pagination.ApplyToSquirrel(p, baseQuery()).ToSql()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(q).To(Equal("SELECT tx_id, code FROM status LIMIT 10"))
+	Expect(args).To(BeEmpty())
+}
+
+func TestApplyToSquirrel_PageSizeAndOffset(t *testing.T) { //nolint:paralleltest
+	RegisterTestingT(t)
+
+	p, err := pagination.Offset(5, 10)
+	Expect(err).ToNot(HaveOccurred())
+
+	q, args, err := pagination.ApplyToSquirrel(p, baseQuery()).ToSql()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(q).To(Equal("SELECT tx_id, code FROM status LIMIT 10 OFFSET 5"))
+	Expect(args).To(BeEmpty())
+}
+
+func TestApplyToSquirrel_Nil(t *testing.T) { //nolint:paralleltest
+	RegisterTestingT(t)
+
+	q, args, err := pagination.ApplyToSquirrel(nil, baseQuery()).ToSql()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(q).To(Equal("SELECT tx_id, code FROM status"))
+	Expect(args).To(BeEmpty())
+}

--- a/platform/view/services/storage/driver/sql/query/pagination/squirrel_test.go
+++ b/platform/view/services/storage/driver/sql/query/pagination/squirrel_test.go
@@ -44,6 +44,7 @@ func TestApplyToSquirrel_Empty(t *testing.T) {
 }
 
 func TestApplyToSquirrel_OffsetPageSizeOnly(t *testing.T) {
+	t.Parallel()
 	p, err := pagination.Offset(0, 10)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Closes #1272

Migrates VaultStore SELECT queries from the legacy query builder to squirrel, following the same pattern as the SignerInfoStore migration (PR #1235).

## Changes
-> `platform/view/services/storage/driver/sql/query/pagination/squirrel.go` - new `ApplyToSquirrel` helper that translates `driver.Pagination` into squirrel `.Limit()/.Offset()` calls
-> `platform/fabric/services/db/driver/sql/common/vault.go` - `NewVaultStore` now takes `sq.PlaceholderFormat` instead of `PagInterpreter`; all SELECT queries migrated to squirrel
-> `platform/fabric/services/db/driver/sql/sqlite/vault.go` - passes `sq.Question`
-> `platform/fabric/services/db/driver/sql/postgres/vault.go` - passes `sq.Dollar`

## Design (per @mbrandenburger)
Built a squirrel-based `ApplyToSquirrel` helper in the pagination package rather than bypassing `PagInterpreter` entirely, preserving existing pagination semantics while removing the dependency on the legacy query builder.

All existing vault tests pass.