### PR TITLE
node: avoid panic on startup config errors

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -17,7 +17,10 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
 )
 
-var logger = logging.MustGetLogger()
+var (
+	logger = logging.MustGetLogger()
+	exit   = os.Exit
+)
 
 type ExecuteCallbackFunc = func() error
 
@@ -41,6 +44,17 @@ type Node struct {
 	executeCallbackFunc ExecuteCallbackFunc
 }
 
+type failedNode struct {
+	err error
+}
+
+func (f *failedNode) ID() string                                    { return "" }
+func (f *failedNode) Start() error                                  { return f.err }
+func (f *failedNode) Stop()                                         {}
+func (f *failedNode) InstallSDK(p node.SDK) error                   { return f.err }
+func (f *failedNode) GetService(v interface{}) (interface{}, error) { return nil, f.err }
+func (f *failedNode) RegisterService(service interface{}) error     { return f.err }
+
 // New returns a new instance of Node from the default configuration path.
 func New() *Node {
 	return NewWithConfPath("")
@@ -48,7 +62,11 @@ func New() *Node {
 
 // NewWithConfPath returns a new instance of Node whose configuration is loaded from the passed path.
 func NewWithConfPath(confPath string) *Node {
-	return newWithFSCNode(node.NewFromConfPath(confPath))
+	fscNode, err := node.NewFromConfPathE(confPath)
+	if err != nil {
+		return newWithFSCNode(&failedNode{err: err})
+	}
+	return newWithFSCNode(fscNode)
 }
 
 func newWithFSCNode(fscNode FSCNode) *Node {
@@ -82,13 +100,16 @@ func (n *Node) listen() {
 	err := <-n.callbackChannel
 	logger.Debugf("Callback signal came with err [%s]", err)
 	if err != nil {
-		panic(err)
+		logger.Errorf("Node startup failed: %s", err)
+		exit(1)
+		return
 	}
 	if n.executeCallbackFunc != nil {
 		logger.Debugf("Calling callback...")
 		err = n.executeCallbackFunc()
 		if err != nil {
-			panic(err)
+			logger.Errorf("Node callback failed: %s", err)
+			exit(1)
 		}
 	}
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package node
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type exitPanic struct {
+	code int
+}
+
+func TestNewWithConfPathInvalidConfigReturnsStartError(t *testing.T) {
+	n := NewWithConfPath("./does-not-exist")
+	require.Error(t, n.Start())
+}
+
+func TestListenExitsOnStartupError(t *testing.T) {
+	originalExit := exit
+	defer func() { exit = originalExit }()
+
+	n := &Node{callbackChannel: make(chan error, 1)}
+	exit = func(code int) { panic(exitPanic{code: code}) }
+
+	done := make(chan interface{}, 1)
+	go func() {
+		defer func() {
+			done <- recover()
+		}()
+		n.listen()
+	}()
+
+	n.callbackChannel <- errors.New("boom")
+	recovered := <-done
+	require.Equal(t, exitPanic{code: 1}, recovered)
+}
+
+func TestListenExitsOnCallbackError(t *testing.T) {
+	originalExit := exit
+	defer func() { exit = originalExit }()
+
+	n := &Node{
+		callbackChannel: make(chan error, 1),
+		executeCallbackFunc: func() error {
+			return errors.New("callback failed")
+		},
+	}
+	exit = func(code int) { panic(exitPanic{code: code}) }
+
+	done := make(chan interface{}, 1)
+	go func() {
+		defer func() {
+			done <- recover()
+		}()
+		n.listen()
+	}()
+
+	n.callbackChannel <- nil
+	recovered := <-done
+	require.Equal(t, exitPanic{code: 1}, recovered)
+}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -39,20 +39,29 @@ type Node struct {
 }
 
 func NewFromConfPath(confPath string) *Node {
-	configService, err := config.NewProvider(confPath)
+	n, err := NewFromConfPathE(confPath)
 	if err != nil {
 		panic(err)
 	}
+	return n
+}
+
+// NewFromConfPathE returns a new node for the given configuration path or an error.
+func NewFromConfPathE(confPath string) (*Node, error) {
+	configService, err := config.NewProvider(confPath)
+	if err != nil {
+		return nil, err
+	}
 	registry := view.NewServiceProvider()
 	if err := registry.RegisterService(configService); err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	return &Node{
 		sdks:     []SDK{},
 		registry: registry,
 		id:       configService.ID(),
-	}
+	}, nil
 }
 
 func (n *Node) AddSDK(sdk SDK) {

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -8,6 +8,7 @@ package node
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -193,5 +194,20 @@ func TestNode_GetService_NotFound(t *testing.T) {
 	t.Parallel()
 	n := newTestNode()
 	_, err := n.GetService((*mockSDK)(nil))
+	require.Error(t, err)
+}
+
+func TestNewFromConfPathE(t *testing.T) {
+	t.Parallel()
+
+	n, err := NewFromConfPathE(filepath.Join("..", "..", "platform", "view", "services", "config", "testdata"))
+	require.NoError(t, err)
+	require.NotNil(t, n)
+}
+
+func TestNewFromConfPathEInvalidPath(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewFromConfPathE("./does-not-exist")
 	require.Error(t, err)
 }


### PR DESCRIPTION
## Summary
- carry configuration-loading failures through node construction instead of panicking immediately
- exit cleanly on startup and callback failures instead of panicking from the callback goroutine
- add regression coverage for invalid config paths and non-panicking startup failure handling

## Testing
- go test ./node ./pkg/node -count=1
- go test ./ci/codeql/node ./node/start/... -count=1

Fixes #410
Related to #209
