### PR TITLE
ci: prototype the contribution process workflows

### DIFF
--- a/.github/scripts/bot-assign-on-comment.js
+++ b/.github/scripts/bot-assign-on-comment.js
@@ -1,0 +1,119 @@
+const READY_LABEL = "ready";
+const MAX_OPEN_ASSIGNMENTS = 2;
+const ASSIGN_MARKER_PREFIX = "<!-- contribution-process-assigned:";
+
+function requestsAssign(body) {
+  return typeof body === "string" && /(^|\s)\/assign(\s|$)/i.test(body);
+}
+
+function isEligibleIssue(issue) {
+  return issue && !issue.pull_request && issue.state === "open";
+}
+
+function hasReadyLabel(issue) {
+  return Array.isArray(issue.labels) && issue.labels.some((label) => label.name === READY_LABEL);
+}
+
+function buildAssignmentMarker(username) {
+  return `${ASSIGN_MARKER_PREFIX}${username} -->`;
+}
+
+async function getPermission(github, owner, repo, username) {
+  try {
+    const response = await github.rest.repos.getCollaboratorPermissionLevel({
+      owner,
+      repo,
+      username,
+    });
+    return response.data.permission || "none";
+  } catch (error) {
+    if (error.status === 404) {
+      return "none";
+    }
+    throw error;
+  }
+}
+
+function isExemptPermission(permission) {
+  return ["admin", "write", "triage"].includes(permission);
+}
+
+async function countOpenAssignedIssues(github, owner, repo, username) {
+  const issues = await github.paginate(github.rest.issues.listForRepo, {
+    owner,
+    repo,
+    assignee: username,
+    state: "open",
+    per_page: 100,
+  });
+
+  return issues.filter((issue) => !issue.pull_request).length;
+}
+
+module.exports = async ({ github, context }) => {
+  try {
+    const { issue, comment, repository } = context.payload;
+    if (!isEligibleIssue(issue) || !comment?.user?.login || comment.user.type === "Bot") {
+      return;
+    }
+    if (!requestsAssign(comment.body)) {
+      return;
+    }
+
+    const owner = repository.owner.login;
+    const repo = repository.name;
+    const username = comment.user.login;
+
+    if (!hasReadyLabel(issue)) {
+      await github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: issue.number,
+        body: `Hi @${username}, this issue is not marked \`${READY_LABEL}\` yet. Please wait for maintainer triage before claiming it.`,
+      });
+      return;
+    }
+
+    if (issue.assignees?.length) {
+      const currentAssignee = issue.assignees[0].login;
+      await github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: issue.number,
+        body: `Hi @${username}, this issue is already assigned to @${currentAssignee}.`,
+      });
+      return;
+    }
+
+    const permission = await getPermission(github, owner, repo, username);
+    if (!isExemptPermission(permission)) {
+      const openAssignments = await countOpenAssignedIssues(github, owner, repo, username);
+      if (openAssignments >= MAX_OPEN_ASSIGNMENTS) {
+        await github.rest.issues.createComment({
+          owner,
+          repo,
+          issue_number: issue.number,
+          body: `Hi @${username}, you already have ${openAssignments} open assigned issue(s). Please finish one before claiming another.`,
+        });
+        return;
+      }
+    }
+
+    await github.rest.issues.addAssignees({
+      owner,
+      repo,
+      issue_number: issue.number,
+      assignees: [username],
+    });
+
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: issue.number,
+      body: `${buildAssignmentMarker(username)}\nAssigned @${username} to this issue.`,
+    });
+  } catch (error) {
+    console.error("[assign] Error:", error.message);
+    throw error;
+  }
+};

