### PR TITLE
test(comm): add unit tests for session package increasing coverage to 89%

### DIFF
--- a/platform/view/services/comm/session/bidi_test.go
+++ b/platform/view/services/comm/session/bidi_test.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
 func TestNewLocalBidirectionalChannel(t *testing.T) {

--- a/platform/view/services/comm/session/bidi_test.go
+++ b/platform/view/services/comm/session/bidi_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
@@ -29,14 +30,16 @@ func TestLocalBidirectionalChannel_SendReceive(t *testing.T) {
 	require.NoError(t, err)
 	payload := []byte("hello")
 	require.NoError(t, ch.LeftSession().Send(payload))
-	select {
-	case msg := <-ch.RightSession().Receive():
-		require.NotNil(t, msg)
-		require.Equal(t, payload, msg.Payload)
-		require.EqualValues(t, view.OK, msg.Status)
-	case <-time.After(time.Second):
-		t.Fatal("timeout waiting for message")
-	}
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		select {
+		case msg := <-ch.RightSession().Receive():
+			assert.NotNil(c, msg)
+			assert.Equal(c, payload, msg.Payload)
+			assert.EqualValues(c, view.OK, msg.Status)
+		default:
+			assert.Fail(c, "no message received yet")
+		}
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestLocalBidirectionalChannel_BidirectionalCommunication(t *testing.T) {
@@ -46,19 +49,23 @@ func TestLocalBidirectionalChannel_BidirectionalCommunication(t *testing.T) {
 	left := ch.LeftSession()
 	right := ch.RightSession()
 	require.NoError(t, left.Send([]byte("from left")))
-	select {
-	case msg := <-right.Receive():
-		require.Equal(t, []byte("from left"), msg.Payload)
-	case <-time.After(time.Second):
-		t.Fatal("timeout")
-	}
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		select {
+		case msg := <-right.Receive():
+			assert.Equal(c, []byte("from left"), msg.Payload)
+		default:
+			assert.Fail(c, "no message received yet")
+		}
+	}, time.Second, 10*time.Millisecond)
 	require.NoError(t, right.Send([]byte("from right")))
-	select {
-	case msg := <-left.Receive():
-		require.Equal(t, []byte("from right"), msg.Payload)
-	case <-time.After(time.Second):
-		t.Fatal("timeout")
-	}
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		select {
+		case msg := <-left.Receive():
+			assert.Equal(c, []byte("from right"), msg.Payload)
+		default:
+			assert.Fail(c, "no message received yet")
+		}
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestLocalBidirectionalChannel_SendError(t *testing.T) {
@@ -67,13 +74,15 @@ func TestLocalBidirectionalChannel_SendError(t *testing.T) {
 	require.NoError(t, err)
 	errPayload := []byte("something went wrong")
 	require.NoError(t, ch.LeftSession().SendError(errPayload))
-	select {
-	case msg := <-ch.RightSession().Receive():
-		require.EqualValues(t, view.ERROR, msg.Status)
-		require.Equal(t, errPayload, msg.Payload)
-	case <-time.After(time.Second):
-		t.Fatal("timeout")
-	}
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		select {
+		case msg := <-ch.RightSession().Receive():
+			assert.EqualValues(c, view.ERROR, msg.Status)
+			assert.Equal(c, errPayload, msg.Payload)
+		default:
+			assert.Fail(c, "no message received yet")
+		}
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestLocalBidirectionalChannel_CloseReceive(t *testing.T) {
@@ -124,20 +133,22 @@ func TestLocalBidirectionalChannel_SendWithContext(t *testing.T) {
 	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
 	require.NoError(t, err)
 	payload := []byte("with context")
-	require.NoError(t, ch.LeftSession().SendWithContext(context.Background(), payload))
-	select {
-	case msg := <-ch.RightSession().Receive():
-		require.Equal(t, payload, msg.Payload)
-	case <-time.After(time.Second):
-		t.Fatal("timeout")
-	}
+	require.NoError(t, ch.LeftSession().SendWithContext(t.Context(), payload))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		select {
+		case msg := <-ch.RightSession().Receive():
+			assert.Equal(c, payload, msg.Payload)
+		default:
+			assert.Fail(c, "no message received yet")
+		}
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestLocalBidirectionalChannel_SendWithCancelledContext(t *testing.T) {
 	t.Parallel()
 	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
 	require.NoError(t, err)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	err = ch.LeftSession().SendWithContext(ctx, []byte("data"))
 	require.Error(t, err)

--- a/platform/view/services/comm/session/bidi_test.go
+++ b/platform/view/services/comm/session/bidi_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewLocalBidirectionalChannel(t *testing.T) {
+	t.Parallel()
+	ch, err := NewLocalBidirectionalChannel("caller", "contextID", "endpoint", []byte("pkid"))
+	require.NoError(t, err)
+	require.NotNil(t, ch)
+	require.NotNil(t, ch.LeftSession())
+	require.NotNil(t, ch.RightSession())
+}
+
+func TestLocalBidirectionalChannel_SendReceive(t *testing.T) {
+	t.Parallel()
+	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
+	require.NoError(t, err)
+	payload := []byte("hello")
+	require.NoError(t, ch.LeftSession().Send(payload))
+	select {
+	case msg := <-ch.RightSession().Receive():
+		require.NotNil(t, msg)
+		require.Equal(t, payload, msg.Payload)
+		require.EqualValues(t, view.OK, msg.Status)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for message")
+	}
+}
+
+func TestLocalBidirectionalChannel_BidirectionalCommunication(t *testing.T) {
+	t.Parallel()
+	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
+	require.NoError(t, err)
+	left := ch.LeftSession()
+	right := ch.RightSession()
+	require.NoError(t, left.Send([]byte("from left")))
+	select {
+	case msg := <-right.Receive():
+		require.Equal(t, []byte("from left"), msg.Payload)
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+	require.NoError(t, right.Send([]byte("from right")))
+	select {
+	case msg := <-left.Receive():
+		require.Equal(t, []byte("from right"), msg.Payload)
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestLocalBidirectionalChannel_SendError(t *testing.T) {
+	t.Parallel()
+	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
+	require.NoError(t, err)
+	errPayload := []byte("something went wrong")
+	require.NoError(t, ch.LeftSession().SendError(errPayload))
+	select {
+	case msg := <-ch.RightSession().Receive():
+		require.EqualValues(t, view.ERROR, msg.Status)
+		require.Equal(t, errPayload, msg.Payload)
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestLocalBidirectionalChannel_CloseReceive(t *testing.T) {
+	t.Parallel()
+	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
+	require.NoError(t, err)
+	left := ch.LeftSession()
+	left.Close()
+	require.Nil(t, left.Receive())
+}
+
+func TestLocalBidirectionalChannel_SendAfterClose(t *testing.T) {
+	t.Parallel()
+	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
+	require.NoError(t, err)
+	left := ch.LeftSession()
+	left.Close()
+	err = left.Send([]byte("data"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "session is closed")
+}
+
+func TestLocalBidirectionalChannel_SendErrorAfterClose(t *testing.T) {
+	t.Parallel()
+	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
+	require.NoError(t, err)
+	left := ch.LeftSession()
+	left.Close()
+	err = left.SendError([]byte("data"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "session is closed")
+}
+
+func TestLocalBidirectionalChannel_Info(t *testing.T) {
+	t.Parallel()
+	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", []byte("pkid"))
+	require.NoError(t, err)
+	left := ch.LeftSession()
+	info := left.Info()
+	require.False(t, info.Closed)
+	require.Equal(t, "endpoint", info.Endpoint)
+	left.Close()
+	require.True(t, left.Info().Closed)
+}
+
+func TestLocalBidirectionalChannel_SendWithContext(t *testing.T) {
+	t.Parallel()
+	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
+	require.NoError(t, err)
+	payload := []byte("with context")
+	require.NoError(t, ch.LeftSession().SendWithContext(context.Background(), payload))
+	select {
+	case msg := <-ch.RightSession().Receive():
+		require.Equal(t, payload, msg.Payload)
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestLocalBidirectionalChannel_SendWithCancelledContext(t *testing.T) {
+	t.Parallel()
+	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = ch.LeftSession().SendWithContext(ctx, []byte("data"))
+	require.Error(t, err)
+}

--- a/platform/view/services/comm/session/json_test.go
+++ b/platform/view/services/comm/session/json_test.go
@@ -9,14 +9,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
-func newTestJSONSession(ch chan *view.Message) *jsonSession {
+func newTestJSONSession(t *testing.T, ch chan *view.Message) *jsonSession {
+	t.Helper()
 	s := &mockSession{ch: ch}
-	return newJSONSession(s, context.Background())
+	return newJSONSession(s, t.Context())
 }
 
 func TestJSONSession_ReceiveSuccess(t *testing.T) {
@@ -25,7 +27,7 @@ func TestJSONSession_ReceiveSuccess(t *testing.T) {
 	type payload struct{ Name string }
 	data := `{"Name":"test"}`
 	ch <- &view.Message{Payload: []byte(data), Status: view.OK}
-	js := newTestJSONSession(ch)
+	js := newTestJSONSession(t, ch)
 	var result payload
 	require.NoError(t, js.Receive(&result))
 	require.Equal(t, "test", result.Name)
@@ -34,7 +36,7 @@ func TestJSONSession_ReceiveSuccess(t *testing.T) {
 func TestJSONSession_ReceiveTimeout(t *testing.T) {
 	t.Parallel()
 	ch := make(chan *view.Message)
-	js := newTestJSONSession(ch)
+	js := newTestJSONSession(t, ch)
 	err := js.ReceiveWithTimeout(nil, 50*time.Millisecond)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "time out reached")
@@ -44,7 +46,7 @@ func TestJSONSession_ReceiveErrorMessage(t *testing.T) {
 	t.Parallel()
 	ch := make(chan *view.Message, 1)
 	ch <- &view.Message{Payload: []byte("remote error"), Status: view.ERROR}
-	js := newTestJSONSession(ch)
+	js := newTestJSONSession(t, ch)
 	var result interface{}
 	err := js.Receive(&result)
 	require.Error(t, err)
@@ -55,7 +57,7 @@ func TestJSONSession_ReceiveNilMessage(t *testing.T) {
 	t.Parallel()
 	ch := make(chan *view.Message, 1)
 	ch <- nil
-	js := newTestJSONSession(ch)
+	js := newTestJSONSession(t, ch)
 	var result interface{}
 	err := js.Receive(&result)
 	require.Error(t, err)
@@ -66,7 +68,7 @@ func TestJSONSession_ReceiveInvalidJSON(t *testing.T) {
 	t.Parallel()
 	ch := make(chan *view.Message, 1)
 	ch <- &view.Message{Payload: []byte("not-json"), Status: view.OK}
-	js := newTestJSONSession(ch)
+	js := newTestJSONSession(t, ch)
 	var result map[string]string
 	err := js.Receive(&result)
 	require.Error(t, err)
@@ -77,51 +79,57 @@ func TestJSONSession_Send(t *testing.T) {
 	t.Parallel()
 	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
 	require.NoError(t, err)
-	js := newJSONSession(ch.LeftSession(), context.Background())
+	js := newJSONSession(ch.LeftSession(), t.Context())
 	type payload struct{ Name string }
 	require.NoError(t, js.Send(payload{Name: "hello"}))
-	select {
-	case msg := <-ch.RightSession().Receive():
-		require.Contains(t, string(msg.Payload), "hello")
-	case <-time.After(time.Second):
-		t.Fatal("timeout")
-	}
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		select {
+		case msg := <-ch.RightSession().Receive():
+			assert.Contains(c, string(msg.Payload), "hello")
+		default:
+			assert.Fail(c, "no message received yet")
+		}
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestJSONSession_SendError(t *testing.T) {
 	t.Parallel()
 	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
 	require.NoError(t, err)
-	js := newJSONSession(ch.LeftSession(), context.Background())
+	js := newJSONSession(ch.LeftSession(), t.Context())
 	require.NoError(t, js.SendError("something failed"))
-	select {
-	case msg := <-ch.RightSession().Receive():
-		require.EqualValues(t, view.ERROR, msg.Status)
-	case <-time.After(time.Second):
-		t.Fatal("timeout")
-	}
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		select {
+		case msg := <-ch.RightSession().Receive():
+			assert.EqualValues(c, view.ERROR, msg.Status)
+		default:
+			assert.Fail(c, "no message received yet")
+		}
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestJSONSession_SendRaw(t *testing.T) {
 	t.Parallel()
 	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
 	require.NoError(t, err)
-	js := newJSONSession(ch.LeftSession(), context.Background())
+	js := newJSONSession(ch.LeftSession(), t.Context())
 	raw := []byte("raw bytes")
-	require.NoError(t, js.SendRaw(context.Background(), raw))
-	select {
-	case msg := <-ch.RightSession().Receive():
-		require.Equal(t, raw, msg.Payload)
-	case <-time.After(time.Second):
-		t.Fatal("timeout")
-	}
+	require.NoError(t, js.SendRaw(t.Context(), raw))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		select {
+		case msg := <-ch.RightSession().Receive():
+			assert.Equal(c, raw, msg.Payload)
+		default:
+			assert.Fail(c, "no message received yet")
+		}
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestJSONSession_Info(t *testing.T) {
 	t.Parallel()
 	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", []byte("pkid"))
 	require.NoError(t, err)
-	js := newJSONSession(ch.LeftSession(), context.Background())
+	js := newJSONSession(ch.LeftSession(), t.Context())
 	info := js.Info()
 	require.Equal(t, "endpoint", info.Endpoint)
 }
@@ -131,14 +139,14 @@ func TestJSONSession_Session(t *testing.T) {
 	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
 	require.NoError(t, err)
 	left := ch.LeftSession()
-	js := newJSONSession(left, context.Background())
+	js := newJSONSession(left, t.Context())
 	require.Equal(t, left, js.Session())
 }
 
 func TestJSONSession_ContextCancelled(t *testing.T) {
 	t.Parallel()
 	ch := make(chan *view.Message)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	js := newJSONSession(&mockSession{ch: ch}, ctx)
 	cancel()
 	var result interface{}
@@ -150,7 +158,7 @@ func TestJSONSession_ReceiveRaw(t *testing.T) {
 	t.Parallel()
 	ch := make(chan *view.Message, 1)
 	ch <- &view.Message{Payload: []byte("raw"), Status: view.OK}
-	js := newTestJSONSession(ch)
+	js := newTestJSONSession(t, ch)
 	raw, err := js.ReceiveRaw()
 	require.NoError(t, err)
 	require.Equal(t, []byte("raw"), raw)

--- a/platform/view/services/comm/session/json_test.go
+++ b/platform/view/services/comm/session/json_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/stretchr/testify/require"
 )
 
 func newTestJSONSession(ch chan *view.Message) *jsonSession {

--- a/platform/view/services/comm/session/json_test.go
+++ b/platform/view/services/comm/session/json_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+package session
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
+
+func newTestJSONSession(ch chan *view.Message) *jsonSession {
+	s := &mockSession{ch: ch}
+	return newJSONSession(s, context.Background())
+}
+
+func TestJSONSession_ReceiveSuccess(t *testing.T) {
+	t.Parallel()
+	ch := make(chan *view.Message, 1)
+	type payload struct{ Name string }
+	data := `{"Name":"test"}`
+	ch <- &view.Message{Payload: []byte(data), Status: view.OK}
+	js := newTestJSONSession(ch)
+	var result payload
+	require.NoError(t, js.Receive(&result))
+	require.Equal(t, "test", result.Name)
+}
+
+func TestJSONSession_ReceiveTimeout(t *testing.T) {
+	t.Parallel()
+	ch := make(chan *view.Message)
+	js := newTestJSONSession(ch)
+	err := js.ReceiveWithTimeout(nil, 50*time.Millisecond)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "time out reached")
+}
+
+func TestJSONSession_ReceiveErrorMessage(t *testing.T) {
+	t.Parallel()
+	ch := make(chan *view.Message, 1)
+	ch <- &view.Message{Payload: []byte("remote error"), Status: view.ERROR}
+	js := newTestJSONSession(ch)
+	var result interface{}
+	err := js.Receive(&result)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "received error from remote")
+}
+
+func TestJSONSession_ReceiveNilMessage(t *testing.T) {
+	t.Parallel()
+	ch := make(chan *view.Message, 1)
+	ch <- nil
+	js := newTestJSONSession(ch)
+	var result interface{}
+	err := js.Receive(&result)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "received message is nil")
+}
+
+func TestJSONSession_ReceiveInvalidJSON(t *testing.T) {
+	t.Parallel()
+	ch := make(chan *view.Message, 1)
+	ch <- &view.Message{Payload: []byte("not-json"), Status: view.OK}
+	js := newTestJSONSession(ch)
+	var result map[string]string
+	err := js.Receive(&result)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed unmarshalling state")
+}
+
+func TestJSONSession_Send(t *testing.T) {
+	t.Parallel()
+	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
+	require.NoError(t, err)
+	js := newJSONSession(ch.LeftSession(), context.Background())
+	type payload struct{ Name string }
+	require.NoError(t, js.Send(payload{Name: "hello"}))
+	select {
+	case msg := <-ch.RightSession().Receive():
+		require.Contains(t, string(msg.Payload), "hello")
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestJSONSession_SendError(t *testing.T) {
+	t.Parallel()
+	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
+	require.NoError(t, err)
+	js := newJSONSession(ch.LeftSession(), context.Background())
+	require.NoError(t, js.SendError("something failed"))
+	select {
+	case msg := <-ch.RightSession().Receive():
+		require.EqualValues(t, view.ERROR, msg.Status)
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestJSONSession_SendRaw(t *testing.T) {
+	t.Parallel()
+	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
+	require.NoError(t, err)
+	js := newJSONSession(ch.LeftSession(), context.Background())
+	raw := []byte("raw bytes")
+	require.NoError(t, js.SendRaw(context.Background(), raw))
+	select {
+	case msg := <-ch.RightSession().Receive():
+		require.Equal(t, raw, msg.Payload)
+	case <-time.After(time.Second):
+		t.Fatal("timeout")
+	}
+}
+
+func TestJSONSession_Info(t *testing.T) {
+	t.Parallel()
+	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", []byte("pkid"))
+	require.NoError(t, err)
+	js := newJSONSession(ch.LeftSession(), context.Background())
+	info := js.Info()
+	require.Equal(t, "endpoint", info.Endpoint)
+}
+
+func TestJSONSession_Session(t *testing.T) {
+	t.Parallel()
+	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
+	require.NoError(t, err)
+	left := ch.LeftSession()
+	js := newJSONSession(left, context.Background())
+	require.Equal(t, left, js.Session())
+}
+
+func TestJSONSession_ContextCancelled(t *testing.T) {
+	t.Parallel()
+	ch := make(chan *view.Message)
+	ctx, cancel := context.WithCancel(context.Background())
+	js := newJSONSession(&mockSession{ch: ch}, ctx)
+	cancel()
+	var result interface{}
+	err := js.ReceiveWithTimeout(&result, time.Second)
+	require.Error(t, err)
+}
+
+func TestJSONSession_ReceiveRaw(t *testing.T) {
+	t.Parallel()
+	ch := make(chan *view.Message, 1)
+	ch <- &view.Message{Payload: []byte("raw"), Status: view.OK}
+	js := newTestJSONSession(ch)
+	raw, err := js.ReceiveRaw()
+	require.NoError(t, err)
+	require.Equal(t, []byte("raw"), raw)
+}
+
+func TestNewFromSession(t *testing.T) {
+	t.Parallel()
+	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
+	require.NoError(t, err)
+	msgCh := make(chan *view.Message, 1)
+	ctx := &mockContext{s: &mockSession{ch: msgCh}}
+	js := NewFromSession(ctx, ch.LeftSession())
+	require.NotNil(t, js)
+}
+
+func TestJSON(t *testing.T) {
+	t.Parallel()
+	msgCh := make(chan *view.Message, 1)
+	ctx := &mockContext{s: &mockSession{ch: msgCh}}
+	js := JSON(ctx)
+	require.NotNil(t, js)
+}

--- a/platform/view/services/comm/session/json_test.go
+++ b/platform/view/services/comm/session/json_test.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
 func newTestJSONSession(ch chan *view.Message) *jsonSession {

--- a/platform/view/services/comm/session/random_test.go
+++ b/platform/view/services/comm/session/random_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetRandomBytes(t *testing.T) {
+	t.Parallel()
+	b, err := GetRandomBytes(32)
+	require.NoError(t, err)
+	require.Len(t, b, 32)
+}
+
+func TestGetRandomBytesUniqueness(t *testing.T) {
+	t.Parallel()
+	b1, err := GetRandomBytes(24)
+	require.NoError(t, err)
+	b2, err := GetRandomBytes(24)
+	require.NoError(t, err)
+	require.NotEqual(t, b1, b2)
+}
+
+func TestGetRandomNonce(t *testing.T) {
+	t.Parallel()
+	nonce, err := GetRandomNonce()
+	require.NoError(t, err)
+	require.Len(t, nonce, NonceSize)
+}
+
+func TestGetRandomNonceUniqueness(t *testing.T) {
+	t.Parallel()
+	n1, err := GetRandomNonce()
+	require.NoError(t, err)
+	n2, err := GetRandomNonce()
+	require.NoError(t, err)
+	require.NotEqual(t, n1, n2)
+}
+
+func TestGetRandomBytesZeroLen(t *testing.T) {
+	t.Parallel()
+	b, err := GetRandomBytes(0)
+	require.NoError(t, err)
+	require.Len(t, b, 0)
+}

--- a/platform/view/services/comm/session/support_test.go
+++ b/platform/view/services/comm/session/support_test.go
@@ -99,3 +99,114 @@ func TestReadFirstMessageOrPanicClosedChannel(t *testing.T) {
 		_ = ReadFirstMessageOrPanic(ctx)
 	})
 }
+
+func TestReadMessageWithTimeoutSuccess(t *testing.T) {
+	t.Parallel()
+	ch := make(chan *view.Message, 1)
+	ch <- &view.Message{Payload: []byte("hello"), Status: view.OK}
+	payload, err := ReadMessageWithTimeout(&mockSession{ch: ch}, time.Second)
+	require.NoError(t, err)
+	require.Equal(t, []byte("hello"), payload)
+}
+
+func TestReadMessageWithTimeoutError(t *testing.T) {
+	t.Parallel()
+	ch := make(chan *view.Message, 1)
+	ch <- &view.Message{Payload: []byte("err"), Status: view.ERROR}
+	_, err := ReadMessageWithTimeout(&mockSession{ch: ch}, time.Second)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "received error from remote")
+}
+
+func TestReadMessageWithTimeoutNilMessage(t *testing.T) {
+	t.Parallel()
+	ch := make(chan *view.Message, 1)
+	ch <- nil
+	_, err := ReadMessageWithTimeout(&mockSession{ch: ch}, time.Second)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "received message is nil")
+}
+
+func TestReadMessageWithTimeoutExpired(t *testing.T) {
+	t.Parallel()
+	ch := make(chan *view.Message)
+	_, err := ReadMessageWithTimeout(&mockSession{ch: ch}, 50*time.Millisecond)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "time out reached")
+}
+
+func TestReadFirstMessageSuccess(t *testing.T) {
+	t.Parallel()
+	ch := make(chan *view.Message, 1)
+	ch <- &view.Message{Payload: []byte("first"), Status: view.OK}
+	ctx := &mockContext{s: &mockSession{ch: ch}}
+	session, payload, err := ReadFirstMessage(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	require.Equal(t, []byte("first"), payload)
+}
+
+func TestReadFirstMessageErrorMessage(t *testing.T) {
+	t.Parallel()
+	ch := make(chan *view.Message, 1)
+	ch <- &view.Message{Payload: []byte("remote err"), Status: view.ERROR}
+	ctx := &mockContext{s: &mockSession{ch: ch}}
+	_, _, err := ReadFirstMessage(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "received error from remote")
+}
+
+func TestReadFirstMessageNilMessage(t *testing.T) {
+	t.Parallel()
+	ch := make(chan *view.Message, 1)
+	ch <- nil
+	ctx := &mockContext{s: &mockSession{ch: ch}}
+	_, _, err := ReadFirstMessage(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "received message is nil")
+}
+
+func TestReadFirstMessageOrPanicSuccess(t *testing.T) {
+	t.Parallel()
+	ch := make(chan *view.Message, 1)
+	ch <- &view.Message{Payload: []byte("panic-test"), Status: view.OK}
+	ctx := &mockContext{s: &mockSession{ch: ch}}
+	payload := ReadFirstMessageOrPanic(ctx)
+	require.Equal(t, []byte("panic-test"), payload)
+}
+
+func TestReadFirstMessageOrPanicNilMessage(t *testing.T) {
+	t.Parallel()
+	ch := make(chan *view.Message, 1)
+	ch <- nil
+	ctx := &mockContext{s: &mockSession{ch: ch}}
+	require.PanicsWithValue(t, "received message is nil", func() {
+		ReadFirstMessageOrPanic(ctx)
+	})
+}
+
+func TestReadFirstMessageOrPanicErrorMessage(t *testing.T) {
+	t.Parallel()
+	ch := make(chan *view.Message, 1)
+	ch <- &view.Message{Payload: []byte("err"), Status: view.ERROR}
+	ctx := &mockContext{s: &mockSession{ch: ch}}
+	require.Panics(t, func() {
+		ReadFirstMessageOrPanic(ctx)
+	})
+}
+
+func TestReadFirstMessageNilChannel(t *testing.T) {
+	t.Parallel()
+	ctx := &mockContext{s: &mockSession{ch: nil}}
+	_, _, err := ReadFirstMessage(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "session receive channel is nil")
+}
+
+func TestReadFirstMessageOrPanicNilChannel(t *testing.T) {
+	t.Parallel()
+	ctx := &mockContext{s: &mockSession{ch: nil}}
+	require.PanicsWithValue(t, "session receive channel is nil", func() {
+		ReadFirstMessageOrPanic(ctx)
+	})
+}


### PR DESCRIPTION
Closes #1420

Adds unit tests for platform/view/services/comm/session increasing coverage from 19.4% to 89.2%.
Tests cover:
-> bidi.go: NewLocalBidirectionalChannel, send/receive, error handling, close behavior, context cancellation
-> json.go: ReceiveRaw, NewFromSession, JSON, receive success/error/timeout/nil/invalid JSON, send, send error, context cancellation
-> random.go: GetRandomBytes, GetRandomNonce, uniqueness
-> support.go: ReadMessageWithTimeout, ReadFirstMessage, ReadFirstMessageOrPanic — success, error, nil, timeout, panic cases

Verified with -count=3 -race, no failures or race conditions.