### PR TITLE
update(endpoint/service): no ip resolution

### DIFF
--- a/integration/nwo/fsc/node/crypto_template.go
+++ b/integration/nwo/fsc/node/crypto_template.go
@@ -21,6 +21,7 @@ PeerOrgs:{{ range .PeerOrgs }}
     - 127.0.0.1
     - ::1
     - "::"
+    - host.docker.internal
   {{- end }}
   {{- end }}
   Users:
@@ -42,6 +43,7 @@ PeerOrgs:{{ range .PeerOrgs }}
     - 127.0.0.1
     - ::1
     - "::"
+    - host.docker.internal
   {{- end }}
 {{- end }}
 {{- end }}

--- a/platform/view/services/endpoint/service.go
+++ b/platform/view/services/endpoint/service.go
@@ -8,7 +8,6 @@ package endpoint
 
 import (
 	"context"
-	"net"
 	"reflect"
 	"strings"
 	"sync"
@@ -228,7 +227,7 @@ func (r *Service) UpdateResolver(
 		// update addresses
 		addressList := make([]string, 0, len(addresses))
 		for k, v := range addresses {
-			addresses[k] = LookupIP(v)
+			addresses[k] = v
 			addressList = append(addressList, v)
 		}
 		resolver.Addresses = convert(addresses)
@@ -276,7 +275,7 @@ func (r *Service) AddResolver(
 	// resolve addresses to their IPs, if needed
 	addressList := make([]string, 0, len(addresses))
 	for k, v := range addresses {
-		addresses[k] = LookupIP(v)
+		addresses[k] = v
 		addressList = append(addressList, v)
 	}
 
@@ -533,25 +532,4 @@ func convert(o map[string]string) map[PortName]string {
 		r[portNameMap[strings.ToLower(k)]] = v
 	}
 	return r
-}
-
-// LookupIP resolves a hostname in an endpoint to its IP address.
-// If the endpoint is already an IP address or resolution fails, returns the original endpoint.
-// The endpoint must be in "host:port" format.
-func LookupIP(endpoint string) string {
-	host, port, err := net.SplitHostPort(endpoint)
-	if err != nil {
-		return endpoint
-	}
-
-	addrs, err := net.LookupIP(host)
-	if err != nil {
-		return endpoint
-	}
-
-	if len(addrs) > 0 {
-		return net.JoinHostPort(addrs[0].String(), port)
-	}
-
-	return endpoint
 }

--- a/platform/view/services/endpoint/service_test.go
+++ b/platform/view/services/endpoint/service_test.go
@@ -7,11 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package endpoint_test
 
 import (
-	"net"
 	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/endpoint"
@@ -93,7 +91,6 @@ func TestGetIdentity(t *testing.T) {
 		"apple",
 		"strawberry",
 		"localhost:1010",
-		"[::1]:1010",
 		"alice_id",
 	} {
 		resultID, err := service.GetIdentity(label, []byte{})
@@ -146,11 +143,10 @@ func TestGetIdentity(t *testing.T) {
 		"apple",
 		"strawberry",
 		"localhost:1010",
-		"[::1]:1010",
 		"alice_id",
 	} {
 		ok, err := service.RemoveResolver(view.Identity(label))
-		require.NoError(t, err)
+		require.NoError(t, err, "failed to remove resolver for [%s]", label)
 		require.True(t, ok)
 
 		resolvers = service.Resolvers()
@@ -172,278 +168,4 @@ func TestGetIdentity(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, endpoint.ErrNotFound)
 	require.False(t, ok)
-}
-
-func TestLookupIP(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		endpoint string
-		// We can't predict exact resolved IPs, but we can verify format
-		checkFunc func(t *testing.T, input, output string)
-	}{
-		// IPv4 addresses
-		{
-			name:     "IPv4 with port",
-			endpoint: "192.168.1.1:8080",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "IPv4 address should be returned as-is")
-			},
-		},
-		{
-			name:     "IPv4 loopback with port",
-			endpoint: "127.0.0.1:9000",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "IPv4 loopback should be returned as-is")
-			},
-		},
-		{
-			name:     "IPv4 with high port",
-			endpoint: "10.0.0.1:65535",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "IPv4 with high port should be returned as-is")
-			},
-		},
-
-		// IPv6 addresses
-		{
-			name:     "IPv6 loopback with port",
-			endpoint: "[::1]:8080",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "IPv6 loopback should be returned as-is")
-			},
-		},
-		{
-			name:     "IPv6 full address with port",
-			endpoint: "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:443",
-			checkFunc: func(t *testing.T, input, output string) {
-				// Go normalizes IPv6 addresses, so the full form gets compressed
-				t.Helper()
-				assert.Equal(t, "[2001:db8:85a3::8a2e:370:7334]:443", output,
-					"IPv6 full address should be normalized by Go")
-			},
-		},
-		{
-			name:     "IPv6 compressed address with port",
-			endpoint: "[2001:db8::1]:8080",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "IPv6 compressed address should be returned as-is")
-			},
-		},
-		{
-			name:     "IPv6 all zeros compressed with port",
-			endpoint: "[::]:8080",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "IPv6 all zeros should be returned as-is")
-			},
-		},
-		{
-			name:     "IPv6 link-local with port",
-			endpoint: "[fe80::1]:8080",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "IPv6 link-local should be returned as-is")
-			},
-		},
-
-		// Hostnames (these will actually resolve)
-		{
-			name:     "localhost with port",
-			endpoint: "localhost:8080",
-			checkFunc: func(t *testing.T, input, output string) {
-				// localhost should resolve to either 127.0.0.1:8080 or [::1]:8080
-				t.Helper()
-				assert.Contains(t, []string{"127.0.0.1:8080", "[::1]:8080"}, output,
-					"localhost should resolve to loopback address")
-			},
-		},
-
-		// Malformed inputs (should return as-is)
-		{
-			name:     "no port",
-			endpoint: "192.168.1.1",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "address without port should be returned as-is")
-			},
-		},
-		{
-			name:     "IPv6 without brackets",
-			endpoint: "::1:8080",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "malformed IPv6 should be returned as-is")
-			},
-		},
-		{
-			name:     "empty string",
-			endpoint: "",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "empty string should be returned as-is")
-			},
-		},
-		{
-			name:     "only port",
-			endpoint: ":8080",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "only port should be returned as-is")
-			},
-		},
-		{
-			name:     "invalid port",
-			endpoint: "192.168.1.1:invalid",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "invalid port should be returned as-is")
-			},
-		},
-		{
-			name:     "multiple colons without brackets",
-			endpoint: "2001:db8::1:8080",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "IPv6 without brackets should be returned as-is")
-			},
-		},
-		{
-			name:     "hostname only",
-			endpoint: "example.com",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "hostname without port should be returned as-is")
-			},
-		},
-
-		// Edge cases
-		{
-			name:     "IPv4 with port 0",
-			endpoint: "192.168.1.1:0",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "IPv4 with port 0 should be returned as-is")
-			},
-		},
-		{
-			name:     "IPv6 with port 0",
-			endpoint: "[::1]:0",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "IPv6 with port 0 should be returned as-is")
-			},
-		},
-		{
-			name:     "IPv4-mapped IPv6 address",
-			endpoint: "[::ffff:192.0.2.1]:8080",
-			checkFunc: func(t *testing.T, input, output string) {
-				// Go converts IPv4-mapped IPv6 addresses to IPv4 format
-				t.Helper()
-				assert.Equal(t, "192.0.2.1:8080", output,
-					"IPv4-mapped IPv6 should be converted to IPv4 by Go")
-			},
-		},
-		{
-			name:     "IPv6 with zone ID",
-			endpoint: "[fe80::1%eth0]:8080",
-			checkFunc: func(t *testing.T, input, output string) {
-				// Zone IDs might not be preserved, so just check it doesn't panic
-				t.Helper()
-				assert.NotEmpty(t, output, "IPv6 with zone ID should return something")
-			},
-		},
-
-		// Unresolvable hostnames (should return as-is)
-		{
-			name:     "unresolvable hostname",
-			endpoint: "this-hostname-does-not-exist-12345.invalid:8080",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "unresolvable hostname should be returned as-is")
-			},
-		},
-
-		// Special addresses
-		{
-			name:     "IPv4 broadcast",
-			endpoint: "255.255.255.255:8080",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "IPv4 broadcast should be returned as-is")
-			},
-		},
-		{
-			name:     "IPv4 any address",
-			endpoint: "0.0.0.0:8080",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "IPv4 any address should be returned as-is")
-			},
-		},
-		{
-			name:     "IPv6 multicast",
-			endpoint: "[ff02::1]:8080",
-			checkFunc: func(t *testing.T, input, output string) {
-				t.Helper()
-				assert.Equal(t, input, output, "IPv6 multicast should be returned as-is")
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			result := endpoint.LookupIP(tt.endpoint)
-			tt.checkFunc(t, tt.endpoint, result)
-		})
-	}
-}
-
-func TestLookupIP_HostnameResolution(t *testing.T) {
-	t.Parallel()
-	// Test that localhost actually resolves
-	result := endpoint.LookupIP("localhost:8080")
-
-	// localhost should resolve to either IPv4 or IPv6 loopback
-	validResults := []string{
-		"127.0.0.1:8080", // IPv4 loopback
-		"[::1]:8080",     // IPv6 loopback
-	}
-
-	require.Containsf(t, validResults, result, "localhost should resolve to a loopback address, got: %s", result)
-}
-
-func TestLookupIP_PreservesPort(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name     string
-		endpoint string
-		wantPort string
-	}{
-		{"IPv4 standard port", "192.168.1.1:8080", "8080"},
-		{"IPv4 low port", "192.168.1.1:80", "80"},
-		{"IPv4 high port", "192.168.1.1:65535", "65535"},
-		{"IPv6 standard port", "[::1]:8080", "8080"},
-		{"IPv6 low port", "[::1]:80", "80"},
-		{"IPv6 high port", "[::1]:65535", "65535"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			result := endpoint.LookupIP(tt.endpoint)
-			// Extract port from result
-			_, port, err := net.SplitHostPort(result)
-			if err == nil {
-				assert.Equal(t, tt.wantPort, port, "port should be preserved")
-			}
-		})
-	}
 }


### PR DESCRIPTION
This PR does the following: It removes the IP resolution on the resolver's address so that the actual address is used. 
This avoids the following situation: Alice tries to connect to Bob via <hostname>:<port>. Alice replaces hostname with the IP. When the connection is establish, the comm layer will enforce that Bob's certificate contains the IP and not the hostname causing a failure in the connection.