### PR TITLE
fix: resolve data race in discovery client tests

### DIFF
--- a/platform/fabric/core/generic/discovery/client_test.go
+++ b/platform/fabric/core/generic/discovery/client_test.go
@@ -366,10 +366,10 @@ func TestClient(t *testing.T) {
 		req = NewRequest()
 		req, err = req.OfChannel("mychannel").AddPeersQuery().AddEndorsersQuery(interest("mycc"))
 		require.NoError(t, err)
-		r, err = cl.Send(ctx, req, authInfo)
+		r2, err := cl.Send(ctx, req, authInfo)
 		require.NoError(t, err)
 
-		mychannel := r.ForChannel("mychannel")
+		mychannel := r2.ForChannel("mychannel")
 		peers, err := mychannel.Peers()
 		require.NoError(t, err)
 		require.Len(t, peers, 3)


### PR DESCRIPTION
Closes #1314 
### Description:
This PR resolves a data race in the discovery client tests by isolating shared variables within subtest scopes.

### Changes:
* Fixed the data race in `TestClient` by ensuring that subtests performing secondary discovery calls use local variables instead of overwriting shared ones.
* Maintained full compatibility with `paralleltest` and `tparallel` linters by keeping `t.Parallel()` in place.

### Verification:
* `go test -v ./platform/fabric/core/generic/discovery/...` passes.
