### PR TITLE
fabric: apply ordering TLS defaults to configured orderers (#1112)

### DIFF
--- a/platform/fabric/core/generic/config/service.go
+++ b/platform/fabric/core/generic/config/service.go
@@ -79,13 +79,23 @@ func NewService(configService Configuration, name string, defaultConfig bool) (*
 	}
 
 	tlsEnabled := configService.GetBool(fmt.Sprintf("fabric.%stls.enabled", prefix))
+	tlsClientAuthRequired := configService.GetBool(fmt.Sprintf("fabric.%stls.clientAuthRequired", prefix))
+	orderingTLSEnabled, ok := orderingTLSEnabled(configService, prefix)
+	if !ok {
+		orderingTLSEnabled = tlsEnabled
+	}
+	orderingTLSClientAuthRequired, ok := orderingTLSClientAuthRequired(configService, prefix)
+	if !ok {
+		orderingTLSClientAuthRequired = tlsClientAuthRequired
+	}
 	orderers, err := readItems[*ConnectionConfig](configService, prefix, "orderers")
 	if err != nil {
 		return nil, err
 	}
 	for _, v := range orderers {
-		v.TLSEnabled = tlsEnabled
-		if tlsEnabled && len(v.TLSRootCertFile) > 0 {
+		v.TLSEnabled = effectiveTLSEnabled(orderingTLSEnabled, v)
+		v.TLSClientSideAuth = orderingTLSClientAuthRequired || v.TLSClientSideAuth
+		if v.TLSEnabled && len(v.TLSRootCertFile) > 0 {
 			v.TLSRootCertFile = configService.TranslatePath(v.TLSRootCertFile)
 		}
 	}
@@ -370,6 +380,30 @@ func createPeerMap(configService Configuration, peers []*ConnectionConfig, tlsEn
 		}
 	}
 	return peerMapping
+}
+
+func orderingTLSEnabled(configService Configuration, prefix string) (bool, bool) {
+	key := fmt.Sprintf("fabric.%sordering.tlsEnabled", prefix)
+	if !configService.IsSet(key) {
+		return false, false
+	}
+	return configService.GetBool(key), true
+}
+
+func orderingTLSClientAuthRequired(configService Configuration, prefix string) (bool, bool) {
+	key := fmt.Sprintf("fabric.%sordering.tlsClientAuthRequired", prefix)
+	if !configService.IsSet(key) {
+		return false, false
+	}
+	return configService.GetBool(key), true
+}
+
+func effectiveTLSEnabled(defaultEnabled bool, cc *ConnectionConfig) bool {
+	if cc.TLSDisabled {
+		return false
+	}
+
+	return defaultEnabled || cc.TLSEnabled
 }
 
 func readItems[T any](configService Configuration, prefix, key string) ([]T, error) {

--- a/platform/fabric/core/generic/config/service_test.go
+++ b/platform/fabric/core/generic/config/service_test.go
@@ -187,6 +187,148 @@ func TestCreatePeerMapAndPickPeer(t *testing.T) {
 	require.NotNil(t, p)
 }
 
+func TestNewService_orderingTLSOverridesConfiguredOrderers(t *testing.T) {
+	t.Parallel()
+
+	m := &mock.Configuration{}
+	m.GetStringReturnsOnCall(0, "")
+	m.GetBoolStub = func(key string) bool {
+		switch key {
+		case "fabric.test.tls.enabled":
+			return true
+		case "fabric.test.ordering.tlsEnabled":
+			return false
+		default:
+			return false
+		}
+	}
+	m.IsSetStub = func(key string) bool {
+		switch key {
+		case "fabric.test", "fabric.test.ordering.tlsEnabled":
+			return true
+		default:
+			return false
+		}
+	}
+	m.UnmarshalKeyStub = func(key string, rawVal interface{}) error {
+		switch key {
+		case "fabric.test.peers", "fabric.testpeers":
+			p := rawVal.(*[]*grpc.ConnectionConfig)
+			*p = []*grpc.ConnectionConfig{{Address: "p1", Usage: "query", TLSRootCertFile: "peer.pem"}}
+		case "fabric.test.orderers", "fabric.testorderers":
+			p := rawVal.(*[]*grpc.ConnectionConfig)
+			*p = []*grpc.ConnectionConfig{{Address: "o1", TLSRootCertFile: "orderer.pem"}}
+		case "fabric.test.channels", "fabric.testchannels":
+			p := rawVal.(*[]*cfg.Channel)
+			*p = []*cfg.Channel{{Name: "ch1"}}
+		}
+		return nil
+	}
+	m.TranslatePathStub = func(path string) string { return "TR:" + path }
+
+	svc, err := cfg.NewService(m, "test", false)
+	require.NoError(t, err)
+
+	require.False(t, svc.Orderers()[0].TLSEnabled)
+	require.Equal(t, "orderer.pem", svc.Orderers()[0].TLSRootCertFile)
+
+	peer := svc.PickPeer(driver.PeerForQuery)
+	require.NotNil(t, peer)
+	require.True(t, peer.TLSEnabled)
+	require.Equal(t, "TR:peer.pem", peer.TLSRootCertFile)
+}
+
+func TestNewService_orderingTLSClientAuthOverridesConfiguredOrderers(t *testing.T) {
+	t.Parallel()
+
+	m := &mock.Configuration{}
+	m.GetStringReturnsOnCall(0, "")
+	m.GetBoolStub = func(key string) bool {
+		switch key {
+		case "fabric.test.tls.enabled":
+			return true
+		case "fabric.test.tls.clientAuthRequired":
+			return false
+		case "fabric.test.ordering.tlsClientAuthRequired":
+			return true
+		default:
+			return false
+		}
+	}
+	m.IsSetStub = func(key string) bool {
+		switch key {
+		case "fabric.test", "fabric.test.ordering.tlsClientAuthRequired":
+			return true
+		default:
+			return false
+		}
+	}
+	m.UnmarshalKeyStub = func(key string, rawVal interface{}) error {
+		switch key {
+		case "fabric.test.peers", "fabric.testpeers":
+			p := rawVal.(*[]*grpc.ConnectionConfig)
+			*p = []*grpc.ConnectionConfig{{Address: "p1", Usage: "query"}}
+		case "fabric.test.orderers", "fabric.testorderers":
+			p := rawVal.(*[]*grpc.ConnectionConfig)
+			*p = []*grpc.ConnectionConfig{{Address: "o1"}}
+		case "fabric.test.channels", "fabric.testchannels":
+			p := rawVal.(*[]*cfg.Channel)
+			*p = []*cfg.Channel{{Name: "ch1"}}
+		}
+		return nil
+	}
+
+	svc, err := cfg.NewService(m, "test", false)
+	require.NoError(t, err)
+
+	require.True(t, svc.Orderers()[0].TLSClientSideAuth)
+	peer := svc.PickPeer(driver.PeerForQuery)
+	require.NotNil(t, peer)
+	require.False(t, peer.TLSClientSideAuth)
+}
+
+func TestNewService_ordererEndpointTLSAndClientAuthStillOptInWhenSharedDefaultsAreDisabled(t *testing.T) {
+	t.Parallel()
+
+	m := &mock.Configuration{}
+	m.GetStringReturnsOnCall(0, "")
+	m.GetBoolStub = func(key string) bool {
+		switch key {
+		case "fabric.test.tls.enabled":
+			return false
+		case "fabric.test.tls.clientAuthRequired":
+			return false
+		default:
+			return false
+		}
+	}
+	m.IsSetStub = func(key string) bool {
+		return key == "fabric.test"
+	}
+	m.UnmarshalKeyStub = func(key string, rawVal interface{}) error {
+		switch key {
+		case "fabric.test.peers", "fabric.testpeers":
+			p := rawVal.(*[]*grpc.ConnectionConfig)
+			*p = []*grpc.ConnectionConfig{{Address: "p1", Usage: "query"}}
+		case "fabric.test.orderers", "fabric.testorderers":
+			p := rawVal.(*[]*grpc.ConnectionConfig)
+			*p = []*grpc.ConnectionConfig{{Address: "o1", TLSEnabled: true, TLSClientSideAuth: true, TLSRootCertFile: "orderer.pem"}}
+		case "fabric.test.channels", "fabric.testchannels":
+			p := rawVal.(*[]*cfg.Channel)
+			*p = []*cfg.Channel{{Name: "ch1"}}
+		}
+		return nil
+	}
+	m.TranslatePathStub = func(path string) string { return "TR:" + path }
+
+	svc, err := cfg.NewService(m, "test", false)
+	require.NoError(t, err)
+
+	require.True(t, svc.Orderers()[0].TLSEnabled)
+	require.True(t, svc.Orderers()[0].TLSClientSideAuth)
+	require.Equal(t, "TR:orderer.pem", svc.Orderers()[0].TLSRootCertFile)
+}
+
 func TestPickOrderer_nilAndSetConfigOrderers(t *testing.T) {
 	t.Parallel()
 	m := &mock.Configuration{}


### PR DESCRIPTION
## What changed
- apply `ordering.tlsEnabled` to configured Fabric `orderers:` entries instead of only discovered channel orderers
- apply `ordering.tlsClientAuthRequired` to configured `orderers:` entries as the default client-auth setting
- preserve explicit per-orderer `tlsEnabled`, `tlsDisabled`, and `tlsClientSideAuth` opt-ins

## Why
Issue `#1112` is aligning FSC TLS behavior with the documented configuration model. Before this change, the `ordering` TLS overrides were only used when deriving orderer connections from channel config, while statically configured `fabric.<network>.orderers` silently ignored them.

## Impact
Configured orderers now follow the same TLS defaulting rules documented for the ordering service. Users can disable or enable TLS for ordering separately from peer traffic, and can enable ordering mTLS centrally without repeating the setting on every configured orderer.

## Validation
- `go test ./platform/fabric/core/generic/config/... ./platform/fabric/core/generic/membership/...`
