### PR TITLE
view: align web TLS field names

### DIFF
--- a/platform/view/sdk/dig/servers.go
+++ b/platform/view/sdk/dig/servers.go
@@ -53,11 +53,11 @@ func NewWebServer(configProvider driver.ConfigService, viewManager server.ViewMa
 		clientRootCAs = append(clientRootCAs, configProvider.TranslatePath(path))
 	}
 	tlsConfig = web.TLS{
-		Enabled:           configProvider.GetBool("fsc.web.tls.enabled"),
-		CertFile:          configProvider.GetPath("fsc.web.tls.cert.file"),
-		KeyFile:           configProvider.GetPath("fsc.web.tls.key.file"),
-		ClientAuth:        configProvider.GetBool("fsc.web.tls.clientAuthRequired"),
-		ClientCACertFiles: clientRootCAs,
+		Enabled:            configProvider.GetBool("fsc.web.tls.enabled"),
+		CertFile:           configProvider.GetPath("fsc.web.tls.cert.file"),
+		KeyFile:            configProvider.GetPath("fsc.web.tls.key.file"),
+		ClientAuthRequired: configProvider.GetBool("fsc.web.tls.clientAuthRequired"),
+		ClientRootCAs:      clientRootCAs,
 	}
 	webServer := web.NewServer(web.Options{
 		ListenAddress: listenAddr,

--- a/platform/view/services/web/server/server.go
+++ b/platform/view/services/web/server/server.go
@@ -27,11 +27,11 @@ var logger = logging.MustGetLogger()
 //go:generate counterfeiter -o fakes/logger.go -fake-name Logger . Logger
 
 type TLS struct {
-	Enabled           bool
-	CertFile          string
-	KeyFile           string
-	ClientAuth        bool
-	ClientCACertFiles []string
+	Enabled            bool
+	CertFile           string
+	KeyFile            string
+	ClientAuthRequired bool
+	ClientRootCAs      []string
 }
 
 func (t TLS) Config() (*tls.Config, error) {
@@ -64,11 +64,11 @@ func (t TLS) Config() (*tls.Config, error) {
 		MaxVersion: tls.VersionTLS13,
 	}
 
-	if !t.ClientAuth {
+	if !t.ClientAuthRequired {
 		// no mTLS
 		// Optional: verify client certificates if provided, but don't require them
-		if len(t.ClientCACertFiles) > 0 {
-			caCertPool, err := loadClientCAs(t.ClientCACertFiles)
+		if len(t.ClientRootCAs) > 0 {
+			caCertPool, err := loadClientCAs(t.ClientRootCAs)
 			if err != nil {
 				return nil, err
 			}
@@ -80,14 +80,14 @@ func (t TLS) Config() (*tls.Config, error) {
 
 	// mTLS
 	// Require client certificates and verify them
-	if len(t.ClientCACertFiles) == 0 {
+	if len(t.ClientRootCAs) == 0 {
 		return nil, errors.Errorf("client TLS CA certificate pool must not be empty when clientAuthRequired is true")
 	}
 
 	// mTLS Enforcement:
 	// 1. Require client certificates: The handshake will fail if the client doesn't provide one.
 	// 2. Verify client certificates: The certificate must be signed by one of the CAs in the pool.
-	caCertPool, err := loadClientCAs(t.ClientCACertFiles)
+	caCertPool, err := loadClientCAs(t.ClientRootCAs)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/view/services/web/server/server_test.go
+++ b/platform/view/services/web/server/server_test.go
@@ -108,11 +108,11 @@ var _ = Describe("Server", func() {
 		options = server2.Options{
 			ListenAddress: "127.0.0.1:0",
 			TLS: server2.TLS{
-				Enabled:           true,
-				CertFile:          filepath.Join(tempDir, "server-cert.pem"),
-				KeyFile:           filepath.Join(tempDir, "server-key.pem"),
-				ClientAuth:        true,
-				ClientCACertFiles: []string{filepath.Join(tempDir, "client-ca.pem")},
+				Enabled:            true,
+				CertFile:           filepath.Join(tempDir, "server-cert.pem"),
+				KeyFile:            filepath.Join(tempDir, "server-key.pem"),
+				ClientAuthRequired: true,
+				ClientRootCAs:      []string{filepath.Join(tempDir, "client-ca.pem")},
 			},
 		}
 
@@ -196,8 +196,8 @@ var _ = Describe("Server", func() {
 
 	When("TLS is enabled without client authentication", func() {
 		BeforeEach(func() {
-			options.TLS.ClientAuth = false
-			options.TLS.ClientCACertFiles = []string{} // No client CA files
+			options.TLS.ClientAuthRequired = false
+			options.TLS.ClientRootCAs = []string{} // No client CA files
 			server = server2.NewServer(options)
 			client = newHTTPClient(tempDir, false) // Client without cert
 		})


### PR DESCRIPTION
## What changed
- renamed the internal web TLS struct fields from `ClientAuth`/`ClientCACertFiles` to `ClientAuthRequired`/`ClientRootCAs`
- updated the view SDK wiring to populate the renamed fields from `fsc.web.tls.*`
- refreshed the web server tests to match the clearer naming

## Why
Issue #1112 documents that the `fsc.web.tls` configuration is expressed with Fabric-style names, but the underlying Go structs still use different field names. This PR removes that internal inconsistency without changing behavior.

## Validation
- `go test ./platform/view/services/web/server ./platform/view/sdk/dig`