--- a/.github/scripts/bot-unassign-on-comment.js
+++ b/.github/scripts/bot-unassign-on-comment.js
@@ -1,0 +1,60 @@
+function isValidContext(issue, comment) {
+  if (!issue?.number || issue.pull_request) return false;
+  if (!comment?.body || !comment?.user?.login) return false;
+  if (comment.user.type === "Bot") return false;
+  if (issue.state !== "open") return false;
+  return true;
+}
+
+function requestsUnassign(body) {
+  return typeof body === "string" && /(^|\s)\/unassign(\s|$)/i.test(body);
+}
+
+function marker(username) {
+  return `<!-- unassign-requested:${username} -->`;
+}
+
+module.exports = async ({ github, context }) => {
+  try {
+    const { issue, comment, repository } = context.payload;
+    if (!isValidContext(issue, comment) || !requestsUnassign(comment.body)) {
+      return;
+    }
+
+    const owner = repository.owner.login;
+    const repo = repository.name;
+    const username = comment.user.login;
+
+    if (!issue.assignees?.some((assignee) => assignee.login === username)) {
+      return;
+    }
+
+    const comments = await github.paginate(github.rest.issues.listComments, {
+      owner,
+      repo,
+      issue_number: issue.number,
+      per_page: 100,
+    });
+
+    if (comments.some((entry) => entry.body?.includes(marker(username)))) {
+      return;
+    }
+
+    await github.rest.issues.removeAssignees({
+      owner,
+      repo,
+      issue_number: issue.number,
+      assignees: [username],
+    });
+
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: issue.number,
+      body: `${marker(username)}\n\n@${username} has been unassigned from this issue.`,
+    });
+  } catch (error) {
+    console.error("[unassign] Error:", error.message);
+    throw error;
+  }
+};

--- a/.github/scripts/bot-working-on-comment.js
+++ b/.github/scripts/bot-working-on-comment.js
@@ -1,0 +1,45 @@
+function isValidContext(comment) {
+  if (!comment?.body || !comment?.user?.login) return false;
+  if (comment.user.type === "Bot") return false;
+  return true;
+}
+
+function requestsWorking(body) {
+  return typeof body === "string" && /(^|\s)\/working(\s|$)/i.test(body);
+}
+
+function isAuthorized(issue, username) {
+  if (issue.pull_request && issue.user?.login === username) {
+    return true;
+  }
+  return issue.assignees?.some((assignee) => assignee.login === username);
+}
+
+module.exports = async ({ github, context }) => {
+  const dryRun = (process.env.DRY_RUN || "false").toLowerCase() === "true";
+  try {
+    const { issue, comment, repository } = context.payload;
+    if (!issue || !isValidContext(comment) || !requestsWorking(comment.body)) {
+      return;
+    }
+
+    const username = comment.user.login;
+    if (!isAuthorized(issue, username)) {
+      return;
+    }
+
+    if (dryRun) {
+      console.log(`[working] Dry run for comment ${comment.id}`);
+      return;
+    }
+
+    await github.rest.reactions.createForIssueComment({
+      owner: repository.owner.login,
+      repo: repository.name,
+      comment_id: comment.id,
+      content: "eyes",
+    });
+  } catch (error) {
+    console.error("[working] Error:", error.message);
+  }
+};

