### PR TITLE
fix(fabric/ordering): always discard failed connections in BFT broadcast

### DIFF
--- a/platform/fabric/core/generic/ordering/bft.go
+++ b/platform/fabric/core/generic/ordering/bft.go
@@ -130,8 +130,11 @@ func (o *BFTBroadcaster) Broadcast(ctx context.Context, env *common2.Envelope) e
 
 		wg.Wait()
 
-		// did we send to enough orderers?
-		// if not, discard all connections
+		// Discard errored connections on every path, including threshold success.
+		for _, connection := range usedConnections {
+			o.discardConnection(connection)
+		}
+
 		if counter >= threshold {
 			// success
 			return nil
@@ -139,10 +142,6 @@ func (o *BFTBroadcaster) Broadcast(ctx context.Context, env *common2.Envelope) e
 
 		// fail
 		logger.WarnfContext(ctx, "failed to broadcast, got [%d of %d] success and errs [%v], retry after a delay", counter, threshold, errs)
-		// cleanup connections
-		for _, connection := range usedConnections {
-			o.discardConnection(connection)
-		}
 	}
 
 	return errors.Errorf("failed to send transaction to the orderering service")

--- a/platform/fabric/core/generic/ordering/bft_test.go
+++ b/platform/fabric/core/generic/ordering/bft_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package ordering
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -68,7 +67,7 @@ func TestBFTBroadcaster_DiscardsFailedConnectionsOnPartialFailureSuccess(t *test
 
 	// Pre-fill the pools and hold the matching semaphore units, so
 	// getConnection bypasses ClientFactory and discard accounting balances.
-	require.NoError(t, b.connSem.Acquire(context.Background(), int64(len(orderers))))
+	require.NoError(t, b.connSem.Acquire(t.Context(), int64(len(orderers))))
 	streams := map[string]*fakeBroadcastStream{
 		"o1": {status: common.Status_SUCCESS},
 		"o2": {status: common.Status_SUCCESS},
@@ -79,7 +78,7 @@ func TestBFTBroadcaster_DiscardsFailedConnectionsOnPartialFailureSuccess(t *test
 		b.connectionPool(o.Address) <- &Connection{Stream: streams[o.Address]}
 	}
 
-	err := b.Broadcast(context.Background(), &common.Envelope{})
+	err := b.Broadcast(t.Context(), &common.Envelope{})
 	require.NoError(t, err)
 
 	// Exactly one unit should be free: o4's discarded connection.

--- a/platform/fabric/core/generic/ordering/bft_test.go
+++ b/platform/fabric/core/generic/ordering/bft_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ordering
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	ab "github.com/hyperledger/fabric-protos-go-apiv2/orderer"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
+)
+
+// fakeBroadcastStream is a Broadcast-interface stub with per-instance outcomes.
+type fakeBroadcastStream struct {
+	sendErr error
+	recvErr error
+	status  common.Status
+}
+
+func (f *fakeBroadcastStream) Send(*common.Envelope) error { return f.sendErr }
+
+func (f *fakeBroadcastStream) Recv() (*ab.BroadcastResponse, error) {
+	if f.recvErr != nil {
+		return nil, f.recvErr
+	}
+	return &ab.BroadcastResponse{Status: f.status}, nil
+}
+
+func (f *fakeBroadcastStream) CloseSend() error { return nil }
+
+// fakeConfigService overrides only the ConfigService methods Broadcast uses.
+type fakeConfigService struct {
+	driver.ConfigService
+	poolSize int
+	retries  int
+	orderers []*grpc.ConnectionConfig
+}
+
+func (c *fakeConfigService) OrdererConnectionPoolSize() int        { return c.poolSize }
+func (c *fakeConfigService) BroadcastNumRetries() int              { return c.retries }
+func (c *fakeConfigService) BroadcastRetryInterval() time.Duration { return 0 }
+func (c *fakeConfigService) Orderers() []*grpc.ConnectionConfig    { return c.orderers }
+
+// A connection that errored mid-broadcast must be discarded even when the
+// broadcast meets its BFT threshold and returns success.
+func TestBFTBroadcaster_DiscardsFailedConnectionsOnPartialFailureSuccess(t *testing.T) {
+	t.Parallel()
+
+	orderers := []*grpc.ConnectionConfig{
+		{Address: "o1"}, {Address: "o2"}, {Address: "o3"}, {Address: "o4"},
+	}
+	cfg := &fakeConfigService{
+		poolSize: len(orderers),
+		retries:  1,
+		orderers: orderers,
+	}
+	b := NewBFTBroadcaster(cfg, nil, nil)
+
+	// Pre-fill the pools and hold the matching semaphore units, so
+	// getConnection bypasses ClientFactory and discard accounting balances.
+	require.NoError(t, b.connSem.Acquire(context.Background(), int64(len(orderers))))
+	streams := map[string]*fakeBroadcastStream{
+		"o1": {status: common.Status_SUCCESS},
+		"o2": {status: common.Status_SUCCESS},
+		"o3": {status: common.Status_SUCCESS},
+		"o4": {recvErr: errors.New("induced Recv failure")},
+	}
+	for _, o := range orderers {
+		b.connectionPool(o.Address) <- &Connection{Stream: streams[o.Address]}
+	}
+
+	err := b.Broadcast(context.Background(), &common.Envelope{})
+	require.NoError(t, err)
+
+	// Exactly one unit should be free: o4's discarded connection.
+	require.True(t, b.connSem.TryAcquire(1), "failed connection's semaphore unit should be released")
+	require.False(t, b.connSem.TryAcquire(1), "only one unit should be released")
+}


### PR DESCRIPTION
## Summary

`BFTBroadcaster.Broadcast()` only ran its `usedConnections` cleanup on the
overall-failure path (`counter < threshold`). When a broadcast partially failed
but still cleared the BFT success threshold — e.g. 3 of 4 orderers acked, the
4th errored on `Send` / `Recv` or returned a non-`SUCCESS` status — the failed
connections never got discarded. Their `connSem` semaphore units stayed held
and their gRPC streams stayed open for the lifetime of the process.

This moves the cleanup loop above the threshold check so it runs on every
path. Successful connections are already returned to their pools by
`releaseConnection` (which does not touch the semaphore), so the change only
affects the previously-leaking failed-connection set.

Closes #1484

## Impact

Under sustained partial-failure conditions (one slow/flaky orderer that
intermittently errors on `Recv`), the leak compounds: each broadcast leaks
one semaphore unit until `connSem` is fully exhausted, at which point
`getConnection` falls back to its slow path and overall ordering throughput
collapses. This matches the symptom of "pool gradually fills with phantom
in-use slots over hours" observed under sustained load in our deployment.

## Test plan

- Added `TestBFTBroadcaster_DiscardsFailedConnectionsOnPartialFailureSuccess`:
  drives `Broadcast()` against four fake orderers (threshold = 3) where three
  ack `SUCCESS` and the fourth errors on `Recv`; asserts the broadcast
  returns nil **and** exactly one `connSem` unit is released (via
  `TryAcquire(1)` returning true once, then false). Pre-fix the test fails
  (no unit released); post-fix it passes. The test pre-fills the per-orderer
  connection pools so `getConnection` never touches `ClientFactory`, and uses
  a `fakeBroadcastStream` (the `Broadcast` interface from `client.go`) so each
  orderer's outcome is independently controllable.
- `go vet`, `gofmt -l` clean; `go test -race ./platform/fabric/core/generic/ordering/...` passes.

## Notes

- The fix is a control-flow refactor (move one `for` loop), with no API change
  and no behavior change for the no-failure success path (`usedConnections`
  empty, loop is a no-op) or the overall-failure path (same cleanup runs in
  the same place relative to the threshold check that now precedes it).
