### PR TITLE
refactor(nwo): flexible committer-x container configuration

### DIFF
--- a/docs/platform/fabric-x/README.md
+++ b/docs/platform/fabric-x/README.md
@@ -154,7 +154,69 @@ This container sets up a test networking including:
 - An ordering service
 - A [committer](https://github.com/hyperledger/fabric-x-committer) instance
 
-The container configuration can be found in: [`integration/nwo/fabricx/extensions/scv2/container.go`](../../../integration/nwo/fabricx/extensions/scv2/container.go).
+### Committer Container Configuration
+
+The committer container is configured through the `nwofabricx.Topology` returned by `NewTopology()`,
+`NewDefaultTopology()`, or `NewTopologyWithName()`. All options have sensible defaults so no additional
+configuration is required for standard test scenarios.
+
+#### Sidecar peer identity
+
+The committer runs as a sidecar peer inside the Fabric network. You can customise the peer name, its
+organisation, and — when running in a non-standard network layout — its host and ports:
+
+| Method | Default | Description |
+|---|---|---|
+| `WithCommitterName(name string)` | `"SC"` | Peer name for the committer sidecar identity in the Fabric network. |
+| `WithCommitterOrg(org string)` | `"Org1"` | Organisation the committer peer belongs to. |
+| `WithCommitterHost(host string)` | *(auto)* | Fixed host for the sidecar peer entry; leave empty to use the Docker bridge IP. |
+| `WithCommitterPorts(ports api.Ports)` | *(auto)* | Pre-allocated ports; leave nil to let the test framework allocate them. |
+
+#### Container image and environment
+
+| Method | Default | Description |
+|---|---|---|
+| `WithCommitterImage(image string)` | `hyperledger/fabric-x-committer-test-node:1.0.0` | Docker image for the committer container. |
+| `WithCommitterEnv(key, value string)` | *(see below)* | Override or add a container environment variable. Pass an empty value to remove a default. |
+
+Default environment variables set by the test framework:
+
+| Variable | Default value |
+|---|---|
+| `SC_SIDECAR_LOGGING_LOGSPEC` | `info:grpc=error` |
+| `SC_QUERY_LOGGING_LOGSPEC` | `info:grpc=error` |
+| `SC_COORDINATOR_LOGGING_LOGSPEC` | `info:grpc=error` |
+| `SC_ORDERER_LOGGING_LOGSPEC` | `info:grpc=error` |
+| `SC_VC_LOGGING_LOGSPEC` | `info:grpc=error` |
+| `SC_VERIFIER_LOGGING_LOGSPEC` | `info:grpc=error` |
+| `SC_ORDERER_BLOCK_SIZE` | `1` |
+| `SC_SIDECAR_ORDERER_SIGNED_ENVELOPES` | `true` |
+| `SC_SIDECAR_SERVER_MAX_CONCURRENT_STREAMS` | `0` |
+| Endpoints and MSP dirs | *(derived from network)* |
+
+#### Example
+
+```go
+fxTopo := nwofabricx.NewDefaultTopology()
+fxTopo.AddOrganizationsByName("Org1", "Org2")
+
+// pin a specific committer image
+fxTopo.WithCommitterImage("hyperledger/fabric-x-committer-test-node:1.1.0")
+
+// increase block size and turn on debug logging for the orderer component
+fxTopo.
+    WithCommitterEnv("SC_ORDERER_BLOCK_SIZE", "10").
+    WithCommitterEnv("SC_ORDERER_LOGGING_LOGSPEC", "debug")
+
+// remove a default env var entirely
+fxTopo.WithCommitterEnv("SC_VC_LOGGING_LOGSPEC", "")
+
+// place the committer in Org2 instead of the default Org1
+fxTopo.WithCommitterOrg("Org2")
+
+// rename the sidecar peer (default is "SC")
+fxTopo.WithCommitterName("committer")
+```
 
 ### Example: Simple Fabric-x Network Topology
 

--- a/integration/fabricx/deployment/topology.go
+++ b/integration/fabricx/deployment/topology.go
@@ -28,6 +28,13 @@ func Topology(sdk node.SDK, commType fsc.P2PCommunicationType, replicationOpts *
 	fabricTopology.SetNamespaceApproverOrgs("Org1")
 	fabricTopology.AddNamespaceWithUnanimity(Namespace, "Org1")
 
+	// Note that we currently spawn a single committer used by all the nodes in the network.
+	fabricTopology.
+		WithCommitterName("committer").
+		WithCommitterOrg("Org2").
+		WithCommitterEnv("SC_ORDERER_BLOCK_SIZE", "10").
+		WithCommitterEnv("SC_ORDERER_BLOCK_TIMEOUT", "1s")
+
 	fscTopology := fsc.NewTopology()
 	fscTopology.P2PCommunicationType = commType
 	fscTopology.SetLogging("grpc=error:fabricx=debug:info", "")

--- a/integration/nwo/fabric/network/network_support.go
+++ b/integration/nwo/fabric/network/network_support.go
@@ -1268,21 +1268,15 @@ func (n *Network) AnchorsForChannel(chanName string) []*topology.Peer {
 }
 
 // AnchorsInOrg returns all peers that are an anchor for at least one channel
-// in the named organization.
+// in the named organization. Returns an empty slice when no peer is explicitly
+// marked as an anchor (callers should omit the AnchorPeers section in that case).
 func (n *Network) AnchorsInOrg(orgName string) []*topology.Peer {
-	anchors := []*topology.Peer{}
+	var anchors []*topology.Peer
 	for _, p := range n.PeersInOrg(orgName) {
 		if p.Anchor() {
 			anchors = append(anchors, p)
-			break
 		}
 	}
-
-	// No explicit anchor means all peers are anchors.
-	if len(anchors) == 0 {
-		anchors = n.PeersInOrg(orgName)
-	}
-
 	return anchors
 }
 

--- a/integration/nwo/fabric/topology/configtx_template.go
+++ b/integration/nwo/fabric/topology/configtx_template.go
@@ -41,9 +41,12 @@ Organizations:{{ range .PeerOrgs }}
       Type: Signature
       Rule: OR('{{.MSPID}}.admin')
     {{- end }}
-  AnchorPeers:{{ range $w.AnchorsInOrg .Name }}
+  {{- $anchors := $w.AnchorsInOrg .Name }}
+  {{- if $anchors }}
+  AnchorPeers:{{ range $anchors }}
   - Host: {{ $w.PeerHost . }}
     Port: {{ $w.PeerPort . "Listen" }}
+  {{- end }}
   {{- end }}
 {{- end }}
 {{- range .IdemixOrgs }}

--- a/integration/nwo/fabricx/extensions/scv2/container.go
+++ b/integration/nwo/fabricx/extensions/scv2/container.go
@@ -42,9 +42,8 @@ func (e *Extension) launchContainer() {
 	logger.Infof("Launch container")
 
 	networkID := e.network.NetworkID
-	orgName := e.network.PeerOrgs()[0].Name
-	sidecarPeer := e.network.Peer(orgName, e.sidecar.Name)
-	containerName := fmt.Sprintf("%s-%s-scalable-committer", networkID, orgName)
+	sidecarPeer := e.network.Peer(e.cfg.SidecarOrg, e.cfg.SidecarName)
+	containerName := fmt.Sprintf("%s-%s-%s-committer", networkID, e.cfg.SidecarOrg, e.cfg.SidecarName)
 	rootCryptoDir := rootCrypto(e.network)
 
 	// get ports
@@ -61,18 +60,10 @@ func (e *Extension) launchContainer() {
 	// orderer config file and load it into the container.
 	// This can be removed and replaced with proper configuration via env vars once the issue #567 is fixed.
 	mockOrdererConfigPath := filepath.Clean(filepath.Join(e.network.Context.RootDir(), e.network.Prefix, "mock-orderer.yaml"))
-	err := generateMockOrdererConfigFile(mockOrdererConfigPath)
-	utils.Must(err)
+	utils.Must(generateMockOrdererConfigFile(mockOrdererConfigPath))
 
-	d, err := docker.GetInstance()
-	utils.Must(err)
-
-	netInfo, err := d.NetworkInfo(networkID)
-	utils.Must(err)
-	logger.Infof("netInfo id: %s", netInfo.ID)
-
-	localIP, err := d.LocalIP(networkID)
-	utils.Must(err)
+	d := utils.MustGet(docker.GetInstance())
+	localIP := utils.MustGet(d.LocalIP(networkID))
 
 	// prep extra hosts:
 	var extraHosts []string
@@ -83,7 +74,7 @@ func (e *Extension) launchContainer() {
 	cfg := containerConfig{
 		ChannelName:           e.channel.Name,
 		SidecarMSPDir:         containerSidecarMSPDir(e.network, sidecarPeer),
-		SidecarMSPID:          fmt.Sprintf("%sMSP", orgName),
+		SidecarMSPID:          fmt.Sprintf("%sMSP", e.cfg.SidecarOrg),
 		SidecarServerEndpoint: net.JoinHostPort("", strconv.Itoa(sidecarPort)),
 		QueryServerEndpoint:   net.JoinHostPort("", strconv.Itoa(queryServicePort)),
 		OrdererServerEndpoint: net.JoinHostPort("", strconv.Itoa(orderingServicePort)),
@@ -91,20 +82,21 @@ func (e *Extension) launchContainer() {
 		CertsBundle:           path.Join("/root/artifacts/crypto", "ca-certs.pem"),
 		SidecarTLSDir:         containerSidecarTLSDir(e.network, sidecarPeer),
 		OrdererTLSDir:         containerOrdererTLSDir(e.network, e.network.Orderers[0]),
+		Image:                 e.cfg.Image,
+		EnvVarOverrides:       e.cfg.EnvVars,
 	}
 
 	logger.Infof("Run fabric-x committer test container on %v ports: sidecar=%v query=%v orderer=%v",
 		localIP, sidecarPort, queryServicePort, orderingServicePort)
 
-	cli, err := dcli.New(dcli.FromEnv)
-	utils.Must(err)
+	cli := utils.MustGet(dcli.New(dcli.FromEnv))
 	ctx := context.TODO()
-	resp, err := cli.ContainerCreate(
+	resp := utils.MustGet(cli.ContainerCreate(
 		ctx,
 		dcli.ContainerCreateOptions{
 			Name: containerName,
 			Config: &container.Config{
-				Image:        scalableCommitterImage,
+				Image:        containerImage(cfg),
 				Tty:          true,
 				AttachStdout: true,
 				AttachStderr: true,
@@ -142,11 +134,9 @@ func (e *Extension) launchContainer() {
 				},
 			},
 		},
-	)
-	utils.Must(err)
+	))
 
-	_, err = cli.ContainerStart(ctx, resp.ID, dcli.ContainerStartOptions{})
-	utils.Must(err)
+	_ = utils.MustGet(cli.ContainerStart(ctx, resp.ID, dcli.ContainerStartOptions{}))
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	dockerLogger := logging.MustGetLogger("sc.container." + resp.ID[:8])
@@ -180,17 +170,15 @@ func (e *Extension) launchContainer() {
 
 	var tlsConfig credentials.TransportCredentials
 	if e.network.TLSEnabled {
-		caCert, err := os.ReadFile(e.network.CACertsBundlePath())
-		utils.Must(err)
+		caCert := utils.MustGet(os.ReadFile(e.network.CACertsBundlePath()))
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(caCert)
 
 		tlsDir := e.network.PeerUserTLSDir(sidecarPeer, "Admin")
-		cert, err := tls.LoadX509KeyPair(
+		cert := utils.MustGet(tls.LoadX509KeyPair(
 			filepath.Join(tlsDir, "client.crt"),
 			filepath.Join(tlsDir, "client.key"),
-		)
-		utils.Must(err)
+		))
 
 		tlsConfig = credentials.NewTLS(&tls.Config{
 			RootCAs:      caCertPool,
@@ -213,6 +201,5 @@ func (e *Extension) launchContainer() {
 			return fabric.WaitUntilReadyWithTLS(ctx, addr, tlsConfig)
 		})
 	}
-	err = g.Wait()
-	utils.Must(err)
+	utils.Must(g.Wait())
 }

--- a/integration/nwo/fabricx/extensions/scv2/container_config.go
+++ b/integration/nwo/fabricx/extensions/scv2/container_config.go
@@ -7,11 +7,13 @@ SPDX-License-Identifier: Apache-2.0
 package scv2
 
 import (
+	"cmp"
 	"path"
+	"sort"
 )
 
 const (
-	scalableCommitterImage = "hyperledger/fabric-x-committer-test-node:1.0.3"
+	committerImageName = "hyperledger/fabric-x-committer-test-node:1.0.3"
 )
 
 type containerConfig struct {
@@ -25,6 +27,12 @@ type containerConfig struct {
 	CertsBundle           string
 	SidecarTLSDir         string
 	OrdererTLSDir         string
+	Image                 string
+	EnvVarOverrides       map[string]string
+}
+
+func containerImage(cfg containerConfig) string {
+	return cmp.Or(cfg.Image, committerImageName)
 }
 
 func containerCmd(cfg containerConfig) []string {
@@ -38,37 +46,55 @@ func containerCmd(cfg containerConfig) []string {
 }
 
 func containerEnvVars(cfg containerConfig) []string {
-	env := []string{
-		"SC_SIDECAR_LOGGING_LOGSPEC=info:grpc=error",
-		"SC_SIDECAR_ORDERER_CHANNEL_ID=" + cfg.ChannelName,
-		"SC_SIDECAR_ORDERER_SIGNED_ENVELOPES=true",
-		"SC_SIDECAR_ORDERER_IDENTITY_MSP_ID=" + cfg.SidecarMSPID,
-		"SC_SIDECAR_ORDERER_IDENTITY_MSP_DIR=" + cfg.SidecarMSPDir,
-		"SC_SIDECAR_SERVER_ENDPOINT=" + cfg.SidecarServerEndpoint,
-		"SC_SIDECAR_SERVER_MAX_CONCURRENT_STREAMS=0",
-		"SC_QUERY_SERVER_ENDPOINT=" + cfg.QueryServerEndpoint,
-		"SC_QUERY_LOGGING_LOGSPEC=info:grpc=error",
-		"SC_COORDINATOR_LOGGING_LOGSPEC=info:grpc=error",
-		"SC_ORDERER_LOGGING_LOGSPEC=info:grpc=error",
-		"SC_ORDERER_BLOCK_SIZE=1",
-		"SC_ORDERER_SERVER_ENDPOINT=" + cfg.OrdererServerEndpoint,
-		"SC_VC_LOGGING_LOGSPEC=info:grpc=error",
-		"SC_VERIFIER_LOGGING_LOGSPEC=info:grpc=error",
+	env := map[string]string{
+		"SC_SIDECAR_LOGGING_LOGSPEC":               "info:grpc=error",
+		"SC_SIDECAR_ORDERER_CHANNEL_ID":            cfg.ChannelName,
+		"SC_SIDECAR_ORDERER_SIGNED_ENVELOPES":      "true",
+		"SC_SIDECAR_ORDERER_IDENTITY_MSP_ID":       cfg.SidecarMSPID,
+		"SC_SIDECAR_ORDERER_IDENTITY_MSP_DIR":      cfg.SidecarMSPDir,
+		"SC_SIDECAR_SERVER_ENDPOINT":               cfg.SidecarServerEndpoint,
+		"SC_SIDECAR_SERVER_MAX_CONCURRENT_STREAMS": "0",
+		"SC_QUERY_SERVER_ENDPOINT":                 cfg.QueryServerEndpoint,
+		"SC_QUERY_LOGGING_LOGSPEC":                 "info:grpc=error",
+		"SC_COORDINATOR_LOGGING_LOGSPEC":           "info:grpc=error",
+		"SC_ORDERER_LOGGING_LOGSPEC":               "info:grpc=error",
+		"SC_ORDERER_BLOCK_SIZE":                    "1",
+		"SC_ORDERER_SERVER_ENDPOINT":               cfg.OrdererServerEndpoint,
+		"SC_VC_LOGGING_LOGSPEC":                    "info:grpc=error",
+		"SC_VERIFIER_LOGGING_LOGSPEC":              "info:grpc=error",
 	}
 	if cfg.TLSEnabled {
-		env = append(env, tlsEnvGroup("SC_SIDECAR_SERVER", cfg.SidecarTLSDir, cfg.CertsBundle)...)
-		env = append(env, tlsEnvGroup("SC_SIDECAR_ORDERER", cfg.SidecarTLSDir, cfg.CertsBundle)...)
-		env = append(env, tlsEnvGroup("SC_QUERY_SERVER", cfg.SidecarTLSDir, cfg.CertsBundle)...)
-		env = append(env, tlsEnvGroup("SC_ORDERER_SERVER", cfg.OrdererTLSDir, cfg.CertsBundle)...)
+		addTLSEnvGroup(env, "SC_SIDECAR_SERVER", cfg.SidecarTLSDir, cfg.CertsBundle)
+		addTLSEnvGroup(env, "SC_SIDECAR_ORDERER", cfg.SidecarTLSDir, cfg.CertsBundle)
+		addTLSEnvGroup(env, "SC_QUERY_SERVER", cfg.SidecarTLSDir, cfg.CertsBundle)
+		addTLSEnvGroup(env, "SC_ORDERER_SERVER", cfg.OrdererTLSDir, cfg.CertsBundle)
 	}
-	return env
+
+	// Apply overrides: empty string removes the default; non-empty overrides or adds.
+	for k, v := range cfg.EnvVarOverrides {
+		if v == "" {
+			delete(env, k)
+		} else {
+			env[k] = v
+		}
+	}
+
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	result := make([]string, 0, len(env))
+	for _, k := range keys {
+		result = append(result, k+"="+env[k])
+	}
+	return result
 }
 
-func tlsEnvGroup(prefix, certDir, caBundle string) []string {
-	return []string{
-		prefix + "_TLS_MODE=mtls",
-		prefix + "_TLS_CERT_PATH=" + path.Join(certDir, "server.crt"),
-		prefix + "_TLS_KEY_PATH=" + path.Join(certDir, "server.key"),
-		prefix + "_TLS_CA_CERT_PATHS=" + caBundle,
-	}
+func addTLSEnvGroup(env map[string]string, prefix, certDir, caBundle string) {
+	env[prefix+"_TLS_MODE"] = "mtls"
+	env[prefix+"_TLS_CERT_PATH"] = path.Join(certDir, "server.crt")
+	env[prefix+"_TLS_KEY_PATH"] = path.Join(certDir, "server.key")
+	env[prefix+"_TLS_CA_CERT_PATHS"] = caBundle
 }

--- a/integration/nwo/fabricx/extensions/scv2/container_config_test.go
+++ b/integration/nwo/fabricx/extensions/scv2/container_config_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package scv2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerEnvVars(t *testing.T) {
+	t.Parallel()
+
+	base := containerConfig{ChannelName: "ch"}
+
+	// collect the default key set so tests can reference it without hardcoding counts
+	defaults := containerEnvVars(base)
+	defaultCount := len(defaults)
+
+	tests := []struct {
+		name      string
+		overrides map[string]string
+		check     func(t *testing.T, result []string)
+	}{
+		{
+			name:      "no overrides returns sorted defaults",
+			overrides: nil,
+			check: func(t *testing.T, result []string) {
+				require.Equal(t, defaults, result, "result should be stable across calls")
+				for i := 1; i < len(result); i++ {
+					require.Less(t, result[i-1], result[i], "env vars must be sorted")
+				}
+			},
+		},
+		{
+			name:      "non-empty value overrides a default",
+			overrides: map[string]string{"SC_ORDERER_BLOCK_SIZE": "10"},
+			check: func(t *testing.T, result []string) {
+				require.Len(t, result, defaultCount)
+				require.Contains(t, result, "SC_ORDERER_BLOCK_SIZE=10")
+				require.NotContains(t, result, "SC_ORDERER_BLOCK_SIZE=1")
+			},
+		},
+		{
+			name:      "empty value removes a default",
+			overrides: map[string]string{"SC_VC_LOGGING_LOGSPEC": ""},
+			check: func(t *testing.T, result []string) {
+				require.Len(t, result, defaultCount-1)
+				for _, entry := range result {
+					require.NotContains(t, entry, "SC_VC_LOGGING_LOGSPEC")
+				}
+			},
+		},
+		{
+			name:      "non-empty value adds a new var",
+			overrides: map[string]string{"SC_ORDERER_BLOCK_TIMEOUT": "1s"},
+			check: func(t *testing.T, result []string) {
+				require.Len(t, result, defaultCount+1)
+				require.Contains(t, result, "SC_ORDERER_BLOCK_TIMEOUT=1s")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := base
+			cfg.EnvVarOverrides = tc.overrides
+			tc.check(t, containerEnvVars(cfg))
+		})
+	}
+}
+
+func TestContainerImage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns default image when empty", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, committerImageName, containerImage(containerConfig{}))
+	})
+
+	t.Run("returns custom image when set", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, "my-image:latest", containerImage(containerConfig{Image: "my-image:latest"}))
+	})
+}

--- a/integration/nwo/fabricx/extensions/scv2/ext.go
+++ b/integration/nwo/fabricx/extensions/scv2/ext.go
@@ -8,7 +8,6 @@ package scv2
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"text/template"
@@ -27,48 +26,46 @@ import (
 
 var logger = logging.MustGetLogger()
 
+// CommitterConfig holds all configuration for the committer test container and its
+// sidecar peer identity in the Fabric network.
+type CommitterConfig struct {
+	SidecarName  string
+	SidecarOrg   string
+	SidecarHost  string
+	SidecarPorts api.Ports
+	Image        string
+	EnvVars      map[string]string
+}
+
 type Extension struct {
 	channel *fabric_topo.Channel
 	network *network.Network
-
-	sidecar *sidecarConfig
+	cfg     CommitterConfig
 }
 
-type sidecarConfig struct {
-	Host  string
-	Ports api.Ports
-	Name  string
-	Org   string
-}
-
-func NewExtension(topology *fabric_topo.Topology, network *network.Network, sidecarHost string, sidecarPorts api.Ports, sidecarName, sidecarOrg string) *Extension {
+func NewExtension(topology *fabric_topo.Topology, network *network.Network, cfg CommitterConfig) *Extension {
 	if len(topology.Channels) != 1 {
-		utils.Must(fmt.Errorf("we currently support a single channel"))
+		panic(fmt.Sprintf("expected exactly one channel, got %d", len(topology.Channels)))
 	}
-	if len(network.PeersInOrg(sidecarOrg)) == 0 {
-		panic(fmt.Sprintf("org [%s] does not exist in the network", sidecarOrg))
+	if len(network.PeersInOrg(cfg.SidecarOrg)) == 0 {
+		panic(fmt.Sprintf("org [%s] does not exist in the network", cfg.SidecarOrg))
 	}
 	return &Extension{
 		channel: topology.Channels[0],
 		network: network,
-		sidecar: &sidecarConfig{
-			Host:  sidecarHost,
-			Ports: sidecarPorts,
-			Name:  sidecarName,
-			Org:   sidecarOrg,
-		},
+		cfg:     cfg,
 	}
 }
 
 func (e *Extension) CheckTopology() {
-	// we add "another peer" for the scalable committer to use its credentials
+	// we add "another peer" for the committer to use its credentials
 	e.addSCPeer()
 }
 
 func (e *Extension) GenerateArtifacts() {
 	// generate fsc node core yaml extensions
-	generateQSExtension(e.network, e.sidecar.Org, e.sidecar.Name)
-	generateNSExtension(e.network, e.sidecar.Org, e.sidecar.Name)
+	generateQSExtension(e.network, e.cfg.SidecarOrg, e.cfg.SidecarName)
+	generateNSExtension(e.network, e.cfg.SidecarOrg, e.cfg.SidecarName)
 }
 
 func (e *Extension) PostRun(load bool) {
@@ -78,45 +75,41 @@ func (e *Extension) PostRun(load bool) {
 }
 
 func (e *Extension) addSCPeer() {
-	if e.sidecar == nil {
-		return
+	// resolve ports: use pre-allocated ones or reserve new ones
+	ports := e.cfg.SidecarPorts
+	if len(ports) == 0 {
+		ports = api.Ports{
+			fabric_network.ListenPort:    e.network.Context.ReservePort(), // sidecar and notification service
+			network.QueryServicePortName: e.network.Context.ReservePort(), // query service
+		}
 	}
 
-	// reserve ports
-	if len(e.sidecar.Ports) == 0 {
-		e.sidecar.Ports = api.Ports{}
-		e.sidecar.Ports[fabric_network.ListenPort] = e.network.Context.ReservePort()    // sidecar and notification service
-		e.sidecar.Ports[network.QueryServicePortName] = e.network.Context.ReservePort() // query service
+	// we add "another peer" for the committer to use its credentials
+	logger.Infof("Add committer for org=%v", e.cfg.SidecarOrg)
+	p := &fabric_topo.Peer{
+		Name:         e.cfg.SidecarName,
+		Organization: e.cfg.SidecarOrg,
+		Type:         fabric_topo.FabricPeer,
+		Bootstrap:    false,
+		Channels:     []*fabric_topo.PeerChannel{{Name: e.channel.Name, Anchor: false}},
+		Usage:        "",
+		SkipInit:     true,
+		SkipRunning:  true,
+		TLSDisabled:  !e.network.TLSEnabled,
 	}
-
-	for _, org := range e.network.PeerOrgs() {
-		logger.Infof("Add committer for org=%v", org.Name)
-		// we add "another peer" for the scalable committer to use its credentials
-		p := &fabric_topo.Peer{
-			Name:         e.sidecar.Name,
-			Organization: org.Name,
-			Type:         fabric_topo.FabricPeer,
-			Bootstrap:    false,
-			Channels:     []*fabric_topo.PeerChannel{{Name: e.channel.Name, Anchor: true}},
-			Usage:        "",
-			SkipInit:     true,
-			SkipRunning:  true,
-			TLSDisabled:  !e.network.TLSEnabled,
-		}
-		e.network.AppendPeer(p)
-		e.network.Context.SetPortsByPeerID(e.network.Prefix, p.ID(), e.sidecar.Ports)
-		if len(e.sidecar.Host) > 0 {
-			e.network.Context.SetHostByPeerID(e.network.Prefix, p.ID(), e.sidecar.Host)
-		}
+	e.network.AppendPeer(p)
+	e.network.Context.SetPortsByPeerID(e.network.Prefix, p.ID(), ports)
+	if len(e.cfg.SidecarHost) > 0 {
+		e.network.Context.SetHostByPeerID(e.network.Prefix, p.ID(), e.cfg.SidecarHost)
 	}
 }
 
 func generateExtensions(n *network.Network, scAddr string, t *template.Template) {
 	context := n.Context
 
-	fscTop, ok := context.TopologyByName("fsc").(*fsc.Topology)
+	fscTopo, ok := context.TopologyByName("fsc").(*fsc.Topology)
 	if !ok {
-		utils.Must(errors.New("cannot get fsc topo instance"))
+		panic(fmt.Sprintf("expected *fsc.Topology, got %T", context.TopologyByName("fsc")))
 	}
 
 	type extensionData struct {
@@ -126,7 +119,7 @@ func generateExtensions(n *network.Network, scAddr string, t *template.Template)
 	}
 
 	topoName := n.Topology().Name()
-	for _, fscNode := range fscTop.Nodes {
+	for _, fscNode := range fscTopo.Nodes {
 		// check that the fsc node is associated with the fabric network
 		fscPeer := n.FSCPeerByName(fscNode.Name)
 		if fscPeer == nil {
@@ -158,8 +151,7 @@ func generateExtensions(n *network.Network, scAddr string, t *template.Template)
 		}
 
 		var extension bytes.Buffer
-		err := t.Execute(&extension, data)
-		utils.Must(err)
+		utils.Must(t.Execute(&extension, data))
 
 		for _, uniqueName := range fscNode.ReplicaUniqueNames() {
 			context.AddExtension(uniqueName, api.FabricExtension, extension.String())

--- a/integration/nwo/fabricx/extensions/scv2/orderer.go
+++ b/integration/nwo/fabricx/extensions/scv2/orderer.go
@@ -39,9 +39,5 @@ consenter-msp-identities:
   - msp-id: OrdererMSP
     msp-dir: /root/artifacts/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp
 `
-	return generateConfigFile(configPath, []byte(configContent))
-}
-
-func generateConfigFile(configPath string, content []byte) error {
-	return os.WriteFile(configPath, content, 0o600)
+	return os.WriteFile(configPath, []byte(configContent), 0o600)
 }

--- a/integration/nwo/fabricx/network/network.go
+++ b/integration/nwo/fabricx/network/network.go
@@ -42,12 +42,14 @@ const (
 
 type Network struct {
 	*fabric_network.Network
+	CommitterOrg  string
+	CommitterName string
 }
 
-func New(reg api.Context, topology *topology.Topology, builderClient fabric_network.BuilderClient, ccps []fabric_network.ChaincodeProcessor, networkID string) *Network {
+func New(reg api.Context, topology *topology.Topology, builderClient fabric_network.BuilderClient, ccps []fabric_network.ChaincodeProcessor, networkID, committerOrg, committerName string) *Network {
 	fabricNetwork := fabric_network.New(reg, topology, builderClient, ccps, networkID)
 	fabricNetwork.EventuallyTimeout = defaultEventuallyTimeout
-	n := &Network{Network: fabricNetwork}
+	n := &Network{Network: fabricNetwork, CommitterOrg: committerOrg, CommitterName: committerName}
 	return n
 }
 
@@ -119,7 +121,6 @@ func (n *Network) CheckTopology() {
 	// cleanup chaincode
 	// TODO cleanup the chaincode
 	n.CheckTopologyOrderers()
-	n.CheckTopologyExtensions()
 }
 
 func (n *Network) removePeers() {
@@ -180,7 +181,7 @@ func createNSCommon(n *Network, chaincode *topology.ChannelChaincode) fxconfig.N
 	adminMspDir := n.PeerUserMSPDir(peers[0], "Admin")
 
 	// get notification service endpoint
-	committerNode := n.Peer(orgName, "SC")
+	committerNode := n.Peer(n.CommitterOrg, n.CommitterName)
 	gomega.Expect(committerNode).NotTo(gomega.BeNil())
 
 	notificationsEndpoint := fmt.Sprintf("127.0.0.1:%d", n.PeerPort(committerNode, fabric_network.ListenPort))
@@ -227,9 +228,9 @@ func (n *Network) tryListInstalledNames() ([]Namespace, error) {
 	if len(peers) == 0 {
 		return nil, fmt.Errorf("no peers found for org %s", orgName)
 	}
-	committerNode := n.Peer(orgName, "SC")
+	committerNode := n.Peer(n.CommitterOrg, n.CommitterName)
 	if committerNode == nil {
-		return nil, fmt.Errorf("no committer peer (name=%v) found for org=%v", "SC", orgName)
+		return nil, fmt.Errorf("no committer peer (name=%v) found for org=%v", n.CommitterName, n.CommitterOrg)
 	}
 	queryEndpoint := fmt.Sprintf("127.0.0.1:%d", n.PeerPort(committerNode, QueryServicePortName))
 

--- a/integration/nwo/fabricx/platform.go
+++ b/integration/nwo/fabricx/platform.go
@@ -16,10 +16,8 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric"
 	fabric_network "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/network"
-	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/topology"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabricx/extensions/scv2"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabricx/network"
-	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
 )
@@ -28,7 +26,7 @@ var logger = logging.MustGetLogger()
 
 const PlatformName = "fabricx"
 
-type ExtensionFactory func(platform *Platform, registry api.Context, t *topology.Topology, builder api.Builder) fabric_network.Extension
+type ExtensionFactory func(platform *Platform, registry api.Context, t api.Topology, builder api.Builder) fabric_network.Extension
 
 type ExtendedPlatformFactory struct {
 	*PlatformFactory
@@ -38,13 +36,8 @@ type ExtendedPlatformFactory struct {
 func (f *ExtendedPlatformFactory) New(registry api.Context, t api.Topology, builder api.Builder) api.Platform {
 	p := f.PlatformFactory.New(registry, t, builder)
 
-	topo, ok := t.(*topology.Topology)
-	if !ok {
-		panic(fmt.Errorf("invalid topology type"))
-	}
-
 	for _, ext := range f.extensions {
-		p.Network.AddExtension(ext(p, registry, topo, builder))
+		p.Network.AddExtension(ext(p, registry, t, builder))
 	}
 
 	return p
@@ -58,13 +51,20 @@ func (f *ExtendedPlatformFactory) WithExtensions(exts ...ExtensionFactory) *Exte
 }
 
 func NewPlatformFactory() *ExtendedPlatformFactory {
-	return NewPlatformFactoryWithSidecar("", nil, "SC", "Org1")
-}
-
-func NewPlatformFactoryWithSidecar(sidecarHost string, sidecarPorts api.Ports, sidecarName, sidecarOrg string) *ExtendedPlatformFactory {
 	return NewFabricxPlatformFactory().WithExtensions(
-		func(platform *Platform, registry api.Context, t *topology.Topology, builder api.Builder) fabric_network.Extension {
-			return scv2.NewExtension(t, platform.Network, sidecarHost, sidecarPorts, sidecarName, sidecarOrg)
+		func(platform *Platform, registry api.Context, t api.Topology, builder api.Builder) fabric_network.Extension {
+			fxTopo, ok := t.(*Topology)
+			if !ok {
+				panic(fmt.Sprintf("expected *fabricx.Topology, got %T", t))
+			}
+			return scv2.NewExtension(fxTopo.Topology, platform.Network, scv2.CommitterConfig{
+				SidecarName:  fxTopo.Committer.Name,
+				SidecarOrg:   fxTopo.Committer.Org,
+				SidecarHost:  fxTopo.Committer.Host,
+				SidecarPorts: fxTopo.Committer.Ports,
+				Image:        fxTopo.Committer.Image,
+				EnvVars:      fxTopo.Committer.EnvVars,
+			})
 		})
 }
 
@@ -86,18 +86,20 @@ func (*PlatformFactory) Name() string {
 }
 
 func (*PlatformFactory) New(registry api.Context, t api.Topology, builder api.Builder) *Platform {
-	topo, ok := t.(*topology.Topology)
+	fxTopo, ok := t.(*Topology)
 	if !ok {
-		utils.Must(errors.New("cannot cast topology"))
+		panic(fmt.Sprintf("expected *fabricx.Topology, got %T", t))
 	}
 
 	// create a new fabricx network
 	n := network.New(
 		registry,
-		topo,
+		fxTopo.Topology,
 		builder,
 		[]fabric_network.ChaincodeProcessor{},
 		common.UniqueName(),
+		fxTopo.Committer.Org,
+		fxTopo.Committer.Name,
 	)
 
 	// create the platform
@@ -153,8 +155,7 @@ func (p *Platform) DeleteVault(id string) {
 
 func (p *Platform) PostRun(load bool) {
 	// set up our docker environment for chaincode containers
-	err := p.dockerSupport.Setup()
-	utils.Must(err)
+	utils.Must(p.dockerSupport.Setup())
 
 	// network post run
 	p.Network.PostRun(load)
@@ -164,6 +165,5 @@ func (p *Platform) Cleanup() {
 	p.Network.Cleanup()
 
 	// cleanup docker environment
-	err := p.dockerSupport.Cleanup()
-	utils.Must(err)
+	utils.Must(p.dockerSupport.Cleanup())
 }

--- a/integration/nwo/fabricx/topology.go
+++ b/integration/nwo/fabricx/topology.go
@@ -7,8 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package fabricx
 
 import (
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric"
-	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/topology"
+	fabric_topology "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/topology"
 )
 
 const (
@@ -16,19 +17,91 @@ const (
 	DefaultTopologyName = "default"
 )
 
-// NewTopology returns a new topology whose name is empty
-func NewTopology() *topology.Topology {
+// CommitterConfig holds all configuration for the committer test container and
+// its corresponding sidecar peer entry in the Fabric network.
+// EnvVars is merged over the container defaults: a non-empty value overrides or
+// adds a var; an empty string value removes the default.
+type CommitterConfig struct {
+	// Fabric network identity
+	Name string
+	Org  string
+
+	// Optional fixed host for the sidecar peer (empty = use docker bridge IP)
+	Host string
+
+	// Optional pre-allocated ports (nil = auto-allocate)
+	Ports api.Ports
+
+	// Container overrides
+	Image   string
+	EnvVars map[string]string
+}
+
+// Topology extends the fabric topology with fabricx-specific committer options.
+type Topology struct {
+	*fabric_topology.Topology
+	Committer CommitterConfig
+}
+
+// WithCommitterName sets the peer name used for the committer sidecar identity.
+func (t *Topology) WithCommitterName(name string) *Topology {
+	t.Committer.Name = name
+	return t
+}
+
+// WithCommitterOrg sets the organization the committer belongs to.
+func (t *Topology) WithCommitterOrg(org string) *Topology {
+	t.Committer.Org = org
+	return t
+}
+
+// WithCommitterHost sets a fixed host for the sidecar peer entry.
+func (t *Topology) WithCommitterHost(host string) *Topology {
+	t.Committer.Host = host
+	return t
+}
+
+// WithCommitterPorts sets pre-allocated ports for the committer container.
+func (t *Topology) WithCommitterPorts(ports api.Ports) *Topology {
+	t.Committer.Ports = ports
+	return t
+}
+
+// WithCommitterImage sets the Docker image for the committer test container.
+func (t *Topology) WithCommitterImage(image string) *Topology {
+	t.Committer.Image = image
+	return t
+}
+
+// WithCommitterEnv sets or overrides a single committer container env var.
+// Pass an empty value to remove a default var.
+func (t *Topology) WithCommitterEnv(key, value string) *Topology {
+	if t.Committer.EnvVars == nil {
+		t.Committer.EnvVars = map[string]string{}
+	}
+	t.Committer.EnvVars[key] = value
+	return t
+}
+
+// SetDefault marks this topology as the default network. Shadows the embedded
+// method so the return type stays *Topology and fluent chaining is preserved.
+func (t *Topology) SetDefault() *Topology {
+	t.Topology.SetDefault()
+	return t
+}
+
+// NewTopology returns a new topology whose name is empty.
+func NewTopology() *Topology {
 	return NewTopologyWithName("")
 }
 
 // NewDefaultTopology is a configuration with two organizations and one peer per org.
-func NewDefaultTopology() *topology.Topology {
+func NewDefaultTopology() *Topology {
 	return NewTopologyWithName(DefaultTopologyName).SetDefault()
 }
 
-// NewTopologyWithName is a configuration with two organizations and one peer per org.
-func NewTopologyWithName(name string) *topology.Topology {
-	// we use a classic fabric topo as our reference
+// NewTopologyWithName returns a fabricx topology with the given name.
+func NewTopologyWithName(name string) *Topology {
 	topo := fabric.NewTopologyWithName(name)
 
 	topo.SetLogging("grpc=error:info", "")
@@ -41,5 +114,11 @@ func NewTopologyWithName(name string) *topology.Topology {
 	topo.TopologyType = PlatformName
 	topo.Driver = PlatformName
 
-	return topo
+	return &Topology{
+		Topology: topo,
+		Committer: CommitterConfig{
+			Name: "SC",
+			Org:  "Org1",
+		},
+	}
 }

--- a/platform/fabric/core/generic/config/service.go
+++ b/platform/fabric/core/generic/config/service.go
@@ -258,7 +258,7 @@ func (s *Service) Resolvers() ([]Resolver, error) {
 }
 
 func (s *Service) GetString(key string) string {
-	logger.Infof("Get string [%s]", key)
+	logger.Debugf("Get string [%s]", key)
 	return s.Configuration.GetString("fabric." + s.prefix + key)
 }
 

--- a/platform/view/services/config/provider.go
+++ b/platform/view/services/config/provider.go
@@ -138,7 +138,7 @@ func (p *Provider) TranslatePath(path string) string {
 
 // GetString returns the string value associated with the given key.
 func (p *Provider) GetString(key string) string {
-	logger.Infof("Get string [%s]", key)
+	logger.Debugf("Get string [%s]", key)
 	return p.Backend.String(strings.ToLower(key))
 }
 


### PR DESCRIPTION
This PR introduces a fluent configuration API for the fabric-x committer test container. Instead of hardcoded defaults ("SC", "Org1") scattered across the codebase, configuration is now centralized in a new CommitterConfig struct on a `fabricx.Topology` wrapper type. The PR also cleans up boilerplate (`utils.MustGet`), lowers two noisy log statements from Info to Debug, and fixes anchor-peer handling in `configtx_template.go`.

Closes #1562