### PR TITLE
test: add unit coverage for view services id

### DIFF
--- a/platform/view/services/id/identity_test.go
+++ b/platform/view/services/id/identity_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package id
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing file returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := readFile(filepath.Join(t.TempDir(), "missing.pem"))
+		require.ErrorContains(t, err, "could not read file")
+	})
+}
+
+func TestReadPemFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid content returns error", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "notpem.txt")
+		err := os.WriteFile(path, []byte("not pem"), 0o600)
+		require.NoError(t, err)
+
+		_, readErr := readPemFile(path)
+		require.ErrorContains(t, readErr, "no pem content")
+	})
+}
+
+func TestGetCertFromPem(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil input returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := getCertFromPem(nil)
+		require.ErrorContains(t, err, "nil idBytes")
+	})
+
+	t.Run("invalid pem bytes returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := getCertFromPem([]byte("bad pem bytes"))
+		require.ErrorContains(t, err, "could not decode pem bytes")
+	})
+
+	t.Run("non certificate pem returns parse error", func(t *testing.T) {
+		t.Parallel()
+		raw, err := os.ReadFile(filepath.Join("testdata", "default", "keystore", "priv_sk"))
+		require.NoError(t, err)
+
+		_, certErr := getCertFromPem(raw)
+		require.ErrorContains(t, certErr, "failed to parse x509 cert")
+	})
+}
+
+func TestLoadIdentityFailurePaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing file", func(t *testing.T) {
+		t.Parallel()
+		_, err := LoadIdentity(filepath.Join(t.TempDir(), "missing.pem"))
+		require.Error(t, err)
+	})
+
+	t.Run("invalid pem", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "bad.pem")
+		err := os.WriteFile(path, []byte("bad"), 0o600)
+		require.NoError(t, err)
+
+		_, loadErr := LoadIdentity(path)
+		require.ErrorContains(t, loadErr, "no pem content")
+	})
+}

--- a/platform/view/services/id/provider_test.go
+++ b/platform/view/services/id/provider_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package id_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,7 +16,31 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/id/kms"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/id/kms/driver/file"
 	mock2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/id/mock"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
+
+type fakeEndpointService struct {
+	identity view.Identity
+	err      error
+	label    string
+}
+
+func (f *fakeEndpointService) GetIdentity(label string, _ []byte) (view.Identity, error) {
+	f.label = label
+	return f.identity, f.err
+}
+
+type fakeServiceProvider struct {
+	service any
+	err     error
+}
+
+func (f *fakeServiceProvider) GetService(any) (any, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.service, nil
+}
 
 func TestLoad(t *testing.T) {
 	t.Parallel()
@@ -39,4 +64,92 @@ func TestLoad(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, idProvider.Clients(), 1)
 	require.Equal(t, raw, []byte(idProvider.Clients()[0]))
+	require.Len(t, idProvider.Admins(), 0)
+}
+
+func TestNewProviderFailurePaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default identity load fails", func(t *testing.T) {
+		t.Parallel()
+		cp := &mock2.ConfigProvider{}
+		cp.GetPathReturnsOnCall(0, "./testdata/default/signcerts/missing.pem")
+		cp.GetPathReturnsOnCall(1, "./testdata/default/keystore/priv_sk")
+		cp.GetStringSliceReturns([]string{})
+		sigService := &mock2.SigService{}
+
+		_, err := id2.NewProvider(cp, sigService, nil, &kms.KMS{Driver: &file.Driver{}})
+		require.ErrorContains(t, err, "failed loading identities")
+		require.ErrorContains(t, err, "failed loading default identity")
+	})
+
+	t.Run("register signer fails", func(t *testing.T) {
+		t.Parallel()
+		cp := &mock2.ConfigProvider{}
+		cp.GetPathReturnsOnCall(0, "./testdata/default/signcerts/default.pem")
+		cp.GetPathReturnsOnCall(1, "./testdata/default/keystore/priv_sk")
+		cp.GetStringSliceReturns([]string{})
+		sigService := &mock2.SigService{}
+		sigService.RegisterSignerReturns(errors.New("register-failed"))
+
+		_, err := id2.NewProvider(cp, sigService, nil, &kms.KMS{Driver: &file.Driver{}})
+		require.ErrorContains(t, err, "failed loading identities")
+		require.ErrorContains(t, err, "failed registering default identity signer")
+	})
+}
+
+func TestProviderIdentity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		cp := &mock2.ConfigProvider{}
+		cp.GetPathReturnsOnCall(0, "./testdata/default/signcerts/default.pem")
+		cp.GetPathReturnsOnCall(1, "./testdata/default/keystore/priv_sk")
+		cp.GetStringSliceReturns([]string{})
+		sigService := &mock2.SigService{}
+		endpoint := &fakeEndpointService{identity: view.Identity([]byte("alice-id"))}
+
+		idProvider, err := id2.NewProvider(cp, sigService, endpoint, &kms.KMS{Driver: &file.Driver{}})
+		require.NoError(t, err)
+
+		got := idProvider.Identity("alice")
+		require.Equal(t, view.Identity([]byte("alice-id")), got)
+		require.Equal(t, "alice", endpoint.label)
+	})
+
+	t.Run("failure returns nil", func(t *testing.T) {
+		t.Parallel()
+		cp := &mock2.ConfigProvider{}
+		cp.GetPathReturnsOnCall(0, "./testdata/default/signcerts/default.pem")
+		cp.GetPathReturnsOnCall(1, "./testdata/default/keystore/priv_sk")
+		cp.GetStringSliceReturns([]string{})
+		sigService := &mock2.SigService{}
+		endpoint := &fakeEndpointService{err: errors.New("lookup-failed")}
+
+		idProvider, err := id2.NewProvider(cp, sigService, endpoint, &kms.KMS{Driver: &file.Driver{}})
+		require.NoError(t, err)
+
+		got := idProvider.Identity("bob")
+		require.Nil(t, got)
+		require.Equal(t, "bob", endpoint.label)
+	})
+}
+
+func TestGetProvider(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		expected := &id2.Provider{}
+		got, err := id2.GetProvider(&fakeServiceProvider{service: expected})
+		require.NoError(t, err)
+		require.Same(t, expected, got)
+	})
+
+	t.Run("provider error", func(t *testing.T) {
+		t.Parallel()
+		_, err := id2.GetProvider(&fakeServiceProvider{err: errors.New("service-missing")})
+		require.ErrorContains(t, err, "service-missing")
+	})
 }


### PR DESCRIPTION
closes #1422 

Summary :
  This PR increases unit test coverage for `platform/view/services/id` to satisfy Stage 2 coverage goals.
coverage: 93.2% of statements

What Changed:
- `platform/view/services/id/identity_test.go`
  - `readFile` missing file
  - `readPemFile` invalid PEM content
  - `getCertFromPem` nil input, invalid PEM bytes, and non-certificate PEM
  - `LoadIdentity` missing file and invalid PEM

- `platform/view/services/id/provider_test.go`
  - `GetProvider` success and provider-error paths
  - `NewProvider` failure paths (default identity load failure, signer registration failure)
  - `Identity(label)` success and failure behavior
  - `Admins()` assertion in the base load test

