### PR TITLE
refactor: replace viper with koanf

### DIFF
--- a/ci/codeql/node/main.go
+++ b/ci/codeql/node/main.go
@@ -8,22 +8,11 @@ package main
 
 import (
 	_ "net/http/pprof"
-	"strings"
-
-	"github.com/spf13/viper"
 
 	node2 "github.com/hyperledger-labs/fabric-smart-client/node"
 )
 
-const CmdRoot = "core"
-
 func main() {
-	// For environment variables.
-	viper.SetEnvPrefix(CmdRoot)
-	viper.AutomaticEnv()
-	replacer := strings.NewReplacer(".", "_")
-	viper.SetEnvKeyReplacer(replacer)
-
 	// Instantiate node and execute
 	node := node2.New()
 	node.Execute(nil)

--- a/cmd/fsccli/main.go
+++ b/cmd/fsccli/main.go
@@ -11,8 +11,10 @@ import (
 	"os"
 	"strings"
 
+	"github.com/knadh/koanf/providers/env/v2"
+	"github.com/knadh/koanf/v2"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	"github.com/spf13/pflag"
 
 	"github.com/hyperledger-labs/fabric-smart-client/cmd/fsccli/validate"
 	"github.com/hyperledger-labs/fabric-smart-client/cmd/fsccli/version"
@@ -28,13 +30,7 @@ const CmdRoot = "fsccli"
 // defaults to printing the help message.
 var mainCmd = &cobra.Command{Use: "fsccli"}
 
-func main() {
-	// For environment variables.
-	viper.SetEnvPrefix(CmdRoot)
-	viper.AutomaticEnv()
-	replacer := strings.NewReplacer(".", "_")
-	viper.SetEnvKeyReplacer(replacer)
-
+func init() {
 	mainCmd.AddCommand(artifactgen.NewCmd())
 	mainCmd.AddCommand(cryptogen.NewCmd())
 	mainCmd.AddCommand(view.NewCmd())
@@ -42,9 +38,40 @@ func main() {
 	mainCmd.AddCommand(validate.NewCmd())
 	mainCmd.AddCommand(version.Cmd())
 
+	// For environment variables with FSCCLI_ prefix.
+	// This ensures that FSCCLI_TOPOLOGY correctly maps to the --topology flag, etc.
+	cobra.OnInitialize(func() {
+		k := koanf.New(".")
+		if err := k.Load(env.Provider("", env.Opt{
+			Prefix: "FSCCLI_",
+			TransformFunc: func(k, v string) (string, any) {
+				return strings.ReplaceAll(strings.ToLower(strings.TrimPrefix(k, "FSCCLI_")), "_", "-"), v
+			},
+		}), nil); err == nil {
+			bindFlags(mainCmd, k)
+		} else {
+			panic(err)
+		}
+	})
+}
+
+func main() {
 	// On failure Cobra prints the usage message and error string, so we only
 	// need to exit with a non-0 status
 	if mainCmd.Execute() != nil {
 		os.Exit(1)
+	}
+}
+
+func bindFlags(cmd *cobra.Command, k *koanf.Koanf) {
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if !f.Changed && k.Exists(f.Name) {
+			if err := f.Value.Set(k.String(f.Name)); err != nil {
+				panic(err)
+			}
+		}
+	})
+	for _, child := range cmd.Commands() {
+		bindFlags(child, k)
 	}
 }

--- a/cmd/fsccli/main.go
+++ b/cmd/fsccli/main.go
@@ -9,12 +9,8 @@ package main
 import (
 	_ "net/http/pprof"
 	"os"
-	"strings"
 
-	"github.com/knadh/koanf/providers/env/v2"
-	"github.com/knadh/koanf/v2"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/hyperledger-labs/fabric-smart-client/cmd/fsccli/validate"
 	"github.com/hyperledger-labs/fabric-smart-client/cmd/fsccli/version"
@@ -24,13 +20,9 @@ import (
 	view "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/view/grpc/client/cmd"
 )
 
-const CmdRoot = "fsccli"
+func main() {
+	mainCmd := &cobra.Command{Use: "fsccli"}
 
-// The main command describes the service and
-// defaults to printing the help message.
-var mainCmd = &cobra.Command{Use: "fsccli"}
-
-func init() {
 	mainCmd.AddCommand(artifactgen.NewCmd())
 	mainCmd.AddCommand(cryptogen.NewCmd())
 	mainCmd.AddCommand(view.NewCmd())
@@ -38,40 +30,9 @@ func init() {
 	mainCmd.AddCommand(validate.NewCmd())
 	mainCmd.AddCommand(version.Cmd())
 
-	// For environment variables with FSCCLI_ prefix.
-	// This ensures that FSCCLI_TOPOLOGY correctly maps to the --topology flag, etc.
-	cobra.OnInitialize(func() {
-		k := koanf.New(".")
-		if err := k.Load(env.Provider("", env.Opt{
-			Prefix: "FSCCLI_",
-			TransformFunc: func(k, v string) (string, any) {
-				return strings.ReplaceAll(strings.ToLower(strings.TrimPrefix(k, "FSCCLI_")), "_", "-"), v
-			},
-		}), nil); err == nil {
-			bindFlags(mainCmd, k)
-		} else {
-			panic(err)
-		}
-	})
-}
-
-func main() {
 	// On failure Cobra prints the usage message and error string, so we only
 	// need to exit with a non-0 status
 	if mainCmd.Execute() != nil {
 		os.Exit(1)
-	}
-}
-
-func bindFlags(cmd *cobra.Command, k *koanf.Koanf) {
-	cmd.Flags().VisitAll(func(f *pflag.Flag) {
-		if !f.Changed && k.Exists(f.Name) {
-			if err := f.Value.Set(k.String(f.Name)); err != nil {
-				panic(err)
-			}
-		}
-	})
-	for _, child := range cmd.Commands() {
-		bindFlags(child, k)
 	}
 }

--- a/cmd/fsccli/main_test.go
+++ b/cmd/fsccli/main_test.go
@@ -16,8 +16,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-
-	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
 )
 
 func TestCompile(t *testing.T) {
@@ -37,10 +35,7 @@ func TestArtifactsGen(t *testing.T) { //nolint:paralleltest
 	Expect(err).NotTo(HaveOccurred())
 	defer gexec.CleanupBuildArtifacts()
 
-	tmpDir, err := os.MkdirTemp("", t.Name())
-	Expect(err).NotTo(HaveOccurred())
-
-	defer utils.IgnoreErrorWithOneArg(os.RemoveAll, tmpDir)
+	tmpDir := t.TempDir()
 
 	topologyFolder := filepath.Join("testdata", "fabric_iou.yaml")
 	session, err := gexec.Start(exec.Command(cli, "artifactsgen", "gen", "-t", topologyFolder, "-o", tmpDir), GinkgoWriter, GinkgoWriter)
@@ -67,9 +62,7 @@ func TestArtifactsGenWithEnv(t *testing.T) { //nolint:paralleltest
 	Expect(err).NotTo(HaveOccurred())
 	defer gexec.CleanupBuildArtifacts()
 
-	tmpDir, err := os.MkdirTemp("", t.Name())
-	Expect(err).NotTo(HaveOccurred())
-	defer utils.IgnoreErrorWithOneArg(os.RemoveAll, tmpDir)
+	tmpDir := t.TempDir()
 
 	topologyFolder, err := filepath.Abs(filepath.Join("testdata", "fabric_iou.yaml"))
 	Expect(err).NotTo(HaveOccurred())

--- a/cmd/fsccli/main_test.go
+++ b/cmd/fsccli/main_test.go
@@ -57,3 +57,36 @@ func TestArtifactsGen(t *testing.T) { //nolint:paralleltest
 
 	Expect(stringEntries).To(Equal([]string{"conf.json", "fabric.default", "fsc", "topology.yaml"}))
 }
+
+func TestArtifactsGenWithEnv(t *testing.T) { //nolint:paralleltest
+	RegisterFailHandler(func(message string, callerSkip ...int) {
+		panic(message)
+	})
+
+	cli, err := gexec.Build("github.com/hyperledger-labs/fabric-smart-client/cmd/fsccli")
+	Expect(err).NotTo(HaveOccurred())
+	defer gexec.CleanupBuildArtifacts()
+
+	tmpDir, err := os.MkdirTemp("", t.Name())
+	Expect(err).NotTo(HaveOccurred())
+	defer utils.IgnoreErrorWithOneArg(os.RemoveAll, tmpDir)
+
+	topologyFolder, err := filepath.Abs(filepath.Join("testdata", "fabric_iou.yaml"))
+	Expect(err).NotTo(HaveOccurred())
+
+	cmd := exec.Command(cli, "artifactsgen", "gen", "-o", tmpDir)
+	cmd.Env = append(os.Environ(), "FSCCLI_TOPOLOGY="+topologyFolder)
+
+	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(session, time.Minute*2).Should(gexec.Exit(0))
+
+	entries, err := os.ReadDir(tmpDir)
+	Expect(err).NotTo(HaveOccurred())
+
+	var stringEntries []string
+	for _, entry := range entries {
+		stringEntries = append(stringEntries, entry.Name())
+	}
+	Expect(stringEntries).To(ContainElement("topology.yaml"))
+}

--- a/cmd/fsccli/main_test.go
+++ b/cmd/fsccli/main_test.go
@@ -52,34 +52,3 @@ func TestArtifactsGen(t *testing.T) { //nolint:paralleltest
 
 	Expect(stringEntries).To(Equal([]string{"conf.json", "fabric.default", "fsc", "topology.yaml"}))
 }
-
-func TestArtifactsGenWithEnv(t *testing.T) { //nolint:paralleltest
-	RegisterFailHandler(func(message string, callerSkip ...int) {
-		panic(message)
-	})
-
-	cli, err := gexec.Build("github.com/hyperledger-labs/fabric-smart-client/cmd/fsccli")
-	Expect(err).NotTo(HaveOccurred())
-	defer gexec.CleanupBuildArtifacts()
-
-	tmpDir := t.TempDir()
-
-	topologyFolder, err := filepath.Abs(filepath.Join("testdata", "fabric_iou.yaml"))
-	Expect(err).NotTo(HaveOccurred())
-
-	cmd := exec.Command(cli, "artifactsgen", "gen", "-o", tmpDir)
-	cmd.Env = append(os.Environ(), "FSCCLI_TOPOLOGY="+topologyFolder)
-
-	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-	Expect(err).NotTo(HaveOccurred())
-	Eventually(session, time.Minute*2).Should(gexec.Exit(0))
-
-	entries, err := os.ReadDir(tmpDir)
-	Expect(err).NotTo(HaveOccurred())
-
-	var stringEntries []string
-	for _, entry := range entries {
-		stringEntries = append(stringEntries, entry.Name())
-	}
-	Expect(stringEntries).To(ContainElement("topology.yaml"))
-}

--- a/cmd/fsccli/validate/cmd.go
+++ b/cmd/fsccli/validate/cmd.go
@@ -51,7 +51,8 @@ func newConfigCmd() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.StringVarP(&configPath, "config-path", "c", "./", "path to the directory containing core.yaml")
+	flags.StringVarP(&configPath, "path", "p", "", "path to the directory containing core.yaml")
+	cmd.MarkFlagRequired("path")
 
 	return cmd
 }

--- a/cmd/fsccli/validate/cmd.go
+++ b/cmd/fsccli/validate/cmd.go
@@ -51,8 +51,7 @@ func newConfigCmd() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	flags.StringVarP(&configPath, "path", "p", "", "path to the directory containing core.yaml")
-	cmd.MarkFlagRequired("path")
+	flags.StringVarP(&configPath, "path", "p", "./", "path to the directory containing core.yaml")
 
 	return cmd
 }

--- a/cmd/fsccli/validate/cmd_test.go
+++ b/cmd/fsccli/validate/cmd_test.go
@@ -25,7 +25,7 @@ func TestValidateConfigCommand(t *testing.T) {
 	out := &bytes.Buffer{}
 	cmd.SetOut(out)
 	cmd.SetErr(out)
-	cmd.SetArgs([]string{"config", "--config-path", confPath})
+	cmd.SetArgs([]string{"config", "--path", confPath})
 
 	require.NoError(t, cmd.Execute())
 	require.Contains(t, out.String(), "configuration is valid")

--- a/docs/reference/fsc-cli.md
+++ b/docs/reference/fsc-cli.md
@@ -22,18 +22,6 @@ make fsccli
 fsccli [command] [flags]
 ```
 
-### Environment Variables
-
-All flags can be set via environment variables using the `FSCCLI_` prefix:
-
-```bash
-# Example: Set config file via environment variable
-export FSCCLI_CONFIG=/path/to/config.yaml
-```
-
-Environment variable names use underscores instead of dots:
-- `fsccli.config.path` → `FSCCLI_CONFIG_PATH`
-
 
 
 ## Commands
@@ -96,13 +84,6 @@ fsccli artifactsgen gen \
   --port 30000
 ```
 
-3. **Using environment variables:**
-```bash
-export FSCCLI_TOPOLOGY=./topology.yaml
-export FSCCLI_OUTPUT=./artifacts
-export FSCCLI_PORT=25000
-fsccli artifactsgen gen
-```
 
 **Topology File Format:**
 
@@ -265,11 +246,6 @@ Run preflight validation on an FSC configuration directory.
 fsccli validate config --path ./testdata/fsc/nodes/default
 ```
 
-2. **Using environment variables:**
-```bash
-export FSCCLI_PATH=./testdata/fsc/nodes/default
-fsccli validate config
-```
 
 **Validation Coverage:**
 - node configuration loading

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,6 @@ require (
 	github.com/onsi/gomega v1.38.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
-	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tedsuo/ifrit v0.0.0-20230516164442-7862c310ad26
 	github.com/uptrace/opentelemetry-go-extra/otelsql v0.3.2
@@ -71,6 +70,7 @@ require (
 	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
+	github.com/spf13/viper v1.21.0 // indirect
 )
 
 require (
@@ -252,7 +252,7 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/spf13/pflag v1.0.10
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -252,7 +252,7 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/pflag v1.0.10
+	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect

--- a/integration/nwo/cmd/main.go
+++ b/integration/nwo/cmd/main.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
@@ -39,12 +38,6 @@ func (m *Main) Cmd() *cobra.Command {
 }
 
 func (m *Main) Execute() {
-	// For environment variables.
-	viper.SetEnvPrefix(m.ProgramName)
-	viper.AutomaticEnv()
-	replacer := strings.NewReplacer(".", "_")
-	viper.SetEnvKeyReplacer(replacer)
-
 	// On failure Cobra prints the usage message and error string, so we only
 	// need to exit with a non-0 status
 	if m.mainCmd.Execute() != nil {

--- a/integration/nwo/fsc/fsc.go
+++ b/integration/nwo/fsc/fsc.go
@@ -24,11 +24,13 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/knadh/koanf/parsers/yaml"
+	"github.com/knadh/koanf/providers/file"
+	"github.com/knadh/koanf/v2"
 	"github.com/miracl/conflate"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-	"github.com/spf13/viper"
 	"github.com/tedsuo/ifrit"
 	"github.com/tedsuo/ifrit/grouper"
 
@@ -298,9 +300,9 @@ func startPostgres(p *Platform) {
 
 func (p *Platform) PostRun(bool) {
 	for _, peer := range p.Peers {
-		v := p.viper(peer)
+		k := p.koanf(peer)
 
-		address := v.GetString("fsc.grpc.address")
+		address := k.String("fsc.grpc.address")
 		p.setIdentities(address, peer)
 	}
 	tracerProvider, err := tracing2.NewProviderFromConfig(tracing2.Config{
@@ -318,14 +320,14 @@ func (p *Platform) PostRun(bool) {
 
 	for _, node := range p.Peers {
 
-		v := p.viper(node)
+		k := p.koanf(node)
 
 		// Prepare GRPC Client, Web Client, and CLI
 
 		// GRPC client
 		grpcClient, err := client3.NewClient(
 			&client3.Config{
-				ID:               v.GetString("fsc.id"),
+				ID:               k.String("fsc.id"),
 				ConnectionConfig: p.Context.ConnectionConfig(node.UniqueName),
 			},
 			p.Context.ClientSigningIdentity(node.Name),
@@ -378,12 +380,11 @@ func (p *Platform) PostRun(bool) {
 	}
 }
 
-func (p *Platform) viper(peer *node2.Replica) *viper.Viper {
-	v := viper.New()
-	v.SetConfigFile(p.NodeConfigPath(peer))
-	err := v.ReadInConfig() // Find and read the config file
+func (p *Platform) koanf(peer *node2.Replica) *koanf.Koanf {
+	k := koanf.New(".")
+	err := k.Load(file.Provider(p.NodeConfigPath(peer)), yaml.Parser())
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	return v
+	return k
 }
 
 func (p *Platform) Cleanup() {

--- a/platform/fabric/core/msp/mgmt/mgmt.go
+++ b/platform/fabric/core/msp/mgmt/mgmt.go
@@ -7,10 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package mgmt
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/hyperledger/fabric-lib-go/bccsp"
-	"github.com/spf13/viper"
+	"github.com/knadh/koanf/providers/env/v2"
+	"github.com/knadh/koanf/v2"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/msp"
@@ -28,6 +30,17 @@ var (
 	mspMap    = make(map[string]msp.MSPManager)
 	mspLogger = logging.MustGetLogger("msp")
 )
+
+func getConfig() (*koanf.Koanf, error) {
+	k := koanf.New(".")
+	err := k.Load(env.Provider(".", env.Opt{
+		Prefix: "CORE",
+		TransformFunc: func(k, v string) (string, any) {
+			return strings.ReplaceAll(strings.ToLower(strings.TrimPrefix(k, "CORE_")), "_", "."), v
+		},
+	}), nil)
+	return k, err
+}
 
 // TODO - this is a temporary solution to allow the peer to track whether the
 // MSPManager has been setup for a channel, which indicates whether the channel
@@ -85,14 +98,19 @@ func GetLocalMSP(cryptoProvider bccsp.BCCSP) msp.MSP {
 		return localMsp
 	}
 
-	localMsp = loadLocalMSP(cryptoProvider)
+	cfg, err := getConfig()
+	if err != nil {
+		mspLogger.Fatalf("Failed to load configuration, received err %+v", err)
+	}
+
+	localMsp = loadLocalMSP(cfg, cryptoProvider)
 
 	return localMsp
 }
 
-func loadLocalMSP(bccsp bccsp.BCCSP) msp.MSP {
+func loadLocalMSP(cfg *koanf.Koanf, bccsp bccsp.BCCSP) msp.MSP {
 	// determine the type of MSP (by default, we'll use bccspMSP)
-	mspType := viper.GetString("peer.localMspType")
+	mspType := cfg.String("peer.localmsptype")
 	if mspType == "" {
 		mspType = msp.ProviderTypeToString(msp.FABRIC)
 	}

--- a/platform/fabric/core/msp/mgmt/mgmt_test.go
+++ b/platform/fabric/core/msp/mgmt/mgmt_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hyperledger/fabric-lib-go/bccsp"
 	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
 	"github.com/hyperledger/fabric-lib-go/bccsp/sw"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/msp"
@@ -163,11 +162,11 @@ func TestLoadLocalMSP_IdemixType(t *testing.T) { //nolint:paralleltest
 	defer func() { localMsp = savedMsp }()
 	localMsp = nil
 
-	// Set idemix type via viper
-	const k = "peer.localMspType"
-	orig := viper.GetString(k)
-	defer viper.Set(k, orig)
-	viper.Set(k, msp.ProviderTypeToString(msp.IDEMIX))
+	// Set idemix type via os.Setenv
+	const k = "CORE_PEER_LOCALMSPTYPE"
+	orig := os.Getenv(k)
+	defer func() { _ = os.Setenv(k, orig) }()
+	_ = os.Setenv(k, msp.ProviderTypeToString(msp.IDEMIX))
 
 	cryptoProvider := factory.GetDefault()
 
@@ -184,10 +183,10 @@ func TestLoadLocalMSP_UnknownType(t *testing.T) { //nolint:paralleltest
 	localMsp = nil
 
 	// Set an unknown MSP type — loadLocalMSP should panic
-	const k = "peer.localMspType"
-	orig := viper.GetString(k)
-	defer viper.Set(k, orig)
-	viper.Set(k, "unknown-type")
+	const k = "CORE_PEER_LOCALMSPTYPE"
+	orig := os.Getenv(k)
+	defer func() { _ = os.Setenv(k, orig) }()
+	_ = os.Setenv(k, "unknown-type")
 
 	require.Panics(t, func() {
 		cryptoProvider := factory.GetDefault()


### PR DESCRIPTION
Closes #1405

# Description
This PR migrates the codebase from `spf13/viper` to `github.com/knadh/koanf/v2` for configuration management. This aligns the repository with modern configuration practices and removes unnecessary global state.

# Changes
- Refactored `platform/fabric/core/msp/mgmt/mgmt.go` to use `koanf` for environment variable lookups.
- Updated `integration/nwo/fsc/fsc.go` to use `koanf` for reading replica configurations.
- Migrated environment variable setup in `fsccli`, `nwo/cmd`, and `codeql/node` main entry points.
- Updated `mgmt_test.go` to use `os.Setenv` for configuration mocking.
- Removed `viper` as a direct dependency in `go.mod`.
