### PR TITLE
tls: align supported protocol versions

### DIFF
--- a/platform/fabricx/core/committer/grpc/grpc.go
+++ b/platform/fabricx/core/committer/grpc/grpc.go
@@ -118,7 +118,8 @@ func TransportCredentials(tlsConfig *config.TLSConfig) (credentials.TransportCre
 	}
 
 	t := &tls.Config{
-		MinVersion: tls.VersionTLS13,
+		MinVersion: tls.VersionTLS12,
+		MaxVersion: tls.VersionTLS13,
 		ServerName: tlsConfig.ServerNameOverride,
 	}
 

--- a/platform/fabricx/core/committer/grpc/grpc_test.go
+++ b/platform/fabricx/core/committer/grpc/grpc_test.go
@@ -329,31 +329,42 @@ func TestClientConn_Integration(t *testing.T) {
 		t.Parallel()
 		certFile, keyFile := generateServerCertAndKey(t)
 
-		serverCert, err := tls.LoadX509KeyPair(certFile, keyFile)
-		require.NoError(t, err)
-		serverTLSCfg := &tls.Config{
-			Certificates: []tls.Certificate{serverCert},
-			MinVersion:   tls.VersionTLS12,
-			MaxVersion:   tls.VersionTLS12,
-		}
-		addr := startTestServer(t, grpc.Creds(credentials.NewTLS(serverTLSCfg)))
+		t.Run("tls12", func(t *testing.T) {
+			t.Parallel()
 
-		cfg := &config.Config{
-			Endpoints: []config.Endpoint{{
-				Address: addr,
-				TLS: &config.TLSConfig{
-					Enabled:       true,
-					RootCertPaths: []string{certFile},
-				},
-			}},
-		}
-		cc, err := grpc2.ClientConn(cfg)
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			_ = cc.Close()
+			addr := startTestServer(t, grpc.Creds(credentials.NewTLS(newServerTLSConfig(t, certFile, keyFile, nil, tls.VersionTLS12, tls.VersionTLS12))))
+			cc := newClientConnWithTLS(t, addr, certFile, "", "")
+			t.Cleanup(func() {
+				_ = cc.Close()
+			})
+
+			invokeHealthCheck(t, cc)
 		})
 
-		invokeHealthCheck(t, cc)
+		t.Run("tls13", func(t *testing.T) {
+			t.Parallel()
+
+			addr := startTestServer(t, grpc.Creds(credentials.NewTLS(newServerTLSConfig(t, certFile, keyFile, nil, tls.VersionTLS13, tls.VersionTLS13))))
+			cc := newClientConnWithTLS(t, addr, certFile, "", "")
+			t.Cleanup(func() {
+				_ = cc.Close()
+			})
+
+			invokeHealthCheck(t, cc)
+		})
+
+		t.Run("tls10-tls11 rejected", func(t *testing.T) {
+			t.Parallel()
+
+			addr := startTestServer(t, grpc.Creds(credentials.NewTLS(newServerTLSConfig(t, certFile, keyFile, nil, tls.VersionTLS10, tls.VersionTLS11))))
+			cc := newClientConnWithTLS(t, addr, certFile, "", "")
+			t.Cleanup(func() {
+				_ = cc.Close()
+			})
+
+			err := invokeHealthCheckErr(t, cc)
+			require.ErrorContains(t, err, "tls: protocol version not supported")
+		})
 	})
 
 	t.Run("mtls", func(t *testing.T) {
@@ -361,42 +372,79 @@ func TestClientConn_Integration(t *testing.T) {
 		serverCertFile, serverKeyFile := generateServerCertAndKey(t)
 		clientCertFile, clientKeyFile := generateServerCertAndKey(t)
 
-		serverCert, err := tls.LoadX509KeyPair(serverCertFile, serverKeyFile)
-		require.NoError(t, err)
-
 		clientCACert, err := os.ReadFile(clientCertFile)
 		require.NoError(t, err)
 		clientCAs := x509.NewCertPool()
 		require.True(t, clientCAs.AppendCertsFromPEM(clientCACert))
 
-		serverTLSCfg := &tls.Config{
-			Certificates: []tls.Certificate{serverCert},
-			ClientAuth:   tls.RequireAndVerifyClientCert,
-			ClientCAs:    clientCAs,
-			MinVersion:   tls.VersionTLS12,
-			MaxVersion:   tls.VersionTLS12,
-		}
-		addr := startTestServer(t, grpc.Creds(credentials.NewTLS(serverTLSCfg)))
+		t.Run("tls12", func(t *testing.T) {
+			t.Parallel()
 
-		cfg := &config.Config{
-			Endpoints: []config.Endpoint{{
-				Address: addr,
-				TLS: &config.TLSConfig{
-					Enabled:        true,
-					RootCertPaths:  []string{serverCertFile},
-					ClientCertPath: clientCertFile,
-					ClientKeyPath:  clientKeyFile,
-				},
-			}},
-		}
-		cc, err := grpc2.ClientConn(cfg)
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			_ = cc.Close()
+			addr := startTestServer(t, grpc.Creds(credentials.NewTLS(newServerTLSConfig(t, serverCertFile, serverKeyFile, clientCAs, tls.VersionTLS12, tls.VersionTLS12))))
+			cc := newClientConnWithTLS(t, addr, serverCertFile, clientCertFile, clientKeyFile)
+			t.Cleanup(func() {
+				_ = cc.Close()
+			})
+
+			invokeHealthCheck(t, cc)
 		})
 
-		invokeHealthCheck(t, cc)
+		t.Run("tls13", func(t *testing.T) {
+			t.Parallel()
+
+			addr := startTestServer(t, grpc.Creds(credentials.NewTLS(newServerTLSConfig(t, serverCertFile, serverKeyFile, clientCAs, tls.VersionTLS13, tls.VersionTLS13))))
+			cc := newClientConnWithTLS(t, addr, serverCertFile, clientCertFile, clientKeyFile)
+			t.Cleanup(func() {
+				_ = cc.Close()
+			})
+
+			invokeHealthCheck(t, cc)
+		})
 	})
+}
+
+func newClientConnWithTLS(t *testing.T, addr, rootCertFile, clientCertFile, clientKeyFile string) *grpc.ClientConn {
+	t.Helper()
+
+	tlsCfg := &config.TLSConfig{
+		Enabled:       true,
+		RootCertPaths: []string{rootCertFile},
+	}
+	if clientCertFile != "" {
+		tlsCfg.ClientCertPath = clientCertFile
+	}
+	if clientKeyFile != "" {
+		tlsCfg.ClientKeyPath = clientKeyFile
+	}
+
+	cc, err := grpc2.ClientConn(&config.Config{
+		Endpoints: []config.Endpoint{{
+			Address: addr,
+			TLS:     tlsCfg,
+		}},
+	})
+	require.NoError(t, err)
+
+	return cc
+}
+
+func newServerTLSConfig(t *testing.T, certFile, keyFile string, clientCAs *x509.CertPool, minVersion, maxVersion uint16) *tls.Config {
+	t.Helper()
+
+	serverCert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	require.NoError(t, err)
+
+	tlsCfg := &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		MinVersion:   minVersion,
+		MaxVersion:   maxVersion,
+	}
+	if clientCAs != nil {
+		tlsCfg.ClientAuth = tls.RequireAndVerifyClientCert
+		tlsCfg.ClientCAs = clientCAs
+	}
+
+	return tlsCfg
 }
 
 // startTestServer starts an in-process gRPC server with a health service on a random
