### PR TITLE
fabric: apply shared TLS root cert defaults (#1112)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -340,12 +340,16 @@ fabric:
       enabled:  true
       # Specifies whether the fabric network requires mutualTLS
       clientAuthRequired: false
-      # The client tls certificate if mutualTLS is required
+      # The client TLS certificate if mutualTLS is required
       clientCert:
         file: /path/to/client.crt
-      # The client tls key if mutualTLS is required
+      # The client TLS key if mutualTLS is required
       clientKey:
         file: /path/to/client.key
+      # Default root CA used for outbound Fabric peer/orderer connections.
+      # Individual peers/orderers can still override this with tlsRootCertFile.
+      rootCert:
+        file: /path/to/fabric/ca.crt
 
     # Client keepalive settings for GRPC.
     # This section can be omitted.
@@ -382,7 +386,8 @@ fabric:
       - address: 'orderer0:7050'
         # connection timeout
         connectionTimeout: 10s
-        # path to orderer org's ca cert if tls is enabled
+        # path to orderer org's CA cert if TLS is enabled
+        # if omitted, fabric.<network>.tls.rootCert.file is used
         tlsRootCertFile: /path/to/ordererorg/ca.crt
         # server name override if tls cert SANS doesn't match address
         serverNameOverride:
@@ -399,7 +404,8 @@ fabric:
       - address: 'peer2:7051'
         # connection timeout
         connectionTimeout: 10s
-        # path to peer org's ca cert if tls is enabled
+        # path to peer org's CA cert if TLS is enabled
+        # if omitted, fabric.<network>.tls.rootCert.file is used
         tlsRootCertFile: /path/to/peerorg/ca.crt
         serverNameOverride:
         # it is possible to customize per peer the TLS behaviour, by using the following attributes

--- a/platform/fabric/core/generic/config/ds.go
+++ b/platform/fabric/core/generic/config/ds.go
@@ -67,14 +67,13 @@ type Files struct {
 }
 
 type TLS struct {
+	// TLS config under fabric.<network>.tls is client-side network config.
+	// Endpoint-specific peer/orderer settings can override these defaults.
 	Enabled            bool
 	ClientAuthRequired bool
-	Cert               File   `yaml:"cert"`
-	Key                File   `yaml:"key"`
 	ClientCert         File   `yaml:"clientCert"`
 	ClientKey          File   `yaml:"clientKey"`
 	RootCert           File   `yaml:"rootCert"`
-	ClientRootCAs      Files  `yaml:"clientRootCAs"`
 	RootCertFile       string `yaml:"rootCertFile"`
 }
 

--- a/platform/fabric/core/generic/config/service.go
+++ b/platform/fabric/core/generic/config/service.go
@@ -79,12 +79,16 @@ func NewService(configService Configuration, name string, defaultConfig bool) (*
 	}
 
 	tlsEnabled := configService.GetBool(fmt.Sprintf("fabric.%stls.enabled", prefix))
+	tlsRootCertFile := tlsRootCertFile(configService, prefix)
 	orderers, err := readItems[*ConnectionConfig](configService, prefix, "orderers")
 	if err != nil {
 		return nil, err
 	}
 	for _, v := range orderers {
 		v.TLSEnabled = tlsEnabled
+		if tlsEnabled && len(v.TLSRootCertFile) == 0 {
+			v.TLSRootCertFile = tlsRootCertFile
+		}
 		if tlsEnabled && len(v.TLSRootCertFile) > 0 {
 			v.TLSRootCertFile = configService.TranslatePath(v.TLSRootCertFile)
 		}
@@ -93,7 +97,7 @@ func NewService(configService Configuration, name string, defaultConfig bool) (*
 	if err != nil {
 		return nil, err
 	}
-	peerMapping := createPeerMap(configService, peers, tlsEnabled)
+	peerMapping := createPeerMap(configService, peers, tlsEnabled, tlsRootCertFile)
 
 	channels, err := readItems[*Channel](configService, prefix, "channels")
 	if err != nil {
@@ -355,10 +359,13 @@ func createChannelMap(channels []*Channel) (map[string]*Channel, string, error) 
 	return channelMap, defaultChannel, nil
 }
 
-func createPeerMap(configService Configuration, peers []*ConnectionConfig, tlsEnabled bool) map[driver.PeerFunctionType][]*ConnectionConfig {
+func createPeerMap(configService Configuration, peers []*ConnectionConfig, tlsEnabled bool, tlsRootCertFile string) map[driver.PeerFunctionType][]*ConnectionConfig {
 	peerMapping := map[driver.PeerFunctionType][]*ConnectionConfig{}
 	for _, peerCC := range peers {
 		peerCC.TLSEnabled = tlsEnabled && !peerCC.TLSDisabled
+		if peerCC.TLSEnabled && len(peerCC.TLSRootCertFile) == 0 {
+			peerCC.TLSRootCertFile = tlsRootCertFile
+		}
 		if peerCC.TLSEnabled && len(peerCC.TLSRootCertFile) > 0 {
 			peerCC.TLSRootCertFile = configService.TranslatePath(peerCC.TLSRootCertFile)
 		}
@@ -370,6 +377,16 @@ func createPeerMap(configService Configuration, peers []*ConnectionConfig, tlsEn
 		}
 	}
 	return peerMapping
+}
+
+func tlsRootCertFile(configService Configuration, prefix string) string {
+	rootCertFile := configService.GetPath(fmt.Sprintf("fabric.%stls.rootCert.file", prefix))
+	if len(rootCertFile) != 0 {
+		return rootCertFile
+	}
+
+	// Keep supporting the legacy flat key while the TLS model is being aligned.
+	return configService.GetPath(fmt.Sprintf("fabric.%stls.rootCertFile", prefix))
 }
 
 func readItems[T any](configService Configuration, prefix, key string) ([]T, error) {

--- a/platform/fabric/core/generic/config/service_test.go
+++ b/platform/fabric/core/generic/config/service_test.go
@@ -78,6 +78,139 @@ func TestNewService_defaultsAndOrderers(t *testing.T) {
 	require.Equal(t, "ch1", svc.DefaultChannel())
 }
 
+func TestNewService_usesSharedTLSRootCertForOrderersAndPeers(t *testing.T) {
+	t.Parallel()
+
+	m := &mock.Configuration{}
+	m.IsSetReturnsOnCall(0, true)
+	m.GetStringReturnsOnCall(0, "")
+	m.GetBoolReturns(true)
+	m.GetPathReturnsOnCall(0, "shared-root.pem")
+	m.TranslatePathStub = func(path string) string {
+		return "TRANSLATED:" + path
+	}
+	m.UnmarshalKeyStub = func(key string, rawVal interface{}) error {
+		switch key {
+		case "fabric.mynet.orderers", "fabric.mynetorderers":
+			p, ok := rawVal.(*[]*grpc.ConnectionConfig)
+			if !ok {
+				return nil
+			}
+			*p = []*grpc.ConnectionConfig{{Address: "o:7050"}}
+			return nil
+		case "fabric.mynet.peers", "fabric.mynetpeers":
+			p, ok := rawVal.(*[]*grpc.ConnectionConfig)
+			if !ok {
+				return nil
+			}
+			*p = []*grpc.ConnectionConfig{{Address: "p:7051", Usage: "query"}}
+			return nil
+		case "fabric.mynet.channels", "fabric.mynetchannels":
+			p, ok := rawVal.(*[]*cfg.Channel)
+			if !ok {
+				return nil
+			}
+			*p = []*cfg.Channel{{Name: "ch1", Default: true}}
+			return nil
+		}
+		return nil
+	}
+
+	svc, err := cfg.NewService(m, "mynet", false)
+	require.NoError(t, err)
+	require.Equal(t, "TRANSLATED:shared-root.pem", svc.Orderers()[0].TLSRootCertFile)
+	require.Equal(t, "TRANSLATED:shared-root.pem", svc.PickPeer(driver.PeerForQuery).TLSRootCertFile)
+}
+
+func TestNewService_prefersPerEndpointTLSRootCertOverSharedTLSRootCert(t *testing.T) {
+	t.Parallel()
+
+	m := &mock.Configuration{}
+	m.IsSetReturnsOnCall(0, true)
+	m.GetStringReturnsOnCall(0, "")
+	m.GetBoolReturns(true)
+	m.GetPathReturnsOnCall(0, "shared-root.pem")
+	m.TranslatePathStub = func(path string) string {
+		return "TRANSLATED:" + path
+	}
+	m.UnmarshalKeyStub = func(key string, rawVal interface{}) error {
+		switch key {
+		case "fabric.mynet.orderers", "fabric.mynetorderers":
+			p, ok := rawVal.(*[]*grpc.ConnectionConfig)
+			if !ok {
+				return nil
+			}
+			*p = []*grpc.ConnectionConfig{{Address: "o:7050", TLSRootCertFile: "orderer-root.pem"}}
+			return nil
+		case "fabric.mynet.peers", "fabric.mynetpeers":
+			p, ok := rawVal.(*[]*grpc.ConnectionConfig)
+			if !ok {
+				return nil
+			}
+			*p = []*grpc.ConnectionConfig{{Address: "p:7051", Usage: "query", TLSRootCertFile: "peer-root.pem"}}
+			return nil
+		case "fabric.mynet.channels", "fabric.mynetchannels":
+			p, ok := rawVal.(*[]*cfg.Channel)
+			if !ok {
+				return nil
+			}
+			*p = []*cfg.Channel{{Name: "ch1", Default: true}}
+			return nil
+		}
+		return nil
+	}
+
+	svc, err := cfg.NewService(m, "mynet", false)
+	require.NoError(t, err)
+	require.Equal(t, "TRANSLATED:orderer-root.pem", svc.Orderers()[0].TLSRootCertFile)
+	require.Equal(t, "TRANSLATED:peer-root.pem", svc.PickPeer(driver.PeerForQuery).TLSRootCertFile)
+}
+
+func TestNewService_supportsLegacySharedTLSRootCertKey(t *testing.T) {
+	t.Parallel()
+
+	m := &mock.Configuration{}
+	m.IsSetReturnsOnCall(0, true)
+	m.GetStringReturnsOnCall(0, "")
+	m.GetBoolReturns(true)
+	m.GetPathReturnsOnCall(0, "")
+	m.GetPathReturnsOnCall(1, "legacy-root.pem")
+	m.TranslatePathStub = func(path string) string {
+		return "TRANSLATED:" + path
+	}
+	m.UnmarshalKeyStub = func(key string, rawVal interface{}) error {
+		switch key {
+		case "fabric.mynet.orderers", "fabric.mynetorderers":
+			p, ok := rawVal.(*[]*grpc.ConnectionConfig)
+			if !ok {
+				return nil
+			}
+			*p = []*grpc.ConnectionConfig{{Address: "o:7050"}}
+			return nil
+		case "fabric.mynet.peers", "fabric.mynetpeers":
+			p, ok := rawVal.(*[]*grpc.ConnectionConfig)
+			if !ok {
+				return nil
+			}
+			*p = []*grpc.ConnectionConfig{{Address: "p:7051", Usage: "query"}}
+			return nil
+		case "fabric.mynet.channels", "fabric.mynetchannels":
+			p, ok := rawVal.(*[]*cfg.Channel)
+			if !ok {
+				return nil
+			}
+			*p = []*cfg.Channel{{Name: "ch1", Default: true}}
+			return nil
+		}
+		return nil
+	}
+
+	svc, err := cfg.NewService(m, "mynet", false)
+	require.NoError(t, err)
+	require.Equal(t, "TRANSLATED:legacy-root.pem", svc.Orderers()[0].TLSRootCertFile)
+	require.Equal(t, "TRANSLATED:legacy-root.pem", svc.PickPeer(driver.PeerForQuery).TLSRootCertFile)
+}
+
 func TestClientKeepAliveConfig_UnmarshalError(t *testing.T) {
 	t.Parallel()
 	m := &mock.Configuration{}
@@ -253,9 +386,17 @@ func TestServiceGetters(t *testing.T) {
 	require.Equal(t, 5*time.Second, svc.ClientConnTimeout())
 
 	// TLS Files
-	m.GetPathReturnsOnCall(0, "client-key")
+	m.GetPathStub = func(key string) string {
+		switch key {
+		case "fabric.mynet.tls.clientKey.file":
+			return "client-key"
+		case "fabric.mynet.tls.clientCert.file":
+			return "client-cert"
+		default:
+			return ""
+		}
+	}
 	require.Equal(t, "client-key", svc.TLSClientKeyFile())
-	m.GetPathReturnsOnCall(1, "client-cert")
 	require.Equal(t, "client-cert", svc.TLSClientCertFile())
 
 	// Vault

--- a/platform/fabric/core/generic/config/testdata/core.yaml
+++ b/platform/fabric/core/generic/config/testdata/core.yaml
@@ -74,24 +74,15 @@ fabric:
     tls:
       enabled:  true
       clientAuthRequired: false
-      cert:
-        file: /home/vagrant/testdata/fabric.default/crypto/peerOrganizations/org1.example.com/peers/approver.org1.example.com/tls/server.crt
-      key:
-        file: /home/vagrant/testdata/fabric.default/crypto/peerOrganizations/org1.example.com/peers/approver.org1.example.com/tls/server.key
       clientCert:
         file: /home/vagrant/testdata/fabric.default/crypto/peerOrganizations/org1.example.com/peers/approver.org1.example.com/tls/server.crt
       clientKey:
         file: /home/vagrant/testdata/fabric.default/crypto/peerOrganizations/org1.example.com/peers/approver.org1.example.com/tls/server.key
-      rootcert:
+      rootCert:
         file: /home/vagrant/testdata/fabric.default/crypto/peerOrganizations/org1.example.com/peers/approver.org1.example.com/tls/ca.crt
-      clientRootCAs:
-        files:
-          - /home/vagrant/testdata/fabric.default/crypto/peerOrganizations/org1.example.com/peers/approver.org1.example.com/tls/ca.crt
-      rootCertFile: /home/vagrant/testdata/fabric.default/crypto/ca-certs.pem
     peers:
       - address: 127.0.0.1:22013
         connectionTimeout: 10s
-        tlsRootCertFile: /home/vagrant/testdata/fabric.default/crypto/ca-certs.pem
         serverNameOverride:
     channels:
       - name: testchannel


### PR DESCRIPTION
## What changed
- apply `fabric.<network>.tls.rootCert.file` as the default outbound TLS root CA for configured Fabric peers and orderers
- preserve per-endpoint `tlsRootCertFile` precedence when a peer or orderer provides its own root CA
- keep compatibility with the legacy flat `fabric.<network>.tls.rootCertFile` key while the TLS model is being aligned
- update the Fabric config model/docs/examples to describe the `tls` section as client-side connection defaults

## Why
The `#1112` TLS refactor discussion calls out that the Fabric network TLS section should describe client-side connection settings clearly. Before this change, the shared TLS root certificate was documented but never actually applied to peer/orderer client connections, so operators had to repeat the same `tlsRootCertFile` value on every endpoint.

## Impact
Configured Fabric peers and orderers now inherit the shared outbound root CA from `fabric.<network>.tls.rootCert.file` unless they override it explicitly. Existing per-endpoint configs keep the same behavior, and older `rootCertFile` configs continue to work.

## Validation
- `go test ./platform/fabric/core/generic/config/... ./platform/fabric/core/generic/membership/...`
