### PR TITLE
comm: add transport round-trip benchmarks (#797)

### DIFF
--- a/platform/view/services/comm/host/libp2p/p2p_bench_test.go
+++ b/platform/view/services/comm/host/libp2p/p2p_bench_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package libp2p
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/comm"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
+
+func BenchmarkSessionRoundTrip(b *testing.B) {
+	benchmarkSessionRoundTrip(b, setupTwoNodes)
+}
+
+func benchmarkSessionRoundTrip(b *testing.B, setup func(testing.TB) (*comm.HostNode, *comm.HostNode)) {
+	b.Helper()
+
+	b.Run("new-session", func(b *testing.B) {
+		aliceNode, bobNode := setup(b)
+		ctx, cancel := context.WithCancel(b.Context())
+		defer cancel()
+		aliceNode.Start(ctx)
+		bobNode.Start(ctx)
+
+		masterSession, err := bobNode.MasterSession()
+		require.NoError(b, err)
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case msg := <-masterSession.Receive():
+					if msg == nil {
+						continue
+					}
+					responder, err := bobNode.NewResponderSession(msg.SessionID, msg.ContextID, "", msg.FromPKID, view.Identity(msg.FromPKID), nil)
+					if err != nil {
+						return
+					}
+					_ = responder.Send(append([]byte("pong:"), msg.Payload...))
+					responder.Close()
+				}
+			}
+		}()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			session, err := aliceNode.NewSession("caller", "ctx", bobNode.Address, []byte(bobNode.ID))
+			require.NoError(b, err)
+			payload := []byte(fmt.Sprintf("ping-%d", i))
+			require.NoError(b, session.Send(payload))
+			reply := <-session.Receive()
+			require.NotNil(b, reply)
+			require.Equal(b, append([]byte("pong:"), payload...), reply.Payload)
+			session.Close()
+		}
+		b.StopTimer()
+		cancel()
+		aliceNode.Stop()
+		bobNode.Stop()
+		<-done
+	})
+
+	b.Run("reused-session", func(b *testing.B) {
+		aliceNode, bobNode := setup(b)
+		ctx, cancel := context.WithCancel(b.Context())
+		defer cancel()
+		aliceNode.Start(ctx)
+		bobNode.Start(ctx)
+
+		session, err := aliceNode.NewSession("caller", "ctx", bobNode.Address, []byte(bobNode.ID))
+		require.NoError(b, err)
+		defer session.Close()
+
+		masterSession, err := bobNode.MasterSession()
+		require.NoError(b, err)
+
+		first := []byte("warmup")
+		require.NoError(b, session.Send(first))
+		msg := <-masterSession.Receive()
+		require.NotNil(b, msg)
+
+		responder, err := bobNode.NewResponderSession(msg.SessionID, msg.ContextID, "", msg.FromPKID, view.Identity(msg.FromPKID), nil)
+		require.NoError(b, err)
+		defer responder.Close()
+		require.NoError(b, responder.Send(append([]byte("pong:"), msg.Payload...)))
+		reply := <-session.Receive()
+		require.NotNil(b, reply)
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case req := <-responder.Receive():
+					if req == nil {
+						continue
+					}
+					_ = responder.Send(append([]byte("pong:"), req.Payload...))
+				}
+			}
+		}()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			payload := []byte(fmt.Sprintf("ping-%d", i))
+			require.NoError(b, session.Send(payload))
+			reply := <-session.Receive()
+			require.NotNil(b, reply)
+			require.Equal(b, append([]byte("pong:"), payload...), reply.Payload)
+		}
+		b.StopTimer()
+		cancel()
+		aliceNode.Stop()
+		bobNode.Stop()
+		<-done
+	})
+}

--- a/platform/view/services/comm/host/libp2p/p2p_test.go
+++ b/platform/view/services/comm/host/libp2p/p2p_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package libp2p
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -69,55 +70,55 @@ func TestSessionsTwoNodesTestRound(t *testing.T) { //nolint:paralleltest
 	comm.SessionsNodesTestRound(t, bootstrapNode, []*comm.HostNode{node1, node2}, 2)
 }
 
