### PR TITLE
refactor!: replace base58 encoding with base64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/miekg/pkcs11 v1.1.1
 	github.com/moby/moby/api v1.54.2
 	github.com/moby/moby/client v0.4.0
-	github.com/mr-tron/base58 v1.3.0
 	github.com/multiformats/go-multiaddr v0.16.1
 	github.com/onsi/ginkgo/v2 v2.27.3
 	github.com/onsi/gomega v1.38.2
@@ -178,6 +177,7 @@ require (
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/mr-tron/base58 v1.3.0 // indirect
 	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect
 	github.com/multiformats/go-multiaddr-dns v0.5.0 // indirect

--- a/platform/view/services/comm/host/websocket/p2p_test.go
+++ b/platform/view/services/comm/host/websocket/p2p_test.go
@@ -13,6 +13,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/pem"
 	"math/big"
 	"net"
@@ -21,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mr-tron/base58/base58"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
 
@@ -312,7 +312,7 @@ func mustPeerIDFromCert(t *testing.T, certPath string) string {
 	marshaledPK, err := x509.MarshalPKIXPublicKey(cert.PublicKey)
 	require.NoError(t, err)
 	h := sha256.Sum256(marshaledPK)
-	return base58.Encode(h[:])
+	return base64.StdEncoding.EncodeToString(h[:])
 }
 
 type staticRoutHostProvider struct {

--- a/platform/view/services/comm/host/websocket/pki.go
+++ b/platform/view/services/comm/host/websocket/pki.go
@@ -10,8 +10,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/sha256"
 	"crypto/x509"
-
-	"github.com/mr-tron/base58/base58"
+	"encoding/base64"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
@@ -40,5 +39,7 @@ func ecdsaPubKeyID(key *ecdsa.PublicKey) ([]byte, error) {
 	}
 
 	h := sha256.Sum256(marshaledPubKey)
-	return []byte(base58.Encode(h[:])), nil
+	buf := make([]byte, base64.StdEncoding.EncodedLen(len(h[:])))
+	base64.StdEncoding.Encode(buf, h[:])
+	return buf, nil
 }

--- a/platform/view/services/comm/host/websocket/ws/auth.go
+++ b/platform/view/services/comm/host/websocket/ws/auth.go
@@ -10,9 +10,8 @@ import (
 	"crypto/ecdsa"
 	"crypto/sha256"
 	"crypto/x509"
+	"encoding/base64"
 	"net/http"
-
-	"github.com/mr-tron/base58/base58"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	host2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/comm/host"
@@ -45,7 +44,7 @@ func peerIDFromCertificate(cert *x509.Certificate) (host2.PeerID, error) {
 			return "", errors.Wrapf(err, "failed to marshal public key")
 		}
 		h := sha256.Sum256(marshaledPubKey)
-		return host2.PeerID(base58.Encode(h[:])), nil
+		return base64.StdEncoding.EncodeToString(h[:]), nil
 	default:
 		return "", errors.Errorf("unsupported public key type [%T]", cert.PublicKey)
 	}


### PR DESCRIPTION
Closes #1498 

Breaking change: While change is not directly exposed to the user, it's a breaking change and requires all nodes in the network to upgrade to that version.