### PR TITLE
Exclude test utility files from coverage reports

### DIFF
--- a/scripts/filter-coverage.sh
+++ b/scripts/filter-coverage.sh
@@ -42,6 +42,10 @@ awk '
   /[^\/]*mock[^\/]*\.go:/ { next }  # Matches any file with mock in filename
   /[^\/]*fake[^\/]*\.go:/ { next }  # Matches any file with fake in filename
 
+  # Exclude test utility files
+  /[^\/]*test_utils\.go:/ { next }  # Matches files ending with test_utils.go
+  /[^\/]*_test_utils\.go:/ { next } # Matches files ending with _test_utils.go
+
   # Exclude integration
   /\/integration\// { next }
 


### PR DESCRIPTION
Test utility files contain helper functions used by tests, not production code. They were appearing in coverage reports with 0% coverage, artificially lowering the overall project coverage percentage. This change aligns with the existing practice of excluding mocks, fakes, and other test infrastructure from coverage metrics.
Closes #1558