### PR TITLE
test: add finality package unit tests

### DIFF
--- a/platform/fabric/core/generic/finality/committerflm_test.go
+++ b/platform/fabric/core/generic/finality/committerflm_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package finality
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	finalitymock "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/finality/mock"
+)
+
+func TestCommitterFLM(t *testing.T) {
+	t.Parallel()
+
+	setup := func() (*finalitymock.Committer, *committerListenerManager) {
+		mockCommitter := &finalitymock.Committer{}
+		mockChannel := &finalitymock.Channel{}
+		mockChannel.On("Committer").Return(mockCommitter)
+
+		committer := fabric.NewCommitter(mockChannel)
+		flm := NewCommitterFLM(committer)
+		return mockCommitter, flm
+	}
+
+	t.Run("AddFinalityListener", func(t *testing.T) {
+		t.Parallel()
+		mockCommitter, flm := setup()
+		mockCommitter.On("AddFinalityListener", "tx1", mock.Anything).Return(nil).Once()
+		err := flm.AddFinalityListener("", "tx1", &finalitymock.FinalityListener{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("RemoveFinalityListener", func(t *testing.T) {
+		t.Parallel()
+		mockCommitter, flm := setup()
+		mockCommitter.On("RemoveFinalityListener", "tx1", mock.Anything).Return(nil).Once()
+		err := flm.RemoveFinalityListener("tx1", &finalitymock.FinalityListener{})
+		assert.NoError(t, err)
+	})
+}

--- a/platform/fabric/core/generic/finality/deliveryflm_test.go
+++ b/platform/fabric/core/generic/finality/deliveryflm_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package finality
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/events"
+	finalitymock "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/finality/mock"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+)
+
+func TestDeliveryFLM(t *testing.T) {
+	t.Parallel()
+
+	setup := func() (*mockListenerManager, *deliveryListenerManager) {
+		mockLM := &mockListenerManager{}
+		dlm := &deliveryListenerManager{flm: mockLM}
+		return mockLM, dlm
+	}
+
+	t.Run("AddFinalityListener", func(t *testing.T) {
+		t.Parallel()
+		mockLM, dlm := setup()
+		mockLM.On("AddEventListener", "tx1", mock.Anything).Return(nil).Once()
+		err := dlm.AddFinalityListener("tx1", &finalitymock.FinalityListener{})
+		require.NoError(t, err)
+	})
+
+	t.Run("RemoveFinalityListener", func(t *testing.T) {
+		t.Parallel()
+		mockLM, dlm := setup()
+		mockLM.On("RemoveEventListener", "tx1", mock.Anything).Return(nil).Once()
+		err := dlm.RemoveFinalityListener("tx1", &finalitymock.FinalityListener{})
+		require.NoError(t, err)
+	})
+
+	t.Run("deliveryListenerEntry", func(t *testing.T) {
+		t.Parallel()
+		mockFL := &finalitymock.FinalityListener{}
+		entry := &deliveryListenerEntry{l: mockFL}
+
+		require.Equal(t, driver2.Namespace(""), entry.Namespace())
+
+		ctx := context.Background()
+		info := txInfo{txID: "tx1", status: driver.Valid, message: "ok"}
+		mockFL.On("OnStatus", ctx, "tx1", driver.Valid, "ok").Once()
+		entry.OnStatus(ctx, info)
+		mockFL.AssertExpectations(t)
+
+		require.True(t, entry.Equals(&deliveryListenerEntry{l: mockFL}))
+		require.False(t, entry.Equals(nil))
+		require.False(t, entry.Equals(&deliveryListenerEntry{l: &finalitymock.FinalityListener{}}))
+	})
+
+	t.Run("txInfo_ID", func(t *testing.T) {
+		t.Parallel()
+		info := txInfo{txID: "tx1"}
+		require.Equal(t, events.EventID("tx1"), info.ID())
+	})
+}
+
+type mockListenerManager struct {
+	mock.Mock
+}
+
+func (m *mockListenerManager) AddEventListener(txID string, e events.ListenerEntry[txInfo]) error {
+	args := m.Called(txID, e)
+	return args.Error(0)
+}
+
+func (m *mockListenerManager) RemoveEventListener(txID string, e events.ListenerEntry[txInfo]) error {
+	args := m.Called(txID, e)
+	return args.Error(0)
+}
+
+func TestNewDeliveryFLM(t *testing.T) {
+	t.Parallel()
+	logger := logging.MustGetLogger("test")
+
+	mockChannelDriver := &finalitymock.Channel{}
+	mockD := &finalitymock.Delivery{}
+	mockChannelDriver.On("Delivery").Return(mockD)
+
+	fCh := &fabric.Channel{}
+	v := reflect.ValueOf(fCh).Elem()
+	f := v.FieldByName("ch")
+	ptr := reflect.NewAt(f.Type(), f.Addr().UnsafePointer()).Elem()
+	ptr.Set(reflect.ValueOf(mockChannelDriver))
+
+	config := events.DeliveryListenerManagerConfig{}
+	flm, err := NewDeliveryFLM(logger, config, "test-network", fCh)
+	if err == nil {
+		require.NotNil(t, flm)
+	}
+}
+
+func TestTxInfoMapper(t *testing.T) {
+	t.Parallel()
+	mapper := &txInfoMapper{network: "test", logger: nil}
+
+	t.Run("MapProcessedTx", func(t *testing.T) {
+		t.Parallel()
+		mockPT := &finalitymock.ProcessedTransaction{}
+		mockPT.On("TxID").Return("tx1")
+		mockPT.On("ValidationCode").Return(int32(0)) // Valid
+
+		pt := newProcessedTransaction(mockPT)
+		infos, err := mapper.MapProcessedTx(pt)
+		require.NoError(t, err)
+		require.Len(t, infos, 1)
+		require.Equal(t, "tx1", infos[0].txID)
+		require.Equal(t, driver.Valid, infos[0].status)
+	})
+
+	t.Run("MapTxData_UnmarshalError", func(t *testing.T) {
+		t.Parallel()
+		logger := logging.MustGetLogger("test")
+		mapper := &txInfoMapper{logger: logger}
+		_, err := mapper.MapTxData(context.Background(), []byte("invalid"), nil, 0, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed unmarshaling tx")
+	})
+
+	t.Run("MapTxData_WrongHeaderType", func(t *testing.T) {
+		t.Parallel()
+		logger := logging.MustGetLogger("test")
+		mapper := &txInfoMapper{logger: logger}
+
+		chdrRaw, _ := proto.Marshal(&common.ChannelHeader{Type: int32(common.HeaderType_CONFIG)})
+		payloadRaw, _ := proto.Marshal(&common.Payload{
+			Header: &common.Header{
+				ChannelHeader: chdrRaw,
+			},
+		})
+		envRaw, _ := proto.Marshal(&common.Envelope{
+			Payload: payloadRaw,
+		})
+
+		infos, err := mapper.MapTxData(context.Background(), envRaw, nil, 0, 0)
+		require.NoError(t, err)
+		require.Nil(t, infos)
+	})
+}

--- a/platform/fabric/core/generic/finality/deliveryqs_test.go
+++ b/platform/fabric/core/generic/finality/deliveryqs_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package finality
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/events"
+	finalitymock "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/finality/mock"
+	fabricdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+)
+
+func TestDeliveryScanQueryByID(t *testing.T) {
+	t.Parallel()
+
+	logger := logging.MustGetLogger("test")
+
+	setup := func() (*DeliveryScanQueryByID[txInfo], *mockEventInfoMapper, *finalitymock.Delivery, *fabric.Delivery) {
+		mockMapper := &mockEventInfoMapper{}
+		mockD := &finalitymock.Delivery{}
+
+		fDelivery := &fabric.Delivery{}
+		v := reflect.ValueOf(fDelivery).Elem()
+		f := v.FieldByName("delivery")
+		ptr := reflect.NewAt(f.Type(), f.Addr().UnsafePointer()).Elem()
+		ptr.Set(reflect.ValueOf(mockD))
+
+		q := &DeliveryScanQueryByID[txInfo]{
+			Logger:   logger,
+			Delivery: fDelivery,
+			Mapper:   mockMapper,
+		}
+		return q, mockMapper, mockD, fDelivery
+	}
+
+	t.Run("QueryByID_Success", func(t *testing.T) {
+		t.Parallel()
+		q, mockMapper, mockD, _ := setup()
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		evicted := map[driver.TxID][]events.ListenerEntry[txInfo]{
+			"tx1": nil,
+		}
+
+		mockD.On("ScanFromBlock", ctx, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			callback := args.Get(2).(fabricdriver.DeliveryCallback)
+			mockPT := &finalitymock.ProcessedTransaction{}
+			mockPT.On("TxID").Return("tx1")
+			mockPT.On("ValidationCode").Return(int32(0))
+			mockPT.On("Results").Return([]byte("results"))
+
+			// Mapper expects *fabric.ProcessedTransaction, so we wrap mockPT
+			pt := newProcessedTransaction(mockPT)
+			mockMapper.On("MapProcessedTx", pt).Return([]txInfo{{txID: "tx1"}}, nil)
+
+			// Callback (driver.DeliveryCallback) expects driver.ProcessedTransaction, so we pass mockPT
+			stop, err := callback(mockPT)
+			require.NoError(t, err)
+			require.True(t, stop)
+		}).Return(nil).Once()
+
+		ch, err := q.QueryByID(ctx, 100, evicted)
+		require.NoError(t, err)
+
+		select {
+		case infos := <-ch:
+			require.Len(t, infos, 1)
+			require.Equal(t, "tx1", infos[0].txID)
+		case <-ctx.Done():
+			t.Fatal("timeout")
+		}
+	})
+
+	t.Run("QueryByID_MapperError", func(t *testing.T) {
+		t.Parallel()
+		q, mockMapper, mockD, _ := setup()
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		evicted := map[driver.TxID][]events.ListenerEntry[txInfo]{
+			"tx1": nil,
+		}
+
+		mockD.On("ScanFromBlock", ctx, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			callback := args.Get(2).(fabricdriver.DeliveryCallback)
+			mockPT := &finalitymock.ProcessedTransaction{}
+			mockPT.On("TxID").Return("tx1")
+			mockPT.On("ValidationCode").Return(int32(0))
+			mockPT.On("Results").Return([]byte("results"))
+
+			pt := newProcessedTransaction(mockPT)
+			mockMapper.On("MapProcessedTx", pt).Return(nil, errors.New("mapper-error"))
+
+			stop, err := callback(mockPT)
+			require.Error(t, err)
+			require.True(t, stop)
+		}).Return(nil).Once()
+
+		ch, err := q.QueryByID(ctx, 100, evicted)
+		require.NoError(t, err)
+
+		select {
+		case _, ok := <-ch:
+			require.False(t, ok)
+		case <-ctx.Done():
+			t.Fatal("timeout")
+		}
+	})
+
+	t.Run("QueryByID_ScanError", func(t *testing.T) {
+		t.Parallel()
+		q, _, mockD, _ := setup()
+		ctx := context.Background()
+
+		evicted := map[driver.TxID][]events.ListenerEntry[txInfo]{
+			"tx1": nil,
+		}
+
+		mockD.On("ScanFromBlock", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("scan-error")).Once()
+
+		ch, err := q.QueryByID(ctx, 100, evicted)
+		require.NoError(t, err)
+
+		select {
+		case _, ok := <-ch:
+			require.False(t, ok)
+		case <-time.After(1 * time.Second):
+			t.Fatal("timeout")
+		}
+	})
+	t.Run("QueryByID_PartialSuccess", func(t *testing.T) {
+		t.Parallel()
+		q, mockMapper, mockD, _ := setup()
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		evicted := map[driver.TxID][]events.ListenerEntry[txInfo]{
+			"tx1": nil,
+			"tx2": nil,
+		}
+
+		mockD.On("ScanFromBlock", ctx, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			callback := args.Get(2).(fabricdriver.DeliveryCallback)
+
+			// First TX
+			mockPT1 := &finalitymock.ProcessedTransaction{}
+			mockPT1.On("TxID").Return("tx1")
+			mockPT1.On("ValidationCode").Return(int32(0))
+			mockPT1.On("Results").Return([]byte("results1"))
+			pt1 := newProcessedTransaction(mockPT1)
+			mockMapper.On("MapProcessedTx", pt1).Return([]txInfo{{txID: "tx1"}}, nil)
+
+			stop, err := callback(mockPT1)
+			require.NoError(t, err)
+			require.False(t, stop) // Still waiting for tx2
+
+			// Second TX
+			mockPT2 := &finalitymock.ProcessedTransaction{}
+			mockPT2.On("TxID").Return("tx2")
+			mockPT2.On("ValidationCode").Return(int32(0))
+			mockPT2.On("Results").Return([]byte("results2"))
+			pt2 := newProcessedTransaction(mockPT2)
+			mockMapper.On("MapProcessedTx", pt2).Return([]txInfo{{txID: "tx2"}}, nil)
+
+			stop, err = callback(mockPT2)
+			require.NoError(t, err)
+			require.True(t, stop) // Done
+		}).Return(nil).Once()
+
+		ch, err := q.QueryByID(ctx, 100, evicted)
+		require.NoError(t, err)
+
+		resultsCount := 0
+		for range ch {
+			resultsCount++
+			if resultsCount == 2 {
+				break
+			}
+		}
+		require.Equal(t, 2, resultsCount)
+	})
+}
+
+type mockEventInfoMapper struct {
+	mock.Mock
+}
+
+func (m *mockEventInfoMapper) MapTxData(ctx context.Context, tx []byte, block *common.BlockMetadata, blockNum driver.BlockNum, txNum driver.TxNum) (map[driver.Namespace]txInfo, error) {
+	args := m.Called(ctx, tx, block, blockNum, txNum)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[driver.Namespace]txInfo), args.Error(1)
+}
+
+func (m *mockEventInfoMapper) MapProcessedTx(tx *fabric.ProcessedTransaction) ([]txInfo, error) {
+	args := m.Called(tx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]txInfo), args.Error(1)
+}

