### PR TITLE
view: return errors from client initiate paths

### DIFF
--- a/platform/view/services/view/grpc/client/client.go
+++ b/platform/view/services/view/grpc/client/client.go
@@ -85,6 +85,13 @@ type client struct {
 
 // NewClient returns a new instance of the view service client.
 func NewClient(config *Config, sID SigningIdentity, tracerProvider tracing.Provider) (*client, error) {
+	if config == nil {
+		return nil, errors.New("missing client config")
+	}
+	if config.ConnectionConfig == nil {
+		return nil, errors.New("missing fsc peer connection config")
+	}
+
 	// create a grpc client for view peer
 	grpcClient, err := grpc2.CreateGRPCClient(config.ConnectionConfig)
 	if err != nil {
@@ -136,7 +143,25 @@ func (s *client) CallViewWithContext(ctx context.Context, fid string, input []by
 }
 
 func (s *client) Initiate(fid string, in []byte) (string, error) {
-	panic("implement me")
+	logger.Debugf("Initiating view [%s] on input [%s]", fid, string(in))
+	payload := &protos2.Command_InitiateView{InitiateView: &protos2.InitiateView{
+		Fid:   fid,
+		Input: in,
+	}}
+	sc, err := s.CreateSignedCommand(payload, s.SigningIdentity)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed creating signed command for [%s,%s]", fid, string(in))
+	}
+
+	commandResp, err := s.processCommand(context.Background(), sc)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed process command for [%s,%s]", fid, string(in))
+	}
+
+	if commandResp.GetInitiateViewResponse() == nil {
+		return "", errors.New("expected initiate view response, got nothing")
+	}
+	return commandResp.GetInitiateViewResponse().GetCid(), nil
 }
 
 // StreamCallView calls the given view with the given input and returns a stream to communicate with it.

--- a/platform/view/services/view/grpc/client/client_api_test.go
+++ b/platform/view/services/view/grpc/client/client_api_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/grpc"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/view/grpc/server/protos"
+)
+
+func TestNewClient_Returns_Error_For_Missing_Config(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewClient(nil, stubSigningIdentity{}, noop.NewTracerProvider())
+
+	require.Error(t, err)
+	require.Nil(t, c)
+	require.Contains(t, err.Error(), "missing client config")
+}
+
+func TestNewClient_Returns_Error_For_Missing_Connection_Config(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewClient(&Config{}, stubSigningIdentity{}, noop.NewTracerProvider())
+
+	require.Error(t, err)
+	require.Nil(t, c)
+	require.Contains(t, err.Error(), "missing fsc peer connection config")
+}
+
+func TestInitiate_Returns_Context_ID(t *testing.T) {
+	t.Parallel()
+
+	rawResponse, err := proto.Marshal(&protos.CommandResponse{
+		Payload: &protos.CommandResponse_InitiateViewResponse{
+			InitiateViewResponse: &protos.InitiateViewResponse{Cid: "ctx-123"},
+		},
+	})
+	require.NoError(t, err)
+
+	viewClient := &fakeViewServiceClient{
+		processCommandResponse: &protos.SignedCommandResponse{Response: rawResponse},
+	}
+	transport := &fakeTransport{
+		viewClient:  viewClient,
+		certificate: &tls.Certificate{},
+		createErr:   nil,
+	}
+
+	c := &client{
+		ViewServiceClient: transport,
+		RandomnessReader:  bytes.NewReader(make([]byte, 32)),
+		Time:              func() time.Time { return time.Unix(1700000000, 0) },
+		SigningIdentity:   stubSigningIdentity{},
+		tracer:            noop.NewTracerProvider().Tracer("test"),
+	}
+
+	contextID, err := c.Initiate("myView", []byte("payload"))
+
+	require.NoError(t, err)
+	require.Equal(t, "ctx-123", contextID)
+	require.NotNil(t, viewClient.lastCommand)
+
+	command := &protos.Command{}
+	err = proto.Unmarshal(viewClient.lastCommand.Command, command)
+	require.NoError(t, err)
+	require.Equal(t, "myView", command.GetInitiateView().GetFid())
+	require.Equal(t, []byte("payload"), command.GetInitiateView().GetInput())
+}
+
+func TestInitiate_Returns_Error_When_Response_Is_Missing(t *testing.T) {
+	t.Parallel()
+
+	rawResponse, err := proto.Marshal(&protos.CommandResponse{})
+	require.NoError(t, err)
+
+	viewClient := &fakeViewServiceClient{
+		processCommandResponse: &protos.SignedCommandResponse{Response: rawResponse},
+	}
+	transport := &fakeTransport{
+		viewClient:  viewClient,
+		certificate: &tls.Certificate{},
+		createErr:   nil,
+	}
+
+	c := &client{
+		ViewServiceClient: transport,
+		RandomnessReader:  bytes.NewReader(make([]byte, 32)),
+		Time:              func() time.Time { return time.Unix(1700000000, 0) },
+		SigningIdentity:   stubSigningIdentity{},
+		tracer:            noop.NewTracerProvider().Tracer("test"),
+	}
+
+	contextID, err := c.Initiate("myView", []byte("payload"))
+
+	require.Error(t, err)
+	require.Empty(t, contextID)
+	require.Contains(t, err.Error(), "expected initiate view response")
+}
+
+func TestValidateClientConfig_Returns_Error_For_Missing_Connection_Config(t *testing.T) {
+	t.Parallel()
+
+	err := ValidateClientConfig(Config{})
+
+	require.EqualError(t, err, "missing fsc peer connection config")
+}
+
+type stubSigningIdentity struct{}
+
+func (s stubSigningIdentity) Serialize() ([]byte, error) {
+	return []byte("creator"), nil
+}
+
+func (s stubSigningIdentity) Sign(message []byte) ([]byte, error) {
+	return []byte("signature"), nil
+}
+
+type fakeViewServiceClient struct {
+	processCommandResponse *protos.SignedCommandResponse
+	processCommandErr      error
+	lastCommand            *protos.SignedCommand
+}
+
+type fakeTransport struct {
+	viewClient  protos.ViewServiceClient
+	certificate *tls.Certificate
+	createErr   error
+}
+
+func (f *fakeTransport) CreateViewClient() (*grpc.ClientConn, protos.ViewServiceClient, error) {
+	return nil, f.viewClient, f.createErr
+}
+
+func (f *fakeTransport) Certificate() *tls.Certificate {
+	return f.certificate
+}
+
+func (f *fakeViewServiceClient) ProcessCommand(_ context.Context, in *protos.SignedCommand, _ ...grpc.CallOption) (*protos.SignedCommandResponse, error) {
+	f.lastCommand = in
+	return f.processCommandResponse, f.processCommandErr
+}
+
+func (f *fakeViewServiceClient) StreamCommand(_ context.Context, _ ...grpc.CallOption) (grpc.BidiStreamingClient[protos.SignedCommand, protos.SignedCommandResponse], error) {
+	return nil, io.EOF
+}
+
+var (
+	_ SigningIdentity          = stubSigningIdentity{}
+	_ ViewServiceClient        = &fakeTransport{}
+	_ protos.ViewServiceClient = &fakeViewServiceClient{}
+)

