### PR TITLE
fix(msp): resolve flaky TestService_IsMe by isolating shared mock state

### DIFF
--- a/platform/fabric/core/generic/msp/service_test.go
+++ b/platform/fabric/core/generic/msp/service_test.go
@@ -265,6 +265,7 @@ func TestService_SetDefaultIdentity(t *testing.T) {
 		require.Equal(t, initialSid, mspService.DefaultSigningIdentity())
 	})
 }
+
 func TestService_IsMe(t *testing.T) {
 	t.Parallel()
 	id := view.Identity("id1")

--- a/platform/fabric/core/generic/msp/service_test.go
+++ b/platform/fabric/core/generic/msp/service_test.go
@@ -265,22 +265,22 @@ func TestService_SetDefaultIdentity(t *testing.T) {
 		require.Equal(t, initialSid, mspService.DefaultSigningIdentity())
 	})
 }
-
 func TestService_IsMe(t *testing.T) {
 	t.Parallel()
-	mspService, signerService, _, _ := setup(t)
 	id := view.Identity("id1")
 
 	t.Run("True", func(t *testing.T) {
 		t.Parallel()
+		mspService, signerService, _, _ := setup(t)
 		signerService.IsMeReturns(true)
-		require.True(t, mspService.IsMe(context.Background(), id))
+		require.True(t, mspService.IsMe(t.Context(), id))
 	})
 
 	t.Run("False", func(t *testing.T) {
 		t.Parallel()
+		mspService, signerService, _, _ := setup(t)
 		signerService.IsMeReturns(false)
-		require.False(t, mspService.IsMe(context.Background(), id))
+		require.False(t, mspService.IsMe(t.Context(), id))
 	})
 }
 


### PR DESCRIPTION
Closes #1453
TestService_IsMe/True and TestService_IsMe/False shared a single signerService mock while running in parallel. Either subtest could overwrite the other's return value before IsMe() was called, causing non-deterministic failures.
Fix: moved setup(t) inside each subtest to give each its own independent mock instance. Also replaced context.Background() with t.Context() for consistency.
Verified with -count=5 -race locally, no failures.