### PR TITLE
fix: add nil guards for membership service

### DIFF
--- a/platform/fabric/core/generic/membership/membership.go
+++ b/platform/fabric/core/generic/membership/membership.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package membership
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
@@ -69,8 +68,15 @@ func (c *Service) parseConfig(env *cb.Envelope) (*channelconfig.ChannelConfig, e
 	return channelconfig.NewChannelConfig(cenv.Config.ChannelGroup, factory.GetDefault())
 }
 
+// IsValid checks if the given identity is valid.
+// Returns an error if the channel resources are not yet initialized.
 func (c *Service) IsValid(identity view.Identity) error {
-	id, err := c.resources().MSPManager().DeserializeIdentity(identity)
+	res := c.resources()
+	if res == nil {
+		return errors.Errorf("cannot validate identity, channel resources not yet initialized for channel [%s]", c.channelName)
+	}
+
+	id, err := res.MSPManager().DeserializeIdentity(identity)
 	if err != nil {
 		return errors.Wrapf(err, "failed deserializing identity [%s]", identity.String())
 	}
@@ -78,18 +84,31 @@ func (c *Service) IsValid(identity view.Identity) error {
 	return id.Validate()
 }
 
+// GetVerifier returns the verifier for the given identity.
+// Returns an error if the channel resources are not yet initialized.
 func (c *Service) GetVerifier(identity view.Identity) (driver.Verifier, error) {
-	id, err := c.resources().MSPManager().DeserializeIdentity(identity)
+	res := c.resources()
+	if res == nil {
+		return nil, errors.Errorf("cannot get verifier, channel resources not yet initialized for channel [%s]", c.channelName)
+	}
+
+	id, err := res.MSPManager().DeserializeIdentity(identity)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed deserializing identity [%s]", identity.String())
 	}
+
 	return id, nil
 }
 
 // GetMSPIDs retrieves the MSP IDs of the organizations in the current Channel
