### PR TITLE
fix(fabric/db): open VaultStore.Store write transaction with BeginTx(ctx)

### DIFF
--- a/platform/fabric/services/db/driver/sql/postgres/vault.go
+++ b/platform/fabric/services/db/driver/sql/postgres/vault.go
@@ -51,7 +51,7 @@ func (db *VaultStore) Store(ctx context.Context, txIDs []driver.TxID, writes dri
 	db.GlobalLock.RLock()
 	defer db.GlobalLock.RUnlock()
 
-	tx, err := db.writeDB.Begin()
+	tx, err := db.writeDB.BeginTx(ctx, nil)
 	if err != nil {
 		return errors.Wrapf(err, "failed to initiate db transaction")
 	}

--- a/platform/fabric/services/db/driver/sql/sqlite/vault.go
+++ b/platform/fabric/services/db/driver/sql/sqlite/vault.go
@@ -53,7 +53,7 @@ func (db *VaultStore) Store(ctx context.Context, txIDs []driver.TxID, writes dri
 	db.GlobalLock.RLock()
 	defer db.GlobalLock.RUnlock()
 
-	tx, err := db.writeDB.Begin()
+	tx, err := db.writeDB.BeginTx(ctx, nil)
 	if err != nil {
 		return errors.Wrapf(err, "failed to initiate db transaction")
 	}

--- a/platform/view/services/storage/driver/sql/common/utils.go
+++ b/platform/view/services/storage/driver/sql/common/utils.go
@@ -18,6 +18,7 @@ import (
 
 type WriteDB interface {
 	Begin() (*sql.Tx, error)
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
 	Exec(query string, args ...any) (sql.Result, error)
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 	Close() error


### PR DESCRIPTION
Closes #1568

`VaultStore.Store` already receives the request context and runs every statement with `ExecContext`, but the enclosing write transaction was opened with a bare `Begin()`. A canceled or timed-out request therefore did not roll the transaction back, and the connection could sit in `idle in transaction` state holding a slot in the bounded write pool. The read path (`common/vault.go`) already ties its transactions to the context with `BeginTx`.

This opens the write transaction with `BeginTx(ctx, nil)` in the postgres and sqlite vault stores, and declares `BeginTx` on the `WriteDB` interface — both implementations (`*sql.DB` and sqlite's `retryWriteDB`, which embeds `*sql.DB`) already provide it, so no implementation changes are needed. Callers passing `context.Background()` see no behavior change.

We run the postgres store in our test environments under sustained load; tying write transactions to the request context is standard `database/sql` hygiene that prevents canceled requests from pinning pool connections.

### Testing

`go build ./...`, `go vet` and `go test -race` on `platform/fabric/services/db/...` and `platform/view/services/storage/driver/sql/...` pass locally (postgres testcontainer suites require Docker and run in CI). `golangci-lint run` with the repo config reports no issues.