### PR TITLE
test: add unit coverage for core generic fabricutils

### DIFF
--- a/platform/fabric/core/generic/fabricutils/fake/fakes.go
+++ b/platform/fabric/core/generic/fabricutils/fake/fakes.go
@@ -1,0 +1,61 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fake
+
+import "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+
+type SerializableSigner struct {
+	Serialized   []byte
+	SerializeErr error
+	Signature    []byte
+	SignErr      error
+}
+
+func (s *SerializableSigner) Sign(_ []byte) ([]byte, error) {
+	if s.SignErr != nil {
+		return nil, s.SignErr
+	}
+	if len(s.Signature) == 0 {
+		return []byte("signature"), nil
+	}
+	return s.Signature, nil
+}
+
+func (s *SerializableSigner) Serialize() ([]byte, error) {
+	if s.SerializeErr != nil {
+		return nil, s.SerializeErr
+	}
+	return s.Serialized, nil
+}
+
+type Proposal struct {
+	HeaderBytes  []byte
+	PayloadBytes []byte
+}
+
+func (p *Proposal) Header() []byte  { return p.HeaderBytes }
+func (p *Proposal) Payload() []byte { return p.PayloadBytes }
+
+type ProposalResponse struct {
+	EndorserBytes          []byte
+	PayloadBytes           []byte
+	EndorserSignatureBytes []byte
+	ResultsBytes           []byte
+	Status                 int32
+	Message                string
+}
+
+func (r *ProposalResponse) Endorser() []byte          { return r.EndorserBytes }
+func (r *ProposalResponse) Payload() []byte           { return r.PayloadBytes }
+func (r *ProposalResponse) EndorserSignature() []byte { return r.EndorserSignatureBytes }
+func (r *ProposalResponse) Results() []byte           { return r.ResultsBytes }
+func (r *ProposalResponse) ResponseStatus() int32     { return r.Status }
+func (r *ProposalResponse) ResponseMessage() string   { return r.Message }
+func (r *ProposalResponse) Bytes() ([]byte, error)    { return nil, nil }
+func (r *ProposalResponse) VerifyEndorsement(driver.VerifierProvider) error {
+	return nil
+}

--- a/platform/fabric/core/generic/fabricutils/pr_test.go
+++ b/platform/fabric/core/generic/fabricutils/pr_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fabricutils
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnpackedProposalResponseResults(t *testing.T) {
+	t.Parallel()
+
+	upr := &UnpackedProposalResponse{
+		ChaincodeAction: &peer.ChaincodeAction{
+			Results: []byte("results"),
+		},
+	}
+
+	require.Equal(t, []byte("results"), upr.Results())
+}
+
+func TestUnpackProposalResponse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid proposal response payload bytes", func(t *testing.T) {
+		t.Parallel()
+		_, err := UnpackProposalResponse([]byte("bad-proposal-response-payload"))
+		require.Error(t, err)
+	})
+
+	t.Run("invalid chaincode action extension", func(t *testing.T) {
+		t.Parallel()
+		prp := &peer.ProposalResponsePayload{
+			Extension: []byte("bad-extension"),
+		}
+
+		_, err := UnpackProposalResponse(mustMarshalProto(t, prp))
+		require.Error(t, err)
+	})
+
+	t.Run("invalid rwset bytes", func(t *testing.T) {
+		t.Parallel()
+		chAction := &peer.ChaincodeAction{
+			Results: []byte("bad-rwset"),
+		}
+		prp := &peer.ProposalResponsePayload{
+			Extension: mustMarshalProto(t, chAction),
+		}
+
+		_, err := UnpackProposalResponse(mustMarshalProto(t, prp))
+		require.Error(t, err)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		rwsetBytes := buildRWSetBytes(t, "k1", []byte("v1"))
+		payload := buildProposalResponsePayload(t, rwsetBytes)
+
+		upr, err := UnpackProposalResponse(payload)
+		require.NoError(t, err)
+		require.NotNil(t, upr)
+		require.NotNil(t, upr.ChaincodeAction)
+		require.NotNil(t, upr.TxRwSet)
+		require.Equal(t, rwsetBytes, upr.Results())
+	})
+}

