### PR TITLE
msp: isolate bccsp keystore config in tests

### DIFF
--- a/platform/fabric/core/msp/configbuilder.go
+++ b/platform/fabric/core/msp/configbuilder.go
@@ -137,10 +137,11 @@ func SetupBCCSPKeystoreConfig(bccspConfig *factory.FactoryOpts, keystoreDir stri
 	if bccspConfig == nil {
 		bccspConfig = factory.GetDefaultOpts()
 	}
+	bccspConfig = cloneFactoryOpts(bccspConfig)
 
 	if bccspConfig.Default == "SW" || bccspConfig.SW != nil {
 		if bccspConfig.SW == nil {
-			bccspConfig.SW = factory.GetDefaultOpts().SW
+			bccspConfig.SW = cloneFactoryOpts(factory.GetDefaultOpts()).SW
 		}
 
 		// Only override the KeyStorePath if it was left empty
@@ -151,6 +152,24 @@ func SetupBCCSPKeystoreConfig(bccspConfig *factory.FactoryOpts, keystoreDir stri
 	}
 
 	return bccspConfig
+}
+
+func cloneFactoryOpts(opts *factory.FactoryOpts) *factory.FactoryOpts {
+	if opts == nil {
+		return nil
+	}
+
+	cloned := *opts
+	if opts.SW != nil {
+		swOpts := *opts.SW
+		if opts.SW.FileKeystore != nil {
+			fileKeystore := *opts.SW.FileKeystore
+			swOpts.FileKeystore = &fileKeystore
+		}
+		cloned.SW = &swOpts
+	}
+
+	return &cloned
 }
 
 // GetLocalMspConfigWithType returns a local MSP

--- a/platform/fabric/core/msp/configbuilder.go
+++ b/platform/fabric/core/msp/configbuilder.go
@@ -154,6 +154,7 @@ func SetupBCCSPKeystoreConfig(bccspConfig *factory.FactoryOpts, keystoreDir stri
 	return bccspConfig
 }
 
+// cloneFactoryOpts shallow-copies provider options other than SW; callers must not mutate those fields.
 func cloneFactoryOpts(opts *factory.FactoryOpts) *factory.FactoryOpts {
 	if opts == nil {
 		return nil

--- a/platform/fabric/core/msp/configbuilder_test.go
+++ b/platform/fabric/core/msp/configbuilder_test.go
@@ -80,6 +80,46 @@ func TestSetupBCCSPKeystoreConfig(t *testing.T) { //nolint:paralleltest
 	require.Equal(t, rtnConfig.SW.FileKeystore.KeyStorePath, keystoreDir)
 }
 
+func TestSetupBCCSPKeystoreConfig_DoesNotMutateDefaultOpts(t *testing.T) { //nolint:paralleltest
+	defaultOpts := factory.GetDefaultOpts()
+	require.NotNil(t, defaultOpts)
+	require.NotNil(t, defaultOpts.SW)
+	originalSW := *defaultOpts.SW
+	var originalKeyStorePath string
+	if defaultOpts.SW.FileKeystore != nil {
+		originalKeyStorePath = defaultOpts.SW.FileKeystore.KeyStorePath
+	}
+
+	rtnConfig := SetupBCCSPKeystoreConfig(nil, "/tmp/fabric-smart-client-test-keystore")
+
+	require.NotNil(t, rtnConfig)
+	require.Equal(t, "/tmp/fabric-smart-client-test-keystore", rtnConfig.SW.FileKeystore.KeyStorePath)
+	require.Equal(t, originalSW.Hash, defaultOpts.SW.Hash)
+	require.Equal(t, originalSW.Security, defaultOpts.SW.Security)
+	if defaultOpts.SW.FileKeystore == nil {
+		require.Empty(t, originalKeyStorePath)
+	} else {
+		require.Equal(t, originalKeyStorePath, defaultOpts.SW.FileKeystore.KeyStorePath)
+	}
+}
+
+func TestSetupBCCSPKeystoreConfig_DoesNotMutateInput(t *testing.T) { //nolint:paralleltest
+	bccspConfig := &factory.FactoryOpts{
+		Default: "SW",
+		SW: &factory.SwOpts{
+			Hash:         "SHA2",
+			Security:     256,
+			FileKeystore: &factory.FileKeystoreOpts{},
+		},
+	}
+
+	rtnConfig := SetupBCCSPKeystoreConfig(bccspConfig, "/tmp/fabric-smart-client-input-keystore")
+
+	require.NotNil(t, rtnConfig)
+	require.Equal(t, "/tmp/fabric-smart-client-input-keystore", rtnConfig.SW.FileKeystore.KeyStorePath)
+	require.Empty(t, bccspConfig.SW.FileKeystore.KeyStorePath)
+}
+
 func TestGetLocalMspConfig(t *testing.T) { //nolint:paralleltest
 	mspDir := "testdata/sampleconfig"
 	_, err := GetLocalMspConfig(mspDir, nil, "SampleOrg")


### PR DESCRIPTION
Fixes #1374

## Summary
- clone BCCSP factory options before overriding the software keystore path
- avoid mutating Fabric's shared default BCCSP config across tests
- add regression coverage that the helper does not mutate global defaults or caller input

## Why
The x509 MSP tests were flaky because one path could mutate shared BCCSP defaults with a bad keystore path, and later tests would inherit that state through Fabric's global factory initialization.

## Testing
- `go test ./platform/fabric/core/msp ./platform/fabric/core/generic/msp/x509`
- `go test ./platform/fabric/core/generic/msp/x509 -count=50`
