### PR TITLE
logging: upgrade otel/log to v0.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.40.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.40.0
-	go.opentelemetry.io/otel/log v0.6.0
+	go.opentelemetry.io/otel/log v0.19.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/atomic v1.11.0
 	go.uber.org/dig v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -1575,8 +1575,8 @@ go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.29.0 h1:WDdP9acbMYjbKI
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.29.0/go.mod h1:BLbf7zbNIONBLPwvFnwNHGj4zge8uTCM/UPIVW1Mq2I=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.40.0 h1:MzfofMZN8ulNqobCmCAVbqVL5syHw+eB2qPRkCMA/fQ=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.40.0/go.mod h1:E73G9UFtKRXrxhBsHtG00TB5WxX57lpsQzogDkqBTz8=
-go.opentelemetry.io/otel/log v0.6.0 h1:nH66tr+dmEgW5y+F9LanGJUBYPrRgP4g2EkmPE3LeK8=
-go.opentelemetry.io/otel/log v0.6.0/go.mod h1:KdySypjQHhP069JX0z/t26VHwa8vSwzgaKmXtIB3fJM=
+go.opentelemetry.io/otel/log v0.19.0 h1:KUZs/GOsw79TBBMfDWsXS+KZ4g2Ckzksd1ymzsIEbo4=
+go.opentelemetry.io/otel/log v0.19.0/go.mod h1:5DQYeGmxVIr4n0/BcJvF4upsraHjg6vudJJpnkL6Ipk=
 go.opentelemetry.io/otel/metric v1.43.0 h1:d7638QeInOnuwOONPp4JAOGfbCEpYb+K6DVWvdxGzgM=
 go.opentelemetry.io/otel/metric v1.43.0/go.mod h1:RDnPtIxvqlgO8GRW18W6Z/4P462ldprJtfxHxyKd2PY=
 go.opentelemetry.io/otel/sdk v1.43.0 h1:pi5mE86i5rTeLXqoF/hhiBtUNcrAGHLKQdhg4h4V9Dg=

--- a/platform/common/services/logging/otel.go
+++ b/platform/common/services/logging/otel.go
@@ -80,7 +80,7 @@ func (l *spanLogger) Emit(ctx context.Context, record log.Record) {
 	trace.SpanFromContext(ctx).AddEvent(record.Body().AsString(), trace.WithAttributes(attribute.String(loggerNameKey, l.loggerName)))
 }
 
-func (l *spanLogger) Enabled(context.Context, log.Record) bool { return true }
+func (l *spanLogger) Enabled(context.Context, log.EnabledParameters) bool { return true }
 
 type sanitizedSpanLogger struct {
 	log.Logger
@@ -94,4 +94,4 @@ func (l *sanitizedSpanLogger) Emit(ctx context.Context, record log.Record) {
 	trace.SpanFromContext(ctx).AddEvent(str, trace.WithAttributes(attribute.String(loggerNameKey, l.loggerName)))
 }
 
-func (l *sanitizedSpanLogger) Enabled(context.Context, log.Record) bool { return true }
+func (l *sanitizedSpanLogger) Enabled(context.Context, log.EnabledParameters) bool { return true }


### PR DESCRIPTION
Fixes #1462

## Summary

The `Logger.Enabled` signature was changed in otel/log starting in v0.7.0 from
`Enabled(ctx, Record) bool` to `Enabled(ctx, EnabledParameters) bool`. The FSC
implementation has been pinned to `otel/log v0.6.0` since this change, which
blocks downstream consumers from aligning otel/log with the rest of the otel
ecosystem (otel v1.43+).

This PR updates the two `Logger.Enabled` implementations in
`platform/common/services/logging/otel.go` to the new signature and bumps the
`go.opentelemetry.io/otel/log` require to v0.19.0.

## Changes

- `platform/common/services/logging/otel.go` — update two `Enabled` method signatures
- `go.mod` — bump `go.opentelemetry.io/otel/log` v0.6.0 → v0.19.0
- `go.sum` — regenerated by `go mod tidy`

## Test plan

- [x] `go build ./...`
- [x] `go test ./platform/common/services/logging/...`
- [ ] CI green

## Note

The PR Helper Bot asks the linked issue to be assigned to me. As a non-collaborator
I cannot self-assign; would a maintainer please assign #1462 to me, or let me know
how you'd like to handle this requirement.