--- a/platform/fabric/core/generic/fabricutils/pr_test.go
+++ b/platform/fabric/core/generic/fabricutils/pr_test.go
@@ -31,7 +31,7 @@ func TestUnpackProposalResponse(t *testing.T) {
 	t.Run("invalid proposal response payload bytes", func(t *testing.T) {
 		t.Parallel()
 		_, err := UnpackProposalResponse([]byte("bad-proposal-response-payload"))
-		require.Error(t, err)
+		require.ErrorContains(t, err, "error unmarshalling ProposalResponsePayload")
 	})
 
 	t.Run("invalid chaincode action extension", func(t *testing.T) {
@@ -41,7 +41,7 @@ func TestUnpackProposalResponse(t *testing.T) {
 		}
 
 		_, err := UnpackProposalResponse(mustMarshalProto(t, prp))
-		require.Error(t, err)
+		require.ErrorContains(t, err, "error unmarshalling ChaincodeAction")
 	})
 
 	t.Run("invalid rwset bytes", func(t *testing.T) {
@@ -54,7 +54,7 @@ func TestUnpackProposalResponse(t *testing.T) {
 		}
 
 		_, err := UnpackProposalResponse(mustMarshalProto(t, prp))
-		require.Error(t, err)
+		require.ErrorContains(t, err, "cannot parse invalid wire-format data")
 	})
 
 	t.Run("success", func(t *testing.T) {

--- a/platform/fabric/core/generic/fabricutils/utils.go
+++ b/platform/fabric/core/generic/fabricutils/utils.go
@@ -38,6 +38,9 @@ func UnmarshalTx(tx []byte) (*common.Envelope, *common.Payload, *common.ChannelH
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "unmarshal payload failed")
 	}
+	if payl.Header == nil {
+		return nil, nil, nil, errors.New("envelope must have a Header")
+	}
 	chdr, err := protoutil.UnmarshalChannelHeader(payl.Header.ChannelHeader)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "unmarshal channel header failed")

--- a/platform/fabric/core/generic/fabricutils/utils_test.go
+++ b/platform/fabric/core/generic/fabricutils/utils_test.go
@@ -17,76 +17,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/fabricutils/fake"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/protoutil"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 )
-
-type testSerializableSigner struct {
-	serialized   []byte
-	serializeErr error
-	signature    []byte
-	signErr      error
-}
-
-func (s *testSerializableSigner) Sign(_ []byte) ([]byte, error) {
-	if s.signErr != nil {
-		return nil, s.signErr
-	}
-	if len(s.signature) == 0 {
-		return []byte("signature"), nil
-	}
-	return s.signature, nil
-}
-
-func (s *testSerializableSigner) Serialize() ([]byte, error) {
-	if s.serializeErr != nil {
-		return nil, s.serializeErr
-	}
-	return s.serialized, nil
-}
-
-type testSigner struct {
-	signature []byte
-	signErr   error
-}
-
-func (s *testSigner) Sign(_ []byte) ([]byte, error) {
-	if s.signErr != nil {
-		return nil, s.signErr
-	}
-	if len(s.signature) == 0 {
-		return []byte("signature"), nil
-	}
-	return s.signature, nil
-}
-
-type testProposal struct {
-	header  []byte
-	payload []byte
-}
-
-func (p *testProposal) Header() []byte  { return p.header }
-func (p *testProposal) Payload() []byte { return p.payload }
-
-type testProposalResponse struct {
-	endorser          []byte
-	payload           []byte
-	endorserSignature []byte
-	results           []byte
-	status            int32
-	message           string
-}
-
-func (r *testProposalResponse) Endorser() []byte          { return r.endorser }
-func (r *testProposalResponse) Payload() []byte           { return r.payload }
-func (r *testProposalResponse) EndorserSignature() []byte { return r.endorserSignature }
-func (r *testProposalResponse) Results() []byte           { return r.results }
-func (r *testProposalResponse) ResponseStatus() int32     { return r.status }
-func (r *testProposalResponse) ResponseMessage() string   { return r.message }
-func (r *testProposalResponse) Bytes() ([]byte, error)    { return nil, nil }
-func (r *testProposalResponse) VerifyEndorsement(driver.VerifierProvider) error {
-	return nil
-}
 
 func mustMarshalProto(t *testing.T, msg proto.Message) []byte {
 	t.Helper()
@@ -125,7 +59,7 @@ func buildProposalResponsePayload(t *testing.T, rwsetBytes []byte) []byte {
 	return payload
 }
 
-func buildProposal(t *testing.T, creator []byte, channel string) *testProposal {
+func buildProposal(t *testing.T, creator []byte, channel string) *fake.Proposal {
 	t.Helper()
 	nonce := []byte("nonce")
 	txID := protoutil.ComputeTxID(nonce, creator)
@@ -150,26 +84,26 @@ func buildProposal(t *testing.T, creator []byte, channel string) *testProposal {
 	)
 	require.NoError(t, err)
 
-	return &testProposal{
-		header:  prop.Header,
-		payload: prop.Payload,
+	return &fake.Proposal{
+		HeaderBytes:  prop.Header,
+		PayloadBytes: prop.Payload,
 	}
 }
 
 func buildResponse(status int32, message string, payload []byte) driver.ProposalResponse {
-	return &testProposalResponse{
-		endorser:          []byte("endorser"),
-		payload:           payload,
-		endorserSignature: []byte("endorser-signature"),
-		status:            status,
-		message:           message,
+	return &fake.ProposalResponse{
+		EndorserBytes:          []byte("endorser"),
+		PayloadBytes:           payload,
+		EndorserSignatureBytes: []byte("endorser-signature"),
+		Status:                 status,
+		Message:                message,
 	}
 }
 
 func buildEndorserEnvelopeBytes(t *testing.T) []byte {
 	t.Helper()
 	creator := []byte("creator")
-	signer := &testSerializableSigner{serialized: creator, signature: []byte("signature")}
+	signer := &fake.SerializableSigner{Serialized: creator, Signature: []byte("signature")}
 	proposal := buildProposal(t, creator, "mychannel")
 	resp := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
 
@@ -205,6 +139,14 @@ func TestUnmarshalTx(t *testing.T) {
 		require.ErrorContains(t, err, "unmarshal channel header failed")
 	})
 
+	t.Run("nil payload header", func(t *testing.T) {
+		t.Parallel()
+		payl := &common.Payload{Data: []byte("data")}
+		env := &common.Envelope{Payload: mustMarshalProto(t, payl)}
+		_, _, _, err := UnmarshalTx(mustMarshalProto(t, env))
+		require.ErrorContains(t, err, "envelope must have a Header")
+	})
+
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 		env, payl, chdr, err := UnmarshalTx(buildEndorserEnvelopeBytes(t))
@@ -222,14 +164,14 @@ func TestCreateEnvelope(t *testing.T) {
 	t.Run("signer error", func(t *testing.T) {
 		t.Parallel()
 		signErr := errors.New("sign-failed")
-		s := &testSigner{signErr: signErr}
+		s := &fake.SerializableSigner{SignErr: signErr}
 		_, err := CreateEnvelope(s, &common.Header{}, []byte("payload"))
 		require.ErrorIs(t, err, signErr)
 	})
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
-		s := &testSigner{signature: []byte("sig")}
+		s := &fake.SerializableSigner{Signature: []byte("sig")}
 		env, err := CreateEnvelope(s, &common.Header{}, []byte("payload"))
 		require.NoError(t, err)
 		require.Equal(t, []byte("sig"), env.Signature)
@@ -244,6 +186,8 @@ func TestCreateEndorserTX(t *testing.T) {
 	t.Parallel()
 
 	serializeErr := errors.New("serialize-failed")
+	successCreator := []byte("creator")
+	successResponsePayload := buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1")))
 	tests := []struct {
 		name   string
 		setup  func(*testing.T) (SerializableSigner, driver.Proposal, []driver.ProposalResponse)
@@ -254,7 +198,7 @@ func TestCreateEndorserTX(t *testing.T) {
 			setup: func(t *testing.T) (SerializableSigner, driver.Proposal, []driver.ProposalResponse) {
 				t.Helper()
 				proposal := buildProposal(t, []byte("creator"), "mychannel")
-				signer := &testSerializableSigner{serialized: []byte("creator")}
+				signer := &fake.SerializableSigner{Serialized: []byte("creator")}
 				return signer, proposal, nil
 			},
 			assert: func(t *testing.T, _ *common.Header, _ []byte, err error) {
@@ -266,14 +210,14 @@ func TestCreateEndorserTX(t *testing.T) {
 			name: "invalid proposal header",
 			setup: func(t *testing.T) (SerializableSigner, driver.Proposal, []driver.ProposalResponse) {
 				t.Helper()
-				proposal := &testProposal{header: []byte("bad-header"), payload: []byte("bad-payload")}
-				signer := &testSerializableSigner{serialized: []byte("creator")}
+				proposal := &fake.Proposal{HeaderBytes: []byte("bad-header"), PayloadBytes: []byte("bad-payload")}
+				signer := &fake.SerializableSigner{Serialized: []byte("creator")}
 				resp := buildResponse(200, "OK", []byte("payload"))
 				return signer, proposal, []driver.ProposalResponse{resp}
 			},
 			assert: func(t *testing.T, _ *common.Header, _ []byte, err error) {
 				t.Helper()
-				require.Error(t, err)
+				require.ErrorContains(t, err, "error unmarshalling Header")
 			},
 		},
 		{
@@ -281,14 +225,14 @@ func TestCreateEndorserTX(t *testing.T) {
 			setup: func(t *testing.T) (SerializableSigner, driver.Proposal, []driver.ProposalResponse) {
 				t.Helper()
 				validProposal := buildProposal(t, []byte("creator"), "mychannel")
-				proposal := &testProposal{header: validProposal.Header(), payload: []byte("bad-payload")}
-				signer := &testSerializableSigner{serialized: []byte("creator")}
+				proposal := &fake.Proposal{HeaderBytes: validProposal.Header(), PayloadBytes: []byte("bad-payload")}
+				signer := &fake.SerializableSigner{Serialized: []byte("creator")}
 				resp := buildResponse(200, "OK", []byte("payload"))
 				return signer, proposal, []driver.ProposalResponse{resp}
 			},
 			assert: func(t *testing.T, _ *common.Header, _ []byte, err error) {
 				t.Helper()
-				require.Error(t, err)
+				require.ErrorContains(t, err, "error unmarshalling ChaincodeProposalPayload")
 			},
 		},
 		{
@@ -296,7 +240,7 @@ func TestCreateEndorserTX(t *testing.T) {
 			setup: func(t *testing.T) (SerializableSigner, driver.Proposal, []driver.ProposalResponse) {
 				t.Helper()
 				proposal := buildProposal(t, []byte("creator"), "mychannel")
-				signer := &testSerializableSigner{serializeErr: serializeErr}
+				signer := &fake.SerializableSigner{SerializeErr: serializeErr}
 				resp := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
 				return signer, proposal, []driver.ProposalResponse{resp}
 			},
@@ -314,17 +258,17 @@ func TestCreateEndorserTX(t *testing.T) {
 					ChannelHeader:   []byte("channel-header"),
 					SignatureHeader: []byte("bad-signature-header"),
 				}
-				proposal := &testProposal{
-					header:  mustMarshalProto(t, hdr),
-					payload: validProposal.Payload(),
+				proposal := &fake.Proposal{
+					HeaderBytes:  mustMarshalProto(t, hdr),
+					PayloadBytes: validProposal.Payload(),
 				}
-				signer := &testSerializableSigner{serialized: []byte("creator")}
+				signer := &fake.SerializableSigner{Serialized: []byte("creator")}
 				resp := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
 				return signer, proposal, []driver.ProposalResponse{resp}
 			},
 			assert: func(t *testing.T, _ *common.Header, _ []byte, err error) {
 				t.Helper()
-				require.Error(t, err)
+				require.ErrorContains(t, err, "error unmarshalling SignatureHeader")
 			},
 		},
 		{
@@ -332,7 +276,7 @@ func TestCreateEndorserTX(t *testing.T) {
 			setup: func(t *testing.T) (SerializableSigner, driver.Proposal, []driver.ProposalResponse) {
 				t.Helper()
 				proposal := buildProposal(t, []byte("creator1"), "mychannel")
-				signer := &testSerializableSigner{serialized: []byte("creator2")}
+				signer := &fake.SerializableSigner{Serialized: []byte("creator2")}
 				resp := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
 				return signer, proposal, []driver.ProposalResponse{resp}
 			},
@@ -346,7 +290,7 @@ func TestCreateEndorserTX(t *testing.T) {
 			setup: func(t *testing.T) (SerializableSigner, driver.Proposal, []driver.ProposalResponse) {
 				t.Helper()
 				proposal := buildProposal(t, []byte("creator"), "mychannel")
-				signer := &testSerializableSigner{serialized: []byte("creator")}
+				signer := &fake.SerializableSigner{Serialized: []byte("creator")}
 				resp := buildResponse(500, "boom", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
 				return signer, proposal, []driver.ProposalResponse{resp}
 			},
@@ -360,7 +304,7 @@ func TestCreateEndorserTX(t *testing.T) {
 			setup: func(t *testing.T) (SerializableSigner, driver.Proposal, []driver.ProposalResponse) {
 				t.Helper()
 				proposal := buildProposal(t, []byte("creator"), "mychannel")
-				signer := &testSerializableSigner{serialized: []byte("creator")}
+				signer := &fake.SerializableSigner{Serialized: []byte("creator")}
 				resp1 := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
 				resp2 := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v2"))))
 				return signer, proposal, []driver.ProposalResponse{resp1, resp2}
@@ -374,11 +318,10 @@ func TestCreateEndorserTX(t *testing.T) {
 			name: "success",
 			setup: func(t *testing.T) (SerializableSigner, driver.Proposal, []driver.ProposalResponse) {
 				t.Helper()
-				proposal := buildProposal(t, []byte("creator"), "mychannel")
-				signer := &testSerializableSigner{serialized: []byte("creator")}
-				payload := buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1")))
-				resp1 := buildResponse(200, "OK", payload)
-				resp2 := buildResponse(200, "OK", payload)
+				proposal := buildProposal(t, successCreator, "mychannel")
+				signer := &fake.SerializableSigner{Serialized: successCreator}
+				resp1 := buildResponse(200, "OK", successResponsePayload)
+				resp2 := buildResponse(200, "OK", successResponsePayload)
 				return signer, proposal, []driver.ProposalResponse{resp1, resp2}
 			},
 			assert: func(t *testing.T, hdr *common.Header, txBytes []byte, err error) {
@@ -386,6 +329,33 @@ func TestCreateEndorserTX(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, hdr)
 				require.NotEmpty(t, txBytes)
+
+				chdr, err := protoutil.UnmarshalChannelHeader(hdr.ChannelHeader)
+				require.NoError(t, err)
+				require.Equal(t, "mychannel", chdr.ChannelId)
+
+				shdr, err := protoutil.UnmarshalSignatureHeader(hdr.SignatureHeader)
+				require.NoError(t, err)
+				require.Equal(t, successCreator, shdr.Creator)
+
+				tx, err := protoutil.UnmarshalTransaction(txBytes)
+				require.NoError(t, err)
+				require.Len(t, tx.Actions, 1)
+				require.Equal(t, hdr.SignatureHeader, tx.Actions[0].Header)
+
+				actionPayload, err := protoutil.UnmarshalChaincodeActionPayload(tx.Actions[0].Payload)
+				require.NoError(t, err)
+				require.Equal(t, successResponsePayload, actionPayload.Action.ProposalResponsePayload)
+				require.Len(t, actionPayload.Action.Endorsements, 2)
+				require.Equal(t, []byte("endorser"), actionPayload.Action.Endorsements[0].Endorser)
+				require.Equal(t, []byte("endorser-signature"), actionPayload.Action.Endorsements[0].Signature)
+
+				proposal := buildProposal(t, successCreator, "mychannel")
+				proposalPayload, err := protoutil.UnmarshalChaincodeProposalPayload(proposal.Payload())
+				require.NoError(t, err)
+				expectedPayload, err := protoutil.GetBytesProposalPayloadForTx(proposalPayload)
+				require.NoError(t, err)
+				require.Equal(t, expectedPayload, actionPayload.ChaincodeProposalPayload)
 			},
 		},
 	}
@@ -406,7 +376,7 @@ func TestCreateEndorserSignedTX(t *testing.T) {
 	t.Run("propagates create endorser tx errors", func(t *testing.T) {
 		t.Parallel()
 		proposal := buildProposal(t, []byte("creator"), "mychannel")
-		signer := &testSerializableSigner{serialized: []byte("creator")}
+		signer := &fake.SerializableSigner{Serialized: []byte("creator")}
 		_, err := CreateEndorserSignedTX(signer, proposal)
 		require.ErrorContains(t, err, "at least one proposal response is required")
 	})
@@ -414,7 +384,7 @@ func TestCreateEndorserSignedTX(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 		proposal := buildProposal(t, []byte("creator"), "mychannel")
-		signer := &testSerializableSigner{serialized: []byte("creator"), signature: []byte("sig")}
+		signer := &fake.SerializableSigner{Serialized: []byte("creator"), Signature: []byte("sig")}
 		resp := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
 
 		env, err := CreateEndorserSignedTX(signer, proposal, resp)

--- a/platform/fabric/core/generic/fabricutils/utils_test.go
+++ b/platform/fabric/core/generic/fabricutils/utils_test.go
@@ -243,103 +243,161 @@ func TestCreateEnvelope(t *testing.T) {
 func TestCreateEndorserTX(t *testing.T) {
 	t.Parallel()
 
-	t.Run("no proposal responses", func(t *testing.T) {
-		t.Parallel()
-		proposal := buildProposal(t, []byte("creator"), "mychannel")
-		signer := &testSerializableSigner{serialized: []byte("creator")}
-		_, _, err := CreateEndorserTX(signer, proposal)
-		require.ErrorContains(t, err, "at least one proposal response is required")
-	})
+	serializeErr := errors.New("serialize-failed")
+	tests := []struct {
+		name   string
+		setup  func(*testing.T) (SerializableSigner, driver.Proposal, []driver.ProposalResponse)
+		assert func(*testing.T, *common.Header, []byte, error)
+	}{
+		{
+			name: "no proposal responses",
+			setup: func(t *testing.T) (SerializableSigner, driver.Proposal, []driver.ProposalResponse) {
+				t.Helper()
+				proposal := buildProposal(t, []byte("creator"), "mychannel")
+				signer := &testSerializableSigner{serialized: []byte("creator")}
+				return signer, proposal, nil
+			},
+			assert: func(t *testing.T, _ *common.Header, _ []byte, err error) {
+				t.Helper()
+				require.ErrorContains(t, err, "at least one proposal response is required")
+			},
+		},
+		{
+			name: "invalid proposal header",
+			setup: func(t *testing.T) (SerializableSigner, driver.Proposal, []driver.ProposalResponse) {
+				t.Helper()
+				proposal := &testProposal{header: []byte("bad-header"), payload: []byte("bad-payload")}
+				signer := &testSerializableSigner{serialized: []byte("creator")}
+				resp := buildResponse(200, "OK", []byte("payload"))
+				return signer, proposal, []driver.ProposalResponse{resp}
+			},
+			assert: func(t *testing.T, _ *common.Header, _ []byte, err error) {
+				t.Helper()
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "invalid proposal payload",
+			setup: func(t *testing.T) (SerializableSigner, driver.Proposal, []driver.ProposalResponse) {
+				t.Helper()
+				validProposal := buildProposal(t, []byte("creator"), "mychannel")
+				proposal := &testProposal{header: validProposal.Header(), payload: []byte("bad-payload")}
+				signer := &testSerializableSigner{serialized: []byte("creator")}
+				resp := buildResponse(200, "OK", []byte("payload"))
+				return signer, proposal, []driver.ProposalResponse{resp}
+			},
+			assert: func(t *testing.T, _ *common.Header, _ []byte, err error) {
+				t.Helper()
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "serialize signer error",
+			setup: func(t *testing.T) (SerializableSigner, driver.Proposal, []driver.ProposalResponse) {
+				t.Helper()
+				proposal := buildProposal(t, []byte("creator"), "mychannel")
+				signer := &testSerializableSigner{serializeErr: serializeErr}
+				resp := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
+				return signer, proposal, []driver.ProposalResponse{resp}
+			},
+			assert: func(t *testing.T, _ *common.Header, _ []byte, err error) {
+				t.Helper()
+				require.ErrorIs(t, err, serializeErr)
+			},
+		},
+		{
+			name: "signature header unmarshal error",
+			setup: func(t *testing.T) (SerializableSigner, driver.Proposal, []driver.ProposalResponse) {
+				t.Helper()
+				validProposal := buildProposal(t, []byte("creator"), "mychannel")
+				hdr := &common.Header{
+					ChannelHeader:   []byte("channel-header"),
+					SignatureHeader: []byte("bad-signature-header"),
+				}
+				proposal := &testProposal{
+					header:  mustMarshalProto(t, hdr),
+					payload: validProposal.Payload(),
+				}
+				signer := &testSerializableSigner{serialized: []byte("creator")}
+				resp := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
+				return signer, proposal, []driver.ProposalResponse{resp}
+			},
+			assert: func(t *testing.T, _ *common.Header, _ []byte, err error) {
+				t.Helper()
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "signer mismatch",
+			setup: func(t *testing.T) (SerializableSigner, driver.Proposal, []driver.ProposalResponse) {
+				t.Helper()
+				proposal := buildProposal(t, []byte("creator1"), "mychannel")
+				signer := &testSerializableSigner{serialized: []byte("creator2")}
+				resp := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
+				return signer, proposal, []driver.ProposalResponse{resp}
+			},
+			assert: func(t *testing.T, _ *common.Header, _ []byte, err error) {
+				t.Helper()
+				require.ErrorContains(t, err, "signer must be the same as the one referenced in the header")
+			},
+		},
+		{
+			name: "response not successful",
+			setup: func(t *testing.T) (SerializableSigner, driver.Proposal, []driver.ProposalResponse) {
+				t.Helper()
+				proposal := buildProposal(t, []byte("creator"), "mychannel")
+				signer := &testSerializableSigner{serialized: []byte("creator")}
+				resp := buildResponse(500, "boom", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
+				return signer, proposal, []driver.ProposalResponse{resp}
+			},
+			assert: func(t *testing.T, _ *common.Header, _ []byte, err error) {
+				t.Helper()
+				require.ErrorContains(t, err, "proposal response was not successful")
+			},
+		},
+		{
+			name: "response payload mismatch",
+			setup: func(t *testing.T) (SerializableSigner, driver.Proposal, []driver.ProposalResponse) {
+				t.Helper()
+				proposal := buildProposal(t, []byte("creator"), "mychannel")
+				signer := &testSerializableSigner{serialized: []byte("creator")}
+				resp1 := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
+				resp2 := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v2"))))
+				return signer, proposal, []driver.ProposalResponse{resp1, resp2}
+			},
+			assert: func(t *testing.T, _ *common.Header, _ []byte, err error) {
+				t.Helper()
+				require.ErrorContains(t, err, "ProposalResponsePayloads do not match")
+			},
+		},
+		{
+			name: "success",
+			setup: func(t *testing.T) (SerializableSigner, driver.Proposal, []driver.ProposalResponse) {
+				t.Helper()
+				proposal := buildProposal(t, []byte("creator"), "mychannel")
+				signer := &testSerializableSigner{serialized: []byte("creator")}
+				payload := buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1")))
+				resp1 := buildResponse(200, "OK", payload)
+				resp2 := buildResponse(200, "OK", payload)
+				return signer, proposal, []driver.ProposalResponse{resp1, resp2}
+			},
+			assert: func(t *testing.T, hdr *common.Header, txBytes []byte, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				require.NotNil(t, hdr)
+				require.NotEmpty(t, txBytes)
+			},
+		},
+	}
 
-	t.Run("invalid proposal header", func(t *testing.T) {
-		t.Parallel()
-		proposal := &testProposal{header: []byte("bad-header"), payload: []byte("bad-payload")}
-		signer := &testSerializableSigner{serialized: []byte("creator")}
-		resp := buildResponse(200, "OK", []byte("payload"))
-		_, _, err := CreateEndorserTX(signer, proposal, resp)
-		require.Error(t, err)
-	})
-
-	t.Run("invalid proposal payload", func(t *testing.T) {
-		t.Parallel()
-		validProposal := buildProposal(t, []byte("creator"), "mychannel")
-		proposal := &testProposal{header: validProposal.Header(), payload: []byte("bad-payload")}
-		signer := &testSerializableSigner{serialized: []byte("creator")}
-		resp := buildResponse(200, "OK", []byte("payload"))
-		_, _, err := CreateEndorserTX(signer, proposal, resp)
-		require.Error(t, err)
-	})
-
-	t.Run("serialize signer error", func(t *testing.T) {
-		t.Parallel()
-		proposal := buildProposal(t, []byte("creator"), "mychannel")
-		serializeErr := errors.New("serialize-failed")
-		signer := &testSerializableSigner{serializeErr: serializeErr}
-		resp := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
-		_, _, err := CreateEndorserTX(signer, proposal, resp)
-		require.ErrorIs(t, err, serializeErr)
-	})
-
-	t.Run("signature header unmarshal error", func(t *testing.T) {
-		t.Parallel()
-		validProposal := buildProposal(t, []byte("creator"), "mychannel")
-		hdr := &common.Header{
-			ChannelHeader:   []byte("channel-header"),
-			SignatureHeader: []byte("bad-signature-header"),
-		}
-		proposal := &testProposal{
-			header:  mustMarshalProto(t, hdr),
-			payload: validProposal.Payload(),
-		}
-		signer := &testSerializableSigner{serialized: []byte("creator")}
-		resp := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
-		_, _, err := CreateEndorserTX(signer, proposal, resp)
-		require.Error(t, err)
-	})
-
-	t.Run("signer mismatch", func(t *testing.T) {
-		t.Parallel()
-		proposal := buildProposal(t, []byte("creator1"), "mychannel")
-		signer := &testSerializableSigner{serialized: []byte("creator2")}
-		resp := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
-		_, _, err := CreateEndorserTX(signer, proposal, resp)
-		require.ErrorContains(t, err, "signer must be the same as the one referenced in the header")
-	})
-
-	t.Run("response not successful", func(t *testing.T) {
-		t.Parallel()
-		proposal := buildProposal(t, []byte("creator"), "mychannel")
-		signer := &testSerializableSigner{serialized: []byte("creator")}
-		resp := buildResponse(500, "boom", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
-		_, _, err := CreateEndorserTX(signer, proposal, resp)
-		require.ErrorContains(t, err, "proposal response was not successful")
-	})
-
-	t.Run("response payload mismatch", func(t *testing.T) {
-		t.Parallel()
-		proposal := buildProposal(t, []byte("creator"), "mychannel")
-		signer := &testSerializableSigner{serialized: []byte("creator")}
-
-		resp1 := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
-		resp2 := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v2"))))
-		_, _, err := CreateEndorserTX(signer, proposal, resp1, resp2)
-		require.ErrorContains(t, err, "ProposalResponsePayloads do not match")
-	})
-
-	t.Run("success", func(t *testing.T) {
-		t.Parallel()
-		proposal := buildProposal(t, []byte("creator"), "mychannel")
-		signer := &testSerializableSigner{serialized: []byte("creator")}
-
-		payload := buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1")))
-		resp1 := buildResponse(200, "OK", payload)
-		resp2 := buildResponse(200, "OK", payload)
-
-		hdr, txBytes, err := CreateEndorserTX(signer, proposal, resp1, resp2)
-		require.NoError(t, err)
-		require.NotNil(t, hdr)
-		require.NotEmpty(t, txBytes)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			signer, proposal, resps := tt.setup(t)
+			hdr, txBytes, err := CreateEndorserTX(signer, proposal, resps...)
+			tt.assert(t, hdr, txBytes, err)
+		})
+	}
 }
 
 func TestCreateEndorserSignedTX(t *testing.T) {

--- a/platform/fabric/core/generic/fabricutils/utils_test.go
+++ b/platform/fabric/core/generic/fabricutils/utils_test.go
@@ -1,0 +1,368 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fabricutils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-protos-go-apiv2/ledger/rwset"
+	"github.com/hyperledger/fabric-protos-go-apiv2/ledger/rwset/kvrwset"
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/protoutil"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+)
+
+type testSerializableSigner struct {
+	serialized   []byte
+	serializeErr error
+	signature    []byte
+	signErr      error
+}
+
+func (s *testSerializableSigner) Sign(_ []byte) ([]byte, error) {
+	if s.signErr != nil {
+		return nil, s.signErr
+	}
+	if len(s.signature) == 0 {
+		return []byte("signature"), nil
+	}
+	return s.signature, nil
+}
+
+func (s *testSerializableSigner) Serialize() ([]byte, error) {
+	if s.serializeErr != nil {
+		return nil, s.serializeErr
+	}
+	return s.serialized, nil
+}
+
+type testSigner struct {
+	signature []byte
+	signErr   error
+}
+
+func (s *testSigner) Sign(_ []byte) ([]byte, error) {
+	if s.signErr != nil {
+		return nil, s.signErr
+	}
+	if len(s.signature) == 0 {
+		return []byte("signature"), nil
+	}
+	return s.signature, nil
+}
+
+type testProposal struct {
+	header  []byte
+	payload []byte
+}
+
+func (p *testProposal) Header() []byte  { return p.header }
+func (p *testProposal) Payload() []byte { return p.payload }
+
+type testProposalResponse struct {
+	endorser          []byte
+	payload           []byte
+	endorserSignature []byte
+	results           []byte
+	status            int32
+	message           string
+}
+
+func (r *testProposalResponse) Endorser() []byte          { return r.endorser }
+func (r *testProposalResponse) Payload() []byte           { return r.payload }
+func (r *testProposalResponse) EndorserSignature() []byte { return r.endorserSignature }
+func (r *testProposalResponse) Results() []byte           { return r.results }
+func (r *testProposalResponse) ResponseStatus() int32     { return r.status }
+func (r *testProposalResponse) ResponseMessage() string   { return r.message }
+func (r *testProposalResponse) Bytes() ([]byte, error)    { return nil, nil }
+func (r *testProposalResponse) VerifyEndorsement(driver.VerifierProvider) error {
+	return nil
+}
+
+func mustMarshalProto(t *testing.T, msg proto.Message) []byte {
+	t.Helper()
+	raw, err := proto.Marshal(msg)
+	require.NoError(t, err)
+	return raw
+}
+
+func buildRWSetBytes(t *testing.T, key string, value []byte) []byte {
+	t.Helper()
+	txRWSet := &rwset.TxReadWriteSet{
+		NsRwset: []*rwset.NsReadWriteSet{
+			{
+				Namespace: "ns1",
+				Rwset: mustMarshalProto(t, &kvrwset.KVRWSet{
+					Writes: []*kvrwset.KVWrite{
+						{Key: key, Value: value},
+					},
+				}),
+			},
+		},
+	}
+	return mustMarshalProto(t, txRWSet)
+}
+
+func buildProposalResponsePayload(t *testing.T, rwsetBytes []byte) []byte {
+	t.Helper()
+	payload, err := protoutil.GetBytesProposalResponsePayload(
+		[]byte("proposal-hash"),
+		&peer.Response{Status: 200, Message: "OK"},
+		rwsetBytes,
+		nil,
+		&peer.ChaincodeID{Name: "mycc", Version: "v1"},
+	)
+	require.NoError(t, err)
+	return payload
+}
+
+func buildProposal(t *testing.T, creator []byte, channel string) *testProposal {
+	t.Helper()
+	nonce := []byte("nonce")
+	txID := protoutil.ComputeTxID(nonce, creator)
+	cis := &peer.ChaincodeInvocationSpec{
+		ChaincodeSpec: &peer.ChaincodeSpec{
+			Type:        peer.ChaincodeSpec_GOLANG,
+			ChaincodeId: &peer.ChaincodeID{Name: "mycc", Version: "v1"},
+			Input: &peer.ChaincodeInput{
+				Args: [][]byte{[]byte("invoke"), []byte("a"), []byte("b")},
+			},
+		},
+	}
+
+	prop, _, err := protoutil.CreateChaincodeProposalWithTxIDNonceAndTransient(
+		txID,
+		common.HeaderType_ENDORSER_TRANSACTION,
+		channel,
+		cis,
+		nonce,
+		creator,
+		nil,
+	)
+	require.NoError(t, err)
+
+	return &testProposal{
+		header:  prop.Header,
+		payload: prop.Payload,
+	}
+}
+
+func buildResponse(status int32, message string, payload []byte) driver.ProposalResponse {
+	return &testProposalResponse{
+		endorser:          []byte("endorser"),
+		payload:           payload,
+		endorserSignature: []byte("endorser-signature"),
+		status:            status,
+		message:           message,
+	}
+}
+
+func buildEndorserEnvelopeBytes(t *testing.T) []byte {
+	t.Helper()
+	creator := []byte("creator")
+	signer := &testSerializableSigner{serialized: creator, signature: []byte("signature")}
+	proposal := buildProposal(t, creator, "mychannel")
+	resp := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
+
+	env, err := CreateEndorserSignedTX(signer, proposal, resp)
+	require.NoError(t, err)
+	return mustMarshalProto(t, env)
+}
+
+func TestUnmarshalTx(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid envelope bytes", func(t *testing.T) {
+		t.Parallel()
+		_, _, _, err := UnmarshalTx([]byte("bad-envelope"))
+		require.ErrorContains(t, err, "Error getting tx from block")
+	})
+
+	t.Run("invalid payload bytes", func(t *testing.T) {
+		t.Parallel()
+		env := &common.Envelope{Payload: []byte("bad-payload")}
+		_, _, _, err := UnmarshalTx(mustMarshalProto(t, env))
+		require.ErrorContains(t, err, "unmarshal payload failed")
+	})
+
+	t.Run("invalid channel header", func(t *testing.T) {
+		t.Parallel()
+		payl := &common.Payload{
+			Header: &common.Header{ChannelHeader: []byte("bad-channel-header")},
+			Data:   []byte("data"),
+		}
+		env := &common.Envelope{Payload: mustMarshalProto(t, payl)}
+		_, _, _, err := UnmarshalTx(mustMarshalProto(t, env))
+		require.ErrorContains(t, err, "unmarshal channel header failed")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		env, payl, chdr, err := UnmarshalTx(buildEndorserEnvelopeBytes(t))
+		require.NoError(t, err)
+		require.NotNil(t, env)
+		require.NotNil(t, payl)
+		require.NotNil(t, chdr)
+		require.Equal(t, "mychannel", chdr.ChannelId)
+	})
+}
+
+func TestCreateEnvelope(t *testing.T) {
+	t.Parallel()
+
+	t.Run("signer error", func(t *testing.T) {
+		t.Parallel()
+		signErr := errors.New("sign-failed")
+		s := &testSigner{signErr: signErr}
+		_, err := CreateEnvelope(s, &common.Header{}, []byte("payload"))
+		require.ErrorIs(t, err, signErr)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		s := &testSigner{signature: []byte("sig")}
+		env, err := CreateEnvelope(s, &common.Header{}, []byte("payload"))
+		require.NoError(t, err)
+		require.Equal(t, []byte("sig"), env.Signature)
+
+		payl := &common.Payload{}
+		require.NoError(t, proto.Unmarshal(env.Payload, payl))
+		require.Equal(t, []byte("payload"), payl.Data)
+	})
+}
+
+func TestCreateEndorserTX(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no proposal responses", func(t *testing.T) {
+		t.Parallel()
+		proposal := buildProposal(t, []byte("creator"), "mychannel")
+		signer := &testSerializableSigner{serialized: []byte("creator")}
+		_, _, err := CreateEndorserTX(signer, proposal)
+		require.ErrorContains(t, err, "at least one proposal response is required")
+	})
+
+	t.Run("invalid proposal header", func(t *testing.T) {
+		t.Parallel()
+		proposal := &testProposal{header: []byte("bad-header"), payload: []byte("bad-payload")}
+		signer := &testSerializableSigner{serialized: []byte("creator")}
+		resp := buildResponse(200, "OK", []byte("payload"))
+		_, _, err := CreateEndorserTX(signer, proposal, resp)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid proposal payload", func(t *testing.T) {
+		t.Parallel()
+		validProposal := buildProposal(t, []byte("creator"), "mychannel")
+		proposal := &testProposal{header: validProposal.Header(), payload: []byte("bad-payload")}
+		signer := &testSerializableSigner{serialized: []byte("creator")}
+		resp := buildResponse(200, "OK", []byte("payload"))
+		_, _, err := CreateEndorserTX(signer, proposal, resp)
+		require.Error(t, err)
+	})
+
+	t.Run("serialize signer error", func(t *testing.T) {
+		t.Parallel()
+		proposal := buildProposal(t, []byte("creator"), "mychannel")
+		serializeErr := errors.New("serialize-failed")
+		signer := &testSerializableSigner{serializeErr: serializeErr}
+		resp := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
+		_, _, err := CreateEndorserTX(signer, proposal, resp)
+		require.ErrorIs(t, err, serializeErr)
+	})
+
+	t.Run("signature header unmarshal error", func(t *testing.T) {
+		t.Parallel()
+		validProposal := buildProposal(t, []byte("creator"), "mychannel")
+		hdr := &common.Header{
+			ChannelHeader:   []byte("channel-header"),
+			SignatureHeader: []byte("bad-signature-header"),
+		}
+		proposal := &testProposal{
+			header:  mustMarshalProto(t, hdr),
+			payload: validProposal.Payload(),
+		}
+		signer := &testSerializableSigner{serialized: []byte("creator")}
+		resp := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
+		_, _, err := CreateEndorserTX(signer, proposal, resp)
+		require.Error(t, err)
+	})
+
+	t.Run("signer mismatch", func(t *testing.T) {
+		t.Parallel()
+		proposal := buildProposal(t, []byte("creator1"), "mychannel")
+		signer := &testSerializableSigner{serialized: []byte("creator2")}
+		resp := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
+		_, _, err := CreateEndorserTX(signer, proposal, resp)
+		require.ErrorContains(t, err, "signer must be the same as the one referenced in the header")
+	})
+
+	t.Run("response not successful", func(t *testing.T) {
+		t.Parallel()
+		proposal := buildProposal(t, []byte("creator"), "mychannel")
+		signer := &testSerializableSigner{serialized: []byte("creator")}
+		resp := buildResponse(500, "boom", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
+		_, _, err := CreateEndorserTX(signer, proposal, resp)
+		require.ErrorContains(t, err, "proposal response was not successful")
+	})
+
+	t.Run("response payload mismatch", func(t *testing.T) {
+		t.Parallel()
+		proposal := buildProposal(t, []byte("creator"), "mychannel")
+		signer := &testSerializableSigner{serialized: []byte("creator")}
+
+		resp1 := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
+		resp2 := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v2"))))
+		_, _, err := CreateEndorserTX(signer, proposal, resp1, resp2)
+		require.ErrorContains(t, err, "ProposalResponsePayloads do not match")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		proposal := buildProposal(t, []byte("creator"), "mychannel")
+		signer := &testSerializableSigner{serialized: []byte("creator")}
+
+		payload := buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1")))
+		resp1 := buildResponse(200, "OK", payload)
+		resp2 := buildResponse(200, "OK", payload)
+
+		hdr, txBytes, err := CreateEndorserTX(signer, proposal, resp1, resp2)
+		require.NoError(t, err)
+		require.NotNil(t, hdr)
+		require.NotEmpty(t, txBytes)
+	})
+}
+
+func TestCreateEndorserSignedTX(t *testing.T) {
+	t.Parallel()
+
+	t.Run("propagates create endorser tx errors", func(t *testing.T) {
+		t.Parallel()
+		proposal := buildProposal(t, []byte("creator"), "mychannel")
+		signer := &testSerializableSigner{serialized: []byte("creator")}
+		_, err := CreateEndorserSignedTX(signer, proposal)
+		require.ErrorContains(t, err, "at least one proposal response is required")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		proposal := buildProposal(t, []byte("creator"), "mychannel")
+		signer := &testSerializableSigner{serialized: []byte("creator"), signature: []byte("sig")}
+		resp := buildResponse(200, "OK", buildProposalResponsePayload(t, buildRWSetBytes(t, "k1", []byte("v1"))))
+
+		env, err := CreateEndorserSignedTX(signer, proposal, resp)
+		require.NoError(t, err)
+		require.NotNil(t, env)
+		require.Equal(t, []byte("sig"), env.Signature)
+		require.NotEmpty(t, env.Payload)
+	})
+}


### PR DESCRIPTION
closes #1438
Adds unit tests for `platform/fabric/core/generic/fabricutils` to raise package coverage above the Stage 2 target.

What changed:
  - Added `pr_test.go` for:
    - `UnpackedProposalResponse.Results`
    - `UnpackProposalResponse` success and failure paths
  - Added `utils_test.go` for:
    - `UnmarshalTx` success and error paths
    - `CreateEnvelope` success and signer-error paths
    - `CreateEndorserTX` success and validation/error paths (missing responses, signer mismatch, bad response status, mismatched payloads, malformed inputs)
    - `CreateEndorserSignedTX` wrapper behavior
