### PR TITLE
perf(fabricx/queryservice): add batched GetTransactionStatuses

### DIFF
--- a/platform/fabricx/core/committer/queryservice/mock/query_service.go
+++ b/platform/fabricx/core/committer/queryservice/mock/query_service.go
@@ -61,6 +61,19 @@ type QueryService struct {
 		result1 int32
 		result2 error
 	}
+	GetTransactionStatusesStub        func([]string) (map[string]int32, error)
+	getTransactionStatusesMutex       sync.RWMutex
+	getTransactionStatusesArgsForCall []struct {
+		arg1 []string
+	}
+	getTransactionStatusesReturns struct {
+		result1 map[string]int32
+		result2 error
+	}
+	getTransactionStatusesReturnsOnCall map[int]struct {
+		result1 map[string]int32
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -310,6 +323,75 @@ func (fake *QueryService) GetTransactionStatusReturnsOnCall(i int, result1 int32
 	}
 	fake.getTransactionStatusReturnsOnCall[i] = struct {
 		result1 int32
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *QueryService) GetTransactionStatuses(arg1 []string) (map[string]int32, error) {
+	var arg1Copy []string
+	if arg1 != nil {
+		arg1Copy = make([]string, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.getTransactionStatusesMutex.Lock()
+	ret, specificReturn := fake.getTransactionStatusesReturnsOnCall[len(fake.getTransactionStatusesArgsForCall)]
+	fake.getTransactionStatusesArgsForCall = append(fake.getTransactionStatusesArgsForCall, struct {
+		arg1 []string
+	}{arg1Copy})
+	stub := fake.GetTransactionStatusesStub
+	fakeReturns := fake.getTransactionStatusesReturns
+	fake.recordInvocation("GetTransactionStatuses", []interface{}{arg1Copy})
+	fake.getTransactionStatusesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *QueryService) GetTransactionStatusesCallCount() int {
+	fake.getTransactionStatusesMutex.RLock()
+	defer fake.getTransactionStatusesMutex.RUnlock()
+	return len(fake.getTransactionStatusesArgsForCall)
+}
+
+func (fake *QueryService) GetTransactionStatusesCalls(stub func([]string) (map[string]int32, error)) {
+	fake.getTransactionStatusesMutex.Lock()
+	defer fake.getTransactionStatusesMutex.Unlock()
+	fake.GetTransactionStatusesStub = stub
+}
+
+func (fake *QueryService) GetTransactionStatusesArgsForCall(i int) []string {
+	fake.getTransactionStatusesMutex.RLock()
+	defer fake.getTransactionStatusesMutex.RUnlock()
+	argsForCall := fake.getTransactionStatusesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *QueryService) GetTransactionStatusesReturns(result1 map[string]int32, result2 error) {
+	fake.getTransactionStatusesMutex.Lock()
+	defer fake.getTransactionStatusesMutex.Unlock()
+	fake.GetTransactionStatusesStub = nil
+	fake.getTransactionStatusesReturns = struct {
+		result1 map[string]int32
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *QueryService) GetTransactionStatusesReturnsOnCall(i int, result1 map[string]int32, result2 error) {
+	fake.getTransactionStatusesMutex.Lock()
+	defer fake.getTransactionStatusesMutex.Unlock()
+	fake.GetTransactionStatusesStub = nil
+	if fake.getTransactionStatusesReturnsOnCall == nil {
+		fake.getTransactionStatusesReturnsOnCall = make(map[int]struct {
+			result1 map[string]int32
+			result2 error
+		})
+	}
+	fake.getTransactionStatusesReturnsOnCall[i] = struct {
+		result1 map[string]int32
 		result2 error
 	}{result1, result2}
 }

--- a/platform/fabricx/core/committer/queryservice/provider.go
+++ b/platform/fabricx/core/committer/queryservice/provider.go
@@ -37,6 +37,7 @@ type QueryService interface {
 	GetState(ns driver.Namespace, key driver.PKey) (*driver.VaultValue, error)
 	GetStates(map[driver.Namespace][]driver.PKey) (map[driver.Namespace]map[driver.PKey]driver.VaultValue, error)
 	GetTransactionStatus(txID string) (int32, error)
+	GetTransactionStatuses(txIDs []string) (map[string]int32, error)
 	GetConfigTransaction() (*ConfigTransactionInfo, error)
 }
 

--- a/platform/fabricx/core/committer/queryservice/query.go
+++ b/platform/fabricx/core/committer/queryservice/query.go
@@ -92,21 +92,34 @@ func (s *RemoteQueryService) GetTransactionStatus(txID string) (int32, error) {
 }
 
 // GetTransactionStatuses resolves the status of many transactions in one query,
-// keyed by transaction ID; transactions unknown to the committer are omitted.
+// keyed by transaction ID. Duplicate input IDs are collapsed before querying.
+// Unlike GetTransactionStatus, which returns an error for a transaction unknown
+// to the committer, unknown transactions are omitted from the result so callers
+// can treat a missing entry as "not final yet".
 func (s *RemoteQueryService) GetTransactionStatuses(txIDs []string) (map[string]int32, error) {
 	if len(txIDs) == 0 {
 		return map[string]int32{}, nil
+	}
+
+	seen := make(map[string]struct{}, len(txIDs))
+	unique := make([]string, 0, len(txIDs))
+	for _, txID := range txIDs {
+		if _, ok := seen[txID]; ok {
+			continue
+		}
+		seen[txID] = struct{}{}
+		unique = append(unique, txID)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), s.config.RequestTimeout)
 	defer cancel()
 
 	now := time.Now()
-	res, err := s.client.GetTransactionStatus(ctx, &committerpb.TxStatusQuery{TxIds: txIDs})
+	res, err := s.client.GetTransactionStatus(ctx, &committerpb.TxStatusQuery{TxIds: unique})
 	if err != nil {
 		return nil, errors.Wrap(err, "query transaction statuses")
 	}
-	logger.Debugf("QS GetTransactionStatuses: %d ids -> %d statuses in %v", len(txIDs), len(res.GetStatuses()), time.Since(now))
+	logger.Debugf("QS GetTransactionStatuses: %d ids -> %d statuses in %v", len(unique), len(res.GetStatuses()), time.Since(now))
 
 	out := make(map[string]int32, len(res.GetStatuses()))
 	for _, st := range res.GetStatuses() {

--- a/platform/fabricx/core/committer/queryservice/query.go
+++ b/platform/fabricx/core/committer/queryservice/query.go
@@ -91,6 +91,32 @@ func (s *RemoteQueryService) GetTransactionStatus(txID string) (int32, error) {
 	return int32(res.Statuses[0].Status), nil
 }
 
+// GetTransactionStatuses resolves the status of many transactions in one query,
+// keyed by transaction ID; transactions unknown to the committer are omitted.
+func (s *RemoteQueryService) GetTransactionStatuses(txIDs []string) (map[string]int32, error) {
+	if len(txIDs) == 0 {
+		return map[string]int32{}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), s.config.RequestTimeout)
+	defer cancel()
+
+	now := time.Now()
+	res, err := s.client.GetTransactionStatus(ctx, &committerpb.TxStatusQuery{TxIds: txIDs})
+	if err != nil {
+		return nil, errors.Wrap(err, "query transaction statuses")
+	}
+	logger.Debugf("QS GetTransactionStatuses: %d ids -> %d statuses in %v", len(txIDs), len(res.GetStatuses()), time.Since(now))
+
+	out := make(map[string]int32, len(res.GetStatuses()))
+	for _, st := range res.GetStatuses() {
+		if ref := st.GetRef(); ref != nil {
+			out[ref.GetTxId()] = int32(st.GetStatus())
+		}
+	}
+	return out, nil
+}
+
 // GetConfigTransaction returns the envelope and version of the most recent config transaction
 func (s *RemoteQueryService) GetConfigTransaction() (*ConfigTransactionInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), s.config.RequestTimeout)

--- a/platform/fabricx/core/committer/queryservice/query_test.go
+++ b/platform/fabricx/core/committer/queryservice/query_test.go
@@ -452,6 +452,22 @@ func TestQueryService(t *testing.T) {
 			require.Equal(t, []string{"tx1", "tx2", "tx3"}, query.GetTxIds())
 		})
 
+		t.Run("duplicate input ids are collapsed", func(t *testing.T) {
+			t.Parallel()
+			qs, fake := setupTest(t)
+			fake.GetTransactionStatusReturns(&committerpb.TxStatusResponse{
+				Statuses: []*committerpb.TxStatus{
+					{Ref: &committerpb.TxRef{TxId: "tx1"}, Status: committerpb.Status_COMMITTED},
+				},
+			}, nil)
+
+			statuses, err := qs.GetTransactionStatuses([]string{"tx1", "tx2", "tx1", "tx2"})
+			require.NoError(t, err)
+			require.Equal(t, map[string]int32{"tx1": int32(committerpb.Status_COMMITTED)}, statuses)
+			_, query, _ := fake.GetTransactionStatusArgsForCall(0)
+			require.Equal(t, []string{"tx1", "tx2"}, query.GetTxIds())
+		})
+
 		t.Run("statuses without ref are dropped", func(t *testing.T) {
 			t.Parallel()
 			qs, fake := setupTest(t)

--- a/platform/fabricx/core/committer/queryservice/query_test.go
+++ b/platform/fabricx/core/committer/queryservice/query_test.go
@@ -426,6 +426,68 @@ func TestQueryService(t *testing.T) {
 		})
 	})
 
+	// New tests for GetTransactionStatuses
+	t.Run("GetTransactionStatuses", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("happy path keyed by tx id", func(t *testing.T) {
+			t.Parallel()
+			qs, fake := setupTest(t)
+			// statuses returned out of order and without the unknown tx3
+			fake.GetTransactionStatusReturns(&committerpb.TxStatusResponse{
+				Statuses: []*committerpb.TxStatus{
+					{Ref: &committerpb.TxRef{TxId: "tx2"}, Status: committerpb.Status_ABORTED_MVCC_CONFLICT},
+					{Ref: &committerpb.TxRef{TxId: "tx1"}, Status: committerpb.Status_COMMITTED},
+				},
+			}, nil)
+
+			statuses, err := qs.GetTransactionStatuses([]string{"tx1", "tx2", "tx3"})
+			require.NoError(t, err)
+			require.Equal(t, map[string]int32{
+				"tx1": int32(committerpb.Status_COMMITTED),
+				"tx2": int32(committerpb.Status_ABORTED_MVCC_CONFLICT),
+			}, statuses)
+			require.Equal(t, 1, fake.GetTransactionStatusCallCount())
+			_, query, _ := fake.GetTransactionStatusArgsForCall(0)
+			require.Equal(t, []string{"tx1", "tx2", "tx3"}, query.GetTxIds())
+		})
+
+		t.Run("statuses without ref are dropped", func(t *testing.T) {
+			t.Parallel()
+			qs, fake := setupTest(t)
+			fake.GetTransactionStatusReturns(&committerpb.TxStatusResponse{
+				Statuses: []*committerpb.TxStatus{
+					{Status: committerpb.Status_COMMITTED},
+					{Ref: &committerpb.TxRef{TxId: "tx1"}, Status: committerpb.Status_COMMITTED},
+				},
+			}, nil)
+
+			statuses, err := qs.GetTransactionStatuses([]string{"tx1", "tx2"})
+			require.NoError(t, err)
+			require.Equal(t, map[string]int32{"tx1": int32(committerpb.Status_COMMITTED)}, statuses)
+		})
+
+		t.Run("empty input does not query", func(t *testing.T) {
+			t.Parallel()
+			qs, fake := setupTest(t)
+
+			statuses, err := qs.GetTransactionStatuses(nil)
+			require.NoError(t, err)
+			require.Empty(t, statuses)
+			require.Equal(t, 0, fake.GetTransactionStatusCallCount())
+		})
+
+		t.Run("client error", func(t *testing.T) {
+			t.Parallel()
+			qs, fake := setupTest(t)
+			expectedError := errors.New("some error")
+			fake.GetTransactionStatusReturns(nil, expectedError)
+
+			_, err := qs.GetTransactionStatuses([]string{"tx1"})
+			require.ErrorIs(t, err, expectedError)
+		})
+	})
+
 	// New tests for GetConfigTransaction
 	t.Run("GetConfigTransaction", func(t *testing.T) {
 		t.Parallel()

--- a/platform/fabricx/core/ledger/mock/query_service.go
+++ b/platform/fabricx/core/ledger/mock/query_service.go
@@ -61,6 +61,19 @@ type QueryService struct {
 		result1 int32
 		result2 error
 	}
+	GetTransactionStatusesStub        func([]string) (map[string]int32, error)
+	getTransactionStatusesMutex       sync.RWMutex
+	getTransactionStatusesArgsForCall []struct {
+		arg1 []string
+	}
+	getTransactionStatusesReturns struct {
+		result1 map[string]int32
+		result2 error
+	}
+	getTransactionStatusesReturnsOnCall map[int]struct {
+		result1 map[string]int32
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -310,6 +323,75 @@ func (fake *QueryService) GetTransactionStatusReturnsOnCall(i int, result1 int32
 	}
 	fake.getTransactionStatusReturnsOnCall[i] = struct {
 		result1 int32
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *QueryService) GetTransactionStatuses(arg1 []string) (map[string]int32, error) {
+	var arg1Copy []string
+	if arg1 != nil {
+		arg1Copy = make([]string, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.getTransactionStatusesMutex.Lock()
+	ret, specificReturn := fake.getTransactionStatusesReturnsOnCall[len(fake.getTransactionStatusesArgsForCall)]
+	fake.getTransactionStatusesArgsForCall = append(fake.getTransactionStatusesArgsForCall, struct {
+		arg1 []string
+	}{arg1Copy})
+	stub := fake.GetTransactionStatusesStub
+	fakeReturns := fake.getTransactionStatusesReturns
+	fake.recordInvocation("GetTransactionStatuses", []interface{}{arg1Copy})
+	fake.getTransactionStatusesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *QueryService) GetTransactionStatusesCallCount() int {
+	fake.getTransactionStatusesMutex.RLock()
+	defer fake.getTransactionStatusesMutex.RUnlock()
+	return len(fake.getTransactionStatusesArgsForCall)
+}
+
+func (fake *QueryService) GetTransactionStatusesCalls(stub func([]string) (map[string]int32, error)) {
+	fake.getTransactionStatusesMutex.Lock()
+	defer fake.getTransactionStatusesMutex.Unlock()
+	fake.GetTransactionStatusesStub = stub
+}
+
+func (fake *QueryService) GetTransactionStatusesArgsForCall(i int) []string {
+	fake.getTransactionStatusesMutex.RLock()
+	defer fake.getTransactionStatusesMutex.RUnlock()
+	argsForCall := fake.getTransactionStatusesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *QueryService) GetTransactionStatusesReturns(result1 map[string]int32, result2 error) {
+	fake.getTransactionStatusesMutex.Lock()
+	defer fake.getTransactionStatusesMutex.Unlock()
+	fake.GetTransactionStatusesStub = nil
+	fake.getTransactionStatusesReturns = struct {
+		result1 map[string]int32
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *QueryService) GetTransactionStatusesReturnsOnCall(i int, result1 map[string]int32, result2 error) {
+	fake.getTransactionStatusesMutex.Lock()
+	defer fake.getTransactionStatusesMutex.Unlock()
+	fake.GetTransactionStatusesStub = nil
+	if fake.getTransactionStatusesReturnsOnCall == nil {
+		fake.getTransactionStatusesReturnsOnCall = make(map[int]struct {
+			result1 map[string]int32
+			result2 error
+		})
+	}
+	fake.getTransactionStatusesReturnsOnCall[i] = struct {
+		result1 map[string]int32
 		result2 error
 	}{result1, result2}
 }

--- a/platform/fabricx/core/vault/vault_test.go
+++ b/platform/fabricx/core/vault/vault_test.go
@@ -61,6 +61,16 @@ func (m *mockQueryService) GetTransactionStatus(txID string) (int32, error) {
 	return 0, nil
 }
 
+func (m *mockQueryService) GetTransactionStatuses(txIDs []string) (map[string]int32, error) {
+	out := make(map[string]int32, len(txIDs))
+	for _, txID := range txIDs {
+		if status, ok := m.txStatuses[txID]; ok {
+			out[txID] = status
+		}
+	}
+	return out, nil
+}
+
 func (m *mockQueryService) GetConfigTransaction() (*queryservice.ConfigTransactionInfo, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Closes #1552

## What

Adds `GetTransactionStatuses(txIDs []string) (map[string]int32, error)` to the fabricx query service: many transaction statuses resolved in one committer round-trip.

- `RemoteQueryService` implementation — a single `TxStatusQuery{TxIds: txIDs}` call; the committer request message is already `repeated`, so no committer-side change is needed.
- Result keyed by `TxStatus.Ref.TxId`, independent of response ordering. Transactions unknown to the committer are omitted from the map (callers treat a missing entry as "not final yet"). Statuses without a `Ref` are dropped. Empty input short-circuits without a network call.
- Added to the `QueryService` interface; counterfeiter mocks regenerated (`queryservice/mock`, `ledger/mock`); the hand-written `mockQueryService` in vault tests extended.
- Unit tests: out-of-order/partial responses keyed correctly, ref-less statuses dropped, empty-input short-circuit, client error propagation.

## Why

The query service only exposed a per-tx call, forcing finality tracking of many in-flight transactions into one gRPC round-trip each. In our deployment this capped finality settlement at ~92 tx/s with tens of thousands of pending transactions, while pollers sat blocked in `GetTransactionStatus` — far below what the committer sustains.

## Notes for reviewers

- A single `RequestTimeout` covers the whole batch; callers issuing very large batches should chunk on their side.
- `go build ./platform/fabricx/...`, `go vet`, and the full `./platform/fabricx/...` test suite pass.