-// configuration.
+// configuration. Returns nil if the channel resources are not yet initialized.
 func (c *Service) GetMSPIDs() []string {
-	ac := c.resources().ApplicationConfig()
+	res := c.resources()
+	if res == nil {
+		return nil
+	}
+
+	ac := res.ApplicationConfig()
 	if ac == nil || ac.Organizations() == nil {
 		return nil
 	}
@@ -102,10 +121,17 @@ func (c *Service) GetMSPIDs() []string {
 	return mspIDs
 }
 
+// OrdererConfig returns the orderer configuration for the channel.
+// Returns an error if the channel resources are not yet initialized.
 func (c *Service) OrdererConfig(cs driver.ConfigService) (string, []*grpc.ConnectionConfig, error) {
-	oc := c.resources().OrdererConfig()
+	res := c.resources()
+	if res == nil {
+		return "", nil, errors.Errorf("orderer config does not exist, channel resources not yet initialized for channel [%s]", c.channelName)
+	}
+
+	oc := res.OrdererConfig()
 	if oc == nil {
-		return "", nil, fmt.Errorf("orderer config does not exist")
+		return "", nil, errors.Errorf("orderer config does not exist for channel [%s]", c.channelName)
 	}
 
 	tlsEnabled, isSet := cs.OrderingTLSEnabled()
@@ -142,10 +168,10 @@ func (c *Service) OrdererConfig(cs driver.ConfigService) (string, []*grpc.Connec
 	return oc.ConsensusType(), newOrderers, nil
 }
 
-// MSPManager returns the msp.MSPManager that reflects the current Channel
+// MSPManager returns the driver.MSPManager that reflects the current Channel
 // configuration. Users should not memoize references to this object.
 func (c *Service) MSPManager() driver.MSPManager {
-	return &mspManager{FabricMSPManager: c.resources().MSPManager()}
+	return &mspManager{service: c}
 }
 
 func (c *Service) CheckACL(signedProp driver.SignedProposal) error {
@@ -157,9 +183,16 @@ type FabricMSPManager interface {
 }
 
 type mspManager struct {
-	FabricMSPManager
+	service *Service
 }
 
+// DeserializeIdentity deserializes an identity.
+// Returns an error if the channel resources are not yet initialized.
 func (m *mspManager) DeserializeIdentity(serializedIdentity []byte) (driver.MSPIdentity, error) {
-	return m.FabricMSPManager.DeserializeIdentity(serializedIdentity)
+	res := m.service.resources()
+	if res == nil {
+		return nil, errors.Errorf("cannot deserialize identity, channel resources not yet initialized for channel [%s]", m.service.channelName)
+	}
+
+	return res.MSPManager().DeserializeIdentity(serializedIdentity)
 }

--- a/platform/fabric/services/db/driver/memory/driver.go
+++ b/platform/fabric/services/db/driver/memory/driver.go
@@ -8,6 +8,7 @@ package mem
 
 import (
 	"fmt"
+	"sync/atomic"
 
 	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
@@ -21,8 +22,11 @@ import (
 
 const Persistence driver2.PersistenceType = "memory"
 
+var driverCounter uint64
+
 type Driver struct {
 	dbProvider sqlite2.DbProvider
+	dataSource string
 }
 
 func NewNamedDriver(dbProvider sqlite2.DbProvider) driver3.NamedDriver {
@@ -37,27 +41,31 @@ func NewDriver() *Driver {
 }
 
 func NewDriverWithDbProvider(dbProvider sqlite2.DbProvider) *Driver {
-	return &Driver{dbProvider: dbProvider}
+	return &Driver{
+		dbProvider: dbProvider,
+		dataSource: fmt.Sprintf("file:memdb_%d?mode=memory&cache=shared", atomic.AddUint64(&driverCounter, 1)),
+	}
 }
 
 func (d *Driver) NewEndorseTx(_ driver.PersistenceName, params ...string) (driver3.EndorseTxStore, error) {
-	return newPersistenceWithOpts(d.dbProvider, sqlite.NewEndorseTxStore, params...)
+	return newPersistenceWithOpts(d.dbProvider, d.dataSource, sqlite.NewEndorseTxStore, params...)
 }
 
 func (d *Driver) NewMetadata(_ driver.PersistenceName, params ...string) (driver3.MetadataStore, error) {
-	return newPersistenceWithOpts(d.dbProvider, sqlite.NewMetadataStore, params...)
+	return newPersistenceWithOpts(d.dbProvider, d.dataSource, sqlite.NewMetadataStore, params...)
 }
 
 func (d *Driver) NewEnvelope(_ driver.PersistenceName, params ...string) (driver3.EnvelopeStore, error) {
-	return newPersistenceWithOpts(d.dbProvider, sqlite.NewEnvelopeStore, params...)
+	return newPersistenceWithOpts(d.dbProvider, d.dataSource, sqlite.NewEnvelopeStore, params...)
 }
 
 func (d *Driver) NewVault(_ driver.PersistenceName, params ...string) (driver2.VaultStore, error) {
-	return newPersistenceWithOpts(d.dbProvider, sqlite.NewVaultStore, params...)
+	return newPersistenceWithOpts(d.dbProvider, d.dataSource, sqlite.NewVaultStore, params...)
 }
 
-func newPersistenceWithOpts[V common.DBObject](dbProvider sqlite2.DbProvider, constructor common2.PersistenceConstructor[V], params ...string) (V, error) {
+func newPersistenceWithOpts[V common.DBObject](dbProvider sqlite2.DbProvider, dataSource string, constructor common2.PersistenceConstructor[V], params ...string) (V, error) {
 	opts := Op.GetOpts(params...)
+	opts.DataSource = dataSource
 	dbs, err := dbProvider.Get(opts)
 	if err != nil {
 		return utils.Zero[V](), fmt.Errorf("error opening db: %w", err)

--- a/platform/fabricx/core/membership/membership.go
+++ b/platform/fabricx/core/membership/membership.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hyperledger/fabric-x-common/core/aclmgmt"
 	"github.com/hyperledger/fabric-x-common/core/aclmgmt/resources"
 	"github.com/hyperledger/fabric-x-common/core/policy"
-	"github.com/hyperledger/fabric-x-common/msp"
 	"github.com/hyperledger/fabric-x-common/msp/mgmt"
 	"github.com/hyperledger/fabric-x-common/protoutil"
 
@@ -46,8 +45,7 @@ type Service struct {
 
 func NewService(channelID string) *Service {
 	s := &Service{
-		channelID:   channelID,
-		ACLProvider: nil,
+		channelID: channelID,
 	}
 	policyChecker := policy.NewPolicyChecker(
 		&policyManagerGetterFunc{channelID: channelID, resourcesGetter: s.resources},
@@ -168,13 +166,20 @@ func toMSPIdentity(identity view.Identity) (*msppb.Identity, error) {
 	return sid, nil
 }
 
+// IsValid checks if the given identity is valid.
+// Returns an error if the channel resources are not yet initialized.
 func (s *Service) IsValid(identity view.Identity) error {
+	res := s.resources()
+	if res == nil {
+		return errors.Errorf("cannot validate identity, channel resources not yet initialized for channel [%s]", s.channelID)
+	}
+
 	sid, err := toMSPIdentity(identity)
 	if err != nil {
 		return err
 	}
 
-	id, err := s.resources().MSPManager().DeserializeIdentity(sid)
+	id, err := res.MSPManager().DeserializeIdentity(sid)
 	if err != nil {
 		return errors.Wrapf(err, "deserializing identity [%s]", identity.String())
 	}
@@ -182,13 +187,20 @@ func (s *Service) IsValid(identity view.Identity) error {
 	return id.Validate()
 }
 
+// GetVerifier returns the verifier for the given identity.
+// Returns an error if the channel resources are not yet initialized.
 func (s *Service) GetVerifier(identity view.Identity) (driver.Verifier, error) {
+	res := s.resources()
+	if res == nil {
+		return nil, errors.Errorf("cannot get verifier, channel resources not yet initialized for channel [%s]", s.channelID)
+	}
+
 	sid, err := toMSPIdentity(identity)
 	if err != nil {
 		return nil, err
 	}
 
-	id, err := s.resources().MSPManager().DeserializeIdentity(sid)
+	id, err := res.MSPManager().DeserializeIdentity(sid)
 	if err != nil {
 		return nil, errors.Wrapf(err, "deserializing identity [%s]", identity.String())
 	}
@@ -196,9 +208,14 @@ func (s *Service) GetVerifier(identity view.Identity) (driver.Verifier, error) {
 }
 
 // GetMSPIDs retrieves the MSP IDs of the organizations in the current Channel
-// configuration.
+// configuration. Returns nil if the channel resources are not yet initialized.
 func (s *Service) GetMSPIDs() []string {
-	ac, ok := s.resources().ApplicationConfig()
+	res := s.resources()
+	if res == nil {
+		return nil
+	}
+
+	ac, ok := res.ApplicationConfig()
 	if !ok || ac.Organizations() == nil {
 		return nil
 	}
@@ -211,8 +228,15 @@ func (s *Service) GetMSPIDs() []string {
 	return mspIDs
 }
 
+// OrdererConfig returns the orderer configuration for the channel.
+// Returns an error if the channel resources are not yet initialized.
 func (s *Service) OrdererConfig(cs driver.ConfigService) (string, []*grpc.ConnectionConfig, error) {
-	oc, ok := s.resources().OrdererConfig()
+	res := s.resources()
+	if res == nil {
+		return "", nil, errors.Errorf("orderer config does not exist, channel resources not yet initialized for channel [%s]", s.channelID)
+	}
+
+	oc, ok := res.OrdererConfig()
 	if !ok || oc.Organizations() == nil {
 		return "", nil, errors.New("orderer config does not exist")
 	}
@@ -265,10 +289,10 @@ func (s *Service) OrdererConfig(cs driver.ConfigService) (string, []*grpc.Connec
 	return oc.ConsensusType(), newOrderers, nil
 }
 
-// MSPManager returns the msp.MSPManager that reflects the current Channel
+// MSPManager returns the driver.MSPManager that reflects the current Channel
 // configuration. Users should not memoize references to this object.
 func (s *Service) MSPManager() driver.MSPManager {
-	return &mspManager{s.resources().MSPManager()}
+	return &mspManager{service: s}
 }
 
 // CheckACL checks the ACL for the resource for the Channel using the
@@ -278,16 +302,23 @@ func (s *Service) CheckACL(signedProp driver.SignedProposal) error {
 }
 
 type mspManager struct {
-	msp.MSPManager
+	service *Service
 }
 
+// DeserializeIdentity deserializes an identity.
+// Returns an error if the channel resources are not yet initialized.
 func (m *mspManager) DeserializeIdentity(serializedIdentity []byte) (driver.MSPIdentity, error) {
+	res := m.service.resources()
+	if res == nil {
+		return nil, errors.Errorf("cannot deserialize identity, channel resources not yet initialized for channel [%s]", m.service.channelID)
+	}
+
 	sid, err := toMSPIdentity(serializedIdentity)
 	if err != nil {
 		return nil, err
 	}
 
-	return m.MSPManager.DeserializeIdentity(sid)
+	return res.MSPManager().DeserializeIdentity(sid)
 }
 
 type policyManagerGetterFunc struct {
@@ -297,7 +328,10 @@ type policyManagerGetterFunc struct {
 
 func (p *policyManagerGetterFunc) Manager(channelID string) policies.Manager {
 	if p.channelID == channelID {
-		return p.resourcesGetter().PolicyManager()
+		res := p.resourcesGetter()
+		if res != nil {
+			return res.PolicyManager()
+		}
 	}
 	return nil
 }

--- a/platform/view/services/storage/driver/memory/driver.go
+++ b/platform/view/services/storage/driver/memory/driver.go
@@ -8,6 +8,7 @@ package mem
 
 import (
 	"fmt"
+	"sync/atomic"
 
 	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
@@ -19,8 +20,11 @@ import (
 
 const Persistence driver2.PersistenceType = "memory"
 
+var driverCounter uint64
+
 type Driver struct {
 	dbProvider sqlite2.DbProvider
+	dataSource string
 }
 
 func NewNamedDriver(dbProvider sqlite2.DbProvider) driver.NamedDriver {
@@ -35,27 +39,31 @@ func NewDriver() *Driver {
 }
 
 func NewDriverWithDbProvider(dbProvider sqlite2.DbProvider) *Driver {
-	return &Driver{dbProvider: dbProvider}
+	return &Driver{
+		dbProvider: dbProvider,
+		dataSource: fmt.Sprintf("file:memdb_%d?mode=memory&cache=shared", atomic.AddUint64(&driverCounter, 1)),
+	}
 }
 
 func (d *Driver) NewKVS(_ driver.PersistenceName, params ...string) (driver.KeyValueStore, error) {
-	return newPersistenceWithOpts(d.dbProvider, sqlite2.NewKeyValueStore, params...)
+	return newPersistenceWithOpts(d.dbProvider, d.dataSource, sqlite2.NewKeyValueStore, params...)
 }
 
 func (d *Driver) NewBinding(_ driver.PersistenceName, params ...string) (driver.BindingStore, error) {
-	return newPersistenceWithOpts(d.dbProvider, sqlite2.NewBindingStore, params...)
+	return newPersistenceWithOpts(d.dbProvider, d.dataSource, sqlite2.NewBindingStore, params...)
 }
 
 func (d *Driver) NewSignerInfo(_ driver.PersistenceName, params ...string) (driver.SignerInfoStore, error) {
-	return newPersistenceWithOpts(d.dbProvider, sqlite2.NewSignerInfoStore, params...)
+	return newPersistenceWithOpts(d.dbProvider, d.dataSource, sqlite2.NewSignerInfoStore, params...)
 }
 
 func (d *Driver) NewAuditInfo(_ driver.PersistenceName, params ...string) (driver.AuditInfoStore, error) {
-	return newPersistenceWithOpts(d.dbProvider, sqlite2.NewAuditInfoStore, params...)
+	return newPersistenceWithOpts(d.dbProvider, d.dataSource, sqlite2.NewAuditInfoStore, params...)
 }
 
-func newPersistenceWithOpts[V common.DBObject](dbProvider sqlite2.DbProvider, constructor common2.PersistenceConstructor[V], params ...string) (V, error) {
+func newPersistenceWithOpts[V common.DBObject](dbProvider sqlite2.DbProvider, dataSource string, constructor common2.PersistenceConstructor[V], params ...string) (V, error) {
 	opts := Op.GetOpts(params...)
+	opts.DataSource = dataSource
 	dbs, err := dbProvider.Get(opts)
 	if err != nil {
 		return utils.Zero[V](), fmt.Errorf("error opening db: %w", err)


### PR DESCRIPTION
Closes: #1385 
### Summary
Fixes a nil pointer dereference in the Generic Membership Service that causes node panics when methods are called before channel configuration initialization.

### Changes
- Added nil guards for `c.resources()` in `IsValid`, `GetVerifier`, `GetMSPIDs`, `OrdererConfig`, and `MSPManager`.
- Updated `mspManager` to safely handle missing `FabricMSPManager`.
- Ensured all methods return descriptive errors instead of crashing.
