### PR TITLE
node: add config validation command

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/hyperledger-labs/fabric-smart-client/node/start"
+	"github.com/hyperledger-labs/fabric-smart-client/node/validate"
 	"github.com/hyperledger-labs/fabric-smart-client/node/version"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/node"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
@@ -61,6 +62,7 @@ func newWithFSCNode(fscNode FSCNode) *Node {
 
 	mainCmd.AddCommand(version.Cmd())
 	mainCmd.AddCommand(start.Cmd(node))
+	mainCmd.AddCommand(validate.Cmd())
 
 	return node
 }

--- a/node/validate/validate.go
+++ b/node/validate/validate.go
@@ -1,0 +1,57 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package validate
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/config"
+)
+
+// Cmd returns the Cobra command used to validate an FSC node configuration.
+func Cmd() *cobra.Command {
+	var configPath string
+
+	cmd := &cobra.Command{
+		Use:   "validate-config",
+		Short: "Validate the fabric smart client node configuration.",
+		Long:  "Validate the fabric smart client node configuration and report the file that was loaded.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return errors.Errorf("trailing args detected")
+			}
+			cmd.SilenceUsage = true
+
+			usedConfig, err := Validate(configPath)
+			if err != nil {
+				return err
+			}
+
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "configuration is valid: %s\n", usedConfig)
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&configPath, "config-path", "", "Path to a directory containing core.yaml")
+
+	return cmd
+}
+
+// Validate loads the FSC node configuration and returns the concrete file used.
+func Validate(configPath string) (string, error) {
+	provider, err := config.NewProvider(configPath)
+	if err != nil {
+		return "", err
+	}
+	if len(provider.ID()) == 0 {
+		return "", errors.New("missing fsc.id in configuration")
+	}
+
+	return provider.ConfigFileUsed(), nil
+}

--- a/node/validate/validate_test.go
+++ b/node/validate/validate_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package validate
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "core.yaml"), []byte("fsc:\n  id: node1\n"), 0o600)
+	require.NoError(t, err)
+
+	usedConfig, err := Validate(dir)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(dir, "core.yaml"), usedConfig)
+}
+
+func TestValidateMissingID(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "core.yaml"), []byte("logging:\n  spec: info\n"), 0o600)
+	require.NoError(t, err)
+
+	_, err = Validate(dir)
+	require.EqualError(t, err, "missing fsc.id in configuration")
+}
+
+func TestCmd(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "core.yaml"), []byte("fsc:\n  id: node1\n"), 0o600)
+	require.NoError(t, err)
+
+	cmd := Cmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--config-path", dir})
+
+	err = cmd.Execute()
+	require.NoError(t, err)
+	require.Contains(t, out.String(), filepath.Join(dir, "core.yaml"))
+}

--- a/node/validate/validate_test.go
+++ b/node/validate/validate_test.go
@@ -8,6 +8,7 @@ package validate
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,6 +39,16 @@ func TestValidateMissingID(t *testing.T) {
 	require.EqualError(t, err, "missing fsc.id in configuration")
 }
 
+func TestValidateMissingConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	_, err := Validate(dir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "core.yaml")
+}
+
 func TestCmd(t *testing.T) {
 	t.Parallel()
 
@@ -54,4 +65,52 @@ func TestCmd(t *testing.T) {
 	err = cmd.Execute()
 	require.NoError(t, err)
 	require.Contains(t, out.String(), filepath.Join(dir, "core.yaml"))
+}
+
+func TestCmdTrailingArgs(t *testing.T) {
+	t.Parallel()
+
+	cmd := Cmd()
+	cmd.SetArgs([]string{"unexpected"})
+
+	err := cmd.Execute()
+	require.EqualError(t, err, "trailing args detected")
+	require.False(t, cmd.SilenceUsage)
+}
+
+func TestCmdValidateError(t *testing.T) {
+	t.Parallel()
+
+	cmd := Cmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--config-path", t.TempDir()})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "core.yaml")
+	require.True(t, cmd.SilenceUsage)
+}
+
+func TestCmdWriteError(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "core.yaml"), []byte("fsc:\n  id: node1\n"), 0o600)
+	require.NoError(t, err)
+
+	cmd := Cmd()
+	cmd.SetOut(failingWriter{})
+	cmd.SetErr(bytes.NewBuffer(nil))
+	cmd.SetArgs([]string{"--config-path", dir})
+
+	err = cmd.Execute()
+	require.EqualError(t, err, "write failed")
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write(p []byte) (int, error) {
+	return 0, errors.New("write failed")
 }

--- a/platform/view/services/config/provider.go
+++ b/platform/view/services/config/provider.go
@@ -142,11 +142,9 @@ func (p *Provider) GetString(key string) string {
 	return p.Backend.String(strings.ToLower(key))
 }
 
-// ConfigFileUsed returns the configuration file used.
-// Currently, this returns an empty string as koanf does not track it directly.
+// ConfigFileUsed returns the absolute path of the configuration file used.
 func (p *Provider) ConfigFileUsed() string {
-	// koanf does not track the config file used, so we return empty string
-	return ""
+	return p.fullPath
 }
 
 // MergeConfig merges the given raw configuration into the current configuration.

--- a/platform/view/services/config/provider_test.go
+++ b/platform/view/services/config/provider_test.go
@@ -9,6 +9,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -219,7 +220,8 @@ func TestProviderMore(t *testing.T) { //nolint:paralleltest
 	assert.Equal(t, []string{"a", "b", "c"}, p.GetStringSlice("slice"))
 
 	// Test ConfigFileUsed
-	assert.Empty(t, p.ConfigFileUsed())
+	assert.NotEmpty(t, p.ConfigFileUsed())
+	assert.True(t, strings.HasSuffix(p.ConfigFileUsed(), filepath.Join("testdata", "core.yaml")))
 
 	// Test String
 	assert.NotEmpty(t, p.String())


### PR DESCRIPTION
## Summary
- add a `peer validate-config` command that loads and validates the FSC node configuration before startup
- fail with a clear error when the config is missing `fsc.id`
- return the concrete config file path via `ConfigFileUsed()` so the validator can report exactly what it checked

## Why
Today, configuration mistakes are often only discovered later during node startup. This adds a lightweight validation tool that helps contributors and operators catch obvious config issues earlier and see which `core.yaml` was actually loaded.

## Testing
- `go test ./node/validate`
- `go test ./platform/view/services/config`
- `go test ./node/...`

Refs #209
Refs #798