--- a/.github/scripts/cron-enforcer-pr-linked-issue.js
+++ b/.github/scripts/cron-enforcer-pr-linked-issue.js
@@ -1,0 +1,161 @@
+const dryRun = (process.env.DRY_RUN || "false").toLowerCase() === "true";
+const hoursBeforeClose = parseInt(process.env.HOURS_BEFORE_CLOSE || "12", 10);
+const requireAuthorAssigned = (process.env.REQUIRE_AUTHOR_ASSIGNED || "true").toLowerCase() === "true";
+const MARKER_PREFIX = "<!-- linked-issue-enforcer:";
+
+function getHoursOpen(pr) {
+  return Math.floor((Date.now() - new Date(pr.created_at)) / (60 * 60 * 1000));
+}
+
+function isBot(pr) {
+  return pr.user?.type === "Bot" || pr.user?.login?.endsWith("[bot]");
+}
+
+async function getPermission(github, owner, repo, username) {
+  try {
+    const response = await github.rest.repos.getCollaboratorPermissionLevel({
+      owner,
+      repo,
+      username,
+    });
+    return response.data.permission || "none";
+  } catch (error) {
+    if (error.status === 404) {
+      return "none";
+    }
+    throw error;
+  }
+}
+
+function isExemptPermission(permission) {
+  return ["admin", "write", "triage"].includes(permission);
+}
+
+async function getLinkedOpenIssues(github, owner, repo, prNumber) {
+  const query = `
+    query($owner: String!, $repo: String!, $prNumber: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $prNumber) {
+          closingIssuesReferences(first: 100) {
+            nodes {
+              number
+              state
+              assignees(first: 100) {
+                nodes {
+                  login
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const result = await github.graphql(query, { owner, repo, prNumber });
+  const issues = result.repository.pullRequest.closingIssuesReferences.nodes || [];
+  return issues.filter((issue) => issue.state === "OPEN");
+}
+
+function authorAssigned(issues, authorLogin) {
+  return issues.some((issue) =>
+    (issue.assignees?.nodes || []).some((assignee) => assignee.login === authorLogin),
+  );
+}
+
+async function commentOnce(github, owner, repo, prNumber, reason, body) {
+  const marker = `${MARKER_PREFIX}${reason} -->`;
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: prNumber,
+    per_page: 100,
+  });
+
+  if (comments.some((comment) => comment.body?.includes(marker))) {
+    return;
+  }
+
+  if (dryRun) {
+    console.log(`[enforcer] DRY RUN comment for PR #${prNumber}: ${reason}`);
+    return;
+  }
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: prNumber,
+    body: `${marker}\n${body}`,
+  });
+}
+
+async function closePr(github, owner, repo, prNumber) {
+  if (dryRun) {
+    console.log(`[enforcer] DRY RUN close PR #${prNumber}`);
+    return;
+  }
+
+  await github.rest.pulls.update({
+    owner,
+    repo,
+    pull_number: prNumber,
+    state: "closed",
+  });
+}
+
+module.exports = async ({ github, context }) => {
+  try {
+    const { owner, repo } = context.repo;
+    const prs = await github.paginate(github.rest.pulls.list, {
+      owner,
+      repo,
+      state: "open",
+      per_page: 100,
+    });
+
+    for (const pr of prs) {
+      if (isBot(pr)) {
+        continue;
+      }
+
+      const permission = await getPermission(github, owner, repo, pr.user.login);
+      if (isExemptPermission(permission)) {
+        continue;
+      }
+
+      if (getHoursOpen(pr) < hoursBeforeClose) {
+        continue;
+      }
+
+      const linkedIssues = await getLinkedOpenIssues(github, owner, repo, pr.number);
+      if (!linkedIssues.length) {
+        await commentOnce(
+          github,
+          owner,
+          repo,
+          pr.number,
+          "no-linked-issue",
+          `Hi @${pr.user.login}, this PR has no linked open issue. Please link it to a triaged issue, for example by adding \`Fixes #123\` to the PR description.`,
+        );
+        await closePr(github, owner, repo, pr.number);
+        continue;
+      }
+
+      if (requireAuthorAssigned && !authorAssigned(linkedIssues, pr.user.login)) {
+        const linkedIssueNumbers = linkedIssues.map((issue) => `#${issue.number}`).join(", ");
+        await commentOnce(
+          github,
+          owner,
+          repo,
+          pr.number,
+          "author-not-assigned",
+          `Hi @${pr.user.login}, this PR links ${linkedIssueNumbers}, but you are not assigned to any of those issues. Please claim the linked issue first and then reopen the PR if it gets closed.`,
+        );
+        await closePr(github, owner, repo, pr.number);
+      }
+    }
+  } catch (error) {
+    console.error("[enforcer] Error:", error.message);
+    throw error;
+  }
+};

--- a/.github/workflows/bot-assign-on-comment.yml
+++ b/.github/workflows/bot-assign-on-comment.yml
@@ -1,0 +1,25 @@
+name: "Bot: Assign On Comment"
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  assign:
+    if: github.event.issue.pull_request == null
+    runs-on: ubuntu-latest
+    concurrency:
+      group: assign-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6
+      - name: Handle /assign command
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const handler = require('./.github/scripts/bot-assign-on-comment.js');
+            await handler({ github, context });

--- a/.github/workflows/cron-enforcer-pr-linked-issue.yml
+++ b/.github/workflows/cron-enforcer-pr-linked-issue.yml
@@ -1,0 +1,32 @@
+name: "Bot: Linked Issue Enforcer"
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "If true, log intended changes without commenting or closing PRs"
+        required: false
+        default: "true"
+        type: string
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  enforce-linked-issues:
+    runs-on: ubuntu-latest
+    env:
+      DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+      HOURS_BEFORE_CLOSE: "12"
+      REQUIRE_AUTHOR_ASSIGNED: "true"
+    steps:
+      - uses: actions/checkout@v6
+      - name: Enforce linked issues on PRs
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const handler = require('./.github/scripts/cron-enforcer-pr-linked-issue.js');
+            await handler({ github, context });

