### PR TITLE
fix(nwo): cmd build failure in git worktrees

### DIFF
--- a/integration/nwo/fsc/fsc.go
+++ b/integration/nwo/fsc/fsc.go
@@ -772,13 +772,21 @@ func (p *Platform) NodeCmdDir(peer *node2.Replica) string {
 }
 
 func (p *Platform) NodeCmdPackage(peer *node2.Replica) string {
-	gopath := os.Getenv("GOPATH")
 	wd, err := os.Getwd()
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "Failed to get working directory: %s", err)
 
-	// if gopath is set to path within codebase, node command package will be relative within the codebase
-	// if gopath is not set or not within codebase, then it will be absolute path where the fsc node code is
-	// both can be built from these paths
+	// Resolve the import path via the module declared in go.mod, rather than assuming the
+	// checkout directory name matches the module name. This keeps things working when the
+	// working directory is a git worktree (whose directory is typically named after the
+	// branch, e.g. "myrepo-1234", while go.mod still declares "module .../myrepo").
+	if modPath, modDir, err := goModuleInfo(wd); err == nil {
+		relDir, err := filepath.Rel(modDir, wd)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		return filepath.ToSlash(filepath.Join(modPath, relDir, "out", "cmd", peer.Name))
+	}
+
+	// Fallback for legacy GOPATH-style checkouts (no go.mod resolvable from wd).
+	gopath := os.Getenv("GOPATH")
 	if withoutGoPath, ok := strings.CutPrefix(wd, filepath.Join(gopath, "src")); ok {
 		return strings.TrimPrefix(
 			filepath.Join(withoutGoPath, "out", "cmd", peer.Name),
@@ -786,6 +794,25 @@ func (p *Platform) NodeCmdPackage(peer *node2.Replica) string {
 		)
 	}
 	return "./" + filepath.ToSlash(filepath.Join("out", "cmd", peer.Name))
+}
+
+// goModuleInfo returns the module path and module root directory (as declared in go.mod)
+// for the module containing dir.
+func goModuleInfo(dir string) (modPath, modDir string, err error) {
+	cmd := exec.Command("go", "list", "-m", "-f", "{{.Path}}|{{.Dir}}")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", "", err
+	}
+
+	parts := strings.SplitN(strings.TrimSpace(string(out)), "|", 2)
+	if len(parts) != 2 || parts[1] == "" {
+		// no go.mod found; "go list -m" falls back to the synthetic
+		// "command-line-arguments" pseudo-module with an empty Dir.
+		return "", "", fmt.Errorf("no module found for %s: %s", dir, out)
+	}
+	return parts[0], parts[1], nil
 }
 
 func (p *Platform) NodeCmdPath(peer *node2.Replica) string {

--- a/integration/nwo/fsc/nodecmdpackage_test.go
+++ b/integration/nwo/fsc/nodecmdpackage_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fsc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc/node"
+)
+
+// writeModule creates a temp module rooted at <tmp>/<rootDirName> declaring the given
+// module path, with a nested package directory under it, and returns the nested
+// directory's absolute path.
+func writeModule(t *testing.T, rootDirName, modulePath string, nestedPkg ...string) string {
+	t.Helper()
+
+	root := filepath.Join(t.TempDir(), rootDirName)
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "go.mod"),
+		[]byte("module "+modulePath+"\n\ngo 1.21\n"),
+		0o644,
+	))
+
+	nested := filepath.Join(append([]string{root}, nestedPkg...)...)
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+
+	return nested
+}
+
+func TestNodeCmdPackage_ResolvesViaGoModRegardlessOfCheckoutDirName(t *testing.T) { //nolint:paralleltest
+	// Simulate a git worktree checkout: the on-disk directory is named "panurus-1226"
+	// (as git worktree creates by default) even though go.mod still declares the
+	// canonical module path "github.com/LFDT-Panurus/panurus". Before the fix,
+	// NodeCmdPackage derived the import path from the checkout directory name via
+	// $GOPATH/src string slicing, which produced a bogus path containing
+	// ".../panurus-1226/..." that no go.mod actually declares.
+	gomega.RegisterTestingT(t)
+
+	nested := writeModule(t, "panurus-1226", "github.com/LFDT-Panurus/panurus",
+		"integration", "token", "fungible", "dlogx")
+
+	t.Chdir(nested)
+
+	var p *Platform
+	replica := node.NewReplica(&node.Peer{Name: "lib-p2p-bootstrap-node"}, "bootstrap.0")
+
+	got := p.NodeCmdPackage(replica)
+
+	want := "github.com/LFDT-Panurus/panurus/integration/token/fungible/dlogx/out/cmd/lib-p2p-bootstrap-node"
+	assert.Equal(t, want, got)
+}
+
+func TestNodeCmdPackage_MatchesCanonicalCheckoutDirName(t *testing.T) { //nolint:paralleltest
+	// Sanity check: when the checkout directory name does match the module name
+	// (the "normal", non-worktree case), the resolved import path is unchanged.
+	gomega.RegisterTestingT(t)
+
+	nested := writeModule(t, "panurus", "github.com/LFDT-Panurus/panurus",
+		"integration", "token", "fungible", "dlogx")
+
+	t.Chdir(nested)
+
+	var p *Platform
+	replica := node.NewReplica(&node.Peer{Name: "lib-p2p-bootstrap-node"}, "bootstrap.0")
+
+	got := p.NodeCmdPackage(replica)
+
+	want := "github.com/LFDT-Panurus/panurus/integration/token/fungible/dlogx/out/cmd/lib-p2p-bootstrap-node"
+	assert.Equal(t, want, got)
+}
+
+func TestNodeCmdPackage_FallsBackWhenNoGoModResolvable(t *testing.T) { //nolint:paralleltest
+	// When run from a directory outside of any go module (no go.mod anywhere in the
+	// tree) and outside of $GOPATH/src, NodeCmdPackage falls back to a relative path.
+	gomega.RegisterTestingT(t)
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("GOPATH", filepath.Join(dir, "unrelated-gopath"))
+
+	var p *Platform
+	replica := node.NewReplica(&node.Peer{Name: "lib-p2p-bootstrap-node"}, "bootstrap.0")
+
+	got := p.NodeCmdPackage(replica)
+
+	want := "./out/cmd/lib-p2p-bootstrap-node"
+	assert.Equal(t, want, got)
+}
+
+func TestGoModuleInfo(t *testing.T) { //nolint:paralleltest
+	nested := writeModule(t, "some-worktree-dir", "github.com/example/proj", "pkg", "sub")
+
+	modPath, modDir, err := goModuleInfo(nested)
+	require.NoError(t, err)
+
+	assert.Equal(t, "github.com/example/proj", modPath)
+
+	rootDir := filepath.Dir(filepath.Dir(nested)) // strip "pkg/sub"
+	resolvedRoot, err := filepath.EvalSymlinks(rootDir)
+	require.NoError(t, err)
+	resolvedModDir, err := filepath.EvalSymlinks(modDir)
+	require.NoError(t, err)
+	assert.Equal(t, resolvedRoot, resolvedModDir)
+}
+
+func TestGoModuleInfo_ErrorsOutsideModule(t *testing.T) { //nolint:paralleltest
+	dir := t.TempDir()
+
+	_, _, err := goModuleInfo(dir)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Description

- Platform.NodeCmdPackage derived the Go import path for generated FSC node binaries (out/cmd/<peer.Name>) by string-slicing os.Getwd() against $GOPATH/src, assuming the checkout directory name always equals the module name declared in go.mod.
  - Under a git worktree checkout (e.g. directory named panurus-1226 while go.mod still declares module .../panurus), this produced a bogus import path containing the worktree directory name, causing go build/gexec.Build to fail with no required module provides package ....
  - NodeCmdPackage now resolves the module path via go list -m (reading the actual module directive in go.mod) and computes the import path relative to the real module root, so it's correct regardless of what the checkout/worktree directory is named. The old $GOPATH/src-based logic is kept only as a fallback for setups where go list -m can't resolve a module.

## Test plan

  - Added integration/nwo/fsc/nodecmdpackage_test.go:
    - Regression test simulating a worktree-style checkout (directory panurus-1226, module github.com/LFDT-Panurus/panurus) confirming the resolved import path is correct.
    - Sanity test for the canonical (non-worktree) case, confirming no behavior change.
    - Test for the legacy fallback path when no go.mod is resolvable.
    - Unit tests for the new goModuleInfo helper, including the case where go list -m returns the synthetic command-line-arguments pseudo-module (no go.mod found).
  - go test ./integration/nwo/fsc/... and go vet ./integration/nwo/fsc/... pass.
