### PR TITLE
integration: move fabricx SP registrations to end SDKs

### DIFF
--- a/integration/fabricx/deployment/sdk.go
+++ b/integration/fabricx/deployment/sdk.go
@@ -12,6 +12,9 @@ import (
 	common "github.com/hyperledger-labs/fabric-smart-client/platform/common/sdk/dig"
 	digutils "github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/dig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/state"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/finality"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/ledger"
 	fabricx "github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/sdk/dig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services"
 )
@@ -34,6 +37,9 @@ func (p *SDK) Install() error {
 	}
 
 	return errors.Join(
+		digutils.Register[*ledger.Provider](p.Container()),
+		digutils.Register[queryservice.Provider](p.Container()),
+		digutils.Register[finality.ListenerManagerProvider](p.Container()),
 		digutils.Register[state.VaultService](p.Container()),
 	)
 }

--- a/integration/fabricx/iou/sdk.go
+++ b/integration/fabricx/iou/sdk.go
@@ -12,6 +12,9 @@ import (
 	common "github.com/hyperledger-labs/fabric-smart-client/platform/common/sdk/dig"
 	digutils "github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/dig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/state"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/finality"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/ledger"
 	fabricx "github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/sdk/dig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services"
 )
@@ -34,6 +37,9 @@ func (p *SDK) Install() error {
 	}
 
 	return errors.Join(
+		digutils.Register[*ledger.Provider](p.Container()),
+		digutils.Register[queryservice.Provider](p.Container()),
+		digutils.Register[finality.ListenerManagerProvider](p.Container()),
 		digutils.Register[state.VaultService](p.Container()),
 	)
 }

--- a/integration/fabricx/multiendorsement/sdk.go
+++ b/integration/fabricx/multiendorsement/sdk.go
@@ -12,6 +12,9 @@ import (
 	common "github.com/hyperledger-labs/fabric-smart-client/platform/common/sdk/dig"
 	digutils "github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/dig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/state"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/finality"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/ledger"
 	fabricx "github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/sdk/dig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services"
 )
@@ -34,6 +37,9 @@ func (p *SDK) Install() error {
 	}
 
 	return errors.Join(
+		digutils.Register[*ledger.Provider](p.Container()),
+		digutils.Register[queryservice.Provider](p.Container()),
+		digutils.Register[finality.ListenerManagerProvider](p.Container()),
 		digutils.Register[state.VaultService](p.Container()),
 	)
 }

--- a/integration/fabricx/simple/sdk.go
+++ b/integration/fabricx/simple/sdk.go
@@ -12,6 +12,9 @@ import (
 	common "github.com/hyperledger-labs/fabric-smart-client/platform/common/sdk/dig"
 	digutils "github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/dig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/state"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/finality"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/ledger"
 	fabricx "github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/sdk/dig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services"
 )
@@ -34,6 +37,9 @@ func (p *SDK) Install() error {
 	}
 
 	return errors.Join(
+		digutils.Register[*ledger.Provider](p.Container()),
+		digutils.Register[queryservice.Provider](p.Container()),
+		digutils.Register[finality.ListenerManagerProvider](p.Container()),
 		digutils.Register[state.VaultService](p.Container()),
 	)
 }

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -104,7 +104,7 @@ outer:
 
 	// build with coverage profiling, more details: https://go.dev/doc/build-cover
 	if _, ok := os.LookupEnv("GOCOVERDIR"); ok {
-		params = append(params, "-cover")
+		params = append(params, "-cover", "-coverpkg=./...")
 	}
 
 	buildServer := common.NewBuildServer(params...)

--- a/platform/fabricx/sdk/dig/sdk.go
+++ b/platform/fabricx/sdk/dig/sdk.go
@@ -71,12 +71,7 @@ func (p *SDK) Install() error {
 		return err
 	}
 
-	// Backward compatibility with SP
-	return errors.Join(
-		digutils.Register[finality.ListenerManagerProvider](p.Container()),
-		digutils.Register[queryservice.Provider](p.Container()),
-		digutils.Register[*ledger.Provider](p.Container()),
-	)
+	return nil
 }
 
 func (p *SDK) Start(ctx context.Context) error {


### PR DESCRIPTION
## Summary
- remove FabricX backward-compatibility service-provider registrations from the core FabricX SDK
- register those services from the FabricX end SDKs instead
- keep the FabricX integration SDKs compiling while preserving the existing helper-based access pattern

## Why
`#802` asks to move `digutils.Register` usage out of the core SDKs and into end SDKs.
The FabricX SDK was still registering `finality.ListenerManagerProvider`, `queryservice.Provider`, and `*ledger.Provider` directly from the core SDK. This PR moves that backward-compatibility layer into the FabricX end SDKs that actually consume those services.

## Testing
- `go test ./platform/fabricx/sdk/dig`
- `go test -run TestDoesNotExist ./integration/fabricx/deployment ./integration/fabricx/simple ./integration/fabricx/iou ./integration/fabricx/multiendorsement`

Fixes #802
Refs #798
