### PR TITLE
Improve core.yaml validation errors for missing FSC settings

### DIFF
--- a/cmd/fsccli/validate/config.go
+++ b/cmd/fsccli/validate/config.go
@@ -14,7 +14,10 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	fabriccore "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/sdk/dig"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/comm"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/config"
+	identity "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/id"
+	filekms "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/id/kms/driver/file"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/tracing"
 	webserver "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/web/server"
 )
@@ -48,6 +51,22 @@ func ValidateConfig(confPath string) (Report, error) {
 	configService, err := config.NewProvider(confPath)
 	if err != nil {
 		return report, errors.Wrap(err, "invalid configuration path")
+	}
+	if err := validateNodeIdentity(configService); err != nil {
+		return report, err
+	}
+	report.Checks = append(report.Checks, "validated FSC node identity configuration")
+
+	if err := validateP2PConfig(configService); err != nil {
+		return report, err
+	}
+	report.Checks = append(report.Checks, "validated fsc.p2p configuration")
+
+	if err := validateResolvers(configService); err != nil {
+		return report, err
+	}
+	if configService.IsSet("fsc.endpoint.resolvers") {
+		report.Checks = append(report.Checks, "validated fsc.endpoint resolvers")
 	}
 
 	if configService.IsSet("fabric") {
@@ -126,4 +145,63 @@ func translatePaths(configService *config.Provider, paths []string) []string {
 		translated = append(translated, configService.TranslatePath(path))
 	}
 	return translated
+}
+
+type resolverConfig struct {
+	Identity struct {
+		Path string `yaml:"path"`
+	} `yaml:"identity"`
+}
+
+func validateNodeIdentity(configService *config.Provider) error {
+	if configService.GetString("fsc.id") == "" {
+		return errors.New("invalid fsc configuration: missing id")
+	}
+
+	identityType := configService.GetString("fsc.identity.type")
+	if identityType != "" && identityType != "file" {
+		return errors.Errorf("invalid fsc.identity configuration: unsupported type [%s]", identityType)
+	}
+
+	if _, _, _, err := (&filekms.Driver{}).Load(configService); err != nil {
+		return errors.Wrap(err, "invalid fsc.identity configuration")
+	}
+
+	return nil
+}
+
+func validateP2PConfig(configService *config.Provider) error {
+	listenAddress := configService.GetString("fsc.p2p.listenAddress")
+	if listenAddress == "" {
+		return errors.New("invalid fsc.p2p configuration: missing listenAddress")
+	}
+
+	if _, err := comm.ConvertAddress(listenAddress); err != nil {
+		return errors.Wrap(err, "invalid fsc.p2p configuration")
+	}
+
+	return nil
+}
+
+func validateResolvers(configService *config.Provider) error {
+	if !configService.IsSet("fsc.endpoint.resolvers") {
+		return nil
+	}
+
+	var resolvers []resolverConfig
+	if err := configService.UnmarshalKey("fsc.endpoint.resolvers", &resolvers); err != nil {
+		return errors.Wrap(err, "invalid fsc.endpoint resolvers configuration")
+	}
+
+	for i, resolver := range resolvers {
+		if resolver.Identity.Path == "" {
+			return errors.Errorf("invalid fsc.endpoint.resolvers[%d].identity.path: missing path", i)
+		}
+
+		if _, err := identity.LoadIdentity(configService.TranslatePath(resolver.Identity.Path)); err != nil {
+			return errors.Wrapf(err, "invalid fsc.endpoint.resolvers[%d].identity.path", i)
+		}
+	}
+
+	return nil
 }

--- a/cmd/fsccli/validate/config_test.go
+++ b/cmd/fsccli/validate/config_test.go
@@ -25,9 +25,48 @@ func TestValidateConfig_Success(t *testing.T) {
 	report, err := ValidateConfig(confPath)
 	require.NoError(t, err)
 	require.Contains(t, report.String(), "configuration is valid")
+	require.Contains(t, report.String(), "validated FSC node identity configuration")
+	require.Contains(t, report.String(), "validated fsc.p2p configuration")
 	require.Contains(t, report.String(), "validated fsc.grpc server configuration")
 	require.Contains(t, report.String(), "validated fsc.web server configuration")
 	require.Contains(t, report.String(), "validated fabric networks [default]")
+}
+
+func TestValidateConfig_MissingNodeID(t *testing.T) {
+	t.Parallel()
+
+	confPath := t.TempDir()
+	raw := strings.Replace(validConfigYAML(t), "  id: node1\n", "", 1)
+	require.NoError(t, os.WriteFile(filepath.Join(confPath, "core.yaml"), []byte(raw), 0o600))
+
+	_, err := ValidateConfig(confPath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid fsc configuration: missing id")
+}
+
+func TestValidateConfig_MissingP2PListenAddress(t *testing.T) {
+	t.Parallel()
+
+	confPath := t.TempDir()
+	raw := strings.Replace(validConfigYAML(t), "  p2p:\n    listenAddress: /ip4/127.0.0.1/tcp/7001\n", "", 1)
+	require.NoError(t, os.WriteFile(filepath.Join(confPath, "core.yaml"), []byte(raw), 0o600))
+
+	_, err := ValidateConfig(confPath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid fsc.p2p configuration: missing listenAddress")
+}
+
+func TestValidateConfig_MissingIdentityKeyPath(t *testing.T) {
+	t.Parallel()
+
+	confPath := t.TempDir()
+	raw := strings.Replace(validConfigYAML(t), "      file: "+repoPath(t, "integration", "fsc", "pingpong", "testdata", "fsc", "crypto", "peerOrganizations", "fsc.example.com", "peers", "initiator.fsc.example.com", "msp", "keystore", "priv_sk")+"\n", "", 1)
+	require.NoError(t, os.WriteFile(filepath.Join(confPath, "core.yaml"), []byte(raw), 0o600))
+
+	_, err := ValidateConfig(confPath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid fsc.identity configuration")
+	require.Contains(t, err.Error(), "failed reading FSC node identity key")
 }
 
 func TestValidateConfig_MissingGRPCAddress(t *testing.T) {
@@ -61,10 +100,19 @@ func validConfigYAML(t *testing.T) string {
 	cert := repoPath(t, "integration", "fsc", "pingpong", "testdata", "fsc", "crypto", "peerOrganizations", "fsc.example.com", "peers", "initiator.fsc.example.com", "tls", "server.crt")
 	key := repoPath(t, "integration", "fsc", "pingpong", "testdata", "fsc", "crypto", "peerOrganizations", "fsc.example.com", "peers", "initiator.fsc.example.com", "tls", "server.key")
 	ca := repoPath(t, "integration", "fsc", "pingpong", "testdata", "fsc", "crypto", "peerOrganizations", "fsc.example.com", "peers", "initiator.fsc.example.com", "tls", "ca.crt")
+	identityCert := repoPath(t, "integration", "fsc", "pingpong", "testdata", "fsc", "crypto", "peerOrganizations", "fsc.example.com", "peers", "initiator.fsc.example.com", "msp", "signcerts", "initiator.fsc.example.com-cert.pem")
+	identityKey := repoPath(t, "integration", "fsc", "pingpong", "testdata", "fsc", "crypto", "peerOrganizations", "fsc.example.com", "peers", "initiator.fsc.example.com", "msp", "keystore", "priv_sk")
 
 	return "" +
 		"fsc:\n" +
 		"  id: node1\n" +
+		"  identity:\n" +
+		"    cert:\n" +
+		"      file: " + identityCert + "\n" +
+		"    key:\n" +
+		"      file: " + identityKey + "\n" +
+		"  p2p:\n" +
+		"    listenAddress: /ip4/127.0.0.1/tcp/7001\n" +
 		"  grpc:\n" +
 		"    enabled: true\n" +
 		"    address: 127.0.0.1:7051\n" +

--- a/platform/view/services/id/kms/driver/file/driver.go
+++ b/platform/view/services/id/kms/driver/file/driver.go
@@ -25,13 +25,15 @@ func NewDriver() driver.NamedDriver {
 type Driver struct{}
 
 func (d *Driver) Load(configProvider driver.ConfigProvider) (view.Identity, driver.Signer, driver.Verifier, error) {
-	idPEM, err := os.ReadFile(configProvider.GetPath("fsc.identity.cert.file"))
+	certPath := configProvider.GetPath("fsc.identity.cert.file")
+	idPEM, err := os.ReadFile(certPath)
 	if err != nil {
-		return nil, nil, nil, errors.Wrapf(err, "failed loading SFC Node Identity")
+		return nil, nil, nil, errors.Wrapf(err, "failed loading FSC node identity from [%s]", certPath)
 	}
-	fileCont, err := os.ReadFile(configProvider.GetPath("fsc.identity.key.file"))
+	keyPath := configProvider.GetPath("fsc.identity.key.file")
+	fileCont, err := os.ReadFile(keyPath)
 	if err != nil {
-		return nil, nil, nil, errors.Wrapf(err, "failed reading file [%s]", fileCont)
+		return nil, nil, nil, errors.Wrapf(err, "failed reading FSC node identity key from [%s]", keyPath)
 	}
 	id, verifier, err := ecdsa.NewIdentityFromPEMCert(idPEM)
 	if err != nil {


### PR DESCRIPTION
## Summary

- validate required FSC identity settings before startup
- validate the required p2p listen address and resolver identity paths
- improve the missing identity key/cert error messages surfaced from config loading

## Why

Issue #410 calls out missing or incorrectly specified core.yaml entries leading to cryptic runtime failures. This change makes the validation command catch common required-field problems earlier and returns clearer errors when identity files are missing or misconfigured.

Fixes #410

## Testing

- go test ./cmd/fsccli/validate/...
