### PR TITLE
fix(grpc): cache *grpc.ClientConn per (service, network) in ClientProvider

### DIFF
--- a/platform/fabricx/core/committer/grpc/grpc.go
+++ b/platform/fabricx/core/committer/grpc/grpc.go
@@ -37,11 +37,7 @@ type ServiceConfigProvider interface {
 
 // ClientProvider provides gRPC client connections for a given network.
 //
-// Connections are cached per (service, network). grpc.NewClient spawns ~6
-// long-lived goroutines per ClientConn (resolver watcher, callback serializers,
-// http2 reader/writer, balancer); callers like fabric-token-sdk's qe.Executor
-// invoke these methods on every state query, so without caching the goroutine
-// count grows linearly with throughput and leaks the underlying connections.
+// Connections are cached per (service, network) to prevent goroutine groth.
 type ClientProvider struct {
 	// configProvider is used to retrieve the configuration for a network.
 	configProvider ServiceConfigProvider

--- a/platform/fabricx/core/committer/grpc/grpc.go
+++ b/platform/fabricx/core/committer/grpc/grpc.go
@@ -10,6 +10,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"os"
+	"sync"
 	"time"
 
 	"google.golang.org/grpc"
@@ -35,9 +36,18 @@ type ServiceConfigProvider interface {
 }
 
 // ClientProvider provides gRPC client connections for a given network.
+//
+// Connections are cached per (service, network). grpc.NewClient spawns ~6
+// long-lived goroutines per ClientConn (resolver watcher, callback serializers,
+// http2 reader/writer, balancer); callers like fabric-token-sdk's qe.Executor
+// invoke these methods on every state query, so without caching the goroutine
+// count grows linearly with throughput and leaks the underlying connections.
 type ClientProvider struct {
 	// configProvider is used to retrieve the configuration for a network.
 	configProvider ServiceConfigProvider
+
+	notificationConn sync.Map // network -> *grpc.ClientConn
+	queryConn        sync.Map // network -> *grpc.ClientConn
 }
 
 // NewClientProvider returns a new ClientProvider instance.
@@ -46,27 +56,30 @@ func NewClientProvider(configProvider ServiceConfigProvider) *ClientProvider {
 }
 
 // NotificationServiceClient returns a gRPC client connection to the notification service for the specified network.
-// It loads the configuration for the network and creates a connection.
+// The connection is created on first use and cached for subsequent calls.
 func (c *ClientProvider) NotificationServiceClient(network string) (*grpc.ClientConn, error) {
-	// Load the specific configuration for this network
-	cfg, err := c.configProvider.NotificationServiceConfig(network)
-	if err != nil {
-		return nil, err
-	}
-
-	cc, err := ClientConn(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	return cc, nil
+	return c.getOrCreate(&c.notificationConn, network, c.configProvider.NotificationServiceConfig)
 }
 
 // QueryServiceClient returns a gRPC client connection to the query service for the specified network.
-// It loads the configuration for the network and creates a connection.
+// The connection is created on first use and cached for subsequent calls.
 func (c *ClientProvider) QueryServiceClient(network string) (*grpc.ClientConn, error) {
-	// Load the specific configuration for this network
-	cfg, err := c.configProvider.QueryServiceConfig(network)
+	return c.getOrCreate(&c.queryConn, network, c.configProvider.QueryServiceConfig)
+}
+
+// getOrCreate returns the cached *grpc.ClientConn for the given network, or
+// dials a new one via loadCfg and caches it. Under a benign race two callers
+// may both dial; the loser closes its connection and returns the winner's.
+func (c *ClientProvider) getOrCreate(
+	cache *sync.Map,
+	network string,
+	loadCfg func(string) (*config.Config, error),
+) (*grpc.ClientConn, error) {
+	if v, ok := cache.Load(network); ok {
+		return v.(*grpc.ClientConn), nil
+	}
+
+	cfg, err := loadCfg(network)
 	if err != nil {
 		return nil, err
 	}
@@ -74,6 +87,11 @@ func (c *ClientProvider) QueryServiceClient(network string) (*grpc.ClientConn, e
 	cc, err := ClientConn(cfg)
 	if err != nil {
 		return nil, err
+	}
+
+	if actual, loaded := cache.LoadOrStore(network, cc); loaded {
+		_ = cc.Close()
+		return actual.(*grpc.ClientConn), nil
 	}
 
 	return cc, nil

--- a/platform/fabricx/core/committer/grpc/grpc_test.go
+++ b/platform/fabricx/core/committer/grpc/grpc_test.go
@@ -20,6 +20,8 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -91,6 +93,29 @@ func TestClientProvider_NotificationServiceClient(t *testing.T) {
 		require.Nil(t, cc)
 		require.Contains(t, err.Error(), "we need a single endpoint")
 	})
+
+	t.Run("caches per network", func(t *testing.T) {
+		t.Parallel()
+		fakeConfigProvider := &mock.ServiceConfigProvider{}
+		fakeConfigProvider.NotificationServiceConfigStub = func(network string) (*config.Config, error) {
+			return &config.Config{
+				Endpoints: []config.Endpoint{{Address: "localhost:1234"}},
+			}, nil
+		}
+
+		cp := grpc2.NewClientProvider(fakeConfigProvider)
+		cc1, err := cp.NotificationServiceClient("net-a")
+		require.NoError(t, err)
+		cc2, err := cp.NotificationServiceClient("net-a")
+		require.NoError(t, err)
+		require.Same(t, cc1, cc2)
+		require.Equal(t, 1, fakeConfigProvider.NotificationServiceConfigCallCount())
+
+		cc3, err := cp.NotificationServiceClient("net-b")
+		require.NoError(t, err)
+		require.NotSame(t, cc1, cc3)
+		require.Equal(t, 2, fakeConfigProvider.NotificationServiceConfigCallCount())
+	})
 }
 
 func TestClientProvider_QueryServiceClient(t *testing.T) {
@@ -137,6 +162,53 @@ func TestClientProvider_QueryServiceClient(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, cc)
 		require.Contains(t, err.Error(), "we need a single endpoint")
+	})
+
+	t.Run("caches per network", func(t *testing.T) {
+		t.Parallel()
+		fakeConfigProvider := &mock.ServiceConfigProvider{}
+		fakeConfigProvider.QueryServiceConfigStub = func(network string) (*config.Config, error) {
+			return &config.Config{
+				Endpoints: []config.Endpoint{{Address: "localhost:5678"}},
+			}, nil
+		}
+
+		cp := grpc2.NewClientProvider(fakeConfigProvider)
+		cc1, err := cp.QueryServiceClient("net-a")
+		require.NoError(t, err)
+		cc2, err := cp.QueryServiceClient("net-a")
+		require.NoError(t, err)
+		require.Same(t, cc1, cc2)
+		require.Equal(t, 1, fakeConfigProvider.QueryServiceConfigCallCount())
+
+		cc3, err := cp.QueryServiceClient("net-b")
+		require.NoError(t, err)
+		require.NotSame(t, cc1, cc3)
+		require.Equal(t, 2, fakeConfigProvider.QueryServiceConfigCallCount())
+	})
+
+	t.Run("notification and query caches are independent", func(t *testing.T) {
+		t.Parallel()
+		fakeConfigProvider := &mock.ServiceConfigProvider{}
+		fakeConfigProvider.NotificationServiceConfigStub = func(network string) (*config.Config, error) {
+			return &config.Config{
+				Endpoints: []config.Endpoint{{Address: "localhost:1111"}},
+			}, nil
+		}
+		fakeConfigProvider.QueryServiceConfigStub = func(network string) (*config.Config, error) {
+			return &config.Config{
+				Endpoints: []config.Endpoint{{Address: "localhost:2222"}},
+			}, nil
+		}
+
+		cp := grpc2.NewClientProvider(fakeConfigProvider)
+		notif, err := cp.NotificationServiceClient("net-a")
+		require.NoError(t, err)
+		query, err := cp.QueryServiceClient("net-a")
+		require.NoError(t, err)
+		require.NotSame(t, notif, query)
+		require.Equal(t, "localhost:1111", notif.Target())
+		require.Equal(t, "localhost:2222", query.Target())
 	})
 }
 
@@ -511,4 +583,125 @@ func generateCertAndKey(t *testing.T) (certFile, keyFile string) {
 	require.NoError(t, f.Close())
 
 	return certFile, keyFile
+}
+
+// TestClientProvider_CachingPreventsPerCallGoroutineLeak reproduces, in miniature,
+// the leak that motivated per-(service,network) connection caching. Every live
+// *grpc.ClientConn carries a handful of long-lived worker goroutines (http2
+// reader, loopyWriter, dns resolver watcher, callback serializer), so dialing a
+// fresh connection on every call — as the provider did before this fix — grows
+// the goroutine count linearly and never reclaims the connections.
+//
+// Both paths run against the same real server with identical usage:
+//   - cached:   ClientProvider.QueryServiceClient reuses one connection
+//   - uncached: grpc.ClientConn dialed per call and kept alive (the pre-fix
+//     behavior: the old QueryServiceClient called ClientConn(cfg) every time and
+//     returned it; callers never closed it)
+//
+// We assert the cached path adds ~no goroutines across many calls while the
+// uncached path leaks roughly a connection's worth per call. Assertions use
+// NumGoroutine deltas (robust across grpc versions); the per-worker breakdown is
+// logged only, since those internal symbol names are version-specific.
+//
+// This test does NOT call t.Parallel(): runtime.NumGoroutine() is process-global,
+// and Go runs non-parallel tests while every t.Parallel() test is paused, which
+// gives a clean measurement window.
+func TestClientProvider_CachingPreventsPerCallGoroutineLeak(t *testing.T) { //nolint:paralleltest
+	addr := startTestServer(t)
+	cfg := &config.Config{Endpoints: []config.Endpoint{{Address: addr}}}
+
+	fakeConfigProvider := &mock.ServiceConfigProvider{}
+	fakeConfigProvider.QueryServiceConfigStub = func(string) (*config.Config, error) {
+		return &config.Config{Endpoints: []config.Endpoint{{Address: addr}}}, nil
+	}
+
+	const calls = 30
+
+	// --- cached path (this fix): one shared connection serves every call ---
+	cp := grpc2.NewClientProvider(fakeConfigProvider)
+	first, err := cp.QueryServiceClient("net")
+	require.NoError(t, err)
+	invokeHealthCheck(t, first) // establish the single connection up front
+
+	cachedBase := settledGoroutineCount()
+	for i := 0; i < calls; i++ {
+		cc, err := cp.QueryServiceClient("net")
+		require.NoError(t, err)
+		require.Same(t, first, cc) // every call returns the cached connection
+		invokeHealthCheck(t, cc)
+	}
+	cachedGrowth := settledGoroutineCount() - cachedBase
+	require.Equal(t, 1, fakeConfigProvider.QueryServiceConfigCallCount()) // dialed exactly once
+
+	// --- uncached path (pre-fix behavior): a fresh conn per call, never closed ---
+	leaked := make([]*grpc.ClientConn, 0, calls)
+	t.Cleanup(func() {
+		for _, cc := range leaked {
+			_ = cc.Close()
+		}
+	})
+	uncachedBase := settledGoroutineCount()
+	for i := 0; i < calls; i++ {
+		cc, err := grpc2.ClientConn(cfg) // exactly what QueryServiceClient did before caching
+		require.NoError(t, err)
+		invokeHealthCheck(t, cc)
+		leaked = append(leaked, cc)
+	}
+	uncachedGrowth := settledGoroutineCount() - uncachedBase
+
+	t.Logf("goroutine growth over %d calls: cached=%d uncached=%d", calls, cachedGrowth, uncachedGrowth)
+	t.Logf("per-connection worker goroutines now live: %v", grpcConnGoroutineBreakdown())
+
+	// cached: well under one new goroutine per call (true value ~0).
+	require.Less(t, cachedGrowth, calls,
+		"cached provider should not grow goroutines per call (grew %d over %d calls)", cachedGrowth, calls)
+	// uncached: at least one extra goroutine per call beyond the cached path.
+	require.Greater(t, uncachedGrowth, cachedGrowth+calls,
+		"dialing per call should leak ~a connection's worth of goroutines each time (cached grew %d, uncached grew %d over %d calls)",
+		cachedGrowth, uncachedGrowth, calls)
+}
+
+// settledGoroutineCount returns runtime.NumGoroutine() after letting transient
+// goroutines (e.g. just-finished RPCs) wind down, so two readings are comparable.
+func settledGoroutineCount() int {
+	prev := -1
+	n := 0
+	for i := 0; i < 25; i++ {
+		runtime.GC()
+		time.Sleep(10 * time.Millisecond)
+		n = runtime.NumGoroutine()
+		if n == prev {
+			break
+		}
+		prev = n
+	}
+	return n
+}
+
+// grpcConnGoroutineBreakdown counts live goroutines whose stacks match grpc's
+// per-connection workers — the ones the PR's production profile saw accumulate.
+// Diagnostic only (logged, never asserted): these internal symbols are grpc
+// version-specific, whereas the test's assertions use NumGoroutine deltas.
+func grpcConnGoroutineBreakdown() map[string]int {
+	buf := make([]byte, 1<<20)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			buf = buf[:n]
+			break
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+	dump := string(buf)
+	markers := map[string]string{
+		"http2.reader":        "http2Client).reader",
+		"loopyWriter.run":     "loopyWriter).run",
+		"dnsResolver.watcher": "dnsResolver).watcher",
+		"callbackSerializer":  "CallbackSerializer).run",
+	}
+	out := make(map[string]int, len(markers))
+	for label, sig := range markers {
+		out[label] = strings.Count(dump, sig)
+	}
+	return out
 }


### PR DESCRIPTION
## Summary

`ClientProvider.NotificationServiceClient` and `QueryServiceClient` called
`grpc.NewClient` on every invocation. `grpc.NewClient` spawns several long-lived
goroutines per `ClientConn` (resolver watcher, callback serializers, http2
reader/writer, balancer); when downstream callers invoke these on the hot path —
e.g. fabric-token-sdk's `qe.Executor` calls `QueryServiceClient` on every state
query — the goroutine count grows linearly with throughput and the underlying
connections leak.

This caches `*grpc.ClientConn` per (service, network) using two `sync.Map`s. The
first call dials and stores; subsequent calls return the cached connection. Under
a benign cold-start race two callers may both dial; the loser closes its
connection and returns the winner's via `LoadOrStore`.

Fixes #1482

## Evidence

In a multi-hour load test on a fabricx-based deployment, a single process
accumulated ~104k goroutines, dominated by grpc per-connection workers (69,447
`CallbackSerializer.run`, ~11.6k each of `http2Client.reader` / `loopyWriter.run`
/ `dnsResolver.watcher`). A heap profile (`inuse_objects`, focus `NewClient`)
traced the chain to `qe.Executor.QueryState → RemoteQueryServiceProvider.Get →
ClientProvider.QueryServiceClient → grpc.NewClient`.

## Test plan

- Added `TestClientProvider_CachingPreventsPerCallGoroutineLeak`: drives the
  cached provider vs. the previous dial-per-call behavior against one real
  in-process server with identical usage, asserting the cached path adds ~no
  goroutines while dialing per call leaks a connection's worth each time (0 vs
  240 goroutines over 30 calls locally). Doubles as a regression guard (removing
  the cache fails `require.Same` and the goroutine-delta assertion).
- Extended the `NotificationServiceClient`/`QueryServiceClient` unit tests to
  assert per-network caching (same `*ClientConn` returned, config loaded once).
- `go test -race ./platform/fabricx/core/committer/grpc/...` passes.

## Notes

- Closing the losing duplicate before any RPC is safe per `grpc.ClientConn.Close`
  semantics.
- gRPC's automatic reconnect handles transient disconnects for an unchanged
  target; a target/TLS change would not be picked up while the cached conn lives
  — acceptable for a process-lifetime provider.
- Connections live until process exit; happy to add a `Close()` hook if preferred.
