### PR TITLE
testing: add unit tests for pkg/utils/proto

### DIFF
--- a/pkg/utils/proto/proto_test.go
+++ b/pkg/utils/proto/proto_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/protoadapt"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -61,4 +62,21 @@ func TestClone(t *testing.T) {
 	// Mutating the clone must not affect the original
 	cloned.Value = "modified"
 	require.Equal(t, "original", msg.Value)
+}
+
+func TestMarshalUnmarshalV1(t *testing.T) {
+	t.Parallel()
+	msg := &wrapperspb.StringValue{Value: "hello v1"}
+
+	// Convert V2 message to V1 using protoadapt
+	msgV1 := protoadapt.MessageV1Of(msg)
+
+	b, err := MarshalV1(msgV1)
+	require.NoError(t, err)
+
+	got := &wrapperspb.StringValue{}
+	gotV1 := protoadapt.MessageV1Of(got)
+
+	require.NoError(t, UnmarshalV1(b, gotV1))
+	require.Equal(t, msg.Value, got.Value)
 }


### PR DESCRIPTION
Closes: #1310 
### Description:
This PR increases the unit test coverage for the `pkg/utils/proto` package to **100%**.

### Changes:
* Implemented `TestMarshalUnmarshalV1` in `proto_test.go`.
* Added unit tests for legacy protobuf adaptation logic (`MarshalV1` and `UnmarshalV1`).

### Verification:
* Ran `go test -v -cover ./pkg/utils/proto/...`
* Statement coverage: **100.0%**.
