### PR TITLE
test: preserve fabricx sample wiring in coverage builds

### DIFF
--- a/integration/fabricx/deployment/sdk.go
+++ b/integration/fabricx/deployment/sdk.go
@@ -12,6 +12,9 @@ import (
 	common "github.com/hyperledger-labs/fabric-smart-client/platform/common/sdk/dig"
 	digutils "github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/dig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/state"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/finality"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/ledger"
 	fabricx "github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/sdk/dig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services"
 )
@@ -34,6 +37,9 @@ func (p *SDK) Install() error {
 	}
 
 	return errors.Join(
+		digutils.Register[*ledger.Provider](p.Container()),
+		digutils.Register[queryservice.Provider](p.Container()),
+		digutils.Register[finality.ListenerManagerProvider](p.Container()),
 		digutils.Register[state.VaultService](p.Container()),
 	)
 }

--- a/integration/fabricx/iou/sdk.go
+++ b/integration/fabricx/iou/sdk.go
@@ -12,6 +12,9 @@ import (
 	common "github.com/hyperledger-labs/fabric-smart-client/platform/common/sdk/dig"
 	digutils "github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/dig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/state"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/finality"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/ledger"
 	fabricx "github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/sdk/dig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services"
 )
@@ -34,6 +37,9 @@ func (p *SDK) Install() error {
 	}
 
 	return errors.Join(
+		digutils.Register[*ledger.Provider](p.Container()),
+		digutils.Register[queryservice.Provider](p.Container()),
+		digutils.Register[finality.ListenerManagerProvider](p.Container()),
 		digutils.Register[state.VaultService](p.Container()),
 	)
 }

--- a/integration/fabricx/multiendorsement/sdk.go
+++ b/integration/fabricx/multiendorsement/sdk.go
@@ -12,6 +12,9 @@ import (
 	common "github.com/hyperledger-labs/fabric-smart-client/platform/common/sdk/dig"
 	digutils "github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/dig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/state"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/finality"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/ledger"
 	fabricx "github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/sdk/dig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services"
 )
@@ -34,6 +37,9 @@ func (p *SDK) Install() error {
 	}
 
 	return errors.Join(
+		digutils.Register[*ledger.Provider](p.Container()),
+		digutils.Register[queryservice.Provider](p.Container()),
+		digutils.Register[finality.ListenerManagerProvider](p.Container()),
 		digutils.Register[state.VaultService](p.Container()),
 	)
 }

--- a/integration/fabricx/simple/sdk.go
+++ b/integration/fabricx/simple/sdk.go
@@ -12,6 +12,9 @@ import (
 	common "github.com/hyperledger-labs/fabric-smart-client/platform/common/sdk/dig"
 	digutils "github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/dig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/state"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/finality"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/ledger"
 	fabricx "github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/sdk/dig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services"
 )
@@ -34,6 +37,9 @@ func (p *SDK) Install() error {
 	}
 
 	return errors.Join(
+		digutils.Register[*ledger.Provider](p.Container()),
+		digutils.Register[queryservice.Provider](p.Container()),
+		digutils.Register[finality.ListenerManagerProvider](p.Container()),
 		digutils.Register[state.VaultService](p.Container()),
 	)
 }

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -104,7 +104,7 @@ outer:
 
 	// build with coverage profiling, more details: https://go.dev/doc/build-cover
 	if _, ok := os.LookupEnv("GOCOVERDIR"); ok {
-		params = append(params, "-cover")
+		params = append(params, "-cover", "-coverpkg=./...")
 	}
 
 	buildServer := common.NewBuildServer(params...)

--- a/platform/fabricx/sdk/dig/sdk.go
+++ b/platform/fabricx/sdk/dig/sdk.go
@@ -71,12 +71,7 @@ func (p *SDK) Install() error {
 		return err
 	}
 
-	// Backward compatibility with SP
-	return errors.Join(
-		digutils.Register[finality.ListenerManagerProvider](p.Container()),
-		digutils.Register[queryservice.Provider](p.Container()),
-		digutils.Register[*ledger.Provider](p.Container()),
-	)
+	return nil
 }
 
 func (p *SDK) Start(ctx context.Context) error {


### PR DESCRIPTION
## Summary
- preserve the legacy fabricx provider registrations in the integration sample SDKs while the shared fabricx SDK stops registering them centrally
- include `-coverpkg=./...` when coverage-enabled integration builds are used so shared packages are counted

## Testing
- go test ./platform/fabricx/sdk/dig -count=1

Fixes #1475