@@ -426,12 +474,25 @@ func startTestServer(t *testing.T, opts ...grpc.ServerOption) string {
 func invokeHealthCheck(t *testing.T, cc *grpc.ClientConn) {
 	t.Helper()
 
+	resp, err := invokeHealthCheckResp(cc)
+	require.NoError(t, err)
+	require.Equal(t, healthpb.HealthCheckResponse_SERVING, resp.GetStatus())
+}
+
+func invokeHealthCheckErr(t *testing.T, cc *grpc.ClientConn) error {
+	t.Helper()
+
+	_, err := invokeHealthCheckResp(cc)
+	require.Error(t, err)
+
+	return err
+}
+
+func invokeHealthCheckResp(cc *grpc.ClientConn) (*healthpb.HealthCheckResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	resp, err := healthpb.NewHealthClient(cc).Check(ctx, &healthpb.HealthCheckRequest{Service: ""})
-	require.NoError(t, err)
-	require.Equal(t, healthpb.HealthCheckResponse_SERVING, resp.GetStatus())
+	return healthpb.NewHealthClient(cc).Check(ctx, &healthpb.HealthCheckRequest{Service: ""})
 }
 
 // generateServerCertAndKey creates a self-signed certificate with IP SAN 127.0.0.1

--- a/platform/fabricx/core/committer/grpc/grpc_test.go
+++ b/platform/fabricx/core/committer/grpc/grpc_test.go
@@ -334,6 +334,7 @@ func TestClientConn_Integration(t *testing.T) {
 		serverTLSCfg := &tls.Config{
 			Certificates: []tls.Certificate{serverCert},
 			MinVersion:   tls.VersionTLS12,
+			MaxVersion:   tls.VersionTLS12,
 		}
 		addr := startTestServer(t, grpc.Creds(credentials.NewTLS(serverTLSCfg)))
 
@@ -373,6 +374,7 @@ func TestClientConn_Integration(t *testing.T) {
 			ClientAuth:   tls.RequireAndVerifyClientCert,
 			ClientCAs:    clientCAs,
 			MinVersion:   tls.VersionTLS12,
+			MaxVersion:   tls.VersionTLS12,
 		}
 		addr := startTestServer(t, grpc.Creds(credentials.NewTLS(serverTLSCfg)))
 

--- a/platform/view/services/comm/host/websocket/config.go
+++ b/platform/view/services/comm/host/websocket/config.go
@@ -250,7 +250,7 @@ func newServerTLSConfig(clientRootCAPool *x509.CertPool, keyFile, certFile strin
 	}
 
 	tlsConfig := &tls.Config{
-		MinVersion:   tls.VersionTLS13,
+		MinVersion:   tls.VersionTLS12,
 		MaxVersion:   tls.VersionTLS13,
 		Certificates: []tls.Certificate{cert},
 		ClientCAs:    caCertPool,

--- a/platform/view/services/comm/host/websocket/config_test.go
+++ b/platform/view/services/comm/host/websocket/config_test.go
@@ -13,9 +13,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc/tlsgen"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTLSConfigVersions(t *testing.T) {

--- a/platform/view/services/comm/host/websocket/config_test.go
+++ b/platform/view/services/comm/host/websocket/config_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package websocket
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc/tlsgen"
+)
+
+func TestTLSConfigVersions(t *testing.T) {
+	t.Parallel()
+
+	ca, err := tlsgen.NewCA()
+	require.NoError(t, err)
+
+	serverKP, err := ca.NewServerCertKeyPair("127.0.0.1")
+	require.NoError(t, err)
+
+	clientKP, err := ca.NewClientCertKeyPair()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	serverCertFile := filepath.Join(dir, "server-cert.pem")
+	serverKeyFile := filepath.Join(dir, "server-key.pem")
+	clientCertFile := filepath.Join(dir, "client-cert.pem")
+	clientKeyFile := filepath.Join(dir, "client-key.pem")
+
+	require.NoError(t, os.WriteFile(serverCertFile, serverKP.Cert, 0o600))
+	require.NoError(t, os.WriteFile(serverKeyFile, serverKP.Key, 0o600))
+	require.NoError(t, os.WriteFile(clientCertFile, clientKP.Cert, 0o600))
+	require.NoError(t, os.WriteFile(clientKeyFile, clientKP.Key, 0o600))
+
+	certPool := x509.NewCertPool()
+	require.True(t, certPool.AppendCertsFromPEM(ca.CertBytes()))
+
+	clientTLS, err := newClientTLSConfig(certPool, clientKeyFile, clientCertFile, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint16(tls.VersionTLS12), clientTLS.MinVersion)
+	require.Equal(t, uint16(tls.VersionTLS13), clientTLS.MaxVersion)
+
+	serverTLS, err := newServerTLSConfig(certPool, serverKeyFile, serverCertFile, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, uint16(tls.VersionTLS12), serverTLS.MinVersion)
+	require.Equal(t, uint16(tls.VersionTLS13), serverTLS.MaxVersion)
+}

--- a/platform/view/services/grpc/client.go
+++ b/platform/view/services/grpc/client.go
@@ -186,7 +186,8 @@ func (client *Client) parseSecureOptions(opts SecureOptions) error {
 
 	client.tlsConfig = &tls.Config{
 		VerifyPeerCertificate: opts.VerifyCertificate,
-		MinVersion:            tls.VersionTLS12, // TLS 1.2 only
+		MinVersion:            tls.VersionTLS12,
+		MaxVersion:            tls.VersionTLS13,
 	}
 	if len(opts.ServerRootCAs) > 0 {
 		client.tlsConfig.RootCAs = x509.NewCertPool()

--- a/platform/view/services/grpc/connection.go
+++ b/platform/view/services/grpc/connection.go
@@ -68,6 +68,8 @@ func (cs *CredentialSupport) GetPeerCredentials() credentials.TransportCredentia
 	return credentials.NewTLS(&tls.Config{
 		Certificates: []tls.Certificate{cs.clientCert},
 		RootCAs:      certPool,
+		MinVersion:   tls.VersionTLS12,
+		MaxVersion:   tls.VersionTLS13,
 	})
 }
 

--- a/platform/view/services/grpc/creds.go
+++ b/platform/view/services/grpc/creds.go
@@ -37,9 +37,9 @@ func NewServerTransportCredentials(
 	// NOTE: unlike the default grpc/credentials implementation, we do not
 	// clone the tls.Config which allows us to update it dynamically
 	serverConfig.config.NextProtos = alpnProtoStr
-	// override TLS version and ensure it is 1.2
+	// Pin the accepted TLS range to the Go defaults we support explicitly.
 	serverConfig.config.MinVersion = tls.VersionTLS12
-	serverConfig.config.MaxVersion = tls.VersionTLS12
+	serverConfig.config.MaxVersion = tls.VersionTLS13
 	return &serverCreds{
 		serverConfig: serverConfig,
 		logger:       logger,

--- a/platform/view/services/grpc/creds_test.go
+++ b/platform/view/services/grpc/creds_test.go
@@ -52,6 +52,8 @@ func TestCreds(t *testing.T) {
 	logger, recorder := logging.NewTestLogger(t)
 
 	creds := grpc.NewServerTransportCredentials(config, logger)
+	require.Equal(t, uint16(tls.VersionTLS12), config.Config().MinVersion)
+	require.Equal(t, uint16(tls.VersionTLS13), config.Config().MaxVersion)
 	_, _, err = creds.ClientHandshake(context.Background(), "", nil)
 	require.EqualError(t, err, grpc.ErrClientHandshakeNotImplemented.Error())
 	//lint:ignore SA1019: creds.OverrideServerName is deprecated: use grpc.WithAuthority instead. Will be supported throughout 1.x.

--- a/platform/view/services/grpc/server.go
+++ b/platform/view/services/grpc/server.go
@@ -99,6 +99,8 @@ func NewGRPCServerFromListener(listener net.Listener, serverConfig ServerConfig)
 				GetCertificate:         getCert,
 				SessionTicketsDisabled: true,
 				CipherSuites:           secureConfig.CipherSuites,
+				MinVersion:             tls.VersionTLS12,
+				MaxVersion:             tls.VersionTLS13,
 			})
 
 			if serverConfig.SecOpts.TimeShift > 0 {

--- a/platform/view/services/grpc/server_test.go
+++ b/platform/view/services/grpc/server_test.go
@@ -719,6 +719,8 @@ func TestVerifyCertificateCallback(t *testing.T) {
 		tlsCfg := &tls.Config{
 			Certificates: []tls.Certificate{cert},
 			RootCAs:      x509.NewCertPool(),
+			MinVersion:   tls.VersionTLS12,
+			MaxVersion:   tls.VersionTLS12,
 		}
 		tlsCfg.RootCAs.AppendCertsFromPEM(ca.CertBytes())
 
@@ -1227,6 +1229,8 @@ func TestCipherSuites(t *testing.T) {
 			tlsConfig := &tls.Config{
 				RootCAs:      certPool,
 				CipherSuites: test.clientCiphers,
+				MinVersion:   tls.VersionTLS12,
+				MaxVersion:   tls.VersionTLS12,
 			}
 			_, err := tls.Dial("tcp", testAddress, tlsConfig)
 			if test.success {

--- a/platform/view/services/web/client/client.go
+++ b/platform/view/services/web/client/client.go
@@ -91,7 +91,9 @@ func NewClient(config *Config) (*Client, error) {
 		}
 		rootCAs.AppendCertsFromPEM(caCert)
 		tlsClientConfig = &tls.Config{
-			RootCAs: rootCAs,
+			RootCAs:    rootCAs,
+			MinVersion: tls.VersionTLS12,
+			MaxVersion: tls.VersionTLS13,
 		}
 
 		if len(config.TLSCertPath) != 0 && len(config.TLSKeyPath) != 0 {


### PR DESCRIPTION
## Summary
- align runtime TLS configs to explicitly support TLS 1.2 through TLS 1.3
- remove the remaining TLS 1.3-only and TLS 1.2-only defaults in the affected runtime builders
- add focused coverage for the updated version bounds and pin legacy TLS 1.2-specific tests where needed

Fixes #1297

## Testing
- go test ./platform/view/services/grpc ./platform/view/services/comm/host/websocket ./platform/fabricx/core/committer/grpc
- go test -run TestTLSConfigVersions -count=1 -v ./platform/view/services/comm/host/websocket