### PR TITLE
bug(config service): yaml tags are not respected #1343

### DIFF
--- a/docs/platform/view/services/config-service.md
+++ b/docs/platform/view/services/config-service.md
@@ -97,3 +97,14 @@ func (s *MyService) UpdateConfig(config *config.Provider, rawYaml []byte) {
 ## Implementation Details
 
 Currently, the configuration service is based on [github.com/knadh/koanf](https://github.com/knadh/koanf), a light-weight, extensible configuration management library for Go. While the `config.Provider` interface abstracts most of these details, the underlying implementation utilizes `koanf` for its powerful parsing, merging, and environment variable substitution capabilities.
+This implementation supports the field tag `yaml` as well. This allows the developer to support something like this:
+
+```go
+type Opts struct {
+	// DriverType has on purpose a different name from what we expect in the configuration file as signaled by the yaml tag.
+	DriverType   DriverType `yaml:"driver"`
+	DataSource   string
+	SkipPragmas  bool
+	MaxOpenConns int
+}
+```

--- a/platform/view/services/config/config_util.go
+++ b/platform/view/services/config/config_util.go
@@ -193,5 +193,6 @@ func EnhancedExactUnmarshal(v *koanf.Koanf, key string, output interface{}) erro
 	}
 	return v.UnmarshalWithConf(key, output, koanf.UnmarshalConf{
 		DecoderConfig: config,
+		Tag:           "yaml",
 	})
 }

--- a/platform/view/services/config/provider_test.go
+++ b/platform/view/services/config/provider_test.go
@@ -20,7 +20,8 @@ import (
 type DriverType string
 
 type Opts struct {
-	Driver       DriverType
+	// DriverType has on purpose a different name from what we expect in the configuration file as signaled by the yaml tag.
+	DriverType   DriverType `yaml:"driver"`
 	DataSource   string
 	SkipPragmas  bool
 	MaxOpenConns int
@@ -77,13 +78,13 @@ func TestEnvSubstitution(t *testing.T) { //nolint:paralleltest
 
 	err = p.UnmarshalKey("fsc.kvs.persistence.opts", &db)
 	require.NoError(t, err)
-	assert.Equal(t, DriverType("sqlite"), db.Driver)
+	assert.Equal(t, DriverType("sqlite"), db.DriverType)
 	assert.Equal(t, "new data source", db.DataSource)
 	assert.True(t, db.SkipPragmas)
 	assert.Equal(t, 0, db.MaxOpenConns)
 	err = p.UnmarshalKey("FSC.kvs.PerSistEnce.opTs", &db)
 	require.NoError(t, err)
-	assert.Equal(t, DriverType("sqlite"), db.Driver)
+	assert.Equal(t, DriverType("sqlite"), db.DriverType)
 	assert.Equal(t, "new data source", db.DataSource)
 	assert.True(t, db.SkipPragmas)
 	assert.Equal(t, 0, db.MaxOpenConns)
@@ -166,7 +167,7 @@ func testBasics(t *testing.T, p *Provider) {
 	assert.Equal(t, "sql", p.GetString("fsc.kvs.persistence.type"))
 	err := p.UnmarshalKey("fsc.kvs.persistence.opts", &db)
 	require.NoError(t, err)
-	assert.Equal(t, DriverType("sqlite"), db.Driver)
+	assert.Equal(t, DriverType("sqlite"), db.DriverType)
 	assert.Equal(t, "ds", db.DataSource)
 	assert.True(t, db.SkipPragmas)
 	assert.Equal(t, 0, db.MaxOpenConns)


### PR DESCRIPTION
This PR fix the bug identified by #1343 by using the following config 

```go
koanf.UnmarshalConf{
		DecoderConfig: config,
		Tag:           "yaml",
	}
```

This way `koanf` will process the `yaml` field tags.