-func generateKey(t *testing.T) (crypto.PrivKey, string) {
-	t.Helper()
+func generateKey(tb testing.TB) (crypto.PrivKey, string) {
+	tb.Helper()
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	privKey, pubKey, err := crypto.ECDSAKeyPairFromKey(priv)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	ID, err := peer.IDFromPublicKey(pubKey)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	return privKey, ID.String()
 }
 
-func freeLibP2PAddresses(t *testing.T, n int) []string {
-	t.Helper()
+func freeLibP2PAddresses(tb testing.TB, n int) []string {
+	tb.Helper()
 	listeners := make([]net.Listener, n)
 	addresses := make([]string, n)
 	for i := range n {
 		l, err := net.Listen("tcp", "127.0.0.1:0")
-		require.NoError(t, err)
+		require.NoError(tb, err)
 		listeners[i] = l
 		addresses[i] = fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", l.Addr().(*net.TCPAddr).Port)
 	}
 	for _, l := range listeners {
-		require.NoError(t, l.Close())
+		require.NoError(tb, l.Close())
 	}
 	return addresses
 }
 
-func setupTwoNodes(t *testing.T) (*comm.HostNode, *comm.HostNode) {
-	t.Helper()
-	bootstrapSK, bootstrapID := generateKey(t)
-	nodeSK, nodeID := generateKey(t)
+func setupTwoNodes(tb testing.TB) (*comm.HostNode, *comm.HostNode) {
+	tb.Helper()
+	bootstrapSK, bootstrapID := generateKey(tb)
+	nodeSK, nodeID := generateKey(tb)
 
-	addrs := freeLibP2PAddresses(t, 2)
+	addrs := freeLibP2PAddresses(tb, 2)
 	bootstrapNodeEndpoint := addrs[0]
 	nodeEndpoint := addrs[1]
 
 	bootstrapConfig := &mock.LibP2PConfig{}
 	bootstrapConfig.ListenAddressReturns(bootstrapNodeEndpoint)
 	bootstrapHost, err := newLibP2PHost(bootstrapConfig, bootstrapSK, newMetrics(&disabled.Provider{}), true, "")
-	require.NoError(t, err)
-	bootstrapNode, err := comm.NewNode(t.Context(), bootstrapHost, &disabled.Provider{})
-	require.NoError(t, err)
+	require.NoError(tb, err)
+	bootstrapNode, err := comm.NewNode(context.Background(), bootstrapHost, &disabled.Provider{})
+	require.NoError(tb, err)
 
 	nodeConfig := &mock.LibP2PConfig{}
 	nodeConfig.ListenAddressReturns(nodeEndpoint)
 	anotherHost, err := newLibP2PHost(nodeConfig, nodeSK, newMetrics(&disabled.Provider{}), false, bootstrapNodeEndpoint+"/p2p/"+bootstrapID)
-	require.NoError(t, err)
-	anotherNode, err := comm.NewNode(t.Context(), anotherHost, &disabled.Provider{})
-	require.NoError(t, err)
+	require.NoError(tb, err)
+	anotherNode, err := comm.NewNode(context.Background(), anotherHost, &disabled.Provider{})
+	require.NoError(tb, err)
 
 	time.Sleep(1 * time.Second)
 
@@ -125,13 +126,13 @@ func setupTwoNodes(t *testing.T) (*comm.HostNode, *comm.HostNode) {
 		&comm.HostNode{P2PNode: anotherNode, ID: nodeID, Address: nodeEndpoint}
 }
 
-func setupThreeNodes(t *testing.T) (*comm.HostNode, *comm.HostNode, *comm.HostNode) {
-	t.Helper()
-	bootstrapSK, bootstrapID := generateKey(t)
-	node1SK, node1ID := generateKey(t)
-	node2SK, node2ID := generateKey(t)
+func setupThreeNodes(tb testing.TB) (*comm.HostNode, *comm.HostNode, *comm.HostNode) {
+	tb.Helper()
+	bootstrapSK, bootstrapID := generateKey(tb)
+	node1SK, node1ID := generateKey(tb)
+	node2SK, node2ID := generateKey(tb)
 
-	addrs := freeLibP2PAddresses(t, 3)
+	addrs := freeLibP2PAddresses(tb, 3)
 	bootstrapNodeEndpoint := addrs[0]
 	node1Endpoint := addrs[1]
 	node2Endpoint := addrs[2]
@@ -139,23 +140,23 @@ func setupThreeNodes(t *testing.T) (*comm.HostNode, *comm.HostNode, *comm.HostNo
 	bootstrapConfig := &mock.LibP2PConfig{}
 	bootstrapConfig.ListenAddressReturns(bootstrapNodeEndpoint)
 	bootstrapHost, err := newLibP2PHost(bootstrapConfig, bootstrapSK, newMetrics(&disabled.Provider{}), true, "")
-	require.NoError(t, err)
-	bootstrapNode, err := comm.NewNode(t.Context(), bootstrapHost, &disabled.Provider{})
-	require.NoError(t, err)
+	require.NoError(tb, err)
+	bootstrapNode, err := comm.NewNode(context.Background(), bootstrapHost, &disabled.Provider{})
+	require.NoError(tb, err)
 
 	node1Config := &mock.LibP2PConfig{}
 	node1Config.ListenAddressReturns(node1Endpoint)
 	node1Host, err := newLibP2PHost(node1Config, node1SK, newMetrics(&disabled.Provider{}), false, bootstrapNodeEndpoint+"/p2p/"+bootstrapID)
-	require.NoError(t, err)
-	node1, err := comm.NewNode(t.Context(), node1Host, &disabled.Provider{})
-	require.NoError(t, err)
+	require.NoError(tb, err)
+	node1, err := comm.NewNode(context.Background(), node1Host, &disabled.Provider{})
+	require.NoError(tb, err)
 
 	node2Config := &mock.LibP2PConfig{}
 	node2Config.ListenAddressReturns(node2Endpoint)
 	node2Host, err := newLibP2PHost(node2Config, node2SK, newMetrics(&disabled.Provider{}), false, bootstrapNodeEndpoint+"/p2p/"+bootstrapID)
-	require.NoError(t, err)
-	node2, err := comm.NewNode(t.Context(), node2Host, &disabled.Provider{})
-	require.NoError(t, err)
+	require.NoError(tb, err)
+	node2, err := comm.NewNode(context.Background(), node2Host, &disabled.Provider{})
+	require.NoError(tb, err)
 
 	time.Sleep(1 * time.Second)
 

--- a/platform/view/services/comm/host/websocket/p2p_bench_test.go
+++ b/platform/view/services/comm/host/websocket/p2p_bench_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package websocket_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/comm"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
+
+func BenchmarkSessionRoundTrip(b *testing.B) {
+	benchmarkSessionRoundTrip(b, setupTwoNodes)
+}
+
+func benchmarkSessionRoundTrip(b *testing.B, setup func(testing.TB) (*comm.HostNode, *comm.HostNode)) {
+	b.Helper()
+
+	b.Run("new-session", func(b *testing.B) {
+		aliceNode, bobNode := setup(b)
+		ctx, cancel := context.WithCancel(b.Context())
+		defer cancel()
+		aliceNode.Start(ctx)
+		bobNode.Start(ctx)
+
+		masterSession, err := bobNode.MasterSession()
+		require.NoError(b, err)
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case msg := <-masterSession.Receive():
+					if msg == nil {
+						continue
+					}
+					responder, err := bobNode.NewResponderSession(msg.SessionID, msg.ContextID, "", msg.FromPKID, view.Identity(msg.FromPKID), nil)
+					if err != nil {
+						return
+					}
+					_ = responder.Send(append([]byte("pong:"), msg.Payload...))
+					responder.Close()
+				}
+			}
+		}()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			session, err := aliceNode.NewSession("caller", "ctx", bobNode.Address, []byte(bobNode.ID))
+			require.NoError(b, err)
+			payload := []byte(fmt.Sprintf("ping-%d", i))
+			require.NoError(b, session.Send(payload))
+
+			reply := <-session.Receive()
+			require.NotNil(b, reply)
+			require.Equal(b, append([]byte("pong:"), payload...), reply.Payload)
+			session.Close()
+		}
+		b.StopTimer()
+		cancel()
+		aliceNode.Stop()
+		bobNode.Stop()
+		<-done
+	})
+
+	b.Run("reused-session", func(b *testing.B) {
+		aliceNode, bobNode := setup(b)
+		ctx, cancel := context.WithCancel(b.Context())
+		defer cancel()
+		aliceNode.Start(ctx)
+		bobNode.Start(ctx)
+
+		session, err := aliceNode.NewSession("caller", "ctx", bobNode.Address, []byte(bobNode.ID))
+		require.NoError(b, err)
+		defer session.Close()
+
+		masterSession, err := bobNode.MasterSession()
+		require.NoError(b, err)
+
+		first := []byte("warmup")
+		require.NoError(b, session.Send(first))
+		msg := <-masterSession.Receive()
+		require.NotNil(b, msg)
+
+		responder, err := bobNode.NewResponderSession(msg.SessionID, msg.ContextID, "", msg.FromPKID, view.Identity(msg.FromPKID), nil)
+		require.NoError(b, err)
+		defer responder.Close()
+		require.NoError(b, responder.Send(append([]byte("pong:"), msg.Payload...)))
+		reply := <-session.Receive()
+		require.NotNil(b, reply)
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case req := <-responder.Receive():
+					if req == nil {
+						continue
+					}
+					_ = responder.Send(append([]byte("pong:"), req.Payload...))
+				}
+			}
+		}()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			payload := []byte(fmt.Sprintf("ping-%d", i))
+			require.NoError(b, session.Send(payload))
+			reply := <-session.Receive()
+			require.NotNil(b, reply)
+			require.Equal(b, append([]byte("pong:"), payload...), reply.Payload)
+		}
+		b.StopTimer()
+		cancel()
+		aliceNode.Stop()
+		bobNode.Stop()
+		<-done
+	})
+}