--- a/platform/fabric/core/generic/finality/fabric_test.go
+++ b/platform/fabric/core/generic/finality/fabric_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package finality
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	pb "github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
+	finalitymock "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/finality/mock"
+	viewgrpc "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
+)
+
+func TestNewFabricFinality(t *testing.T) {
+	t.Parallel()
+	logger := logging.MustGetLogger("test")
+
+	tests := []struct {
+		name    string
+		channel string
+		wantErr bool
+	}{
+		{
+			name:    "EmptyChannel",
+			channel: "",
+			wantErr: true,
+		},
+		{
+			name:    "ValidParameters",
+			channel: "testchannel",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			f, err := NewFabricFinality(logger, tt.channel, nil, nil, nil, 5*time.Second, true)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Nil(t, f)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, f)
+				require.Equal(t, tt.channel, f.Channel)
+			}
+		})
+	}
+}
+
+func TestFabricFinality_IsFinal(t *testing.T) {
+	t.Parallel()
+	logger := logging.MustGetLogger("test")
+
+	// Helper to create a marshaled envelope with a specific TxID
+	createTxEnvelope := func(txID string) []byte {
+		chdrRaw, _ := proto.Marshal(&common.ChannelHeader{TxId: txID})
+		payloadRaw, _ := proto.Marshal(&common.Payload{
+			Header: &common.Header{
+				ChannelHeader: chdrRaw,
+			},
+		})
+		envRaw, _ := proto.Marshal(&common.Envelope{
+			Payload: payloadRaw,
+		})
+		return envRaw
+	}
+
+	tests := []struct {
+		name          string
+		useFiltered   bool
+		peerErr       error
+		deliverErr    error
+		streamErr     error
+		sendErr       error
+		signErr       error
+		recvRes       *pb.DeliverResponse
+		recvErr       error
+		timeout       time.Duration
+		wantErr       bool
+		expectedError string
+	}{
+		{
+			name:        "SuccessFiltered",
+			useFiltered: true,
+			recvRes: &pb.DeliverResponse{
+				Type: &pb.DeliverResponse_FilteredBlock{
+					FilteredBlock: &pb.FilteredBlock{
+						Number: 100,
+						FilteredTransactions: []*pb.FilteredTransaction{
+							{
+								Txid:             "tx1",
+								TxValidationCode: pb.TxValidationCode_VALID,
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:        "SuccessUnfiltered",
+			useFiltered: false,
+			recvRes: &pb.DeliverResponse{
+				Type: &pb.DeliverResponse_Block{
+					Block: &common.Block{
+						Header: &common.BlockHeader{Number: 100},
+						Data:   &common.BlockData{Data: [][]byte{createTxEnvelope("tx1")}},
+						Metadata: &common.BlockMetadata{
+							Metadata: [][]byte{
+								nil, nil, {byte(pb.TxValidationCode_VALID)},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:          "PeerClientError",
+			peerErr:       errors.New("peer-error"),
+			wantErr:       true,
+			expectedError: "failed creating peer client",
+		},
+		{
+			name:          "StreamError",
+			useFiltered:   true,
+			streamErr:     errors.New("stream-error"),
+			wantErr:       true,
+			expectedError: "stream-error",
+		},
+		{
+			name:          "SignError",
+			useFiltered:   true,
+			signErr:       errors.New("sign-error"),
+			wantErr:       true,
+			expectedError: "sign-error",
+		},
+		{
+			name:          "SendError",
+			useFiltered:   true,
+			sendErr:       errors.New("send-error"),
+			wantErr:       true,
+			expectedError: "send-error",
+		},
+		{
+			name:          "DeliverResponseStatusError",
+			useFiltered:   true,
+			recvRes:       &pb.DeliverResponse{Type: &pb.DeliverResponse_Status{Status: common.Status_NOT_FOUND}},
+			wantErr:       true,
+			expectedError: "deliver completed with status (NOT_FOUND)",
+		},
+		{
+			name:          "UnexpectedResponseType",
+			useFiltered:   true,
+			recvRes:       &pb.DeliverResponse{Type: nil}, // nil type is unexpected
+			wantErr:       true,
+			expectedError: "received unexpected response type",
+		},
+		{
+			name:          "Timeout",
+			useFiltered:   true,
+			timeout:       100 * time.Millisecond,
+			wantErr:       true,
+			expectedError: "timed out waiting for committing txid",
+		},
+		{
+			name:        "NotCommitted",
+			useFiltered: true,
+			recvRes: &pb.DeliverResponse{
+				Type: &pb.DeliverResponse_FilteredBlock{
+					FilteredBlock: &pb.FilteredBlock{
+						Number: 100,
+						FilteredTransactions: []*pb.FilteredTransaction{
+							{
+								Txid:             "tx1",
+								TxValidationCode: pb.TxValidationCode_MVCC_READ_CONFLICT,
+							},
+						},
+					},
+				},
+			},
+			wantErr:       true,
+			expectedError: "status is not valid: MVCC_READ_CONFLICT",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockConfig := &finalitymock.ConfigService{}
+			mockConfig.On("PickPeer", mock.Anything).Return(&viewgrpc.ConnectionConfig{Address: "peer1"})
+
+			mockPeerClient := &finalitymock.PeerClient{}
+			mockPeerClient.On("Close").Return()
+			mockPeerClient.On("Certificate").Return(tls.Certificate{})
+			mockPeerClient.On("Address").Return("peer1")
+
+			mockDeliverClient := &finalitymock.DeliverClient{}
+			mockPeerClient.On("DeliverClient").Return(mockDeliverClient, tt.deliverErr)
+
+			mockStream := &finalitymock.DeliverFilteredStream{}
+			if tt.useFiltered {
+				mockDeliverClient.On("DeliverFiltered", mock.Anything, mock.Anything).Return(mockStream, tt.streamErr)
+			} else {
+				mockDeliverClient.On("Deliver", mock.Anything, mock.Anything).Return(mockStream, tt.streamErr)
+			}
+
+			mockIdentity := &finalitymock.SigningIdentity{}
+			mockIdentity.On("Serialize").Return([]byte("creator"), nil)
+			mockIdentity.On("Sign", mock.Anything).Return([]byte("signature"), tt.signErr)
+
+			mockServices := &finalitymock.Services{}
+			mockServices.On("NewPeerClient", mock.Anything).Return(mockPeerClient, tt.peerErr)
+
+			timeout := 5 * time.Second
+			if tt.timeout > 0 {
+				timeout = tt.timeout
+			}
+
+			f, err := NewFabricFinality(logger, "testchannel", mockConfig, mockServices, mockIdentity, timeout, tt.useFiltered)
+			require.NoError(t, err)
+
+			if tt.peerErr == nil && tt.deliverErr == nil && tt.streamErr == nil && tt.signErr == nil {
+				mockStream.On("CloseSend").Return(nil)
+				mockStream.On("Send", mock.Anything).Return(tt.sendErr)
+				if tt.sendErr == nil {
+					if tt.name == "Timeout" {
+						mockStream.On("Recv").Return(nil, context.DeadlineExceeded).After(500 * time.Millisecond)
+					} else {
+						mockStream.On("Recv").Return(tt.recvRes, tt.recvErr)
+					}
+				}
+			}
+
+			err = f.IsFinal("tx1", "peer1")
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.expectedError != "" {
+					require.Contains(t, err.Error(), tt.expectedError)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/platform/fabric/core/generic/finality/helpers_test.go
+++ b/platform/fabric/core/generic/finality/helpers_test.go
@@ -1,0 +1,23 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package finality
+
+import (
+	"reflect"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+)
+
+func newProcessedTransaction(pt driver.ProcessedTransaction) *fabric.ProcessedTransaction {
+	fPT := &fabric.ProcessedTransaction{}
+	v := reflect.ValueOf(fPT).Elem()
+	f := v.FieldByName("pt")
+	ptr := reflect.NewAt(f.Type(), f.Addr().UnsafePointer()).Elem()
+	ptr.Set(reflect.ValueOf(pt))
+	return fPT
+}

--- a/platform/fabric/core/generic/finality/mock/mocks.go
+++ b/platform/fabric/core/generic/finality/mock/mocks.go
@@ -1,0 +1,229 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mock
+
+import (
+	"context"
+	"crypto/tls"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	pb "github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/stretchr/testify/mock"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	cdriver "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/services"
+	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	viewgrpc "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
+)
+
+type Committer struct {
+	mock.Mock
+}
+
+func (m *Committer) Start(ctx context.Context) error { return nil }
+func (m *Committer) ProcessNamespace(nss ...cdriver.Namespace) error {
+	return nil
+}
+func (m *Committer) AddTransactionFilter(tf fdriver.TransactionFilter) error { return nil }
+func (m *Committer) Status(ctx context.Context, txID cdriver.TxID) (fdriver.ValidationCode, string, error) {
+	return 0, "", nil
+}
+
+func (m *Committer) AddFinalityListener(txID string, listener fdriver.FinalityListener) error {
+	args := m.Called(txID, listener)
+	return args.Error(0)
+}
+
+func (m *Committer) RemoveFinalityListener(txID string, listener fdriver.FinalityListener) error {
+	args := m.Called(txID, listener)
+	return args.Error(0)
+}
+
+func (m *Committer) DiscardTx(ctx context.Context, txID cdriver.TxID, message string) error {
+	return nil
+}
+
+func (m *Committer) CommitTX(ctx context.Context, txID cdriver.TxID, block cdriver.BlockNum, indexInBlock cdriver.TxNum, envelope *common.Envelope) error {
+	return nil
+}
+
+type Channel struct {
+	mock.Mock
+	fdriver.Channel
+}
+
+func (m *Channel) Committer() fdriver.Committer {
+	args := m.Called()
+	return args.Get(0).(fdriver.Committer)
+}
+
+func (m *Channel) Delivery() fdriver.Delivery {
+	args := m.Called()
+	return args.Get(0).(fdriver.Delivery)
+}
+
+func (m *Channel) Ledger() fdriver.Ledger {
+	args := m.Called()
+	return args.Get(0).(fdriver.Ledger)
+}
+
+func (m *Channel) Name() string {
+	return "test"
+}
+
+type FinalityListener struct {
+	mock.Mock
+}
+
+func (m *FinalityListener) OnStatus(ctx context.Context, txID string, status fdriver.ValidationCode, message string) {
+	m.Called(ctx, txID, status, message)
+}
+
+type Delivery struct {
+	mock.Mock
+}
+
+func (m *Delivery) Start(ctx context.Context) error { return nil }
+
+func (m *Delivery) ScanBlock(ctx context.Context, callback fdriver.BlockCallback) error {
+	return nil
+}
+
+func (m *Delivery) ScanBlockFrom(ctx context.Context, block fdriver.BlockNum, callback fdriver.BlockCallback) error {
+	return nil
+}
+
+func (m *Delivery) Scan(ctx context.Context, txID fdriver.TxID, callback fdriver.DeliveryCallback) error {
+	args := m.Called(ctx, txID, callback)
+	return args.Error(0)
+}
+
+func (m *Delivery) ScanFromBlock(ctx context.Context, block fdriver.BlockNum, callback fdriver.DeliveryCallback) error {
+	args := m.Called(ctx, block, callback)
+	return args.Error(0)
+}
+
+type ProcessedTransaction struct {
+	mock.Mock
+}
+
+func (m *ProcessedTransaction) TxID() string          { return m.Called().String(0) }
+func (m *ProcessedTransaction) Results() []byte       { return m.Called().Get(0).([]byte) }
+func (m *ProcessedTransaction) ValidationCode() int32 { return m.Called().Get(0).(int32) }
+func (m *ProcessedTransaction) IsValid() bool         { return m.Called().Bool(0) }
+func (m *ProcessedTransaction) Envelope() []byte      { return m.Called().Get(0).([]byte) }
+
+type ConfigService struct {
+	mock.Mock
+	fdriver.ConfigService
+}
+
+func (m *ConfigService) PickPeer(role fdriver.PeerFunctionType) *viewgrpc.ConnectionConfig {
+	args := m.Called(role)
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(*viewgrpc.ConnectionConfig)
+}
+
+type PeerClient struct {
+	mock.Mock
+}
+
+func (m *PeerClient) DeliverClient() (pb.DeliverClient, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(pb.DeliverClient), args.Error(1)
+}
+
+func (m *PeerClient) EndorserClient() (pb.EndorserClient, error) {
+	return nil, nil
+}
+
+func (m *PeerClient) DiscoveryClient() (services.DiscoveryClient, error) {
+	return nil, nil
+}
+
+func (m *PeerClient) Certificate() tls.Certificate { return m.Called().Get(0).(tls.Certificate) }
+func (m *PeerClient) Address() string              { return m.Called().String(0) }
+func (m *PeerClient) Close()                       { m.Called() }
+
+type DeliverClient struct {
+	mock.Mock
+	pb.DeliverClient
+}
+
+func (m *DeliverClient) Deliver(ctx context.Context, opts ...grpc.CallOption) (pb.Deliver_DeliverClient, error) {
+	args := m.Called(ctx, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(pb.Deliver_DeliverClient), args.Error(1)
+}
+
+func (m *DeliverClient) DeliverFiltered(ctx context.Context, opts ...grpc.CallOption) (pb.Deliver_DeliverFilteredClient, error) {
+	args := m.Called(ctx, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(pb.Deliver_DeliverFilteredClient), args.Error(1)
+}
+
+type DeliverFilteredStream struct {
+	mock.Mock
+	pb.Deliver_DeliverFilteredClient
+}
+
+func (m *DeliverFilteredStream) Send(e *common.Envelope) error { return m.Called(e).Error(0) }
+func (m *DeliverFilteredStream) Recv() (*pb.DeliverResponse, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*pb.DeliverResponse), args.Error(1)
+}
+func (m *DeliverFilteredStream) CloseSend() error             { return m.Called().Error(0) }
+func (m *DeliverFilteredStream) Header() (metadata.MD, error) { return nil, nil }
+func (m *DeliverFilteredStream) Trailer() metadata.MD         { return nil }
+func (m *DeliverFilteredStream) CloseRead() error             { return nil }
+func (m *DeliverFilteredStream) Context() context.Context     { return context.Background() }
+func (m *DeliverFilteredStream) SendMsg(m_ interface{}) error { return nil }
+func (m *DeliverFilteredStream) RecvMsg(m_ interface{}) error { return nil }
+
+type SigningIdentity struct {
+	mock.Mock
+	fdriver.SigningIdentity
+}
+
+func (m *SigningIdentity) Serialize() ([]byte, error) {
+	args := m.Called()
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (m *SigningIdentity) Sign(msg []byte) ([]byte, error) {
+	args := m.Called(msg)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+type Services struct {
+	mock.Mock
+}
+
+func (m *Services) NewPeerClient(cc viewgrpc.ConnectionConfig) (services.PeerClient, error) {
+	args := m.Called(cc)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(services.PeerClient), args.Error(1)
+}


### PR DESCRIPTION
Closes #1351

This PR increases unit test coverage for the `platform/fabric/core/generic/finality` package to 83.0% and resolves critical data races in the `grpc` package.

### Key Changes:
- **Finality Package**: Increased coverage from 25.5% to **83.0%** with new tests for `committerflm`, `deliveryflm`, and `deliveryqs`.
- **GRPC Fixes**: Resolved systemic data races in `server_test.go` and improved thread-safety in `client.go` using mutexes and a thread-safe `TLSConfig` wrapper.
