### PR TITLE
refactor: remove pretty, spew, and go-kit/log deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,8 @@ require (
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/cockroachdb/errors v1.12.0
 	github.com/containerd/errdefs v1.0.0
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/gin-contrib/cors v1.7.2
 	github.com/gin-gonic/gin v1.10.0
-	github.com/go-kit/log v0.2.1
 	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
@@ -34,7 +32,6 @@ require (
 	github.com/knadh/koanf/providers/file v1.2.1
 	github.com/knadh/koanf/providers/rawbytes v1.0.0
 	github.com/knadh/koanf/v2 v2.3.4
-	github.com/kr/pretty v0.3.1
 	github.com/libp2p/go-libp2p v0.48.0
 	github.com/libp2p/go-libp2p-kad-dht v0.39.0
 	github.com/miekg/pkcs11 v1.1.1
@@ -95,6 +92,7 @@ require (
 	github.com/cockroachdb/redact v1.1.5 // indirect
 	github.com/consensys/gnark-crypto v0.19.2 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
@@ -109,7 +107,6 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/getsentry/sentry-go v0.27.0 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
-	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
@@ -149,6 +146,7 @@ require (
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect
 	github.com/koron/go-ssdp v0.0.6 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -792,13 +792,9 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
-github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
-github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-latex/latex v0.0.0-20210118124228-b3d85cf34e07/go.mod h1:CO1AlKB2CSIqUrmQPqA0gdRIlnLEY0gK5JGjh37zN5U=
 github.com/go-latex/latex v0.0.0-20210823091927-c0d11ff05a81/go.mod h1:SX0U8uGpxhq9o2S/CELCSUxEWWAuoCUcVCQWv7G2OCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
-github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/platform/fabric/core/generic/ledger/kvledger/rwsetutil/rwset_proto_util_test.go
+++ b/platform/fabric/core/generic/ledger/kvledger/rwsetutil/rwset_proto_util_test.go
@@ -19,9 +19,7 @@ package rwsetutil
 import (
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/hyperledger/fabric-protos-go-apiv2/ledger/rwset/kvrwset"
-	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
@@ -65,7 +63,6 @@ func TestTxRWSetMarshalUnmarshal(t *testing.T) {
 	require.NoError(t, err)
 	txRwSet1 := &TxRwSet{}
 	require.NoError(t, txRwSet1.FromProtoBytes(protoBytes))
-	t.Logf("txRwSet=%s, txRwSet1=%s", spew.Sdump(txRwSet), spew.Sdump(txRwSet1))
 	require.Len(t, txRwSet.NsRwSets, len(txRwSet1.NsRwSets))
 	for i, rwset := range txRwSet.NsRwSets {
 		require.Equal(t, txRwSet1.NsRwSets[i].NameSpace, rwset.NameSpace)
@@ -81,7 +78,6 @@ func TestTxRwSetConversion(t *testing.T) {
 	require.NoError(t, err)
 	txRwSet1, err := TxRwSetFromProtoMsg(protoMsg)
 	require.NoError(t, err)
-	t.Logf("txRwSet=%s, txRwSet1=%s", spew.Sdump(txRwSet), spew.Sdump(txRwSet1))
 	require.Len(t, txRwSet.NsRwSets, len(txRwSet1.NsRwSets))
 	for i, rwset := range txRwSet.NsRwSets {
 		require.Equal(t, txRwSet1.NsRwSets[i].NameSpace, rwset.NameSpace)
@@ -101,7 +97,6 @@ func TestNsRwSetConversion(t *testing.T) {
 	require.NoError(t, err)
 	nsRwSet1, err := nsRwSetFromProtoMsg(protoMsg)
 	require.NoError(t, err)
-	t.Logf("nsRwSet=%s, nsRwSet1=%s", spew.Sdump(nsRwSet), spew.Sdump(nsRwSet1))
 	require.Equal(t, nsRwSet1.NameSpace, nsRwSet.NameSpace)
 	require.True(t, proto.Equal(nsRwSet1.KvRwSet, nsRwSet.KvRwSet), "proto messages are not equal")
 	for j, hashedRwSet := range nsRwSet.CollHashedRwSets {
@@ -205,7 +200,6 @@ func TestTxPvtRwSetConversion(t *testing.T) {
 	require.NoError(t, err)
 	txPvtRwSet1, err := TxPvtRwSetFromProtoMsg(protoMsg)
 	require.NoError(t, err)
-	t.Logf("txPvtRwSet=%s, txPvtRwSet1=%s, Diff:%s", spew.Sdump(txPvtRwSet), spew.Sdump(txPvtRwSet1), pretty.Diff(txPvtRwSet, txPvtRwSet1))
 	require.Len(t, txPvtRwSet.NsPvtRwSet, len(txPvtRwSet1.NsPvtRwSet))
 	for i, rwset := range txPvtRwSet.NsPvtRwSet {
 		require.Equal(t, txPvtRwSet1.NsPvtRwSet[i].NameSpace, rwset.NameSpace)

--- a/platform/view/sdk/dig/sdk.go
+++ b/platform/view/sdk/dig/sdk.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/go-kit/log"
 	"go.uber.org/dig"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
@@ -152,13 +151,13 @@ func (p *SDK) Install() error {
 
 		// Tracing
 		p.Container().Provide(NewOperationsLogger),
-		p.Container().Provide(digutils.Identity[operations.OperationsLogger](), dig.As(new(operations.Logger)), dig.As(new(log.Logger))),
+		p.Container().Provide(digutils.Identity[operations.OperationsLogger](), dig.As(new(operations.Logger))),
 		p.Container().Provide(NewOperationsOptions),
 		p.Container().Provide(operations.NewOperationSystem),
 		p.Container().Provide(newTracerProvider),
 		// Metrics
-		p.Container().Provide(func(o *operations.Options, l operations.OperationsLogger) metrics2.Provider {
-			return operations.NewMetricsProvider(o.Metrics, l, true)
+		p.Container().Provide(func(o *operations.Options) metrics2.Provider {
+			return operations.NewMetricsProvider(o.Metrics, true)
 		}),
 		p.Container().Provide(viewgrpcserver.NewMetrics),
 

--- a/platform/view/services/metrics/operations/logger.go
+++ b/platform/view/services/metrics/operations/logger.go
@@ -7,23 +7,15 @@ SPDX-License-Identifier: Apache-2.0
 package operations
 
 import (
-	log2 "github.com/go-kit/log"
-
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
 )
 
 type OperationsLogger interface {
 	Logger
-	log2.Logger
 }
 
 type operationsLogger struct {
 	Logger
-}
-
-func (l *operationsLogger) Log(keyvals ...any) error {
-	l.Warn(keyvals...)
-	return nil
 }
 
 func NewOperationsLogger(l Logger) *operationsLogger {

--- a/platform/view/services/metrics/operations/metrics.go
+++ b/platform/view/services/metrics/operations/metrics.go
@@ -9,8 +9,6 @@ package operations
 import (
 	"sync"
 
-	log2 "github.com/go-kit/log"
-
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics/disabled"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics/prometheus"
@@ -42,7 +40,7 @@ func versionGauge(provider metrics.Provider) metrics.Gauge {
 	}
 }
 
-func NewMetricsProvider(m MetricsOptions, l log2.Logger, skipRegisterErr bool) metrics.Provider {
+func NewMetricsProvider(m MetricsOptions, skipRegisterErr bool) metrics.Provider {
 	switch m.Provider {
 	case "prometheus":
 		return &prometheus.Provider{SkipRegisterErr: skipRegisterErr}

--- a/platform/view/services/metrics/operations/system.go
+++ b/platform/view/services/metrics/operations/system.go
@@ -86,10 +86,6 @@ func (s *System) Stop() error {
 	return nil
 }
 
-func (s *System) Log(keyvals ...any) error {
-	return s.logger.Log(keyvals)
-}
-
 func (s *System) initializeMetricsProvider(provider metrics.Provider, m MetricsOptions) error {
 	s.logger.Debugf("Initializing metrics provider: [%s]", m.Provider)
 	s.Provider = provider


### PR DESCRIPTION
This PR removes `go-kit/log` from the project as it's not used anymore. Additionally, we remove `pretty` and `spew` used for debug logging in a unit-test.

Closes #1501 