### PR TITLE
integration: enable TLS for the fabric-x committer test container

### DIFF
--- a/integration/nwo/fabric/docker.go
+++ b/integration/nwo/fabric/docker.go
@@ -8,12 +8,16 @@ package fabric
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
@@ -67,6 +71,10 @@ func (d *Docker) Cleanup() error {
 }
 
 func WaitUntilReady(ctx context.Context, grpcEndpoint string) error {
+	return WaitUntilReadyWithTLS(ctx, grpcEndpoint, nil)
+}
+
+func WaitUntilReadyWithTLS(ctx context.Context, grpcEndpoint string, tlsConfig *tls.Config) error {
 	logger.Infof("Wait until ready %v", grpcEndpoint)
 
 	startWaitingAt := time.Now()
@@ -88,8 +96,13 @@ func WaitUntilReady(ctx context.Context, grpcEndpoint string) error {
 		}]
 	}`
 
+	creds := insecure.NewCredentials()
+	if tlsConfig != nil {
+		creds = credentials.NewTLS(tlsConfig)
+	}
+
 	options := []grpc.DialOption{
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithTransportCredentials(creds),
 		grpc.WithDefaultServiceConfig(serviceConfig),
 	}
 
@@ -116,4 +129,22 @@ func WaitUntilReady(ctx context.Context, grpcEndpoint string) error {
 
 	logger.Infof("Ready! (t=%v)", time.Since(startWaitingAt))
 	return nil
+}
+
+func TLSClientConfig(rootCertPaths []string) (*tls.Config, error) {
+	cp := x509.NewCertPool()
+	for _, rootCertPath := range rootCertPaths {
+		rootCert, err := os.ReadFile(rootCertPath)
+		if err != nil {
+			return nil, fmt.Errorf("read root cert %q: %w", rootCertPath, err)
+		}
+		if !cp.AppendCertsFromPEM(rootCert) {
+			return nil, fmt.Errorf("parse root cert %q", rootCertPath)
+		}
+	}
+
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    cp,
+	}, nil
 }

--- a/integration/nwo/fabricx/extensions/scv2/container.go
+++ b/integration/nwo/fabricx/extensions/scv2/container.go
@@ -8,8 +8,10 @@ package scv2
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
+	"path/filepath"
 	"runtime"
 	"time"
 
@@ -70,11 +72,15 @@ func (e *Extension) launchContainer() {
 	logger.Infof("Sidecar running on port [%s]", sidecarPort)
 	containerName := fmt.Sprintf("%s-scalable-committer", networkID)
 	orderer := e.network.Orderer("orderer")
-	ordererEndpoint := fmt.Sprintf("%s:%d", dockerHostAlias(), e.network.OrdererPort(orderer, fabric_network.ListenPort))
+	ordererEndpoint := ""
+	if e.network.TLSEnabled {
+		ordererEndpoint = fmt.Sprintf("%s:%d", dockerHostAlias(), e.network.OrdererPort(orderer, fabric_network.ListenPort))
+	}
 	scMSPID := fmt.Sprintf("%sMSP", orgName)
 
 	rootCryptoDir := rootCrypto(e.network)
 	peerMSPDir := peerDockerMSPDir(e.network, scPeer)
+	ordererTLSDir := e.network.OrdererLocalTLSDir(orderer)
 
 	// genesis block
 	configBlockPath := e.network.OutputBlockPath(e.channel.Name)
@@ -97,7 +103,10 @@ func (e *Extension) launchContainer() {
 	}
 
 	containerEnvOverride := envVars[committerVersion](peerMSPDir, scMSPID, e.channel.Name, ordererEndpoint)
-	containerCmd := containerCmds[committerVersion]
+	containerCmd := append([]string(nil), containerCmds[committerVersion]...)
+	if !e.network.TLSEnabled {
+		containerCmd = append(containerCmd, "--insecure")
+	}
 	containerSidecarPort := sidecarDefaultPort[committerVersion]
 	containerQueryServicePort := queryServiceDefaultPort[committerVersion]
 
@@ -131,6 +140,42 @@ func (e *Extension) launchContainer() {
 					Type:   mount.TypeBind,
 					Source: rootCryptoDir,
 					Target: "/root/artifacts/crypto",
+				},
+				{
+					Type:     mount.TypeBind,
+					Source:   filepath.Join(ordererTLSDir, "server.crt"),
+					Target:   "/server-certs/public-key.pem",
+					ReadOnly: true,
+				},
+				{
+					Type:     mount.TypeBind,
+					Source:   filepath.Join(ordererTLSDir, "server.key"),
+					Target:   "/server-certs/private-key.pem",
+					ReadOnly: true,
+				},
+				{
+					Type:     mount.TypeBind,
+					Source:   filepath.Join(ordererTLSDir, "ca.crt"),
+					Target:   "/server-certs/ca-certificate.pem",
+					ReadOnly: true,
+				},
+				{
+					Type:     mount.TypeBind,
+					Source:   filepath.Join(ordererTLSDir, "server.crt"),
+					Target:   "/client-certs/public-key.pem",
+					ReadOnly: true,
+				},
+				{
+					Type:     mount.TypeBind,
+					Source:   filepath.Join(ordererTLSDir, "server.key"),
+					Target:   "/client-certs/private-key.pem",
+					ReadOnly: true,
+				},
+				{
+					Type:     mount.TypeBind,
+					Source:   filepath.Join(ordererTLSDir, "ca.crt"),
+					Target:   "/client-certs/ca-certificate.pem",
+					ReadOnly: true,
 				},
 				{ // config block
 					Type:     mount.TypeBind,
@@ -204,14 +249,19 @@ func (e *Extension) launchContainer() {
 	}()
 
 	// let's wait until the sidecar is ready
-	sidecarEndpoint := fmt.Sprintf("%s:%s", localIP, sidecarPort)
-	timeout := 90 * time.Second
+	sidecarEndpoint := "127.0.0.1:" + sidecarPort
+	timeout := 240 * time.Second
 
 	ctx, cancel = context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	logger.Infof("Checking sidecar health-check at %v", sidecarEndpoint)
-	err = fabric.WaitUntilReady(ctx, sidecarEndpoint)
+	var healthCheckTLSConfig *tls.Config
+	if e.network.TLSEnabled {
+		healthCheckTLSConfig, err = fabric.TLSClientConfig([]string{filepath.Join(ordererTLSDir, "ca.crt")})
+		utils.Must(err)
+	}
+	err = fabric.WaitUntilReadyWithTLS(ctx, sidecarEndpoint, healthCheckTLSConfig)
 	utils.Must(err)
 
 	time.Sleep(1 * time.Second)

--- a/integration/nwo/fabricx/extensions/scv2/notificationservice.go
+++ b/integration/nwo/fabricx/extensions/scv2/notificationservice.go
@@ -40,10 +40,8 @@ func generateNSExtension(n *network.Network, notificationServicePort uint16, not
 				Address:           fmt.Sprintf("%s:%v", notificationServiceHost, notificationServicePort),
 				ConnectionTimeout: grpc.DefaultConnectionTimeout,
 				TLS: &fxgrpc.TLSConfig{
-					// TODO: allow TLS and mTLS integration tests
-					Enabled: false,
-					// note that this bundle contains all root certs of the network
-					RootCertPaths: []string{n.CACertsBundlePath()},
+					Enabled:       n.TLSEnabled,
+					RootCertPaths: []string{n.OrgOrdererTLSCACertificatePath(n.OrdererOrgs()[0])},
 				},
 			},
 		},

--- a/integration/nwo/fabricx/extensions/scv2/queryservice.go
+++ b/integration/nwo/fabricx/extensions/scv2/queryservice.go
@@ -45,10 +45,8 @@ func generateQSExtension(n *network.Network) {
 				Address:           fmt.Sprintf("%s:%v", queryServiceHost, queryServicePort),
 				ConnectionTimeout: grpc.DefaultConnectionTimeout,
 				TLS: &config.TLSConfig{
-					// TODO: allow TLS and mTLS integration tests
-					Enabled: false,
-					// note that this bundle contains all root certs of the network
-					RootCertPaths: []string{n.CACertsBundlePath()},
+					Enabled:       n.TLSEnabled,
+					RootCertPaths: []string{n.OrgOrdererTLSCACertificatePath(n.OrdererOrgs()[0])},
 				},
 			},
 		},

--- a/integration/nwo/fabricx/extensions/v3/test_utils.go
+++ b/integration/nwo/fabricx/extensions/v3/test_utils.go
@@ -13,14 +13,13 @@ const (
 	QueryServiceDefaultPort = "7001/tcp"
 )
 
-var ContainerCmd = []string{"run", "db", "orderer", "committer", "--insecure"}
+var ContainerCmd = []string{"run", "db", "orderer", "committer"}
 
 func ContainerEnvVars(peerMSPDir, scMSPID, channelName, ordererEndpoint string) []string {
-	return []string{
+	env := []string{
 		"SC_SIDECAR_LOGGING_LOGSPEC=debug",
 		"SC_SIDECAR_ORDERER_CHANNEL_ID=" + channelName,
 		"SC_SIDECAR_ORDERER_SIGNED_ENVELOPES=true",
-		"SC_SIDECAR_ORDERER_TLS_MODE=none",
 		"SC_SIDECAR_ORDERER_IDENTITY_MSP_ID=" + scMSPID,
 		"SC_SIDECAR_ORDERER_IDENTITY_MSP_DIR=" + peerMSPDir,
 		"SC_QUERY_SERVICE_SERVER_ENDPOINT=:7001",
@@ -32,4 +31,26 @@ func ContainerEnvVars(peerMSPDir, scMSPID, channelName, ordererEndpoint string) 
 		"SC_VERIFIER_LOGGING_LOGSPEC=INFO",
 		"SC_SIDECAR_SERVER_MAX_CONCURRENT_STREAMS=0",
 	}
+
+	if ordererEndpoint == "" {
+		return append(env, "SC_SIDECAR_ORDERER_TLS_MODE=none")
+	}
+
+	return append(env,
+		"SC_COORDINATOR_SERVER_TLS_MODE=none",
+		"SC_COORDINATOR_VERIFIER_TLS_MODE=none",
+		"SC_COORDINATOR_VALIDATOR_COMMITTER_TLS_MODE=none",
+		"SC_COORDINATOR_MONITORING_TLS_MODE=none",
+		"SC_QUERY_SERVER_TLS_MODE=tls",
+		"SC_QUERY_MONITORING_TLS_MODE=none",
+		"SC_SIDECAR_SERVER_TLS_MODE=tls",
+		"SC_SIDECAR_MONITORING_TLS_MODE=none",
+		"SC_SIDECAR_COMMITTER_TLS_MODE=none",
+		"SC_SIDECAR_ORDERER_TLS_MODE=tls",
+		"SC_VC_SERVER_TLS_MODE=none",
+		"SC_VC_MONITORING_TLS_MODE=none",
+		"SC_VERIFIER_SERVER_TLS_MODE=none",
+		"SC_VERIFIER_MONITORING_TLS_MODE=none",
+		"SC_ORDERER_SERVER_TLS_MODE=tls",
+	)
 }

--- a/integration/nwo/fabricx/fxconfig/namespace.go
+++ b/integration/nwo/fabricx/fxconfig/namespace.go
@@ -73,7 +73,6 @@ func (n *CreateNamespace) Args() []string {
 		"--policy=" + n.Policy,
 		"--endorse",
 		"--submit",
-		"--wait",
 	}
 }
 
@@ -125,7 +124,6 @@ func (n *UpdateNamespace) Args() []string {
 		"--policy=" + n.Policy,
 		"--endorse",
 		"--submit",
-		"--wait",
 	}
 }
 

--- a/integration/nwo/fabricx/network/network.go
+++ b/integration/nwo/fabricx/network/network.go
@@ -207,13 +207,16 @@ func (n *Network) DeployNamespace(chaincode *topology.ChannelChaincode) {
 			OrdererConfig: fxconfig.OrdererConfig{
 				Address: n.OrdererAddress(n.Orderers[0], fabric_network.ListenPort),
 				TLSConfig: fxconfig.TLSConfig{
-					Enabled:   false,
-					RootCerts: []string{n.OrgOrdererTLSCACertificatePath(n.Organizations[0])},
+					Enabled:   n.TLSEnabled,
+					RootCerts: []string{n.OrgOrdererTLSCACertificatePath(n.OrdererOrgs()[0])},
 				},
 			},
 			NotificationsConfig: fxconfig.NotificationsConfig{
-				Address:   notificationsEndpoint,
-				TLSConfig: fxconfig.TLSConfig{},
+				Address: notificationsEndpoint,
+				TLSConfig: fxconfig.TLSConfig{
+					Enabled:   n.TLSEnabled,
+					RootCerts: []string{n.OrgOrdererTLSCACertificatePath(n.OrdererOrgs()[0])},
+				},
 			},
 			Policy: chaincode.Chaincode.Policy,
 		},
@@ -234,8 +237,11 @@ func (n *Network) UpdateNamespace(chaincodeID, version, path, packageFile string
 // gomega.Eventually for retrying.
 func (n *Network) tryListInstalledNames() ([]Namespace, error) {
 	cmd := &fxconfig.ListNamespaces{QueryConfig: fxconfig.QueryConfig{
-		Address:   "127.0.0.1:7001",
-		TLSConfig: fxconfig.TLSConfig{},
+		Address: "127.0.0.1:7001",
+		TLSConfig: fxconfig.TLSConfig{
+			Enabled:   n.TLSEnabled,
+			RootCerts: []string{n.OrgOrdererTLSCACertificatePath(n.OrdererOrgs()[0])},
+		},
 	}}
 	sess, err := n.StartSession(common.NewCommand(fxconfig.CMDPath(), cmd), cmd.SessionName())
 	if err != nil {

--- a/integration/nwo/fabricx/topology.go
+++ b/integration/nwo/fabricx/topology.go
@@ -25,10 +25,6 @@ func NewTopologyWithName(name string) *topology.Topology {
 
 	topo.SetLogging("grpc=error:info", "")
 
-	// TODO: the ordering service provided by the committer all-in-one does not support TLS;
-	// 	once supported we can remove this
-	topo.TLSEnabled = false
-
 	// set fabricx specific settings
 	topo.TopologyType = PlatformName
 	topo.Driver = PlatformName


### PR DESCRIPTION
## Summary
- enable Fabric-x TLS in the committer all-in-one test container without forcing mTLS across internal committer services
- mount the generated orderer TLS material into the container and use TLS-aware readiness, query, notification, and namespace config paths
- stop relying on `fxconfig --wait` in the NWO wrapper and use the existing namespace polling to observe commit completion

## Testing
- go test ./integration/nwo/fabric ./integration/nwo/fabricx/...
- manual committer-container repro using the generated Fabric-x test artifacts to verify TLS health checks and orderer submit path

Fixes #1295
Supersedes #1298