### PR TITLE
test: add unit coverage for core generic endpoint

### DIFF
--- a/platform/fabric/core/generic/endpoint/endpoint_test.go
+++ b/platform/fabric/core/generic/endpoint/endpoint_test.go
@@ -12,39 +12,15 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/endpoint/fake"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
-
-type stubResolverService struct {
-	id        view.Identity
-	lastLabel string
-}
-
-func (s *stubResolverService) GetIdentity(label string) view.Identity {
-	s.lastLabel = label
-	return s.id
-}
-
-type stubEndpointService struct {
-	id        view.Identity
-	err       error
-	callCount int
-	lastLabel string
-	lastPKIID []byte
-}
-
-func (s *stubEndpointService) GetIdentity(label string, pkiID []byte) (view.Identity, error) {
-	s.callCount++
-	s.lastLabel = label
-	s.lastPKIID = pkiID
-	return s.id, s.err
-}
 
 func TestNewResolver(t *testing.T) {
 	t.Parallel()
 
-	rs := &stubResolverService{}
-	es := &stubEndpointService{}
+	rs := &fake.ResolverService{}
+	es := &fake.EndpointService{}
 
 	r, err := NewResolver(rs, es)
 	require.NoError(t, err)
@@ -56,45 +32,45 @@ func TestNewResolver(t *testing.T) {
 func TestResolverGetIdentity_LocalResolverHit(t *testing.T) {
 	t.Parallel()
 
-	rs := &stubResolverService{id: view.Identity("alice-id")}
-	es := &stubEndpointService{}
+	rs := &fake.ResolverService{ID: view.Identity("alice-id")}
+	es := &fake.EndpointService{}
 	r, err := NewResolver(rs, es)
 	require.NoError(t, err)
 
 	id, err := r.GetIdentity("alice")
 	require.NoError(t, err)
 	require.Equal(t, view.Identity("alice-id"), id)
-	require.Equal(t, "alice", rs.lastLabel)
-	require.Equal(t, 0, es.callCount)
+	require.Equal(t, "alice", rs.LastLabel)
+	require.Equal(t, 0, es.CallCount)
 }
 
 func TestResolverGetIdentity_FallbackToEndpointService(t *testing.T) {
 	t.Parallel()
 
-	rs := &stubResolverService{id: nil}
-	es := &stubEndpointService{id: view.Identity("alice-from-endpoint")}
+	rs := &fake.ResolverService{ID: nil}
+	es := &fake.EndpointService{ID: view.Identity("alice-from-endpoint")}
 	r, err := NewResolver(rs, es)
 	require.NoError(t, err)
 
 	id, err := r.GetIdentity("alice")
 	require.NoError(t, err)
 	require.Equal(t, view.Identity("alice-from-endpoint"), id)
-	require.Equal(t, "alice", es.lastLabel)
-	require.Equal(t, 1, es.callCount)
-	require.Nil(t, es.lastPKIID)
+	require.Equal(t, "alice", es.LastLabel)
+	require.Equal(t, 1, es.CallCount)
+	require.Nil(t, es.LastPKIID)
 }
 
 func TestResolverGetIdentity_FallbackError(t *testing.T) {
 	t.Parallel()
 
 	expectedErr := errors.New("endpoint lookup failed")
-	rs := &stubResolverService{id: nil}
-	es := &stubEndpointService{err: expectedErr}
+	rs := &fake.ResolverService{ID: nil}
+	es := &fake.EndpointService{Err: expectedErr}
 	r, err := NewResolver(rs, es)
 	require.NoError(t, err)
 
 	id, err := r.GetIdentity("alice")
 	require.ErrorIs(t, err, expectedErr)
 	require.Nil(t, id)
-	require.Equal(t, 1, es.callCount)
+	require.Equal(t, 1, es.CallCount)
 }

--- a/platform/fabric/core/generic/endpoint/endpoint_test.go
+++ b/platform/fabric/core/generic/endpoint/endpoint_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package endpoint
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
+
+type stubResolverService struct {
+	id        view.Identity
+	lastLabel string
+}
+
+func (s *stubResolverService) GetIdentity(label string) view.Identity {
+	s.lastLabel = label
+	return s.id
+}
+
+type stubEndpointService struct {
+	id        view.Identity
+	err       error
+	callCount int
+	lastLabel string
+	lastPKIID []byte
+}
+
+func (s *stubEndpointService) GetIdentity(label string, pkiID []byte) (view.Identity, error) {
+	s.callCount++
+	s.lastLabel = label
+	s.lastPKIID = pkiID
+	return s.id, s.err
+}
+
+func TestNewResolver(t *testing.T) {
+	t.Parallel()
+
+	rs := &stubResolverService{}
+	es := &stubEndpointService{}
+
+	r, err := NewResolver(rs, es)
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	require.Equal(t, rs, r.rs)
+	require.Equal(t, es, r.es)
+}
+
+func TestResolverGetIdentity_LocalResolverHit(t *testing.T) {
+	t.Parallel()
+
+	rs := &stubResolverService{id: view.Identity("alice-id")}
+	es := &stubEndpointService{}
+	r, err := NewResolver(rs, es)
+	require.NoError(t, err)
+
+	id, err := r.GetIdentity("alice")
+	require.NoError(t, err)
+	require.Equal(t, view.Identity("alice-id"), id)
+	require.Equal(t, "alice", rs.lastLabel)
+	require.Equal(t, 0, es.callCount)
+}
+
+func TestResolverGetIdentity_FallbackToEndpointService(t *testing.T) {
+	t.Parallel()
+
+	rs := &stubResolverService{id: nil}
+	es := &stubEndpointService{id: view.Identity("alice-from-endpoint")}
+	r, err := NewResolver(rs, es)
+	require.NoError(t, err)
+
+	id, err := r.GetIdentity("alice")
+	require.NoError(t, err)
+	require.Equal(t, view.Identity("alice-from-endpoint"), id)
+	require.Equal(t, "alice", es.lastLabel)
+	require.Equal(t, 1, es.callCount)
+	require.Nil(t, es.lastPKIID)
+}
+
+func TestResolverGetIdentity_FallbackError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("endpoint lookup failed")
+	rs := &stubResolverService{id: nil}
+	es := &stubEndpointService{err: expectedErr}
+	r, err := NewResolver(rs, es)
+	require.NoError(t, err)
+
+	id, err := r.GetIdentity("alice")
+	require.ErrorIs(t, err, expectedErr)
+	require.Nil(t, id)
+	require.Equal(t, 1, es.callCount)
+}

--- a/platform/fabric/core/generic/endpoint/fake/fakes.go
+++ b/platform/fabric/core/generic/endpoint/fake/fakes.go
@@ -1,0 +1,134 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fake
+
+import (
+	"context"
+	"maps"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
+	viewendpoint "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/endpoint"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
+
+type Config struct {
+	ResolversList []config.Resolver
+	ResolveErr    error
+	TranslateFn   func(path string) string
+}
+
+func (f *Config) Resolvers() ([]config.Resolver, error) {
+	if f.ResolveErr != nil {
+		return nil, f.ResolveErr
+	}
+	return f.ResolversList, nil
+}
+
+func (f *Config) TranslatePath(path string) string {
+	if f.TranslateFn != nil {
+		return f.TranslateFn(path)
+	}
+	return path
+}
+
+type BindCall struct {
+	LongTerm  view.Identity
+	Ephemeral []view.Identity
+}
+
+type AddResolverCall struct {
+	Name      string
+	Domain    string
+	Addresses map[string]string
+	Aliases   []string
+	ID        []byte
+	RootID    view.Identity
+}
+
+type ResolverServiceBackend struct {
+	AddPublicKeyExtractorErr error
+	AddPublicKeyCalls        int
+
+	AddResolverErr error
+	AddResolverFn  func(name, domain string, addresses map[string]string, aliases []string, id []byte) (view.Identity, error)
+	AddResolverIDs []view.Identity
+	AddCalls       []AddResolverCall
+
+	BindErr   error
+	BindCalls []BindCall
+}
+
+func (f *ResolverServiceBackend) Bind(_ context.Context, longTerm view.Identity, ephemeral ...view.Identity) error {
+	f.BindCalls = append(f.BindCalls, BindCall{
+		LongTerm:  longTerm,
+		Ephemeral: append([]view.Identity(nil), ephemeral...),
+	})
+	return f.BindErr
+}
+
+func (f *ResolverServiceBackend) AddResolver(name, domain string, addresses map[string]string, aliases []string, id []byte) (view.Identity, error) {
+	call := AddResolverCall{
+		Name:      name,
+		Domain:    domain,
+		Addresses: maps.Clone(addresses),
+		Aliases:   append([]string(nil), aliases...),
+		ID:        append([]byte(nil), id...),
+	}
+	if f.AddResolverErr != nil {
+		f.AddCalls = append(f.AddCalls, call)
+		return nil, f.AddResolverErr
+	}
+
+	var rootID view.Identity
+	if f.AddResolverFn != nil {
+		var err error
+		rootID, err = f.AddResolverFn(name, domain, addresses, aliases, id)
+		call.RootID = rootID
+		f.AddCalls = append(f.AddCalls, call)
+		return rootID, err
+	} else if len(f.AddResolverIDs) > 0 {
+		next := f.AddResolverIDs[0]
+		f.AddResolverIDs = f.AddResolverIDs[1:]
+		rootID = next
+	} else {
+		rootID = view.Identity("root-id")
+	}
+
+	call.RootID = rootID
+	f.AddCalls = append(f.AddCalls, call)
+	return rootID, nil
+}
+
+func (f *ResolverServiceBackend) AddPublicKeyExtractor(_ viewendpoint.PublicKeyExtractor) error {
+	f.AddPublicKeyCalls++
+	return f.AddPublicKeyExtractorErr
+}
+
+type ResolverService struct {
+	ID        view.Identity
+	LastLabel string
+}
+
+func (s *ResolverService) GetIdentity(label string) view.Identity {
+	s.LastLabel = label
+	return s.ID
+}
+
+type EndpointService struct {
+	ID        view.Identity
+	Err       error
+	CallCount int
+	LastLabel string
+	LastPKIID []byte
+}
+
+func (s *EndpointService) GetIdentity(label string, pkiID []byte) (view.Identity, error) {
+	s.CallCount++
+	s.LastLabel = label
+	s.LastPKIID = pkiID
+	return s.ID, s.Err
+}

--- a/platform/fabric/core/generic/endpoint/pki_test.go
+++ b/platform/fabric/core/generic/endpoint/pki_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package endpoint
+
+import (
+	"crypto/sha256"
+	"encoding/pem"
+	"path/filepath"
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/msp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	x509msp "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/x509"
+)
+
+func TestPublicKeyExtractorExtractPublicKey_InvalidSerializedIdentity(t *testing.T) {
+	t.Parallel()
+
+	extractor := PublicKeyExtractor{}
+	_, err := extractor.ExtractPublicKey([]byte("not-a-protobuf"))
+	require.Error(t, err)
+}
+
+func TestPublicKeyExtractorExtractPublicKey_X509Identity(t *testing.T) {
+	t.Parallel()
+
+	certPath := filepath.Join("..", "msp", "x509", "testdata", "msp", "signcerts", "auditor.org1.example.com-cert.pem")
+	rawIdentity, err := x509msp.Serialize("apple", certPath)
+	require.NoError(t, err)
+
+	extractor := PublicKeyExtractor{}
+	publicKey, err := extractor.ExtractPublicKey(rawIdentity)
+	require.NoError(t, err)
+	require.NotNil(t, publicKey)
+}
+
+func TestPublicKeyExtractorExtractPublicKey_InvalidCertificatePayload(t *testing.T) {
+	t.Parallel()
+
+	si := &msp.SerializedIdentity{
+		Mspid: "apple",
+		IdBytes: pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: []byte("bad-cert-der"),
+		}),
+	}
+	rawIdentity, err := proto.Marshal(si)
+	require.NoError(t, err)
+
+	extractor := PublicKeyExtractor{}
+	_, err = extractor.ExtractPublicKey(rawIdentity)
+	require.Error(t, err)
+}
+
+func TestPublicKeyExtractorExtractPublicKey_InvalidIdemixPayload(t *testing.T) {
+	t.Parallel()
+
+	si := &msp.SerializedIdentity{
+		Mspid:   "idemix-msp",
+		IdBytes: []byte("not-pem-and-not-idemix"),
+	}
+	rawIdentity, err := proto.Marshal(si)
+	require.NoError(t, err)
+
+	extractor := PublicKeyExtractor{}
+	_, err = extractor.ExtractPublicKey(rawIdentity)
+	require.Error(t, err)
+}
+
+func TestPublicKeyExtractorExtractPublicKey_IdemixIdentity(t *testing.T) {
+	t.Parallel()
+
+	serialized := &msp.SerializedIdemixIdentity{
+		NymX:  []byte("nym-x"),
+		NymY:  []byte("nym-y"),
+		Proof: []byte("proof"),
+		Ou:    []byte("ou"),
+		Role:  []byte("role"),
+	}
+	idemixRaw, err := proto.Marshal(serialized)
+	require.NoError(t, err)
+
+	si := &msp.SerializedIdentity{
+		Mspid:   "idemix-msp",
+		IdBytes: idemixRaw,
+	}
+	rawIdentity, err := proto.Marshal(si)
+	require.NoError(t, err)
+
+	extractor := PublicKeyExtractor{}
+	publicKey, err := extractor.ExtractPublicKey(rawIdentity)
+	require.NoError(t, err)
+
+	hashBytes, ok := publicKey.([]byte)
+	require.True(t, ok)
+
+	h := sha256.New()
+	h.Write(serialized.NymX)
+	h.Write(serialized.NymY)
+	h.Write(serialized.Proof)
+	h.Write(serialized.Ou)
+	h.Write(serialized.Role)
+	require.Equal(t, h.Sum(nil), hashBytes)
+}