--- a/platform/view/services/comm/host/websocket/p2p_test.go
+++ b/platform/view/services/comm/host/websocket/p2p_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package websocket_test
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -109,8 +110,9 @@ func TestMTLSCallerIdentityBinding(t *testing.T) { //nolint:paralleltest
 	require.Equal(t, []byte("pong"), reply.Payload)
 }
 
-func setupTwoNodes(t *testing.T) (*comm.HostNode, *comm.HostNode) {
-	t.Helper()
+func setupTwoNodes(tb testing.TB) (*comm.HostNode, *comm.HostNode) {
+	tb.Helper()
+	t := tb
 	tlsFiles := generateTLSFiles(t)
 
 	addresses := freeTCPAddresses(t, 2)
@@ -133,7 +135,7 @@ func setupTwoNodes(t *testing.T) (*comm.HostNode, *comm.HostNode) {
 		true,
 		100, nil,
 	)).GetNewHost()
-	bootstrapNode, err := comm.NewNode(t.Context(), bootstrap, &disabled.Provider{})
+	bootstrapNode, err := comm.NewNode(context.Background(), bootstrap, &disabled.Provider{})
 	require.NoError(t, err)
 
 	other, _ := newStaticRouteHostProvider(&routing.StaticIDRouter{
@@ -148,7 +150,7 @@ func setupTwoNodes(t *testing.T) (*comm.HostNode, *comm.HostNode) {
 		true,
 		100, nil,
 	)).GetNewHost()
-	otherNode, err := comm.NewNode(t.Context(), other, &disabled.Provider{})
+	otherNode, err := comm.NewNode(context.Background(), other, &disabled.Provider{})
 	require.NoError(t, err)
 
 	<-time.After(1 * time.Second)
@@ -162,8 +164,9 @@ func TestSessionsTwoNodesTestRound(t *testing.T) { //nolint:paralleltest
 	comm.SessionsNodesTestRound(t, bootstrapNode, []*comm.HostNode{node1, node2}, 50)
 }
 
-func setupThreeNodes(t *testing.T) (*comm.HostNode, *comm.HostNode, *comm.HostNode) {
-	t.Helper()
+func setupThreeNodes(tb testing.TB) (*comm.HostNode, *comm.HostNode, *comm.HostNode) {
+	tb.Helper()
+	t := tb
 	// Create TLS certificates for three nodes: bootstrap, node1, node2
 	dir := t.TempDir()
 
@@ -285,7 +288,8 @@ func setupThreeNodes(t *testing.T) (*comm.HostNode, *comm.HostNode, *comm.HostNo
 		&comm.HostNode{P2PNode: node2Node, ID: node2ID, Address: node2Address}
 }
 
-func freeTCPAddresses(t *testing.T, n int) []string {
+func freeTCPAddresses(tb testing.TB, n int) []string {
+	t := tb
 	t.Helper()
 	var listeners []net.Listener
 	for i := 0; i < n; i++ {
@@ -301,8 +305,9 @@ func freeTCPAddresses(t *testing.T, n int) []string {
 	return addresses
 }
 
-func mustPeerIDFromCert(t *testing.T, certPath string) string {
-	t.Helper()
+func mustPeerIDFromCert(tb testing.TB, certPath string) string {
+	tb.Helper()
+	t := tb
 	raw, err := os.ReadFile(certPath)
 	require.NoError(t, err)
 	block, _ := pem.Decode(raw)
@@ -328,8 +333,9 @@ type generatedTLSFiles struct {
 	otherKey      string
 }
 
-func generateTLSFiles(t *testing.T) generatedTLSFiles {
-	t.Helper()
+func generateTLSFiles(tb testing.TB) generatedTLSFiles {
+	tb.Helper()
+	t := tb
 	dir := t.TempDir()
 
 	caPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -528,8 +534,9 @@ func generateThreeNodesTLSFiles(t *testing.T) threeNodesTLSFiles {
 	}
 }
 
-func setupTwoNodesFromTLS(t *testing.T, alice, bob nodeTLSFiles, caCert string) (*comm.HostNode, *comm.HostNode) {
-	t.Helper()
+func setupTwoNodesFromTLS(tb testing.TB, alice, bob nodeTLSFiles, caCert string) (*comm.HostNode, *comm.HostNode) {
+	tb.Helper()
+	t := tb
 	addrs := freeTCPAddresses(t, 2)
 	aliceAddr := addrs[0]
 	bobAddr := addrs[1]
@@ -540,15 +547,16 @@ func setupTwoNodesFromTLS(t *testing.T, alice, bob nodeTLSFiles, caCert string) 
 		bobID:   []host2.PeerIPAddress{bobAddr},
 	}
 	aliceH, _ := newStaticRouteHostProvider(routes, websocket.NewConfigFromProperties(aliceAddr, alice.key, alice.cert, []string{caCert}, []string{caCert}, true, 100, nil)).GetNewHost()
-	aliceNode, _ := comm.NewNode(t.Context(), aliceH, &disabled.Provider{})
+	aliceNode, _ := comm.NewNode(context.Background(), aliceH, &disabled.Provider{})
 	bobH, _ := newStaticRouteHostProvider(routes, websocket.NewConfigFromProperties(bobAddr, bob.key, bob.cert, []string{caCert}, []string{caCert}, true, 100, nil)).GetNewHost()
-	bobNode, _ := comm.NewNode(t.Context(), bobH, &disabled.Provider{})
+	bobNode, _ := comm.NewNode(context.Background(), bobH, &disabled.Provider{})
 	return &comm.HostNode{P2PNode: aliceNode, ID: aliceID, Address: aliceAddr},
 		&comm.HostNode{P2PNode: bobNode, ID: bobID, Address: bobAddr}
 }
 
-func writePEM(t *testing.T, path, typ string, raw []byte) {
-	t.Helper()
+func writePEM(tb testing.TB, path, typ string, raw []byte) {
+	tb.Helper()
+	t := tb
 	f, err := os.Create(path)
 	require.NoError(t, err)
 	defer func() { _ = f.Close() }()


### PR DESCRIPTION
## What changed
- add websocket P2P transport microbenchmarks for new-session and reused-session round trips
- add libp2p P2P transport microbenchmarks for the same session patterns
- widen existing transport test setup helpers from `*testing.T` to `testing.TB` so the same node setups can be reused by benchmarks

## Why
Issue `#797` asks for communication-layer performance testing so FSC can compare transports with actual measurements instead of assumptions. We already had functional transport tests, but no runnable microbenchmarks in the transport packages themselves.

## Impact
Developers can now run apples-to-apples local benchmarks for websocket and libp2p session round trips and use those numbers as a baseline when changing the comm layer.

## Validation
- `go test -run '^$' -bench BenchmarkSessionRoundTrip -benchtime=1x ./platform/view/services/comm/host/websocket`
- `go test -run '^$' -bench BenchmarkSessionRoundTrip -benchtime=1x ./platform/view/services/comm/host/libp2p`

Fixes #797
