### PR TITLE
fabric: tolerate partial peer failures on query

### DIFF
--- a/platform/fabric/core/generic/chaincode/invoke.go
+++ b/platform/fabric/core/generic/chaincode/invoke.go
@@ -9,6 +9,7 @@ package chaincode
 import (
 	"bytes"
 	"context"
+	stderrors "errors"
 	"strconv"
 	"strings"
 	"sync"
@@ -366,7 +367,7 @@ func (i *Invoke) prepare(query bool) (string, *pb.Proposal, []*pb.ProposalRespon
 	}
 
 	// collect responses
-	responses, err := i.collectResponses(endorserClients, signedProp)
+	responses, err := i.collectResponses(endorserClients, signedProp, query)
 	if err != nil {
 		return "", nil, nil, nil, errors.Wrapf(err, "failed collecting proposal responses")
 	}
@@ -434,7 +435,7 @@ func (i *Invoke) createChaincodeProposalWithTxIDAndTransient(typ common.HeaderTy
 }
 
 // collectResponses sends a signed proposal to a set of peers, and gathers all the responses.
-func (i *Invoke) collectResponses(endorserClients []pb.EndorserClient, signedProposal *pb.SignedProposal) ([]*pb.ProposalResponse, error) {
+func (i *Invoke) collectResponses(endorserClients []pb.EndorserClient, signedProposal *pb.SignedProposal, ignorePeerErrors bool) ([]*pb.ProposalResponse, error) {
 	responsesCh := make(chan *pb.ProposalResponse, len(endorserClients))
 	errorCh := make(chan error, len(endorserClients))
 	wg := sync.WaitGroup{}
@@ -453,13 +454,24 @@ func (i *Invoke) collectResponses(endorserClients []pb.EndorserClient, signedPro
 	wg.Wait()
 	close(responsesCh)
 	close(errorCh)
-	for err := range errorCh {
-		return nil, err
-	}
+
 	var responses []*pb.ProposalResponse
 	for response := range responsesCh {
 		responses = append(responses, response)
 	}
+
+	var errs []error
+	for err := range errorCh {
+		errs = append(errs, err)
+	}
+	if len(errs) == 0 {
+		return responses, nil
+	}
+	if !ignorePeerErrors || len(responses) == 0 {
+		return nil, stderrors.Join(errs...)
+	}
+
+	logger.Warnf("ignoring %d failed proposal responses because %d peers replied successfully", len(errs), len(responses))
 	return responses, nil
 }
 

--- a/platform/fabric/core/generic/chaincode/invoke_test.go
+++ b/platform/fabric/core/generic/chaincode/invoke_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	pb "github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+type stubEndorserClient struct {
+	response *pb.ProposalResponse
+	err      error
+}
+
+func (s *stubEndorserClient) ProcessProposal(context.Context, *pb.SignedProposal, ...grpc.CallOption) (*pb.ProposalResponse, error) {
+	return s.response, s.err
+}
+
+func TestCollectResponsesIgnoresQueryPeerErrorsWhenSomePeersReply(t *testing.T) {
+	t.Parallel()
+
+	invoke := &Invoke{}
+	responses, err := invoke.collectResponses([]pb.EndorserClient{
+		&stubEndorserClient{response: &pb.ProposalResponse{Response: &pb.Response{Payload: []byte("ok")}}},
+		&stubEndorserClient{err: errors.New("peer down")},
+	}, &pb.SignedProposal{}, true)
+	require.NoError(t, err)
+	require.Len(t, responses, 1)
+	require.Equal(t, []byte("ok"), responses[0].GetResponse().Payload)
+}
+
+func TestCollectResponsesReturnsErrorWhenAllQueryPeersFail(t *testing.T) {
+	t.Parallel()
+
+	invoke := &Invoke{}
+	_, err := invoke.collectResponses([]pb.EndorserClient{
+		&stubEndorserClient{err: errors.New("peer one down")},
+		&stubEndorserClient{err: errors.New("peer two down")},
+	}, &pb.SignedProposal{}, true)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "peer one down")
+	require.ErrorContains(t, err, "peer two down")
+}
+
+func TestCollectResponsesStillFailsForEndorsementOnPeerError(t *testing.T) {
+	t.Parallel()
+
+	invoke := &Invoke{}
+	_, err := invoke.collectResponses([]pb.EndorserClient{
+		&stubEndorserClient{response: &pb.ProposalResponse{Response: &pb.Response{Payload: []byte("ok")}}},
+		&stubEndorserClient{err: errors.New("peer down")},
+	}, &pb.SignedProposal{}, false)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "peer down")
+}


### PR DESCRIPTION
## Summary
- allow query collection to keep successful proposal responses when some peers fail
- preserve the stricter fail-on-any-error behavior for endorsement and submit paths
- add regression tests for partial peer failure and all-peers-down cases

## Testing
- go test ./platform/fabric ./platform/fabric/core/generic/chaincode -count=1

Fixes #474
