### PR TITLE
fabricx: expose GetNamespacePolicies via query service

### DIFF
--- a/platform/fabricx/core/channel/config/mock/query_service.go
+++ b/platform/fabricx/core/channel/config/mock/query_service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/channel/config"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 )
 
 type QueryService struct {
@@ -79,6 +80,11 @@ func (fake *QueryService) GetConfigTransactionReturnsOnCall(i int, result1 *quer
 		result1 *queryservice.ConfigTransactionInfo
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *QueryService) GetNamespacePolicies() (*applicationpb.NamespacePolicies, error) {
+	fake.recordInvocation("GetNamespacePolicies", []interface{}{})
+	return nil, nil
 }
 
 func (fake *QueryService) Invocations() map[string][][]interface{} {

--- a/platform/fabricx/core/committer/queryservice/mock/query_service.go
+++ b/platform/fabricx/core/committer/queryservice/mock/query_service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 )
 
 type QueryService struct {
@@ -119,6 +120,11 @@ func (fake *QueryService) GetConfigTransactionReturnsOnCall(i int, result1 *quer
 		result1 *queryservice.ConfigTransactionInfo
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *QueryService) GetNamespacePolicies() (*applicationpb.NamespacePolicies, error) {
+	fake.recordInvocation("GetNamespacePolicies", []interface{}{})
+	return nil, nil
 }
 
 func (fake *QueryService) GetState(arg1 driver.Namespace, arg2 driver.PKey) (*driver.VaultValue, error) {

--- a/platform/fabricx/core/committer/queryservice/provider.go
+++ b/platform/fabricx/core/committer/queryservice/provider.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"google.golang.org/grpc"
 
@@ -38,6 +39,7 @@ type QueryService interface {
 	GetStates(map[driver.Namespace][]driver.PKey) (map[driver.Namespace]map[driver.PKey]driver.VaultValue, error)
 	GetTransactionStatus(txID string) (int32, error)
 	GetConfigTransaction() (*ConfigTransactionInfo, error)
+	GetNamespacePolicies() (*applicationpb.NamespacePolicies, error)
 }
 
 // ServiceConfigProvider provides gRPC configuration for a given network.

--- a/platform/fabricx/core/committer/queryservice/query.go
+++ b/platform/fabricx/core/committer/queryservice/query.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
@@ -113,6 +114,20 @@ func (s *RemoteQueryService) GetConfigTransaction() (*ConfigTransactionInfo, err
 		Envelope: envelope,
 		Version:  res.GetVersion(),
 	}, nil
+}
+
+func (s *RemoteQueryService) GetNamespacePolicies() (*applicationpb.NamespacePolicies, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), s.config.RequestTimeout)
+	defer cancel()
+
+	now := time.Now()
+	res, err := s.client.GetNamespacePolicies(ctx, &emptypb.Empty{})
+	if err != nil {
+		return nil, errors.Wrap(err, "get namespace policies")
+	}
+	logger.Debugf("QS GetNamespacePolicies: got response in %v", time.Since(now))
+
+	return res, nil
 }
 
 func (s *RemoteQueryService) query(m map[driver.Namespace][]driver.PKey) (map[driver.Namespace]map[driver.PKey]driver.VaultValue, error) {

--- a/platform/fabricx/core/committer/queryservice/query_test.go
+++ b/platform/fabricx/core/committer/queryservice/query_test.go
@@ -466,4 +466,33 @@ func TestQueryService(t *testing.T) {
 			require.ErrorIs(t, err, expectedError)
 		})
 	})
+
+	t.Run("GetNamespacePolicies", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("happy path", func(t *testing.T) {
+			t.Parallel()
+			qs, fake := setupTest(t)
+			expected := &applicationpb.NamespacePolicies{
+				Policies: []*applicationpb.PolicyItem{
+					{Namespace: "ns1", Version: 1},
+				},
+			}
+			fake.GetNamespacePoliciesReturns(expected, nil)
+
+			resp, err := qs.GetNamespacePolicies()
+			require.NoError(t, err)
+			require.Equal(t, expected, resp)
+		})
+
+		t.Run("client error", func(t *testing.T) {
+			t.Parallel()
+			qs, fake := setupTest(t)
+			expectedError := errors.New("some error")
+			fake.GetNamespacePoliciesReturns(nil, expectedError)
+
+			_, err := qs.GetNamespacePolicies()
+			require.ErrorIs(t, err, expectedError)
+		})
+	})
 }

--- a/platform/fabricx/core/ledger/mock/query_service.go
+++ b/platform/fabricx/core/ledger/mock/query_service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 )
 
 type QueryService struct {
@@ -119,6 +120,11 @@ func (fake *QueryService) GetConfigTransactionReturnsOnCall(i int, result1 *quer
 		result1 *queryservice.ConfigTransactionInfo
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *QueryService) GetNamespacePolicies() (*applicationpb.NamespacePolicies, error) {
+	fake.recordInvocation("GetNamespacePolicies", []interface{}{})
+	return nil, nil
 }
 
 func (fake *QueryService) GetState(arg1 driver.Namespace, arg2 driver.PKey) (*driver.VaultValue, error) {

--- a/platform/fabricx/core/vault/vault_test.go
+++ b/platform/fabricx/core/vault/vault_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protowire"
 
@@ -62,6 +63,10 @@ func (m *mockQueryService) GetTransactionStatus(txID string) (int32, error) {
 }
 
 func (m *mockQueryService) GetConfigTransaction() (*queryservice.ConfigTransactionInfo, error) {
+	return nil, nil
+}
+
+func (m *mockQueryService) GetNamespacePolicies() (*applicationpb.NamespacePolicies, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
## Summary
- add `GetNamespacePolicies` to the FSC-side Fabric-x query service interface
- wire the method through `RemoteQueryService` to the underlying committer gRPC client
- add focused tests and update local query-service test doubles to satisfy the expanded interface

## Testing
- go test ./platform/fabricx/core/committer/queryservice ./platform/fabricx/core/vault ./platform/fabricx/core/channel/config ./platform/fabricx/core/ledger

Fixes #1228