### PR TITLE
Added NativeHistogram fields to HistogramOpts

### DIFF
--- a/platform/view/services/metrics/prometheus/provider.go
+++ b/platform/view/services/metrics/prometheus/provider.go
@@ -97,11 +97,14 @@ func (p *Provider) NewHistogram(o metrics.HistogramOpts) metrics.Histogram {
 	p.applyNamespaceSubsystem(&o.Namespace, &o.Subsystem)
 
 	hv := prom.NewHistogramVec(prom.HistogramOpts{
-		Namespace: o.Namespace,
-		Subsystem: o.Subsystem,
-		Name:      o.Name,
-		Help:      o.Help,
-		Buckets:   o.Buckets,
+		Namespace:                      o.Namespace,
+		Subsystem:                      o.Subsystem,
+		Name:                           o.Name,
+		Help:                           o.Help,
+		Buckets:                        o.Buckets,
+		NativeHistogramBucketFactor:    o.NativeHistogramBucketFactor,
+		NativeHistogramMaxBucketNumber: o.NativeHistogramMaxBucketNumber,
+		NativeHistogramZeroThreshold:   o.NativeHistogramZeroThreshold,
 	}, o.LabelNames)
 	p.register(hv)
 	return &Histogram{prometheus.NewHistogram(hv)}

--- a/platform/view/services/metrics/provider.go
+++ b/platform/view/services/metrics/provider.go
@@ -124,6 +124,25 @@ type HistogramOpts struct {
 	// omitted, the default Prometheus bucket values are used.
 	Buckets []float64
 
+	// NativeHistogramBucketFactor determines the resolution of native histogram
+	// buckets. A value of 1.1 (schema=3) means each bucket boundary is ~9% wider
+	// than the previous. Setting this to a value > 1 enables native histogram
+	// collection alongside classic buckets (dual mode). When zero, only classic
+	// buckets are used.
+	NativeHistogramBucketFactor float64
+
+	// NativeHistogramMaxBucketNumber is the maximum number of populated sparse
+	// buckets allowed. If this limit is exceeded during observation, the
+	// histogram resolution is reduced (buckets are merged) to stay within the
+	// limit. A value of 0 means no limit.
+	NativeHistogramMaxBucketNumber uint32
+
+	// NativeHistogramZeroThreshold defines the width of the zero bucket.
+	// Observations in the range [-ZeroThreshold, +ZeroThreshold] are counted in
+	// a dedicated zero bucket. A value of 0 means the zero bucket only contains
+	// observations that are exactly zero.
+	NativeHistogramZeroThreshold float64
+
 	// LabelNames provides the names of the labels that can be attached to this
 	// metric. When a metric is recorded, label values must be provided for each
 	// of these label names.


### PR DESCRIPTION
## Summary

Closes #1397 

Add `NativeHistogramBucketFactor`, `NativeHistogramMaxBucketNumber`, and `NativeHistogramZeroThreshold` fields to `HistogramOpts` and pass them through to the Prometheus provider.

## What

- Added 3 new fields to `HistogramOpts` in `platform/view/services/metrics/provider.go`
- Updated `platform/view/services/metrics/prometheus/provider.go` to pass these fields to `prom.HistogramOpts`

## Why

The underlying `prometheus/client_golang v1.23.2` supports [native histograms](https://prometheus.io/docs/concepts/metric_types/#native-histograms) — exponentially-spaced, self-adjusting bucket histograms that provide significantly better percentile accuracy than fixed buckets. However, these options are not currently exposed through the FSC metrics abstraction, blocking downstream consumers (e.g., fabric-token-sdk) from using them.

Fixed-bucket histograms require developers to guess production data distributions at development time and produce inaccurate percentile estimates when values fall between wide bucket gaps. Native histograms solve this by automatically placing bucket boundaries at exponential intervals based on a single resolution parameter.

## Backward Compatibility

Fully backward compatible — all three new fields default to their zero value, which preserves current behavior (classic buckets only). Native histograms only activate when a consumer explicitly sets `NativeHistogramBucketFactor` to a value greater than 1.