### PR TITLE
fix(lazy): add read lock to lazyProvider.Length

### DIFF
--- a/platform/common/utils/lazy/provider.go
+++ b/platform/common/utils/lazy/provider.go
@@ -114,5 +114,7 @@ func (v *lazyProvider[I, K, V]) Delete(input I) (V, bool) {
 }
 
 func (v *lazyProvider[I, K, V]) Length() int {
+	v.cacheLock.RLock()
+	defer v.cacheLock.RUnlock()
 	return len(v.cache)
 }

--- a/platform/common/utils/lazy/provider_test.go
+++ b/platform/common/utils/lazy/provider_test.go
@@ -170,6 +170,42 @@ func TestParallel(t *testing.T) {
 	require.Len(t, values, 1, "we always got one value back (the one we first set)")
 }
 
+// TestLengthConcurrentWithWrites exercises Length alongside Update / Delete
+// to expose the missing read lock. Without the RLock fix on Length, this
+// test panics under `go test -race` with "concurrent map iteration and map
+// write" or trips the race detector.
+func TestLengthConcurrentWithWrites(t *testing.T) {
+	t.Parallel()
+	const iterations = 200
+	cache := newTestCache()
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_, _, _ = cache.Update(entry{key: fmt.Sprintf("k%d", i), value: fmt.Sprintf("v%d", i)})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_, _ = cache.Delete(entry{key: fmt.Sprintf("k%d", i)})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = cache.Length()
+		}
+	}()
+
+	wg.Wait()
+}
+
 func newTestCache() Provider[entry, string] {
 	return NewProviderWithKeyMapper(func(in entry) string {
 		return in.key


### PR DESCRIPTION
Resolves #1324.

\`lazyProvider.Length()\` in \`platform/common/utils/lazy/provider.go\` read \`len(v.cache)\` without holding \`cacheLock\`. Every other cache reader (\`Get\`, \`Peek\`, \`Update\`, \`Delete\`) acquires the lock first, so calling \`Length\` concurrently with any of those is a data race that the Go runtime detects under \`-race\` and panics on in production.

## Fix

Adds the symmetric read-lock acquisition the issue calls out:

\`\`\`go
func (v *lazyProvider[I, K, V]) Length() int {
    v.cacheLock.RLock()
    defer v.cacheLock.RUnlock()
    return len(v.cache)
}
\`\`\`

## Test

Added \`TestLengthConcurrentWithWrites\` in \`provider_test.go\` that drives 200 \`Update\` calls, 200 \`Delete\` calls, and 200 \`Length\` calls from three goroutines in parallel. Without the RLock fix this would trip the race detector or panic with "concurrent map iteration and map write".

\`go test -race ./platform/common/utils/lazy/...\` passes locally with the fix.