--- a/platform/view/services/view/grpc/client/config.go
+++ b/platform/view/services/view/grpc/client/config.go
@@ -51,6 +51,9 @@ func FromJSON(raw []byte) (Configs, error) {
 
 // ValidateClientConfig validates the given client config.
 func ValidateClientConfig(config Config) error {
+	if config.ConnectionConfig == nil {
+		return errors.New("missing fsc peer connection config")
+	}
 	if config.ConnectionConfig.Address == "" {
 		return errors.New("missing fsc peer address")
 	}

--- a/platform/view/services/view/manager.go
+++ b/platform/view/services/view/manager.go
@@ -148,7 +148,7 @@ func (cm *Manager) InitiateView(ctx context.Context, view view.View) (any, error
 // InitiateViewWithIdentity initiates a protocol for the given view and initiator identity.
 func (cm *Manager) InitiateViewWithIdentity(ctx context.Context, view view.View, id view.Identity) (any, error) {
 	if ctx == nil {
-		panic("context is nil")
+		return nil, errors.New("context is nil")
 	}
 	ctx = trace.ContextWithSpanContext(ctx, trace.SpanContextFromContext(ctx))
 	c, err := cm.newChildContextForInitiator(ctx, view, id, "")

--- a/platform/view/services/view/manager_test.go
+++ b/platform/view/services/view/manager_test.go
@@ -86,6 +86,12 @@ func TestManager(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "result", res)
 
+	var nilCtx context.Context
+	res, err = manager.InitiateViewWithIdentity(nilCtx, v, view2.Identity("alice"))
+	require.Error(t, err)
+	require.Nil(t, res)
+	require.Contains(t, err.Error(), "context is nil")
+
 	// Test InitiateContextWithIdentity
 	c2, err := manager.InitiateContextWithIdentity(ctx, v, view2.Identity("alice"))
 	require.NoError(t, err)

--- a/platform/view/services/web/client/client.go
+++ b/platform/view/services/web/client/client.go
@@ -74,6 +74,10 @@ type Client struct {
 
 // NewClient returns a new web client
 func NewClient(config *Config) (*Client, error) {
+	if config == nil {
+		return nil, errors.New("missing client config")
+	}
+
 	var tlsClientConfig *tls.Config
 
 	tlsEnabled := len(config.CACertPath) != 0 || len(config.CACertRaw) != 0
@@ -193,5 +197,5 @@ func (c *Client) CallViewWithContext(ctx context.Context, fid string, in []byte)
 }
 
 func (c *Client) Initiate(fid string, in []byte) (string, error) {
-	panic("implement me")
+	return "", errors.Errorf("initiate is not supported by the web client for view [%s]", fid)
 }

--- a/platform/view/services/web/client/client_test.go
+++ b/platform/view/services/web/client/client_test.go
@@ -226,6 +226,16 @@ func TestNewClient_Error_Returns_Descriptive_Failure(t *testing.T) {
 	}
 }
 
+func TestNewClient_Error_Returns_Missing_Config(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(nil)
+
+	require.Error(t, err)
+	require.Nil(t, client)
+	require.Contains(t, err.Error(), "missing client config")
+}
+
 // --- CallView / CallViewWithContext ---
 
 // Verifies the full happy path: CallView sends a PUT to /v1/Views/{fid},
@@ -326,6 +336,18 @@ func TestCallViewWithContext_Cancelled_Context_Returns_Error(t *testing.T) {
 	result, err := client.CallViewWithContext(ctx, "slowView", nil)
 	require.Error(t, err)
 	require.Nil(t, result)
+}
+
+func TestInitiate_Returns_Not_Supported_Error(t *testing.T) {
+	t.Parallel()
+
+	client := &Client{}
+
+	contextID, err := client.Initiate("someView", []byte("input"))
+
+	require.Error(t, err)
+	require.Empty(t, contextID)
+	require.Contains(t, err.Error(), "initiate is not supported by the web client")
 }
 
 // --- Metrics ---


### PR DESCRIPTION
## Summary
- implement the gRPC view client `Initiate` path instead of panicking
- return explicit errors for unsupported web-client initiate calls and missing client configs
- return an error instead of panicking when `InitiateViewWithIdentity` receives a nil context
- add focused regression tests for the new error-handling paths

## Testing
- go test ./platform/view/services/web/client
- go test ./platform/view/services/view/grpc/client
- go test ./platform/view/services/view

Refs #183