### PR TITLE
Add fabricx support to fsccli artifactsgen

### DIFF
--- a/docs/reference/fsc-cli.md
+++ b/docs/reference/fsc-cli.md
@@ -121,7 +121,8 @@ topologies:
 **For more topology examples, see the integration tests in [`integration/`](../../integration/) directory.**
 
 **Supported Topology Types:**
-- `fabric` - Hyperledger Fabric(x) network topology
+- `fabric` - Hyperledger Fabric network topology
+- `fabricx` - Hyperledger Fabric-X network topology
 - `fsc` - Fabric Smart Client network topology
 
 **Output:**

--- a/integration/nwo/cmd/artifactgen/gen.go
+++ b/integration/nwo/cmd/artifactgen/gen.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabricx"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
@@ -101,6 +102,16 @@ func gen(args []string) error {
 			t2 = append(t2, top)
 		case fsc.TopologyName:
 			top := fsc.NewTopology()
+			r, err := yaml.Marshal(t.Topologies[i])
+			if err != nil {
+				return errors.Wrapf(err, "failed remarshalling topology configuration [%s]", topologyFile)
+			}
+			if err := yaml.Unmarshal(r, top); err != nil {
+				return errors.Wrapf(err, "failed unmarshalling topology file [%s]", topologyFile)
+			}
+			t2 = append(t2, top)
+		case fabricx.TopologyName:
+			top := fabricx.NewTopology()
 			r, err := yaml.Marshal(t.Topologies[i])
 			if err != nil {
 				return errors.Wrapf(err, "failed remarshalling topology configuration [%s]", topologyFile)

--- a/integration/nwo/fabricx/topology.go
+++ b/integration/nwo/fabricx/topology.go
@@ -11,7 +11,15 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/topology"
 )
 
-const DefaultTopologyName = "default"
+const (
+	TopologyName        = PlatformName
+	DefaultTopologyName = "default"
+)
+
+// NewTopology returns a new topology whose name is empty
+func NewTopology() *topology.Topology {
+	return NewTopologyWithName("")
+}
 
 // NewDefaultTopology is a configuration with two organizations and one peer per org.
 func NewDefaultTopology() *topology.Topology {

--- a/platform/view/services/grpc/server_test.go
+++ b/platform/view/services/grpc/server_test.go
@@ -740,18 +740,19 @@ func TestVerifyCertificateCallback(t *testing.T) {
 			VerifyCertificate: verifyFunc,
 		},
 	})
+	require.NoError(t, err)
 	go utils.IgnoreErrorFunc(gRPCServer.Start)
 	t.Cleanup(gRPCServer.Stop)
 
 	t.Run("Success path", func(t *testing.T) {
 		t.Parallel()
-		err = probeTLS(gRPCServer.Address(), authorizedClientKeyPair)
+		err := probeTLS(gRPCServer.Address(), authorizedClientKeyPair)
 		require.NoError(t, err)
 	})
 
 	t.Run("Failure path", func(t *testing.T) {
 		t.Parallel()
-		err = probeTLS(gRPCServer.Address(), notAuthorizedClientKeyPair)
+		err := probeTLS(gRPCServer.Address(), notAuthorizedClientKeyPair)
 		require.EqualError(t, err, "remote error: tls: bad certificate")
 	})
 }


### PR DESCRIPTION
Closes #1370 
## Summary
This PR enables the `fsccli artifactsgen` command to process topologies using the `fabricx` platform. Previously, the CLI only supported `fabric` and `fsc` topology types, causing `fabricx` configurations to be ignored during artifact generation.

## Key Changes
- **`fabricx` Standardization**: Exported `TopologyName` and `NewTopology()` in `integration/nwo/fabricx/topology.go`.
- **CLI Integration**: Added support for the `fabricx` topology type in the `artifactsgen` command.
- **Documentation**: Updated the `fsccli` reference guide to include `fabricx`.
- **Lint/Format**: Resolved pre-existing `gci` formatting issues in the `fabricx` package.

## Verification
- Verified with `go build ./cmd/fsccli`.