--- a/.github/workflows/unassign-on-comment.yml
+++ b/.github/workflows/unassign-on-comment.yml
@@ -1,0 +1,25 @@
+name: "Bot: Unassign On Comment"
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  unassign:
+    if: github.event.issue.pull_request == null
+    runs-on: ubuntu-latest
+    concurrency:
+      group: unassign-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6
+      - name: Handle /unassign command
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const handler = require('./.github/scripts/bot-unassign-on-comment.js');
+            await handler({ github, context });

--- a/.github/workflows/working-on-comment.yml
+++ b/.github/workflows/working-on-comment.yml
@@ -1,0 +1,36 @@
+name: "Bot: Working On Comment"
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Log the run without making any changes"
+        required: false
+        default: "true"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  working:
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.comment.body, '/working')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    concurrency:
+      group: working-${{ github.event.issue.number || github.run_id }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6
+      - name: Handle /working command
+        uses: actions/github-script@v8
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        with:
+          script: |
+            const handler = require('./.github/scripts/bot-working-on-comment.js');
+            await handler({ github, context });

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Each platform section includes a local `README.md` plus a `configuration.md` pag
 
 - [Development guide](development.md)
 - [Contributor guide](../CONTRIBUTING.md)
+- [Contribution process prototype](contribution-process-prototype.md)
 
 ## Guides and Tutorials
 

--- a/docs/contribution-process-prototype.md
+++ b/docs/contribution-process-prototype.md
@@ -1,0 +1,66 @@
+# Contribution Process Prototype
+
+This document describes the prototype automation added for the Fabric Smart Client contribution process.
+
+The goal is to provide a small, runnable showcase on a fork before the full workflow is enabled or expanded in the main repository.
+
+## Included Prototype Pieces
+
+- `/assign` on issues marked `ready`
+- `/unassign` for the current assignee
+- `/working` as a lightweight activity signal
+- a scheduled PR enforcer that checks whether external contributors link a PR to an open issue and are assigned to that issue
+
+## Implemented Rules
+
+### Issue Claiming
+
+- The `/assign` command only works on open issues.
+- The issue must carry the `ready` label.
+- A contributor may hold at most 2 open assigned issues at a time.
+- Repository collaborators with `triage`, `write`, or `admin` permission are exempt from the assignment limit.
+
+### Issue Release
+
+- The `/unassign` command removes the commenter from the issue, but only when that commenter is already assigned.
+
+### Activity Signal
+
+- The `/working` command reacts to the comment with `eyes`.
+- It is accepted from the issue assignee or the PR author.
+- This is intended as a simple signal that can later be consumed by inactivity workflows.
+
+### Pull Request Enforcement
+
+- A scheduled workflow checks open PRs from non-collaborators.
+- After 12 hours, the workflow closes PRs that:
+  - do not link an open issue, or
+  - link an open issue that the PR author is not assigned to.
+
+Maintainers, core contributors, and bot-authored PRs are exempt from this enforcement.
+
+## How To Showcase On A Fork
+
+1. Label an issue with `ready`.
+2. Comment `/assign` from a non-collaborator account.
+3. Open a PR from that account with and without `Fixes #<issue>` in the description.
+4. Run the `Bot: Linked Issue Enforcer` workflow manually with `dry_run=false` to verify the close-and-comment behavior.
+5. Comment `/unassign` and `/working` to verify the issue command handlers.
+
+## Files Added
+
+- `.github/workflows/bot-assign-on-comment.yml`
+- `.github/workflows/unassign-on-comment.yml`
+- `.github/workflows/working-on-comment.yml`
+- `.github/workflows/cron-enforcer-pr-linked-issue.yml`
+- `.github/scripts/bot-assign-on-comment.js`
+- `.github/scripts/bot-unassign-on-comment.js`
+- `.github/scripts/bot-working-on-comment.js`
+- `.github/scripts/cron-enforcer-pr-linked-issue.js`
+
+## Next Steps
+
+- add inactivity reminder and unassignment workflows,
+- integrate additional labels such as `good-first-issue`,
+- refine contributor messaging,
+- and decide which parts should remain prototype-only versus move into the default repository workflow.


### PR DESCRIPTION
## Summary
- add a small contribution-process prototype for issue claiming and PR enforcement
- implement `/assign`, `/unassign`, and `/working` handlers through GitHub Actions
- add a showcase document describing how maintainers can try the prototype on a fork

Fixes #1355
