### PR TITLE
bug(fabricx): skip CertificateID for idemix  #1556

### DIFF
--- a/platform/fabric/core/generic/membership/membership.go
+++ b/platform/fabric/core/generic/membership/membership.go
@@ -102,6 +102,22 @@ func (c *Service) GetMSPIDs() []string {
 	return mspIDs
 }
 
+// IsIdemixMSP returns true if the MSP identified by mspID is of type Idemix.
+func (c *Service) IsIdemixMSP(mspID string) bool {
+	ac := c.resources().ApplicationConfig()
+	if ac == nil || ac.Organizations() == nil {
+		return false
+	}
+
+	for _, org := range ac.Organizations() {
+		if org.MSPID() == mspID {
+			return org.MSP().GetType() == msp.IDEMIX
+		}
+	}
+
+	return false
+}
+
 func (c *Service) OrdererConfig(cs driver.ConfigService) (string, []*grpc.ConnectionConfig, error) {
 	oc := c.resources().OrdererConfig()
 	if oc == nil {

--- a/platform/fabric/core/generic/transaction/mock/channel_membership.go
+++ b/platform/fabric/core/generic/transaction/mock/channel_membership.go
@@ -54,6 +54,17 @@ type ChannelMembership struct {
 	isValidReturnsOnCall map[int]struct {
 		result1 error
 	}
+	IsIdemixMSPStub        func(string) bool
+	isIdemixMSPMutex       sync.RWMutex
+	isIdemixMSPArgsForCall []struct {
+		arg1 string
+	}
+	isIdemixMSPReturns struct {
+		result1 bool
+	}
+	isIdemixMSPReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	MSPManagerStub        func() driver.MSPManager
 	mSPManagerMutex       sync.RWMutex
 	mSPManagerArgsForCall []struct {
@@ -304,6 +315,67 @@ func (fake *ChannelMembership) IsValidReturnsOnCall(i int, result1 error) {
 	}
 	fake.isValidReturnsOnCall[i] = struct {
 		result1 error
+	}{result1}
+}
+
+func (fake *ChannelMembership) IsIdemixMSP(arg1 string) bool {
+	fake.isIdemixMSPMutex.Lock()
+	ret, specificReturn := fake.isIdemixMSPReturnsOnCall[len(fake.isIdemixMSPArgsForCall)]
+	fake.isIdemixMSPArgsForCall = append(fake.isIdemixMSPArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.IsIdemixMSPStub
+	fakeReturns := fake.isIdemixMSPReturns
+	fake.recordInvocation("IsIdemixMSP", []interface{}{arg1})
+	fake.isIdemixMSPMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *ChannelMembership) IsIdemixMSPCallCount() int {
+	fake.isIdemixMSPMutex.RLock()
+	defer fake.isIdemixMSPMutex.RUnlock()
+	return len(fake.isIdemixMSPArgsForCall)
+}
+
+func (fake *ChannelMembership) IsIdemixMSPCalls(stub func(string) bool) {
+	fake.isIdemixMSPMutex.Lock()
+	defer fake.isIdemixMSPMutex.Unlock()
+	fake.IsIdemixMSPStub = stub
+}
+
+func (fake *ChannelMembership) IsIdemixMSPArgsForCall(i int) string {
+	fake.isIdemixMSPMutex.RLock()
+	defer fake.isIdemixMSPMutex.RUnlock()
+	argsForCall := fake.isIdemixMSPArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *ChannelMembership) IsIdemixMSPReturns(result1 bool) {
+	fake.isIdemixMSPMutex.Lock()
+	defer fake.isIdemixMSPMutex.Unlock()
+	fake.IsIdemixMSPStub = nil
+	fake.isIdemixMSPReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *ChannelMembership) IsIdemixMSPReturnsOnCall(i int, result1 bool) {
+	fake.isIdemixMSPMutex.Lock()
+	defer fake.isIdemixMSPMutex.Unlock()
+	fake.IsIdemixMSPStub = nil
+	if fake.isIdemixMSPReturnsOnCall == nil {
+		fake.isIdemixMSPReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.isIdemixMSPReturnsOnCall[i] = struct {
+		result1 bool
 	}{result1}
 }
 

--- a/platform/fabric/driver/membership.go
+++ b/platform/fabric/driver/membership.go
@@ -59,6 +59,8 @@ type ChannelMembership interface {
 	// CheckACL checks the ACL for the resource for the Channel using the
 	// SignedProposal from which an id can be extracted for testing against a policy
 	CheckACL(signedProp SignedProposal) error
+	// IsIdemixMSP returns true if the MSP with the given ID is of type Idemix.
+	IsIdemixMSP(mspID string) bool
 }
 
 type MembershipService interface {

--- a/platform/fabricx/core/membership/membership.go
+++ b/platform/fabricx/core/membership/membership.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hyperledger/fabric-x-common/core/aclmgmt"
 	"github.com/hyperledger/fabric-x-common/core/aclmgmt/resources"
 	"github.com/hyperledger/fabric-x-common/core/policy"
-	"github.com/hyperledger/fabric-x-common/msp"
+	xmsp "github.com/hyperledger/fabric-x-common/msp"
 	"github.com/hyperledger/fabric-x-common/msp/mgmt"
 	"github.com/hyperledger/fabric-x-common/protoutil"
 
@@ -271,6 +271,22 @@ func (s *Service) MSPManager() driver.MSPManager {
 	return &mspManager{s.resources().MSPManager()}
 }
 
+// IsIdemixMSP returns true if the MSP identified by mspID is of type Idemix.
+func (s *Service) IsIdemixMSP(mspID string) bool {
+	ac, ok := s.resources().ApplicationConfig()
+	if !ok || ac.Organizations() == nil {
+		return false
+	}
+
+	for _, org := range ac.Organizations() {
+		if org.MSPID() == mspID {
+			return org.MSP().GetType() == xmsp.IDEMIX
+		}
+	}
+
+	return false
+}
+
 // CheckACL checks the ACL for the resource for the Channel using the
 // SignedProposal from which an id can be extracted for testing against a policy
 func (s *Service) CheckACL(signedProp driver.SignedProposal) error {
@@ -278,7 +294,7 @@ func (s *Service) CheckACL(signedProp driver.SignedProposal) error {
 }
 
 type mspManager struct {
-	msp.MSPManager
+	xmsp.MSPManager
 }
 
 func (m *mspManager) DeserializeIdentity(serializedIdentity []byte) (driver.MSPIdentity, error) {

--- a/platform/fabricx/core/membership/membership_test.go
+++ b/platform/fabricx/core/membership/membership_test.go
@@ -7,11 +7,13 @@ SPDX-License-Identifier: Apache-2.0
 package membership
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
 	msp_proto "github.com/hyperledger/fabric-protos-go-apiv2/msp"
+	pb "github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/hyperledger/fabric-x-common/api/msppb"
 	"github.com/hyperledger/fabric-x-common/common/channelconfig"
 	"github.com/hyperledger/fabric-x-common/common/configtx"
@@ -23,7 +25,14 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
+	idemix2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/idemix"
+	fabricmsp "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/msp"
 	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/sig"
+	storagedriver "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
+	mem "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/memory"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/kvs"
 )
 
 // --- minimal mocks ---
@@ -542,4 +551,154 @@ func TestService_MSPManager(t *testing.T) {
 		_, err := mgr.DeserializeIdentity([]byte{0xff})
 		require.Error(t, err)
 	})
+}
+
+// TestService_CheckACL_IdemixSignedProposal verifies that CheckACL accepts a
+// SignedProposal whose creator is a real Idemix identity.
+//
+// The test builds a channel configuration bundle that contains a single Idemix
+// MSP org (using the pre-generated testdata from the idemix provider package),
+// loads it into a Service, then creates an authentic signed proposal using the
+// Idemix signing identity and asserts that CheckACL passes.
+func TestService_CheckACL_IdemixSignedProposal(t *testing.T) { //nolint:paralleltest
+	// ── 1. Locate the Idemix MSP testdata (absolute path) ──────────────────
+	idemixMSPDir, err := filepath.Abs("../../../fabric/core/generic/msp/idemix/testdata/idemix")
+	require.NoError(t, err)
+
+	// ── 2. Build a channel genesis block with the Idemix org ───────────────
+	//
+	// Load the standard EtcdRaft application-channel profile, then swap the
+	// application org for our Idemix one.  Because we provide an absolute
+	// MSPDir we do not need to call CompleteInitialization.
+	const (
+		channelID  = "idemix-test"
+		idemixMSPI = "idemix"
+	)
+	prof := configtxgen.Load(configtxgen.SampleAppChannelEtcdRaftProfile, configtest.GetDevConfigDir())
+
+	// Set capabilities to V1_1 on all three levels (channel, orderer,
+	// application) so that the MSP version resolves to MSPv1_1, which is
+	// accepted by the Idemix MSP factory.  The default sampleconfig leaves all
+	// capability maps empty, which yields MSPv1_0 (= 0) — a version the
+	// Idemix factory rejects.  The orderer must also declare capabilities
+	// whenever the channel or application groups do (enforced by preValidate).
+	prof.Capabilities = map[string]bool{"V1_1": true}
+	prof.Orderer.Capabilities = map[string]bool{"V1_1": true}
+	prof.Application.Capabilities = map[string]bool{"V1_1": true}
+
+	idemixOrg := &configtxgen.Organization{
+		Name:           "IdemixOrg",
+		ID:             idemixMSPI,
+		MSPDir:         idemixMSPDir,
+		MSPType:        fxmsp.ProviderTypeToString(fxmsp.IDEMIX),
+		AdminPrincipal: configtxgen.AdminRoleAdminPrincipal,
+		Policies: map[string]*configtxgen.Policy{
+			"Readers":     {Type: "Signature", Rule: "OR('" + idemixMSPI + ".member')"},
+			"Writers":     {Type: "Signature", Rule: "OR('" + idemixMSPI + ".member')"},
+			"Admins":      {Type: "Signature", Rule: "OR('" + idemixMSPI + ".admin')"},
+			"Endorsement": {Type: "Signature", Rule: "OR('" + idemixMSPI + ".member')"},
+		},
+	}
+	prof.Application.Organizations = []*configtxgen.Organization{idemixOrg}
+
+	gb := configtxgen.New(prof).GenesisBlockForChannel(channelID)
+	env := protoutil.ExtractEnvelopeOrPanic(gb, 0)
+
+	s := NewService(channelID)
+	require.NoError(t, s.Update(env))
+
+	// ── 3. Build a real Idemix identity and a matching signer ─────────────
+	mspConf, err := fabricmsp.GetLocalMspConfigWithType(idemixMSPDir, nil, idemixMSPI, "idemix")
+	require.NoError(t, err)
+
+	kvss, err := kvs.New(newKVS(), "", kvs.DefaultCacheSize)
+	require.NoError(t, err)
+
+	sigService := sig.NewService(sig.NewMultiplexDeserializer(), newAuditInfo(), newSignerInfo())
+
+	provider, err := idemix2.NewProviderWithAnyPolicy(mspConf, kvss, sigService)
+	require.NoError(t, err)
+
+	identityBytes, _, err := provider.Identity(nil)
+	require.NoError(t, err)
+
+	signer, err := provider.DeserializeSigner(identityBytes)
+	require.NoError(t, err)
+
+	// ── 4. Create a signed proposal whose creator is the Idemix identity ──
+	//
+	// protoutil.GetSignedProposal requires an identity.SignerSerializer.
+	// We wrap the Idemix signer and the pre-serialised identity bytes.
+	ss := &idemixSignerSerializer{
+		identityBytes: identityBytes,
+		signer:        signer,
+	}
+
+	proposal, _, err := protoutil.CreateChaincodeProposalWithTxIDNonceAndTransient(
+		"txid-1",
+		cb.HeaderType_ENDORSER_TRANSACTION,
+		channelID,
+		&pb.ChaincodeInvocationSpec{
+			ChaincodeSpec: &pb.ChaincodeSpec{
+				Type:        pb.ChaincodeSpec_GOLANG,
+				ChaincodeId: &pb.ChaincodeID{Name: "mychaincode"},
+				Input:       &pb.ChaincodeInput{Args: [][]byte{[]byte("invoke")}},
+			},
+		},
+		[]byte("nonce"),
+		identityBytes,
+		nil,
+	)
+	require.NoError(t, err)
+
+	rawSP, err := protoutil.GetSignedProposal(proposal, ss)
+	require.NoError(t, err)
+
+	// ── 5. CheckACL must pass for a valid Idemix signed proposal ──────────
+	require.NoError(t, s.CheckACL(&rawSignedProposal{sp: rawSP}))
+}
+
+// rawSignedProposal is a minimal driver.SignedProposal that wraps a
+// *pb.SignedProposal for use in unit tests.  CheckACL only needs Internal()
+// to return the underlying *pb.SignedProposal; the remaining methods are
+// not exercised by the ACL path.
+type rawSignedProposal struct {
+	sp *pb.SignedProposal
+}
+
+func (r *rawSignedProposal) ProposalBytes() []byte    { return r.sp.ProposalBytes }
+func (r *rawSignedProposal) Signature() []byte        { return r.sp.Signature }
+func (r *rawSignedProposal) ProposalHash() []byte     { return nil }
+func (r *rawSignedProposal) ChaincodeName() string    { return "" }
+func (r *rawSignedProposal) ChaincodeVersion() string { return "" }
+func (r *rawSignedProposal) Internal() any            { return r.sp }
+
+// idemixSignerSerializer adapts an Idemix driver.Signer and pre-serialised
+// identity bytes to the identity.SignerSerializer interface expected by
+// protoutil.GetSignedProposal.
+type idemixSignerSerializer struct {
+	identityBytes []byte
+	signer        fdriver.Signer
+}
+
+func (s *idemixSignerSerializer) Sign(message []byte) ([]byte, error) {
+	return s.signer.Sign(message)
+}
+
+func (s *idemixSignerSerializer) Serialize() ([]byte, error) {
+	return s.identityBytes, nil
+}
+
+// KVS helpers shared with the Idemix provider test (same pattern as provider_test.go).
+
+func newSignerInfo() storagedriver.SignerInfoStore {
+	return utils.MustGet(mem.NewDriver().NewSignerInfo(""))
+}
+
+func newAuditInfo() storagedriver.AuditInfoStore {
+	return utils.MustGet(mem.NewDriver().NewAuditInfo(""))
+}
+
+func newKVS() storagedriver.KeyValueStore {
+	return utils.MustGet(mem.NewDriver().NewKVS(""))
 }

--- a/platform/fabricx/core/transaction/marshal.go
+++ b/platform/fabricx/core/transaction/marshal.go
@@ -61,7 +61,7 @@ func (t *Transaction) createSCEnvelope() (*cb.Envelope, error) {
 	if membership == nil {
 		return nil, errors.Errorf("no channel membership for channel [%s]", t.Channel())
 	}
-	creatorBytes, err := toMSPSignerIdentityWithCertificateID(signerID, ch.ChannelMembership().IsIdemixMSP)
+	creatorBytes, err := toMSPSignerIdentityWithCertificateID(signerID, membership.IsIdemixMSP)
 	if err != nil {
 		return nil, errors.Wrap(err, "converting creator to cached identity")
 	}

--- a/platform/fabricx/core/transaction/marshal.go
+++ b/platform/fabricx/core/transaction/marshal.go
@@ -52,13 +52,18 @@ func (t *Transaction) createSCEnvelope() (*cb.Envelope, error) {
 		return nil, errors.Wrapf(err, "signer not found for %s while creating tx envelope for ordering", signerID.UniqueID())
 	}
 
-	mspIdentity, err := toMSPSignerIdentityWithCertificateID(signerID)
+	ch, err := t.fns.Channel(t.Channel())
+	if err != nil {
+		return nil, errors.Wrapf(err, "get channel [%s]", t.Channel())
+	}
+
+	membership := ch.ChannelMembership()
+	if membership == nil {
+		return nil, errors.Errorf("no channel membership for channel [%s]", t.Channel())
+	}
+	creatorBytes, err := toMSPSignerIdentityWithCertificateID(signerID, ch.ChannelMembership().IsIdemixMSP)
 	if err != nil {
 		return nil, errors.Wrap(err, "converting creator to cached identity")
-	}
-	creatorBytes, err := proto.Marshal(mspIdentity)
-	if err != nil {
-		return nil, errors.Wrap(err, "marshalling creator identity")
 	}
 	signatureHeader := &cb.SignatureHeader{Creator: creatorBytes, Nonce: t.Nonce()}
 	channelHeader := protoutil.MakeChannelHeader(cb.HeaderType_MESSAGE, 0, t.Channel(), 0)

--- a/platform/fabricx/core/transaction/marshal_test.go
+++ b/platform/fabricx/core/transaction/marshal_test.go
@@ -24,6 +24,7 @@ import (
 //go:generate counterfeiter -o mock/fabric_network_service.go --fake-name FabricNetworkService github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver.FabricNetworkService
 //go:generate counterfeiter -o mock/signer_service.go --fake-name SignerService github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver.SignerService
 //go:generate counterfeiter -o mock/signer.go --fake-name Signer github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver.Signer
+//go:generate counterfeiter -o mock/channel_membership.go --fake-name ChannelMembership github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver.ChannelMembership
 
 // TestCreateSCEnvelopeNoProposalResponses verifies that envelope creation fails
 // when the transaction carries no proposal responses at all.
@@ -168,10 +169,14 @@ func TestCreateSCEnvelopeSuccess(t *testing.T) {
 	fakeFNS := &mock.FabricNetworkService{}
 	fakeSignerService := &mock.SignerService{}
 	fakeSigner := &mock.Signer{}
+	fakeChannel := &mock.Channel{}
+	fakeMembership := &mock.ChannelMembership{}
 
 	fakeFNS.SignerServiceReturns(fakeSignerService)
 	fakeSignerService.GetSignerReturns(fakeSigner, nil)
 	fakeSigner.SignReturns([]byte("envelope-signature"), nil)
+	fakeChannel.ChannelMembershipReturns(fakeMembership)
+	fakeFNS.ChannelReturns(fakeChannel, nil)
 
 	_, creatorBytes := mustSerializedIdentityWithRealCert(t, "Org1MSP")
 

--- a/platform/fabricx/core/transaction/mock/channel_membership.go
+++ b/platform/fabricx/core/transaction/mock/channel_membership.go
@@ -43,17 +43,6 @@ type ChannelMembership struct {
 		result1 driver.Verifier
 		result2 error
 	}
-	IsValidStub        func(view.Identity) error
-	isValidMutex       sync.RWMutex
-	isValidArgsForCall []struct {
-		arg1 view.Identity
-	}
-	isValidReturns struct {
-		result1 error
-	}
-	isValidReturnsOnCall map[int]struct {
-		result1 error
-	}
 	IsIdemixMSPStub        func(string) bool
 	isIdemixMSPMutex       sync.RWMutex
 	isIdemixMSPArgsForCall []struct {
@@ -64,6 +53,17 @@ type ChannelMembership struct {
 	}
 	isIdemixMSPReturnsOnCall map[int]struct {
 		result1 bool
+	}
+	IsValidStub        func(view.Identity) error
+	isValidMutex       sync.RWMutex
+	isValidArgsForCall []struct {
+		arg1 view.Identity
+	}
+	isValidReturns struct {
+		result1 error
+	}
+	isValidReturnsOnCall map[int]struct {
+		result1 error
 	}
 	MSPManagerStub        func() driver.MSPManager
 	mSPManagerMutex       sync.RWMutex
@@ -257,67 +257,6 @@ func (fake *ChannelMembership) GetVerifierReturnsOnCall(i int, result1 driver.Ve
 	}{result1, result2}
 }
 
-func (fake *ChannelMembership) IsValid(arg1 view.Identity) error {
-	fake.isValidMutex.Lock()
-	ret, specificReturn := fake.isValidReturnsOnCall[len(fake.isValidArgsForCall)]
-	fake.isValidArgsForCall = append(fake.isValidArgsForCall, struct {
-		arg1 view.Identity
-	}{arg1})
-	stub := fake.IsValidStub
-	fakeReturns := fake.isValidReturns
-	fake.recordInvocation("IsValid", []interface{}{arg1})
-	fake.isValidMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *ChannelMembership) IsValidCallCount() int {
-	fake.isValidMutex.RLock()
-	defer fake.isValidMutex.RUnlock()
-	return len(fake.isValidArgsForCall)
-}
-
-func (fake *ChannelMembership) IsValidCalls(stub func(view.Identity) error) {
-	fake.isValidMutex.Lock()
-	defer fake.isValidMutex.Unlock()
-	fake.IsValidStub = stub
-}
-
-func (fake *ChannelMembership) IsValidArgsForCall(i int) view.Identity {
-	fake.isValidMutex.RLock()
-	defer fake.isValidMutex.RUnlock()
-	argsForCall := fake.isValidArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *ChannelMembership) IsValidReturns(result1 error) {
-	fake.isValidMutex.Lock()
-	defer fake.isValidMutex.Unlock()
-	fake.IsValidStub = nil
-	fake.isValidReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *ChannelMembership) IsValidReturnsOnCall(i int, result1 error) {
-	fake.isValidMutex.Lock()
-	defer fake.isValidMutex.Unlock()
-	fake.IsValidStub = nil
-	if fake.isValidReturnsOnCall == nil {
-		fake.isValidReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.isValidReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
 func (fake *ChannelMembership) IsIdemixMSP(arg1 string) bool {
 	fake.isIdemixMSPMutex.Lock()
 	ret, specificReturn := fake.isIdemixMSPReturnsOnCall[len(fake.isIdemixMSPArgsForCall)]
@@ -376,6 +315,67 @@ func (fake *ChannelMembership) IsIdemixMSPReturnsOnCall(i int, result1 bool) {
 	}
 	fake.isIdemixMSPReturnsOnCall[i] = struct {
 		result1 bool
+	}{result1}
+}
+
+func (fake *ChannelMembership) IsValid(arg1 view.Identity) error {
+	fake.isValidMutex.Lock()
+	ret, specificReturn := fake.isValidReturnsOnCall[len(fake.isValidArgsForCall)]
+	fake.isValidArgsForCall = append(fake.isValidArgsForCall, struct {
+		arg1 view.Identity
+	}{arg1})
+	stub := fake.IsValidStub
+	fakeReturns := fake.isValidReturns
+	fake.recordInvocation("IsValid", []interface{}{arg1})
+	fake.isValidMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *ChannelMembership) IsValidCallCount() int {
+	fake.isValidMutex.RLock()
+	defer fake.isValidMutex.RUnlock()
+	return len(fake.isValidArgsForCall)
+}
+
+func (fake *ChannelMembership) IsValidCalls(stub func(view.Identity) error) {
+	fake.isValidMutex.Lock()
+	defer fake.isValidMutex.Unlock()
+	fake.IsValidStub = stub
+}
+
+func (fake *ChannelMembership) IsValidArgsForCall(i int) view.Identity {
+	fake.isValidMutex.RLock()
+	defer fake.isValidMutex.RUnlock()
+	argsForCall := fake.isValidArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *ChannelMembership) IsValidReturns(result1 error) {
+	fake.isValidMutex.Lock()
+	defer fake.isValidMutex.Unlock()
+	fake.IsValidStub = nil
+	fake.isValidReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *ChannelMembership) IsValidReturnsOnCall(i int, result1 error) {
+	fake.isValidMutex.Lock()
+	defer fake.isValidMutex.Unlock()
+	fake.IsValidStub = nil
+	if fake.isValidReturnsOnCall == nil {
+		fake.isValidReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.isValidReturnsOnCall[i] = struct {
+		result1 error
 	}{result1}
 }
 

--- a/platform/fabricx/core/transaction/transaction.go
+++ b/platform/fabricx/core/transaction/transaction.go
@@ -684,8 +684,6 @@ func toMSPSignerIdentityWithCertificateID(identity view.Identity, idemixMSP func
 		return identity, nil
 	}
 
-	logger.Debugf("identity [%s] is NOT an idemix identity, return it. [%s]", identity, sID.GetMspid())
-
 	id, err := pemToMSPIdentity(sID.GetMspid(), sID.GetIdBytes())
 	if err != nil {
 		return nil, errors.Wrap(err, "converting signer identity to msp identity")

--- a/platform/fabricx/core/transaction/transaction.go
+++ b/platform/fabricx/core/transaction/transaction.go
@@ -617,7 +617,7 @@ func (t *Transaction) getProposalResponse(signer SerializableSigner) (*pb.Propos
 	}
 
 	// convert serialized identity to the msppb.Identity expected by Fabric-X
-	signerIdentity, err := toMSPSignerIdentityWithCertificateID(view.Identity(creator))
+	signerIdentity, err := toEndorserIdentityWithCertID(creator)
 	if err != nil {
 		return nil, errors.Wrap(err, "converting signer identity to msp identity")
 	}
@@ -666,22 +666,62 @@ func (t *Transaction) getProposalResponse(signer SerializableSigner) (*pb.Propos
 	}, nil
 }
 
-// toMSPSignerIdentityWithCertificateID converts a serialized MSP identity to an
+// toMSPSignerIdentityWithCertificateID is the serializing counterpart of
+// toEndorserIdentityWithCertID. It differs in two ways:
+//   - It returns the proto-marshaled bytes of the resulting msppb.Identity
+//     rather than a pointer, making it suitable for direct use in a
+//     SignatureHeader.Creator field.
+//   - When the identity's MSP is an Idemix MSP (as determined by idemixMSP),
+//     the original identity bytes are returned unchanged, because Idemix
+//     identities carry no X.509 certificate to hash.
+func toMSPSignerIdentityWithCertificateID(identity view.Identity, idemixMSP func(mspID string) bool) ([]byte, error) {
+	sID := &msp.SerializedIdentity{}
+	if err := proto.Unmarshal(identity, sID); err != nil {
+		return nil, errors.Wrap(err, "unmarshal serialized identity")
+	}
+	if idemixMSP(sID.GetMspid()) {
+		logger.Debugf("identity [%s] is an idemix identity, return it. [%s]", identity, sID.GetMspid())
+		return identity, nil
+	}
+
+	logger.Debugf("identity [%s] is NOT an idemix identity, return it. [%s]", identity, sID.GetMspid())
+
+	id, err := pemToMSPIdentity(sID.GetMspid(), sID.GetIdBytes())
+	if err != nil {
+		return nil, errors.Wrap(err, "converting signer identity to msp identity")
+	}
+	return proto.Marshal(id)
+}
+
+// toEndorserIdentityWithCertID converts a serialized MSP identity to an
 // msppb.Identity that uses a SHA-256 hash of the DER-encoded certificate as the
 // creator. This matches the cached-identity format expected by Fabric-X committers,
 // which look up the identity by cert hash rather than the full certificate bytes.
 // The hash must be consistent with the IdentityIdentifierHashFunction configured
 // in the committer's MSP (default: SHA-256 of cert.Raw).
-func toMSPSignerIdentityWithCertificateID(identity view.Identity) (*msppb.Identity, error) {
+func toEndorserIdentityWithCertID(identity view.Identity) (*msppb.Identity, error) {
 	sID := &msp.SerializedIdentity{}
 	if err := proto.Unmarshal(identity, sID); err != nil {
 		return nil, errors.Wrap(err, "unmarshal serialized identity")
 	}
-	block, _ := pem.Decode(sID.GetIdBytes())
+
+	return pemToMSPIdentity(sID.GetMspid(), sID.GetIdBytes())
+}
+
+// pemToMSPIdentity decodes a PEM-encoded X.509 certificate and constructs an
+// msppb.Identity that identifies the signer by a SHA-256 hash of the
+// DER-encoded certificate bytes (hex-encoded). The returned Identity uses the
+// cached-identity (certificate-ID) format expected by Fabric-X committers and
+// contains no raw certificate bytes, keeping the SignatureHeader compact.
+//
+// id is the MSP identifier string (e.g. "Org1MSP").
+// raw must be a PEM block whose Bytes field contains the DER-encoded cert.
+func pemToMSPIdentity(id string, raw []byte) (*msppb.Identity, error) {
+	block, _ := pem.Decode(raw)
 	if block == nil {
 		return nil, errors.New("failed to decode PEM certificate")
 	}
 	digest := sha256.Sum256(block.Bytes)
 	certID := hex.EncodeToString(digest[:])
-	return msppb.NewIdentityWithIDOfCert(sID.GetMspid(), certID), nil
+	return msppb.NewIdentityWithIDOfCert(id, certID), nil
 }

--- a/platform/fabricx/core/transaction/transaction_test.go
+++ b/platform/fabricx/core/transaction/transaction_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/msp"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	"github.com/hyperledger/fabric-x-common/api/msppb"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
@@ -391,15 +392,22 @@ func TestToMSPSignerIdentityWithCertificateID(t *testing.T) {
 	tests := []struct {
 		name           string
 		identity       view.Identity
+		isIdemix       bool
 		expectedMSP    string
 		expectedCertID string
 		expectedError  string
 	}{
 		{
-			name:           "success",
+			name:           "x509 success — cert-ID format",
 			identity:       view.Identity(serialized),
 			expectedMSP:    "Org1MSP",
 			expectedCertID: expectedCertID,
+		},
+		{
+			// Idemix identities carry no X.509 cert; the bytes are returned as-is.
+			name:     "idemix identity — pass-through unchanged",
+			identity: view.Identity(serialized),
+			isIdemix: true,
 		},
 		{
 			name:          "invalid serialized identity",
@@ -420,7 +428,9 @@ func TestToMSPSignerIdentityWithCertificateID(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			id, err := toMSPSignerIdentityWithCertificateID(tc.identity)
+			id, err := toMSPSignerIdentityWithCertificateID(tc.identity, func(mspID string) bool {
+				return tc.isIdemix
+			})
 			if tc.expectedError != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.expectedError)
@@ -428,8 +438,134 @@ func TestToMSPSignerIdentityWithCertificateID(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+
+			if tc.isIdemix {
+				// For Idemix MSPs the original bytes must be returned unchanged.
+				require.Equal(t, []byte(tc.identity), id)
+				return
+			}
+
+			var identity msppb.Identity
+			require.NoError(t, proto.Unmarshal(id, &identity))
+			require.Equal(t, tc.expectedMSP, identity.GetMspId())
+			require.Equal(t, tc.expectedCertID, identity.GetCertificateId())
+			require.Empty(t, identity.GetCertificate())
+		})
+	}
+}
+
+func TestToEndorserIdentityWithCertID(t *testing.T) {
+	t.Parallel()
+
+	certPEM, serialized := mustSerializedIdentityWithRealCert(t, "Org2MSP")
+
+	block, _ := pem.Decode(certPEM)
+	require.NotNil(t, block)
+	digest := sha256.Sum256(block.Bytes)
+	expectedCertID := hex.EncodeToString(digest[:])
+
+	tests := []struct {
+		name           string
+		identity       view.Identity
+		expectedMSP    string
+		expectedCertID string
+		expectedError  string
+	}{
+		{
+			name:           "success — returns msppb.Identity with cert-ID",
+			identity:       view.Identity(serialized),
+			expectedMSP:    "Org2MSP",
+			expectedCertID: expectedCertID,
+		},
+		{
+			name:          "invalid serialized identity",
+			identity:      view.Identity([]byte("not-a-protobuf")),
+			expectedError: "unmarshal serialized identity",
+		},
+		{
+			name: "non-PEM cert bytes",
+			identity: func() view.Identity {
+				raw, err := proto.Marshal(&msp.SerializedIdentity{Mspid: "Org2MSP", IdBytes: []byte("not-pem")})
+				require.NoError(t, err)
+				return view.Identity(raw)
+			}(),
+			expectedError: "failed to decode PEM certificate",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			id, err := toEndorserIdentityWithCertID(tc.identity)
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, id)
 			require.Equal(t, tc.expectedMSP, id.GetMspId())
 			require.Equal(t, tc.expectedCertID, id.GetCertificateId())
+			// Certificate bytes must be absent — only the hash is stored.
+			require.Empty(t, id.GetCertificate())
+		})
+	}
+}
+
+func TestPemToMSPIdentity(t *testing.T) {
+	t.Parallel()
+
+	certPEM, _ := mustSerializedIdentityWithRealCert(t, "Org3MSP")
+
+	block, _ := pem.Decode(certPEM)
+	require.NotNil(t, block)
+	digest := sha256.Sum256(block.Bytes)
+	expectedCertID := hex.EncodeToString(digest[:])
+
+	tests := []struct {
+		name           string
+		mspID          string
+		raw            []byte
+		expectedCertID string
+		expectedError  string
+	}{
+		{
+			name:           "success — SHA-256 cert-ID, no raw cert",
+			mspID:          "Org3MSP",
+			raw:            certPEM,
+			expectedCertID: expectedCertID,
+		},
+		{
+			name:          "nil PEM block",
+			mspID:         "Org3MSP",
+			raw:           []byte("this is not pem"),
+			expectedError: "failed to decode PEM certificate",
+		},
+		{
+			name:          "empty input",
+			mspID:         "Org3MSP",
+			raw:           []byte{},
+			expectedError: "failed to decode PEM certificate",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			id, err := pemToMSPIdentity(tc.mspID, tc.raw)
+			if tc.expectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedError)
+				require.Nil(t, id)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, id)
+			require.Equal(t, tc.mspID, id.GetMspId())
+			require.Equal(t, tc.expectedCertID, id.GetCertificateId())
+			// The raw certificate bytes must not be embedded.
 			require.Empty(t, id.GetCertificate())
 		})
 	}


### PR DESCRIPTION
This PR fixes #1556 in the following way: It enhance the channel membership service to be able to tell if an MSP is and Idemix-based MSP. If that is the case, then CertID generation will be skipped.