### PR TITLE
fabric: align shared TLS server name override (#1112)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -340,6 +340,9 @@ fabric:
       enabled:  true
       # Specifies whether the fabric network requires mutualTLS
       clientAuthRequired: false
+      # Optional default server name override for outbound TLS hostname verification.
+      # Individual peers/orderers can still override this with serverNameOverride.
+      serverNameOverride: orderer.example.com
       # The client tls certificate if mutualTLS is required
       clientCert:
         file: /path/to/client.crt

--- a/platform/fabric/core/generic/config/service.go
+++ b/platform/fabric/core/generic/config/service.go
@@ -153,6 +153,11 @@ func (s *Service) TLSClientAuthRequired() bool {
 }
 
 func (s *Service) TLSServerHostOverride() string {
+	if override := s.GetString("tls.serverNameOverride"); len(override) != 0 {
+		return override
+	}
+
+	// Keep supporting the legacy key while the TLS model is being aligned.
 	return s.GetString("tls.serverhostoverride")
 }
 

--- a/platform/fabric/core/generic/config/service_test.go
+++ b/platform/fabric/core/generic/config/service_test.go
@@ -241,6 +241,23 @@ func TestServiceGetters(t *testing.T) {
 	m.GetBoolReturns(true)
 	require.True(t, svc.TLSClientAuthRequired())
 
+	m.GetStringStub = func(key string) string {
+		if key == "fabric.mynet.tls.serverNameOverride" {
+			return "server-name"
+		}
+		return ""
+	}
+	require.Equal(t, "server-name", svc.TLSServerHostOverride())
+
+	m.GetStringStub = func(key string) string {
+		if key == "fabric.mynet.tls.serverhostoverride" {
+			return "legacy-server-host"
+		}
+		return ""
+	}
+	require.Equal(t, "legacy-server-host", svc.TLSServerHostOverride())
+
+	m.GetStringStub = nil
 	m.GetStringReturns("server-host")
 	require.Equal(t, "server-host", svc.TLSServerHostOverride())
 

--- a/platform/fabric/core/generic/config/testdata/core.yaml
+++ b/platform/fabric/core/generic/config/testdata/core.yaml
@@ -74,6 +74,7 @@ fabric:
     tls:
       enabled:  true
       clientAuthRequired: false
+      serverNameOverride: approver.org1.example.com
       cert:
         file: /home/vagrant/testdata/fabric.default/crypto/peerOrganizations/org1.example.com/peers/approver.org1.example.com/tls/server.crt
       key:


### PR DESCRIPTION
## What changed
- accept `fabric.<network>.tls.serverNameOverride` as the shared Fabric client-side TLS hostname override
- keep the legacy `fabric.<network>.tls.serverhostoverride` key as a fallback for compatibility
- document the shared override in the Fabric configuration guide and test fixture

## Why
Issue `#1112` is aligning FSC TLS configuration around clearer, more consistent names. The shared Fabric client-side override still used the older `serverhostoverride` spelling even though endpoint-level configs and newer docs use `serverNameOverride`.

## Impact
Operators can now configure the shared outbound hostname override with the same `serverNameOverride` spelling used elsewhere in FSC, without breaking existing configs that still use the legacy key.

## Validation
- `go test ./platform/fabric/core/generic/config/... ./platform/fabric/core/generic/membership/...`
