### PR TITLE
test: increase coverage for crypto provider

### DIFF
--- a/platform/fabric/services/crypto/provider.go
+++ b/platform/fabric/services/crypto/provider.go
@@ -21,8 +21,24 @@ func NewProvider() *provider {
 	return &provider{}
 }
 
+// getDefaultFactory is a package-level variable that returns the default
+// factory. It is assigned to factory.GetDefault by default and can be
+// replaced in tests to simulate error conditions without changing
+// production APIs.
+// bccspFactory is a local interface with the small subset of methods
+// used by this package. It is satisfied by the real `bccsp.BCCSP`.
+type bccspFactory interface {
+	Hash([]byte, bccsp.HashOpts) ([]byte, error)
+	GetHash(bccsp.HashOpts) (hash.Hash, error)
+}
+
+// getDefaultFactory returns a bccspFactory. By default it wraps
+// `factory.GetDefault`, but tests can replace it with a function
+// returning a test double that implements `bccspFactory`.
+var getDefaultFactory = func() bccspFactory { return factory.GetDefault() }
+
 func (p *provider) Hash(msg []byte) ([]byte, error) {
-	hash, err := factory.GetDefault().Hash(msg, &bccsp.SHA256Opts{})
+	hash, err := getDefaultFactory().Hash(msg, &bccsp.SHA256Opts{})
 	if err != nil {
 		panic(errors.Errorf("failed computing SHA256 on [% x]", msg))
 	}
@@ -30,7 +46,7 @@ func (p *provider) Hash(msg []byte) ([]byte, error) {
 }
 
 func (p *provider) GetHash() hash.Hash {
-	hash, err := factory.GetDefault().GetHash(&bccsp.SHA256Opts{})
+	hash, err := getDefaultFactory().GetHash(&bccsp.SHA256Opts{})
 	if err != nil {
 		panic(errors.Errorf("failed getting SHA256"))
 	}

--- a/platform/fabric/services/crypto/provider_test.go
+++ b/platform/fabric/services/crypto/provider_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+package crypto
+
+import (
+	"crypto/sha256"
+	"errors"
+	"hash"
+	"testing"
+
+	"github.com/hyperledger/fabric-lib-go/bccsp"
+	"github.com/stretchr/testify/require"
+)
+
+// mockFactoryErr implements the minimal subset of the factory
+// interface required to exercise provider panic branches.
+type mockFactoryErr struct{}
+
+func (m *mockFactoryErr) Hash(msg []byte, opts bccsp.HashOpts) ([]byte, error) {
+	return nil, errors.New("boom")
+}
+func (m *mockFactoryErr) GetHash(opts bccsp.HashOpts) (hash.Hash, error) {
+	return nil, errors.New("boom")
+}
+
+func TestNewProvider(t *testing.T) {
+	p := NewProvider()
+	require.NotNil(t, p)
+}
+
+func TestHash(t *testing.T) {
+	p := NewProvider()
+
+	msg := []byte("hello world")
+	got, err := p.Hash(msg)
+	require.NoError(t, err)
+	require.Len(t, got, sha256.Size)
+
+	// compare against stdlib sha256
+	exp := sha256.Sum256(msg)
+	require.Equal(t, exp[:], got)
+}
+
+func TestHash_NilInput(t *testing.T) {
+	p := NewProvider()
+
+	got, err := p.Hash(nil)
+	require.NoError(t, err)
+	require.Len(t, got, sha256.Size)
+
+	exp := sha256.Sum256(nil)
+	require.Equal(t, exp[:], got)
+}
+
+func TestHash_Table(t *testing.T) {
+	p := NewProvider()
+
+	tests := [][]byte{
+		[]byte("hello"),
+		[]byte("world"),
+		[]byte(""),
+		nil,
+	}
+
+	for _, tt := range tests {
+		got, err := p.Hash(tt)
+		require.NoError(t, err)
+		require.Len(t, got, sha256.Size)
+
+		exp := sha256.Sum256(tt)
+		require.Equal(t, exp[:], got)
+	}
+}
+
+func TestGetHash(t *testing.T) {
+	p := NewProvider()
+	h := p.GetHash()
+	require.NotNil(t, h)
+
+	msg := []byte("abc")
+	_, err := h.Write(msg)
+	require.NoError(t, err)
+	got := h.Sum(nil)
+
+	exp := sha256.Sum256(msg)
+	require.Equal(t, exp[:], got)
+}
+
+func TestGetHash_NewInstance(t *testing.T) {
+	p := NewProvider()
+
+	h1 := p.GetHash()
+	h2 := p.GetHash()
+	require.NotSame(t, h1, h2)
+}
+
+func TestHash_PanicOnFactoryError(t *testing.T) {
+	p := NewProvider()
+
+	// replace factory with a mock that returns an error
+	orig := getDefaultFactory
+	defer func() { getDefaultFactory = orig }()
+
+	getDefaultFactory = func() bccspFactory { return &mockFactoryErr{} }
+
+	require.Panics(t, func() { _, _ = p.Hash([]byte("abc")) })
+}
+
+func TestGetHash_PanicOnFactoryError(t *testing.T) {
+	p := NewProvider()
+
+	orig := getDefaultFactory
+	defer func() { getDefaultFactory = orig }()
+
+	getDefaultFactory = func() bccspFactory { return &mockFactoryErr{} }
+
+	require.Panics(t, func() { _ = p.GetHash() })
+}


### PR DESCRIPTION
## Summary

Improved test coverage for `platform/fabric/services/crypto`.

### Changes

* Added unit tests for:

  * `NewProvider`
  * `Hash`
  * `GetHash`
* Added table-driven hash validation tests.
* Added coverage for defensive panic branches by introducing a minimal package-local factory indirection for test injection.

### Notes

The refactor is intentionally minimal:

* no public API changes,
* no behavioral changes,
* package-local injection only for testing error branches.

### Result

Package coverage increased to 100%.

### Validation

```bash
go test ./platform/fabric/services/crypto/... -cover
```

Output:

```text
coverage: 100.0% of statements
```

Fixes #1427
