### PR TITLE
refactor: remove consul sdk dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
-	github.com/hashicorp/consul/sdk v0.1.1
 	github.com/hyperledger/fabric-chaincode-go/v2 v2.3.0
 	github.com/hyperledger/fabric-config v0.3.0
 	github.com/hyperledger/fabric-contract-api-go/v2 v2.2.0
@@ -72,7 +71,6 @@ require (
 	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
-	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1026,7 +1026,6 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3/go.mod h1:o//XUCC/F+yRGJoPO/VU
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 h1:X+2YciYSxvMQK0UZ7sg45ZVabVZBeBuvMkmuI2V3Fak=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7/go.mod h1:lW34nIZuQ8UDPdkon5fmfp2l3+ZkQ2me/+oecHYLOII=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
-github.com/hashicorp/consul/sdk v0.1.1 h1:LnuDWGNsoajlhGyHJvuWW6FVqRl8JOTPqS6CPTsYjhY=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -1243,7 +1242,6 @@ github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceT
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=

--- a/platform/view/services/comm/host/websocket/p2p_test.go
+++ b/platform/view/services/comm/host/websocket/p2p_test.go
@@ -14,7 +14,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"fmt"
 	"math/big"
 	"net"
 	"os"
@@ -22,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/sdk/freeport"
 	"github.com/mr-tron/base58/base58"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
@@ -115,8 +113,9 @@ func setupTwoNodes(t *testing.T) (*comm.HostNode, *comm.HostNode) {
 	t.Helper()
 	tlsFiles := generateTLSFiles(t)
 
-	bootstrapAddress := freeTCPAddress(t)
-	otherAddress := freeTCPAddress(t)
+	addresses := freeTCPAddresses(t, 2)
+	bootstrapAddress := addresses[0]
+	otherAddress := addresses[1]
 	bootstrapCertPath := tlsFiles.bootstrapCert
 	otherCertPath := tlsFiles.otherCert
 	bootstrapID := mustPeerIDFromCert(t, bootstrapCertPath)
@@ -226,9 +225,10 @@ func setupThreeNodes(t *testing.T) (*comm.HostNode, *comm.HostNode, *comm.HostNo
 	node1ID := mustPeerIDFromCert(t, node1Cert)
 	node2ID := mustPeerIDFromCert(t, node2Cert)
 
-	bootstrapAddress := freeTCPAddress(t)
-	node1Address := freeTCPAddress(t)
-	node2Address := freeTCPAddress(t)
+	addresses := freeTCPAddresses(t, 3)
+	bootstrapAddress := addresses[0]
+	node1Address := addresses[1]
+	node2Address := addresses[2]
 
 	bootstrapHost, _ := newStaticRouteHostProvider(&routing.StaticIDRouter{
 		bootstrapID: []host2.PeerIPAddress{bootstrapAddress},
@@ -285,10 +285,20 @@ func setupThreeNodes(t *testing.T) (*comm.HostNode, *comm.HostNode, *comm.HostNo
 		&comm.HostNode{P2PNode: node2Node, ID: node2ID, Address: node2Address}
 }
 
-func freeTCPAddress(t *testing.T) string {
+func freeTCPAddresses(t *testing.T, n int) []string {
 	t.Helper()
-	ports := freeport.GetT(t, 1)
-	return fmt.Sprintf("127.0.0.1:%d", ports[0])
+	var listeners []net.Listener
+	for i := 0; i < n; i++ {
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		listeners = append(listeners, l)
+	}
+	var addresses []string
+	for _, l := range listeners {
+		addresses = append(addresses, l.Addr().String())
+		_ = l.Close()
+	}
+	return addresses
 }
 
 func mustPeerIDFromCert(t *testing.T, certPath string) string {
@@ -420,11 +430,12 @@ func TestSessionInfoSecurityGuarantees(t *testing.T) { //nolint:paralleltest
 	require.Equal(t, []byte(aliceNode.ID), info.EndpointPKID, "EndpointPKID mismatch")
 
 	charlieID := mustPeerIDFromCert(t, allTlsFiles.charlie.cert)
+	charlieAddresses := freeTCPAddresses(t, 2)
 	charlieHost, _ := newStaticRouteHostProvider(&routing.StaticIDRouter{
-		charlieID:  []host2.PeerIPAddress{freeTCPAddress(t)},
+		charlieID:  []host2.PeerIPAddress{charlieAddresses[0]},
 		bobNode.ID: []host2.PeerIPAddress{bobNode.Address},
 	}, websocket.NewConfigFromProperties(
-		freeTCPAddress(t),
+		charlieAddresses[1],
 		allTlsFiles.charlie.key,
 		allTlsFiles.charlie.cert,
 		[]string{allTlsFiles.caCert},
@@ -519,8 +530,9 @@ func generateThreeNodesTLSFiles(t *testing.T) threeNodesTLSFiles {
 
 func setupTwoNodesFromTLS(t *testing.T, alice, bob nodeTLSFiles, caCert string) (*comm.HostNode, *comm.HostNode) {
 	t.Helper()
-	aliceAddr := freeTCPAddress(t)
-	bobAddr := freeTCPAddress(t)
+	addrs := freeTCPAddresses(t, 2)
+	aliceAddr := addrs[0]
+	bobAddr := addrs[1]
 	aliceID := mustPeerIDFromCert(t, alice.cert)
 	bobID := mustPeerIDFromCert(t, bob.cert)
 	routes := &routing.StaticIDRouter{


### PR DESCRIPTION
Closes #1404
# Description
This PR removes the `github.com/hashicorp/consul/sdk` dependency from the project by refactoring the port allocation logic in the P2P test suite.
# Changes
- Replaced `github.com/hashicorp/consul/sdk/freeport` in `p2p_test.go` with a native implementation using the standard `net` library.
- Implemented `freeTCPAddress` helper to safely acquire available ports.
- Updated `go.mod` to remove the `consul` dependency.