### PR TITLE
test(coverage): use -coverpkg so cross-package code is credited

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,18 +139,24 @@ GO_PACKAGES_SDK = $$(go list ./... | grep '/sdk/dig$$')
 GO_TEST_PARAMS ?= -race -cover
 TEST_PKGS ?= $(GO_PACKAGES)
 
+# Instrument every package under the root module so that coverage is credited
+# even when a package is exercised only by tests living in another package
+# (e.g. the exported helpers in .../sql/common used by the sqlite/postgres tests).
+# Kept separate from GO_TEST_PARAMS because CI overrides GO_TEST_PARAMS wholesale.
+GO_COVERPKG ?= -coverpkg=./...
+
 .PHONY: unit-tests
 unit-tests: ## Run unit tests
 	@echo "Running unit tests..."
 	export FABRIC_LOGGING_SPEC=error; \
 	export FAB_BINS=$(FAB_BINS); \
-	go test $(GO_TEST_PARAMS) --skip '(Postgres)' $(TEST_PKGS)
+	go test $(GO_TEST_PARAMS) $(GO_COVERPKG) --skip '(Postgres)' $(TEST_PKGS)
 
 .PHONY: unit-tests-postgres
 unit-tests-postgres: ## Run unit tests for postgres (requires container images as defined in testing-docker-images)
 	@echo "Running unit tests..."
 	export FABRIC_LOGGING_SPEC=error; \
-	go test $(GO_TEST_PARAMS) --run '(Postgres)' $(TEST_PKGS)
+	go test $(GO_TEST_PARAMS) $(GO_COVERPKG) --run '(Postgres)' $(TEST_PKGS)
 
 .PHONY: unit-tests-sdk
 unit-tests-sdk: ## Run sdk wiring tests
@@ -239,7 +245,7 @@ clean-fabric-peer-images: ## Clean up generated fabric peer images
 .PHONY: coverage-local
 coverage-local: ## Run unit tests and show filtered coverage
 	@echo "Running unit tests with coverage..."
-	@env FABRIC_LOGGING_SPEC=error FAB_BINS=$(FAB_BINS) go test $(GO_TEST_PARAMS) -coverprofile=coverage.tmp $(TEST_PKGS)
+	@env FABRIC_LOGGING_SPEC=error FAB_BINS=$(FAB_BINS) go test $(GO_TEST_PARAMS) $(GO_COVERPKG) -coverprofile=coverage.tmp $(TEST_PKGS)
 	@./scripts/filter-coverage.sh coverage.tmp coverage.out
 	@go tool cover -func=coverage.out | tail -n 1
 	@rm coverage.tmp


### PR DESCRIPTION
Adds a `GO_COVERPKG=-coverpkg=./...` flag to the `go test` unit-test targets in the Makefile (`unit-tests`, `unit-tests-postgres`, `coverage-local`).

## Impact on the Coveralls number
full-repo coverage moves **77% → 81%** (+4 pts). This increase because the repo has a lot of cross package exercised code
closes #1564 