### PR TITLE
fabricx: add nil guards to ProposalResponse accessors

### DIFF
--- a/platform/fabricx/core/transaction/pr.go
+++ b/platform/fabricx/core/transaction/pr.go
@@ -39,6 +39,9 @@ func NewProposalResponseFromBytes(raw []byte) (*ProposalResponse, error) {
 }
 
 func (p *ProposalResponse) Endorser() []byte {
+	if p.pr.Endorsement == nil {
+		return nil
+	}
 	return p.pr.Endorsement.Endorser
 }
 
@@ -47,6 +50,9 @@ func (p *ProposalResponse) Payload() []byte {
 }
 
 func (p *ProposalResponse) EndorserSignature() []byte {
+	if p.pr.Endorsement == nil {
+		return nil
+	}
 	return p.pr.Endorsement.Signature
 }
 
@@ -59,10 +65,16 @@ func (p *ProposalResponse) PR() *pb.ProposalResponse {
 }
 
 func (p *ProposalResponse) ResponseStatus() int32 {
+	if p.pr.Response == nil {
+		return 0
+	}
 	return p.pr.Response.Status
 }
 
 func (p *ProposalResponse) ResponseMessage() string {
+	if p.pr.Response == nil {
+		return ""
+	}
 	return p.pr.Response.Message
 }
 

--- a/platform/fabricx/core/transaction/pr_test.go
+++ b/platform/fabricx/core/transaction/pr_test.go
@@ -107,6 +107,41 @@ func TestProposalResponseAccessors(t *testing.T) {
 	require.Equal(t, "accepted", pr.ResponseMessage())
 }
 
+// TestProposalResponseAccessorsNilEndorsement verifies that accessors do not
+// panic when the underlying ProposalResponse has a nil Endorsement field.
+// This can happen with malformed or rejected responses from misbehaving peers.
+func TestProposalResponseAccessorsNilEndorsement(t *testing.T) {
+	t.Parallel()
+	pr, err := NewProposalResponseFromResponse(&peer.ProposalResponse{
+		Payload:  []byte("payload"),
+		Response: &peer.Response{Status: 500, Message: "internal error"},
+		// Endorsement intentionally nil
+	})
+	require.NoError(t, err)
+
+	require.Nil(t, pr.Endorser())
+	require.Nil(t, pr.EndorserSignature())
+	require.Equal(t, []byte("payload"), pr.Payload())
+}
+
+// TestProposalResponseAccessorsNilResponse verifies that accessors do not
+// panic when the underlying ProposalResponse has a nil Response field.
+func TestProposalResponseAccessorsNilResponse(t *testing.T) {
+	t.Parallel()
+	pr, err := NewProposalResponseFromResponse(&peer.ProposalResponse{
+		Payload: []byte("payload"),
+		Endorsement: &peer.Endorsement{
+			Endorser:  []byte("endorser"),
+			Signature: []byte("signature"),
+		},
+		// Response intentionally nil
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, int32(0), pr.ResponseStatus())
+	require.Equal(t, "", pr.ResponseMessage())
+}
+
 // TestProposalResponseBytes verifies that a wrapped proposal response can be
 // marshaled back into protobuf bytes.
 func TestProposalResponseBytes(t *testing.T) {

--- a/platform/fabricx/core/transaction/transaction.go
+++ b/platform/fabricx/core/transaction/transaction.go
@@ -563,7 +563,8 @@ func (t *Transaction) generateProposal(signer SerializableSigner) error {
 
 func (t *Transaction) appendProposalResponse(response *pb.ProposalResponse) error {
 	for _, r := range t.TProposalResponses {
-		if bytes.Equal(r.Endorsement.Endorser, response.Endorsement.Endorser) {
+		if r.Endorsement != nil && response.Endorsement != nil &&
+			bytes.Equal(r.Endorsement.Endorser, response.Endorsement.Endorser) {
 			logger.Debugf("an endorsement from [%s] found, skip it", view.Identity(r.Endorsement.Endorser))
 			return nil
 		}


### PR DESCRIPTION
Fixes #1379 

## Problem

`ProposalResponse` accessor methods dereference `Endorsement` and `Response` fields without nil checks. A malformed proposal response (e.g., from a misbehaving peer or a rejected endorsement) crashes the FSC node with a nil pointer dereference.

## Changes

- Add nil checks in `Endorser()` and `EndorserSignature()` for nil `Endorsement`, returning `nil` safely
- Add nil checks in `ResponseStatus()` and `ResponseMessage()` for nil `Response`, returning zero values
- Add nil guard in `appendProposalResponse()` to prevent panic when comparing endorsers
- Add unit tests for both nil `Endorsement` and nil `Response` edge cases

## Testing

All existing + new tests pass:

go test ./platform/fabricx/core/transaction/... -v -count=1

New tests:
- `TestProposalResponseAccessorsNilEndorsement`
- `TestProposalResponseAccessorsNilResponse`
