### PR TITLE
chore(view service): Runner for InitiateView #1389

### DIFF
--- a/platform/view/sdk/dig/sdk.go
+++ b/platform/view/sdk/dig/sdk.go
@@ -122,6 +122,7 @@ func (p *SDK) Install() error {
 		p.Container().Provide(view.NewMetrics),
 		p.Container().Provide(view.NewContextFactory),
 		p.Container().Provide(view.NewManager),
+		p.Container().Provide(view.NewDefaultRunner),
 		p.Container().Provide(
 			digutils.Identity[*view.Manager](),
 			dig.As(new(viewgrpcserver.ViewManager), new(p2p.ViewManager)),

--- a/platform/view/services/view/manager.go
+++ b/platform/view/services/view/manager.go
@@ -69,6 +69,7 @@ type Manager struct {
 	identityProvider IdentityProvider
 	registry         *Registry
 	metrics          *Metrics
+	runner           Runner
 
 	contexts   map[string]DisposableContext
 	contextsMu sync.RWMutex
@@ -80,6 +81,7 @@ func NewManager(
 	registry *Registry,
 	metrics *Metrics,
 	contextFactory ContextFactory,
+	runner Runner,
 ) *Manager {
 	return &Manager{
 		identityProvider: identityProvider,
@@ -89,6 +91,8 @@ func NewManager(
 
 		metrics:        metrics,
 		contextFactory: contextFactory,
+
+		runner: runner,
 	}
 }
 
@@ -156,7 +160,7 @@ func (cm *Manager) InitiateViewWithIdentity(ctx context.Context, view view.View,
 	if logger.IsEnabledFor(zapcore.DebugLevel) {
 		logger.DebugfContext(ctx, "[%s] InitiateView [view:%s], [ContextID:%s], from [%s]", id, logging.Identifier(view), c.ID(), string(debug.Stack()))
 	}
-	res, err := c.RunView(view)
+	res, err := cm.runner.RunView(c, view)
 	if err != nil {
 		logger.DebugfContext(ctx, "[%s] InitiateView [view:%s], [ContextID:%s] failed [%s]", id, logging.Identifier(view), c.ID(), err)
 		return nil, err
@@ -321,4 +325,21 @@ func (cm *Manager) DeleteContext(contextID string) {
 		delete(cm.contexts, contextID)
 		cm.metrics.Contexts.Set(float64(len(cm.contexts)))
 	}
+}
+
+// Runner models a view runner.
+type Runner interface {
+	// RunView runs the given responder view in the given view context.
+	RunView(viewCtx view.Context, responder view.View) (any, error)
+}
+
+type defaultRunner struct{}
+
+func (r *defaultRunner) RunView(viewCtx view.Context, responder view.View) (any, error) {
+	return viewCtx.RunView(responder)
+}
+
+// NewDefaultRunner returns a new instance of the default view runner.
+func NewDefaultRunner() Runner {
+	return &defaultRunner{}
 }

--- a/platform/view/services/view/manager_factory_test.go
+++ b/platform/view/services/view/manager_factory_test.go
@@ -26,7 +26,7 @@ func TestManagerWithMockFactory(t *testing.T) {
 
 	metrics := view.NewMetrics(mp)
 	cf := &mock.ContextFactory{}
-	manager := view.NewManager(ip, registry, metrics, cf)
+	manager := view.NewManager(ip, registry, metrics, cf, view.NewDefaultRunner())
 
 	t.Run("InitiateContextCallsFactory", func(t *testing.T) {
 		t.Parallel()

--- a/platform/view/services/view/manager_test.go
+++ b/platform/view/services/view/manager_test.go
@@ -39,7 +39,7 @@ func TestManager(t *testing.T) {
 
 	metrics := view.NewMetrics(mp)
 	cf := view.NewContextFactory(sp, sf, es, ip, registry, tp, metrics, lic)
-	manager := view.NewManager(ip, registry, metrics, cf)
+	manager := view.NewManager(ip, registry, metrics, cf, view.NewDefaultRunner())
 	require.NotNil(t, manager)
 
 	// Test Me
@@ -134,7 +134,7 @@ func TestManagerRegistry(t *testing.T) {
 
 	metrics := view.NewMetrics(mp)
 	cf := view.NewContextFactory(sp, sf, es, ip, registry, tp, metrics, lic)
-	manager := view.NewManager(ip, registry, metrics, cf)
+	manager := view.NewManager(ip, registry, metrics, cf, view.NewDefaultRunner())
 
 	responder := &mock.View{}
 	err := manager.RegisterResponder(responder, "initiator")
@@ -166,7 +166,7 @@ func TestNewSessionContext(t *testing.T) {
 
 	metrics := view.NewMetrics(mp)
 	cf := view.NewContextFactory(sp, sf, es, ip, registry, tp, metrics, lic)
-	manager := view.NewManager(ip, registry, metrics, cf)
+	manager := view.NewManager(ip, registry, metrics, cf, view.NewDefaultRunner())
 	ip.DefaultIdentityReturns(view2.Identity("me"))
 
 	session := &mock.Session{}
@@ -206,7 +206,7 @@ func TestManagerOther(t *testing.T) {
 
 	metrics := view.NewMetrics(mp)
 	cf := view.NewContextFactory(sp, sf, es, ip, registry, tp, metrics, lic)
-	manager := view.NewManager(ip, registry, metrics, cf)
+	manager := view.NewManager(ip, registry, metrics, cf, view.NewDefaultRunner())
 
 	// RegisterContext
 	mockCtx := &mock.DisposableContext{}


### PR DESCRIPTION
This PR allows the developer to replace the way `InitiateView` invokes the view. This allows the developer to inject business logic to augment the view context.