--- a/platform/fabric/core/generic/endpoint/pki_test.go
+++ b/platform/fabric/core/generic/endpoint/pki_test.go
@@ -24,7 +24,7 @@ func TestPublicKeyExtractorExtractPublicKey_InvalidSerializedIdentity(t *testing
 
 	extractor := PublicKeyExtractor{}
 	_, err := extractor.ExtractPublicKey([]byte("not-a-protobuf"))
-	require.Error(t, err)
+	require.ErrorContains(t, err, "cannot parse invalid wire-format data")
 }
 
 func TestPublicKeyExtractorExtractPublicKey_X509Identity(t *testing.T) {
@@ -55,7 +55,7 @@ func TestPublicKeyExtractorExtractPublicKey_InvalidCertificatePayload(t *testing
 
 	extractor := PublicKeyExtractor{}
 	_, err = extractor.ExtractPublicKey(rawIdentity)
-	require.Error(t, err)
+	require.ErrorContains(t, err, "malformed certificate")
 }
 
 func TestPublicKeyExtractorExtractPublicKey_InvalidIdemixPayload(t *testing.T) {
@@ -70,7 +70,7 @@ func TestPublicKeyExtractorExtractPublicKey_InvalidIdemixPayload(t *testing.T) {
 
 	extractor := PublicKeyExtractor{}
 	_, err = extractor.ExtractPublicKey(rawIdentity)
-	require.Error(t, err)
+	require.ErrorContains(t, err, "cannot parse invalid wire-format data")
 }
 
 func TestPublicKeyExtractorExtractPublicKey_IdemixIdentity(t *testing.T) {

--- a/platform/fabric/core/generic/endpoint/resolver_test.go
+++ b/platform/fabric/core/generic/endpoint/resolver_test.go
@@ -9,6 +9,7 @@ package endpoint
 import (
 	"context"
 	"errors"
+	"maps"
 	"path/filepath"
 	"testing"
 
@@ -102,9 +103,7 @@ func (f *fakeResolverServiceBackend) AddPublicKeyExtractor(_ viewendpoint.Public
 
 func copyStringMap(src map[string]string) map[string]string {
 	dst := make(map[string]string, len(src))
-	for k, v := range src {
-		dst[k] = v
-	}
+	maps.Copy(dst, src)
 	return dst
 }
 

--- a/platform/fabric/core/generic/endpoint/resolver_test.go
+++ b/platform/fabric/core/generic/endpoint/resolver_test.go
@@ -194,7 +194,6 @@ func TestResolverServiceLoadResolvers_SuccessAndLookups(t *testing.T) {
 	require.Equal(t, 1, backend.AddPublicKeyCalls)
 	require.Len(t, backend.AddCalls, 2)
 	require.Len(t, backend.BindCalls, 2)
-	require.Len(t, service.resolvers, 2)
 	requireResolverLookups(t, cfg.ResolversList, backend.AddCalls, backend.BindCalls, service)
 
 	require.Nil(t, service.GetIdentity("unknown"))

--- a/platform/fabric/core/generic/endpoint/resolver_test.go
+++ b/platform/fabric/core/generic/endpoint/resolver_test.go
@@ -7,105 +7,16 @@ SPDX-License-Identifier: Apache-2.0
 package endpoint
 
 import (
-	"context"
 	"errors"
-	"maps"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
-	viewendpoint "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/endpoint"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/endpoint/fake"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
-
-type fakeConfig struct {
-	resolvers  []config.Resolver
-	resolveErr error
-	translate  func(path string) string
-}
-
-func (f *fakeConfig) Resolvers() ([]config.Resolver, error) {
-	if f.resolveErr != nil {
-		return nil, f.resolveErr
-	}
-	return f.resolvers, nil
-}
-
-func (f *fakeConfig) TranslatePath(path string) string {
-	if f.translate != nil {
-		return f.translate(path)
-	}
-	return path
-}
-
-type bindCall struct {
-	longTerm  view.Identity
-	ephemeral []view.Identity
-}
-
-type addResolverCall struct {
-	name      string
-	domain    string
-	addresses map[string]string
-	aliases   []string
-	id        []byte
-}
-
-type fakeResolverServiceBackend struct {
-	addPublicKeyExtractorErr error
-	addPublicKeyCalls        int
-
-	addResolverErr error
-	addResolverFn  func(name, domain string, addresses map[string]string, aliases []string, id []byte) (view.Identity, error)
-	addResolverIDs []view.Identity
-	addCalls       []addResolverCall
-
-	bindErr   error
-	bindCalls []bindCall
-}
-
-func (f *fakeResolverServiceBackend) Bind(_ context.Context, longTerm view.Identity, ephemeral ...view.Identity) error {
-	f.bindCalls = append(f.bindCalls, bindCall{
-		longTerm:  longTerm,
-		ephemeral: append([]view.Identity(nil), ephemeral...),
-	})
-	return f.bindErr
-}
-
-func (f *fakeResolverServiceBackend) AddResolver(name, domain string, addresses map[string]string, aliases []string, id []byte) (view.Identity, error) {
-	f.addCalls = append(f.addCalls, addResolverCall{
-		name:      name,
-		domain:    domain,
-		addresses: copyStringMap(addresses),
-		aliases:   append([]string(nil), aliases...),
-		id:        append([]byte(nil), id...),
-	})
-	if f.addResolverErr != nil {
-		return nil, f.addResolverErr
-	}
-	if f.addResolverFn != nil {
-		return f.addResolverFn(name, domain, addresses, aliases, id)
-	}
-	if len(f.addResolverIDs) > 0 {
-		next := f.addResolverIDs[0]
-		f.addResolverIDs = f.addResolverIDs[1:]
-		return next, nil
-	}
-	return view.Identity("root-id"), nil
-}
-
-func (f *fakeResolverServiceBackend) AddPublicKeyExtractor(_ viewendpoint.PublicKeyExtractor) error {
-	f.addPublicKeyCalls++
-	return f.addPublicKeyExtractorErr
-}
-
-func copyStringMap(src map[string]string) map[string]string {
-	dst := make(map[string]string, len(src))
-	maps.Copy(dst, src)
-	return dst
-}
 
 func TestResolverGetIdentity_WithIdentityGetter(t *testing.T) {
 	t.Parallel()
@@ -134,38 +45,37 @@ func TestNewResolverService_AddPublicKeyExtractorError(t *testing.T) {
 	t.Parallel()
 
 	expectedErr := errors.New("extractor registration failed")
-	cfg := &fakeConfig{}
-	backend := &fakeResolverServiceBackend{
-		addPublicKeyExtractorErr: expectedErr,
+	cfg := &fake.Config{}
+	backend := &fake.ResolverServiceBackend{
+		AddPublicKeyExtractorErr: expectedErr,
 	}
 
 	service, err := NewResolverService(cfg, backend)
-	require.Error(t, err)
 	require.ErrorIs(t, err, expectedErr)
 	require.Nil(t, service)
-	require.Equal(t, 1, backend.addPublicKeyCalls)
+	require.Equal(t, 1, backend.AddPublicKeyCalls)
 }
 
 func TestResolverServiceLoadResolvers_ConfigError(t *testing.T) {
 	t.Parallel()
 
 	expectedErr := errors.New("resolvers not available")
-	cfg := &fakeConfig{resolveErr: expectedErr}
-	backend := &fakeResolverServiceBackend{}
+	cfg := &fake.Config{ResolveErr: expectedErr}
+	backend := &fake.ResolverServiceBackend{}
 	service, err := NewResolverService(cfg, backend)
 	require.NoError(t, err)
 
 	err = service.LoadResolvers()
 	require.ErrorIs(t, err, expectedErr)
-	require.Empty(t, backend.addCalls)
-	require.Empty(t, backend.bindCalls)
+	require.Empty(t, backend.AddCalls)
+	require.Empty(t, backend.BindCalls)
 }
 
 func TestResolverServiceLoadResolvers_StatError(t *testing.T) {
 	t.Parallel()
 
-	cfg := &fakeConfig{
-		resolvers: []config.Resolver{
+	cfg := &fake.Config{
+		ResolversList: []config.Resolver{
 			{
 				Name: "alice",
 				Identity: config.MSP{
@@ -175,22 +85,21 @@ func TestResolverServiceLoadResolvers_StatError(t *testing.T) {
 			},
 		},
 	}
-	backend := &fakeResolverServiceBackend{}
+	backend := &fake.ResolverServiceBackend{}
 	service, err := NewResolverService(cfg, backend)
 	require.NoError(t, err)
 
 	err = service.LoadResolvers()
-	require.Error(t, err)
 	require.ErrorContains(t, err, "failed to stat")
-	require.Empty(t, backend.addCalls)
+	require.Empty(t, backend.AddCalls)
 }
 
 func TestResolverServiceLoadResolvers_AddResolverError(t *testing.T) {
 	t.Parallel()
 
 	certPath := filepath.Join("..", "msp", "x509", "testdata", "msp", "signcerts", "auditor.org1.example.com-cert.pem")
-	cfg := &fakeConfig{
-		resolvers: []config.Resolver{
+	cfg := &fake.Config{
+		ResolversList: []config.Resolver{
 			{
 				Name: "alice",
 				Identity: config.MSP{
@@ -201,25 +110,24 @@ func TestResolverServiceLoadResolvers_AddResolverError(t *testing.T) {
 		},
 	}
 	expectedErr := errors.New("add resolver failed")
-	backend := &fakeResolverServiceBackend{
-		addResolverErr: expectedErr,
+	backend := &fake.ResolverServiceBackend{
+		AddResolverErr: expectedErr,
 	}
 	service, err := NewResolverService(cfg, backend)
 	require.NoError(t, err)
 
 	err = service.LoadResolvers()
-	require.Error(t, err)
 	require.ErrorIs(t, err, expectedErr)
-	require.Len(t, backend.addCalls, 1)
-	require.Empty(t, backend.bindCalls)
+	require.Len(t, backend.AddCalls, 1)
+	require.Empty(t, backend.BindCalls)
 }
 
 func TestResolverServiceLoadResolvers_BindAliasError(t *testing.T) {
 	t.Parallel()
 
 	certPath := filepath.Join("..", "msp", "x509", "testdata", "msp", "signcerts", "auditor.org1.example.com-cert.pem")
-	cfg := &fakeConfig{
-		resolvers: []config.Resolver{
+	cfg := &fake.Config{
+		ResolversList: []config.Resolver{
 			{
 				Name: "alice",
 				Identity: config.MSP{
@@ -231,18 +139,17 @@ func TestResolverServiceLoadResolvers_BindAliasError(t *testing.T) {
 		},
 	}
 	expectedErr := errors.New("bind failed")
-	backend := &fakeResolverServiceBackend{
-		bindErr: expectedErr,
+	backend := &fake.ResolverServiceBackend{
+		BindErr: expectedErr,
 	}
 	service, err := NewResolverService(cfg, backend)
 	require.NoError(t, err)
 
 	err = service.LoadResolvers()
-	require.Error(t, err)
 	require.ErrorIs(t, err, expectedErr)
-	require.Len(t, backend.addCalls, 1)
-	require.Len(t, backend.bindCalls, 1)
-	require.Equal(t, view.Identity("alice-alias"), backend.bindCalls[0].ephemeral[0])
+	require.Len(t, backend.AddCalls, 1)
+	require.Len(t, backend.BindCalls, 1)
+	require.Equal(t, view.Identity("alice-alias"), backend.BindCalls[0].Ephemeral[0])
 }
 
 func TestResolverServiceLoadResolvers_SuccessAndLookups(t *testing.T) {
@@ -250,8 +157,8 @@ func TestResolverServiceLoadResolvers_SuccessAndLookups(t *testing.T) {
 
 	mspPath := filepath.Join("..", "msp", "x509", "testdata", "msp")
 	certPath := filepath.Join("..", "msp", "x509", "testdata", "msp", "signcerts", "auditor.org1.example.com-cert.pem")
-	cfg := &fakeConfig{
-		resolvers: []config.Resolver{
+	cfg := &fake.Config{
+		ResolversList: []config.Resolver{
 			{
 				Name:    "alice",
 				Domain:  "example.com",
@@ -274,8 +181,8 @@ func TestResolverServiceLoadResolvers_SuccessAndLookups(t *testing.T) {
 			},
 		},
 	}
-	backend := &fakeResolverServiceBackend{
-		addResolverFn: func(name, _ string, _ map[string]string, _ []string, _ []byte) (view.Identity, error) {
+	backend := &fake.ResolverServiceBackend{
+		AddResolverFn: func(name, _ string, _ map[string]string, _ []string, _ []byte) (view.Identity, error) {
 			return view.Identity("root-" + name), nil
 		},
 	}
@@ -284,23 +191,53 @@ func TestResolverServiceLoadResolvers_SuccessAndLookups(t *testing.T) {
 
 	err = service.LoadResolvers()
 	require.NoError(t, err)
-	require.Equal(t, 1, backend.addPublicKeyCalls)
-	require.Len(t, backend.addCalls, 2)
-	require.Len(t, backend.bindCalls, 2)
+	require.Equal(t, 1, backend.AddPublicKeyCalls)
+	require.Len(t, backend.AddCalls, 2)
+	require.Len(t, backend.BindCalls, 2)
 	require.Len(t, service.resolvers, 2)
-
-	alice := service.resolvers[0]
-	bob := service.resolvers[1]
-
-	require.Equal(t, view.Identity(alice.Id), service.GetIdentity("alice"))
-	require.Equal(t, view.Identity(alice.Id), service.GetIdentity("a1"))
-	require.Equal(t, view.Identity(alice.Id), service.GetIdentity(view.Identity(alice.Id).UniqueID()))
-	require.Equal(t, view.Identity(alice.Id), service.GetIdentity(alice.RootID.UniqueID()))
-
-	require.Equal(t, view.Identity(bob.Id), service.GetIdentity("bob"))
-	require.Equal(t, view.Identity(bob.Id), service.GetIdentity("b1"))
-	require.Equal(t, view.Identity(bob.Id), service.GetIdentity(view.Identity(bob.Id).UniqueID()))
-	require.Equal(t, view.Identity(bob.Id), service.GetIdentity(bob.RootID.UniqueID()))
+	requireResolverLookups(t, cfg.ResolversList, backend.AddCalls, backend.BindCalls, service)
 
 	require.Nil(t, service.GetIdentity("unknown"))
+}
+
+func requireResolverLookups(t *testing.T, resolvers []config.Resolver, addCalls []fake.AddResolverCall, bindCalls []fake.BindCall, service *ResolverService) {
+	t.Helper()
+
+	callsByName := map[string]fake.AddResolverCall{}
+	for _, call := range addCalls {
+		callsByName[call.Name] = call
+	}
+
+	bindCallsByLongTerm := map[string][]fake.BindCall{}
+	for _, call := range bindCalls {
+		bindCallsByLongTerm[string(call.LongTerm)] = append(bindCallsByLongTerm[string(call.LongTerm)], call)
+	}
+
+	for _, resolver := range resolvers {
+		call, ok := callsByName[resolver.Name]
+		require.True(t, ok, "missing add resolver call for %s", resolver.Name)
+		require.Equal(t, resolver.Domain, call.Domain)
+		require.Equal(t, resolver.Addresses, call.Addresses)
+		require.Equal(t, resolver.Aliases, call.Aliases)
+		require.NotEmpty(t, call.ID)
+		require.NotEmpty(t, call.RootID)
+
+		expected := view.Identity(call.ID)
+		require.Equal(t, expected, service.GetIdentity(resolver.Name))
+		require.Equal(t, expected, service.GetIdentity(expected.UniqueID()))
+		require.Equal(t, expected, service.GetIdentity(call.RootID.UniqueID()))
+
+		nameBindCalls := bindCallsByLongTerm[string(expected)]
+		require.Len(t, nameBindCalls, len(resolver.Aliases))
+
+		boundAliases := map[string]struct{}{}
+		for _, call := range nameBindCalls {
+			require.Len(t, call.Ephemeral, 1)
+			boundAliases[string(call.Ephemeral[0])] = struct{}{}
+		}
+		for _, alias := range resolver.Aliases {
+			require.Equal(t, expected, service.GetIdentity(alias))
+			require.Contains(t, boundAliases, alias)
+		}
+	}
 }

--- a/platform/fabric/core/generic/endpoint/resolver_test.go
+++ b/platform/fabric/core/generic/endpoint/resolver_test.go
@@ -1,0 +1,307 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package endpoint
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
+	viewendpoint "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/endpoint"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
+
+type fakeConfig struct {
+	resolvers  []config.Resolver
+	resolveErr error
+	translate  func(path string) string
+}
+
+func (f *fakeConfig) Resolvers() ([]config.Resolver, error) {
+	if f.resolveErr != nil {
+		return nil, f.resolveErr
+	}
+	return f.resolvers, nil
+}
+
+func (f *fakeConfig) TranslatePath(path string) string {
+	if f.translate != nil {
+		return f.translate(path)
+	}
+	return path
+}
+
+type bindCall struct {
+	longTerm  view.Identity
+	ephemeral []view.Identity
+}
+
+type addResolverCall struct {
+	name      string
+	domain    string
+	addresses map[string]string
+	aliases   []string
+	id        []byte
+}
+
+type fakeResolverServiceBackend struct {
+	addPublicKeyExtractorErr error
+	addPublicKeyCalls        int
+
+	addResolverErr error
+	addResolverFn  func(name, domain string, addresses map[string]string, aliases []string, id []byte) (view.Identity, error)
+	addResolverIDs []view.Identity
+	addCalls       []addResolverCall
+
+	bindErr   error
+	bindCalls []bindCall
+}
+
+func (f *fakeResolverServiceBackend) Bind(_ context.Context, longTerm view.Identity, ephemeral ...view.Identity) error {
+	f.bindCalls = append(f.bindCalls, bindCall{
+		longTerm:  longTerm,
+		ephemeral: append([]view.Identity(nil), ephemeral...),
+	})
+	return f.bindErr
+}
+
+func (f *fakeResolverServiceBackend) AddResolver(name, domain string, addresses map[string]string, aliases []string, id []byte) (view.Identity, error) {
+	f.addCalls = append(f.addCalls, addResolverCall{
+		name:      name,
+		domain:    domain,
+		addresses: copyStringMap(addresses),
+		aliases:   append([]string(nil), aliases...),
+		id:        append([]byte(nil), id...),
+	})
+	if f.addResolverErr != nil {
+		return nil, f.addResolverErr
+	}
+	if f.addResolverFn != nil {
+		return f.addResolverFn(name, domain, addresses, aliases, id)
+	}
+	if len(f.addResolverIDs) > 0 {
+		next := f.addResolverIDs[0]
+		f.addResolverIDs = f.addResolverIDs[1:]
+		return next, nil
+	}
+	return view.Identity("root-id"), nil
+}
+
+func (f *fakeResolverServiceBackend) AddPublicKeyExtractor(_ viewendpoint.PublicKeyExtractor) error {
+	f.addPublicKeyCalls++
+	return f.addPublicKeyExtractorErr
+}
+
+func copyStringMap(src map[string]string) map[string]string {
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func TestResolverGetIdentity_WithIdentityGetter(t *testing.T) {
+	t.Parallel()
+
+	r := &Resolver{
+		IdentityGetter: func() (view.Identity, []byte, error) {
+			return view.Identity("from-getter"), []byte("ignored-info"), nil
+		},
+	}
+
+	id, err := r.GetIdentity()
+	require.NoError(t, err)
+	require.Equal(t, view.Identity("from-getter"), id)
+}
+
+func TestResolverGetIdentity_WithoutIdentityGetter(t *testing.T) {
+	t.Parallel()
+
+	r := &Resolver{Id: []byte("from-id")}
+	id, err := r.GetIdentity()
+	require.NoError(t, err)
+	require.Equal(t, view.Identity("from-id"), id)
+}
+
+func TestNewResolverService_AddPublicKeyExtractorError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("extractor registration failed")
+	cfg := &fakeConfig{}
+	backend := &fakeResolverServiceBackend{
+		addPublicKeyExtractorErr: expectedErr,
+	}
+
+	service, err := NewResolverService(cfg, backend)
+	require.Error(t, err)
+	require.ErrorIs(t, err, expectedErr)
+	require.Nil(t, service)
+	require.Equal(t, 1, backend.addPublicKeyCalls)
+}
+
+func TestResolverServiceLoadResolvers_ConfigError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("resolvers not available")
+	cfg := &fakeConfig{resolveErr: expectedErr}
+	backend := &fakeResolverServiceBackend{}
+	service, err := NewResolverService(cfg, backend)
+	require.NoError(t, err)
+
+	err = service.LoadResolvers()
+	require.ErrorIs(t, err, expectedErr)
+	require.Empty(t, backend.addCalls)
+	require.Empty(t, backend.bindCalls)
+}
+
+func TestResolverServiceLoadResolvers_StatError(t *testing.T) {
+	t.Parallel()
+
+	cfg := &fakeConfig{
+		resolvers: []config.Resolver{
+			{
+				Name: "alice",
+				Identity: config.MSP{
+					MSPID: "apple",
+					Path:  "/path/does/not/exist",
+				},
+			},
+		},
+	}
+	backend := &fakeResolverServiceBackend{}
+	service, err := NewResolverService(cfg, backend)
+	require.NoError(t, err)
+
+	err = service.LoadResolvers()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to stat")
+	require.Empty(t, backend.addCalls)
+}
+
+func TestResolverServiceLoadResolvers_AddResolverError(t *testing.T) {
+	t.Parallel()
+
+	certPath := filepath.Join("..", "msp", "x509", "testdata", "msp", "signcerts", "auditor.org1.example.com-cert.pem")
+	cfg := &fakeConfig{
+		resolvers: []config.Resolver{
+			{
+				Name: "alice",
+				Identity: config.MSP{
+					MSPID: "apple",
+					Path:  certPath,
+				},
+			},
+		},
+	}
+	expectedErr := errors.New("add resolver failed")
+	backend := &fakeResolverServiceBackend{
+		addResolverErr: expectedErr,
+	}
+	service, err := NewResolverService(cfg, backend)
+	require.NoError(t, err)
+
+	err = service.LoadResolvers()
+	require.Error(t, err)
+	require.ErrorIs(t, err, expectedErr)
+	require.Len(t, backend.addCalls, 1)
+	require.Empty(t, backend.bindCalls)
+}
+
+func TestResolverServiceLoadResolvers_BindAliasError(t *testing.T) {
+	t.Parallel()
+
+	certPath := filepath.Join("..", "msp", "x509", "testdata", "msp", "signcerts", "auditor.org1.example.com-cert.pem")
+	cfg := &fakeConfig{
+		resolvers: []config.Resolver{
+			{
+				Name: "alice",
+				Identity: config.MSP{
+					MSPID: "apple",
+					Path:  certPath,
+				},
+				Aliases: []string{"alice-alias"},
+			},
+		},
+	}
+	expectedErr := errors.New("bind failed")
+	backend := &fakeResolverServiceBackend{
+		bindErr: expectedErr,
+	}
+	service, err := NewResolverService(cfg, backend)
+	require.NoError(t, err)
+
+	err = service.LoadResolvers()
+	require.Error(t, err)
+	require.ErrorIs(t, err, expectedErr)
+	require.Len(t, backend.addCalls, 1)
+	require.Len(t, backend.bindCalls, 1)
+	require.Equal(t, view.Identity("alice-alias"), backend.bindCalls[0].ephemeral[0])
+}
+
+func TestResolverServiceLoadResolvers_SuccessAndLookups(t *testing.T) {
+	t.Parallel()
+
+	mspPath := filepath.Join("..", "msp", "x509", "testdata", "msp")
+	certPath := filepath.Join("..", "msp", "x509", "testdata", "msp", "signcerts", "auditor.org1.example.com-cert.pem")
+	cfg := &fakeConfig{
+		resolvers: []config.Resolver{
+			{
+				Name:    "alice",
+				Domain:  "example.com",
+				Aliases: []string{"a1"},
+				Identity: config.MSP{
+					MSPID: "apple",
+					Path:  mspPath,
+				},
+				Addresses: map[string]string{"p2p": "127.0.0.1:1001"},
+			},
+			{
+				Name:    "bob",
+				Domain:  "example.com",
+				Aliases: []string{"b1"},
+				Identity: config.MSP{
+					MSPID: "banana",
+					Path:  certPath,
+				},
+				Addresses: map[string]string{"p2p": "127.0.0.1:1002"},
+			},
+		},
+	}
+	backend := &fakeResolverServiceBackend{
+		addResolverFn: func(name, _ string, _ map[string]string, _ []string, _ []byte) (view.Identity, error) {
+			return view.Identity("root-" + name), nil
+		},
+	}
+	service, err := NewResolverService(cfg, backend)
+	require.NoError(t, err)
+
+	err = service.LoadResolvers()
+	require.NoError(t, err)
+	require.Equal(t, 1, backend.addPublicKeyCalls)
+	require.Len(t, backend.addCalls, 2)
+	require.Len(t, backend.bindCalls, 2)
+	require.Len(t, service.resolvers, 2)
+
+	alice := service.resolvers[0]
+	bob := service.resolvers[1]
+
+	require.Equal(t, view.Identity(alice.Id), service.GetIdentity("alice"))
+	require.Equal(t, view.Identity(alice.Id), service.GetIdentity("a1"))
+	require.Equal(t, view.Identity(alice.Id), service.GetIdentity(view.Identity(alice.Id).UniqueID()))
+	require.Equal(t, view.Identity(alice.Id), service.GetIdentity(alice.RootID.UniqueID()))
+
+	require.Equal(t, view.Identity(bob.Id), service.GetIdentity("bob"))
+	require.Equal(t, view.Identity(bob.Id), service.GetIdentity("b1"))
+	require.Equal(t, view.Identity(bob.Id), service.GetIdentity(view.Identity(bob.Id).UniqueID()))
+	require.Equal(t, view.Identity(bob.Id), service.GetIdentity(bob.RootID.UniqueID()))
+
+	require.Nil(t, service.GetIdentity("unknown"))
+}


### PR DESCRIPTION
 Closes #1436

  Description
  This PR adds focused unit tests for platform/fabric/core/generic/endpoint to satisfy Stage 2 coverage work for the endpoint package.

  What Changed

  - Added resolver wrapper tests:
      - NewResolver
      - resolver.GetIdentity local-hit path
      - fallback-to-endpoint path
      - fallback error propagation
  - Added resolver service tests:
      - Resolver.GetIdentity with and without IdentityGetter
      - NewResolverService extractor-registration error path
      - LoadResolvers success path with resolver/alias/unique-id lookups
      - LoadResolvers error paths for config failure, missing identity path, AddResolver failure, and alias Bind failure
  - Added PKI extractor tests:
      - invalid serialized identity input
      - x509 identity public key extraction
      - invalid x509 certificate payload handling
      - invalid idemix payload handling
      - valid idemix identity hash path verification
