### PR TITLE
test(memory): fix parallel schema lock by serializing DB tests

### DIFF
--- a/platform/fabric/services/db/driver/memory/driver_test.go
+++ b/platform/fabric/services/db/driver/memory/driver_test.go
@@ -70,7 +70,7 @@ func TestNewDriverWithDbProvider_NotNil(t *testing.T) {
 	require.NotNil(t, d)
 }
 
-func TestNewEndorseTx_CRUD(t *testing.T) {
+func TestNewEndorseTx_CRUD(t *testing.T) { //nolint:paralleltest
 	d := mem.NewDriver()
 	store, err := d.NewEndorseTx(viewdriver.PersistenceName(t.Name()), t.Name())
 	require.NoError(t, err)
@@ -95,7 +95,7 @@ func TestNewEndorseTx_CRUD(t *testing.T) {
 	require.Equal(t, []byte("payload"), val)
 }
 
-func TestNewMetadata_CRUD(t *testing.T) {
+func TestNewMetadata_CRUD(t *testing.T) { //nolint:paralleltest
 	d := mem.NewDriver()
 	store, err := d.NewMetadata(viewdriver.PersistenceName(t.Name()), t.Name())
 	require.NoError(t, err)
@@ -120,7 +120,7 @@ func TestNewMetadata_CRUD(t *testing.T) {
 	require.Equal(t, []byte("meta-value"), val)
 }
 
-func TestNewEnvelope_CRUD(t *testing.T) {
+func TestNewEnvelope_CRUD(t *testing.T) { //nolint:paralleltest
 	d := mem.NewDriver()
 	store, err := d.NewEnvelope(viewdriver.PersistenceName(t.Name()), t.Name())
 	require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestNewEnvelope_CRUD(t *testing.T) {
 	require.Equal(t, []byte("env-data"), val)
 }
 
-func TestNewVault_CRUD(t *testing.T) {
+func TestNewVault_CRUD(t *testing.T) { //nolint:paralleltest
 	d := mem.NewDriver()
 	store, err := d.NewVault(viewdriver.PersistenceName(t.Name()), t.Name())
 	require.NoError(t, err)
@@ -170,7 +170,7 @@ func TestNewVault_CRUD(t *testing.T) {
 	require.Equal(t, fabricdriver.Valid, status.Code)
 }
 
-func TestNewEndorseTx_MultipleInstances(t *testing.T) {
+func TestNewEndorseTx_MultipleInstances(t *testing.T) { //nolint:paralleltest
 	d := mem.NewDriver()
 
 	store1, err := d.NewEndorseTx(viewdriver.PersistenceName(t.Name()+"_1"), "alpha")

--- a/platform/fabric/services/db/driver/memory/driver_test.go
+++ b/platform/fabric/services/db/driver/memory/driver_test.go
@@ -71,9 +71,8 @@ func TestNewDriverWithDbProvider_NotNil(t *testing.T) {
 }
 
 func TestNewEndorseTx_CRUD(t *testing.T) {
-	t.Parallel()
 	d := mem.NewDriver()
-	store, err := d.NewEndorseTx(viewdriver.PersistenceName("test"), t.Name())
+	store, err := d.NewEndorseTx(viewdriver.PersistenceName(t.Name()), t.Name())
 	require.NoError(t, err)
 	require.NotNil(t, store)
 
@@ -97,7 +96,6 @@ func TestNewEndorseTx_CRUD(t *testing.T) {
 }
 
 func TestNewMetadata_CRUD(t *testing.T) {
-	t.Parallel()
 	d := mem.NewDriver()
 	store, err := d.NewMetadata(viewdriver.PersistenceName(t.Name()), t.Name())
 	require.NoError(t, err)
@@ -123,7 +121,6 @@ func TestNewMetadata_CRUD(t *testing.T) {
 }
 
 func TestNewEnvelope_CRUD(t *testing.T) {
-	t.Parallel()
 	d := mem.NewDriver()
 	store, err := d.NewEnvelope(viewdriver.PersistenceName(t.Name()), t.Name())
 	require.NoError(t, err)
@@ -149,7 +146,6 @@ func TestNewEnvelope_CRUD(t *testing.T) {
 }
 
 func TestNewVault_CRUD(t *testing.T) {
-	t.Parallel()
 	d := mem.NewDriver()
 	store, err := d.NewVault(viewdriver.PersistenceName(t.Name()), t.Name())
 	require.NoError(t, err)
@@ -158,19 +154,23 @@ func TestNewVault_CRUD(t *testing.T) {
 	ctx := t.Context()
 	txID := "tx1"
 
+	// Confirm clean state before writing
+	status, err := store.GetTxStatus(ctx, txID)
+	require.NoError(t, err)
+	require.Nil(t, status)
+
 	// Write status
 	err = store.SetStatuses(ctx, fabricdriver.Valid, "ok", txID)
 	require.NoError(t, err)
 
 	// Read status
-	status, err := store.GetTxStatus(ctx, txID)
+	status, err = store.GetTxStatus(ctx, txID)
 	require.NoError(t, err)
 	require.NotNil(t, status)
 	require.Equal(t, fabricdriver.Valid, status.Code)
 }
 
 func TestNewEndorseTx_MultipleInstances(t *testing.T) {
-	t.Parallel()
 	d := mem.NewDriver()
 
 	store1, err := d.NewEndorseTx(viewdriver.PersistenceName(t.Name()+"_1"), "alpha")


### PR DESCRIPTION
Running the memory driver tests in parallel caused intermittent database schema is locked errors because all tests shared the same file::memory:?cache=shared SQLite database and raced on CreateSchema().
Changes:

Removed t.Parallel() from DB tests; kept it on pure logic tests (opts, config, constructor)
Fixed hardcoded PersistenceName("test") → t.Name() in TestNewEndorseTx_CRUD
Fixed TestNewEndorseTx_MultipleInstances to pass distinct table params per store
Added pre-write existence check in TestNewVault_CRUD for consistency with other CRUD tests


closes #1469 