### PR TITLE
node: add safe constructors

### DIFF
--- a/integration/benchmark/node/benchmark.go
+++ b/integration/benchmark/node/benchmark.go
@@ -52,7 +52,10 @@ func GenerateConfig(testdataDir string) error {
 }
 
 func SetupNode(confPath string, factories ...NamedFactory) (*node.Node, error) {
-	fsc := node.NewWithConfPath(confPath)
+	fsc, err := node.NewWithConfPathE(confPath)
+	if err != nil {
+		return nil, err
+	}
 	if err := fsc.InstallSDK(viewsdk.NewSDK(fsc)); err != nil {
 		return nil, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -43,12 +43,34 @@ type Node struct {
 
 // New returns a new instance of Node from the default configuration path.
 func New() *Node {
-	return NewWithConfPath("")
+	node, err := NewE()
+	if err != nil {
+		panic(err)
+	}
+	return node
+}
+
+// NewE returns a new instance of Node from the default configuration path.
+func NewE() (*Node, error) {
+	return NewWithConfPathE("")
 }
 
 // NewWithConfPath returns a new instance of Node whose configuration is loaded from the passed path.
 func NewWithConfPath(confPath string) *Node {
-	return newWithFSCNode(node.NewFromConfPath(confPath))
+	node, err := NewWithConfPathE(confPath)
+	if err != nil {
+		panic(err)
+	}
+	return node
+}
+
+// NewWithConfPathE returns a new instance of Node whose configuration is loaded from the passed path.
+func NewWithConfPathE(confPath string) (*Node, error) {
+	fscNode, err := node.NewFromConfPathE(confPath)
+	if err != nil {
+		return nil, err
+	}
+	return newWithFSCNode(fscNode), nil
 }
 
 func newWithFSCNode(fscNode FSCNode) *Node {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package node
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewWithConfPathE(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "core.yaml"), []byte("fsc:\n  id: test-node\n"), 0o600)
+	require.NoError(t, err)
+
+	n, err := NewWithConfPathE(dir)
+	require.NoError(t, err)
+	require.NotNil(t, n)
+	require.Equal(t, "test-node", n.ID())
+}
+
+func TestNewWithConfPathE_InvalidPath(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewWithConfPathE("./does-not-exist")
+	require.Error(t, err)
+}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -39,20 +39,28 @@ type Node struct {
 }
 
 func NewFromConfPath(confPath string) *Node {
-	configService, err := config.NewProvider(confPath)
+	node, err := NewFromConfPathE(confPath)
 	if err != nil {
 		panic(err)
 	}
+	return node
+}
+
+func NewFromConfPathE(confPath string) (*Node, error) {
+	configService, err := config.NewProvider(confPath)
+	if err != nil {
+		return nil, err
+	}
 	registry := view.NewServiceProvider()
 	if err := registry.RegisterService(configService); err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	return &Node{
 		sdks:     []SDK{},
 		registry: registry,
 		id:       configService.ID(),
-	}
+	}, nil
 }
 
 func (n *Node) AddSDK(sdk SDK) {

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -8,6 +8,8 @@ package node
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -193,5 +195,24 @@ func TestNode_GetService_NotFound(t *testing.T) {
 	t.Parallel()
 	n := newTestNode()
 	_, err := n.GetService((*mockSDK)(nil))
+	require.Error(t, err)
+}
+
+func TestNewFromConfPathE(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "core.yaml"), []byte("fsc:\n  id: test-node\n"), 0o600)
+	require.NoError(t, err)
+
+	n, err := NewFromConfPathE(dir)
+	require.NoError(t, err)
+	require.Equal(t, "test-node", n.ID())
+}
+
+func TestNewFromConfPathE_InvalidPath(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewFromConfPathE("./does-not-exist")
 	require.Error(t, err)
 }


### PR DESCRIPTION
## Summary
- add explicit error-returning node constructors (`NewFromConfPathE`, `NewE`, `NewWithConfPathE`)
- keep the legacy panicing constructors as compatibility wrappers
- adopt the safe constructor path in benchmark setup so bad config returns an error instead of crashing the process

## Why
`#183` calls out panic-heavy API paths. The node construction flow was one of the clearest user-facing cases: bad config could trigger a panic during setup. This PR introduces safe alternatives without breaking existing callers and starts moving internal code onto the error-returning path.

## Testing
- `go test ./pkg/node`
- `go test ./node`
- `go test ./integration/benchmark/node`

Refs #183
