### PR TITLE
validate directory existence before BCCSP initialization

### DIFF
--- a/platform/fabric/core/msp/configbuilder.go
+++ b/platform/fabric/core/msp/configbuilder.go
@@ -172,14 +172,14 @@ func GetLocalMspConfig(dir string, bccspConfig *factory.FactoryOpts, ID string) 
 	keystoreDir := filepath.Join(dir, keystore)
 	bccspConfig = SetupBCCSPKeystoreConfig(bccspConfig, keystoreDir)
 
-	err := factory.InitFactories(bccspConfig)
-	if err != nil {
-		return nil, errors.WithMessage(err, "could not initialize BCCSP Factories")
-	}
-
 	signcert, err := getPemMaterialFromDir(signcertDir)
 	if err != nil || len(signcert) == 0 {
 		return nil, errors.Wrapf(err, "could not load a valid signer certificate from directory %s", signcertDir)
+	}
+
+	err = factory.InitFactories(bccspConfig)
+	if err != nil {
+		return nil, errors.WithMessage(err, "could not initialize BCCSP Factories")
 	}
 
 	/* FIXME: for now we're making the following assumptions


### PR DESCRIPTION
Closes #1374 
### Summary
Fixes flaky MSP tests by moving the BCCSP initialization after the directory existence check in `GetLocalMspConfig`.

### Problem
Invalid MSP paths caused BCCSP to attempt directory creation in unauthorized locations (e.g., `/nonexistent`), leading to `permission denied` errors and global state corruption.

### Changes
- **platform/fabric/core/msp/configbuilder.go**: Moved `factory.InitFactories` to execute only after signer certificates are validated.

### Verification
- All MSP tests passed.

