### PR TITLE
Fix: Resolve fragile Docker image and subnet matching

### DIFF
--- a/integration/nwo/common/docker/utils.go
+++ b/integration/nwo/common/docker/utils.go
@@ -13,7 +13,6 @@ import (
 	"net"
 	"net/netip"
 	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/containerd/errdefs"
@@ -64,7 +63,7 @@ func (d *Docker) CheckImagesExist(requiredImages ...string) error {
 			return err
 		}
 
-		if len(images.Items) != 1 {
+		if len(images.Items) == 0 {
 			return errors.Errorf("missing required image: %s", imageName)
 		}
 	}
@@ -187,9 +186,6 @@ func (d *Docker) LocalIP(networkID string) (string, error) {
 		break
 	}
 
-	subnet := config.Subnet.Addr().String()
-	dockerPrefix := subnet[:strings.Index(subnet, ".0")]
-
 	ifaces, err := net.Interfaces()
 	if err != nil {
 		return "", err
@@ -201,10 +197,9 @@ func (d *Docker) LocalIP(networkID string) (string, error) {
 			return "", err
 		}
 		for _, addr := range addrs {
-			if strings.Index(addr.String(), dockerPrefix) == 0 {
-				ipWithSubnet := addr.String()
-				i := strings.Index(ipWithSubnet, "/")
-				return ipWithSubnet[:i], nil
+			prefix, err := netip.ParsePrefix(addr.String())
+			if err == nil && config.Subnet.Contains(prefix.Addr()) {
+				return prefix.Addr().String(), nil
 			}
 		}
 	}


### PR DESCRIPTION
### Description
This PR resolves two fragility issues in the Docker NWO utilities:
- **Fixes #1367**: Updates `CheckImagesExist` to allow multiple matching tags. The check now only fails if zero matches are found.
- **Fixes #1368**: Refactors `LocalIP` to use `netip.Prefix.Contains` for robust subnet matching, replacing the fragile `.0` string-based prefix extraction.

### Verification
- Verified logic handles 0, 1, and multiple image matches.
- Verified robust CIDR matching for `LocalIP` across various subnet configurations.
- Verified package build passes.
