### PR TITLE
fix(fabric/config): add missing GetInt prefix wrapper

### DIFF
--- a/platform/fabric/core/generic/config/service.go
+++ b/platform/fabric/core/generic/config/service.go
@@ -262,6 +262,10 @@ func (s *Service) GetString(key string) string {
 	return s.Configuration.GetString("fabric." + s.prefix + key)
 }
 
+func (s *Service) GetInt(key string) int {
+	return s.Configuration.GetInt("fabric." + s.prefix + key)
+}
+
 func (s *Service) GetDuration(key string) time.Duration {
 	return s.Configuration.GetDuration("fabric." + s.prefix + key)
 }

--- a/platform/fabric/core/generic/config/service_test.go
+++ b/platform/fabric/core/generic/config/service_test.go
@@ -269,9 +269,11 @@ func TestServiceGetters(t *testing.T) {
 	require.Equal(t, 3, svc.MSPCacheSize())
 
 	// Ordering retries
-	m.GetIntReturnsOnCall(0, 5)
+	getIntCallsBefore := m.GetIntCallCount()
+	m.GetIntReturnsOnCall(getIntCallsBefore, 5)
 	require.Equal(t, 5, svc.BroadcastNumRetries())
-	m.GetIntReturnsOnCall(1, 0)
+	require.Equal(t, "fabric.mynet.ordering.numRetries", m.GetIntArgsForCall(getIntCallsBefore))
+	m.GetIntReturnsOnCall(getIntCallsBefore+1, 0)
 	require.Equal(t, 3, svc.BroadcastNumRetries())
 
 	m.IsSetReturns(true)
@@ -283,7 +285,9 @@ func TestServiceGetters(t *testing.T) {
 	// Orderer connection pool
 	m.IsSetReturns(true)
 	m.GetIntReturns(20)
+	poolCallIndex := m.GetIntCallCount()
 	require.Equal(t, 20, svc.OrdererConnectionPoolSize())
+	require.Equal(t, "fabric.mynet.ordering.connectionPoolSize", m.GetIntArgsForCall(poolCallIndex))
 	m.IsSetReturns(false)
 	require.Equal(t, 10, svc.OrdererConnectionPoolSize())
 


### PR DESCRIPTION
Fixes #1465

## Summary

`Service` exposes prefixed accessors (`GetString`, `GetBool`, `IsSet`, `GetDuration`, `GetPath`, `UnmarshalKey`) that wrap the embedded `Configuration` with `"fabric.<prefix>."` for all keys. The `GetInt` wrapper was missing, so callers like `OrdererConnectionPoolSize` and `BroadcastNumRetries` silently fell through Go's embedded-interface method promotion to `Configuration.GetInt`, which does **not** prepend the prefix.

The `IsSet` branch correctly reported the key as present (because `IsSet` is prefixed), but the immediately following value lookup missed and returned `0`.

Practical effect: setting `fabric.default.ordering.connectionPoolSize: 20` in yaml made `OrdererConnectionPoolSize()` return `0` instead of `20` — silently worse than leaving the key unset (which falls back to the `10` default). The same bug applies to `ordering.numRetries` via `BroadcastNumRetries`.

## Fix

Add the missing 4-line `GetInt` wrapper between `GetString` and `GetDuration`, following the exact pattern used by the other accessors.

## Test plan

- [x] Extended `service_test.go` to capture `GetIntArgsForCall(...)` and assert the prefixed key (`fabric.mynet.ordering.numRetries` / `fabric.mynet.ordering.connectionPoolSize`) is what gets passed down to `Configuration`.
- [x] `go test ./platform/fabric/core/generic/config/...` passes.
- [x] Without the wrapper (verified via `git stash`), the new assertions fail with `expected "fabric.mynet.ordering.numRetries" actual "ordering.numRetries"` — confirms the new tests catch the bug.