### PR TITLE
Add configurable size limit for incoming messages

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,6 +106,10 @@ fsc:
     # Larger values can improve read performance for large messages
     # but will consume more memory per active connection.
     streamReaderBufferSize: 4096
+    # Maximum allowed size (in bytes) for incoming P2P messages. Default: 10485760 (10 MiB)
+    # This protects the node from memory exhaustion by rejecting oversized payloads before deserialization.
+    # Set to 0 to disable the limit (allow arbitrarily large messages).
+    maxMessageSize: 10485760
     opts:
       # ------------------- libp2p specific options -------------------------
       # Only needed when type == libp2p

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,8 +108,8 @@ fsc:
     streamReaderBufferSize: 4096
     # Maximum allowed size (in bytes) for incoming P2P messages. Default: 10485760 (10 MiB)
     # This protects the node from memory exhaustion by rejecting oversized payloads before deserialization.
-    # Set to 0 to disable the limit (allow arbitrarily large messages).
-    maxMessageSize: 10485760
+    # Set to 0 to disable the limit (allow arbitrarily large messages - not recommended).
+    maxRecvMsgSize: 10485760
     opts:
       # ------------------- libp2p specific options -------------------------
       # Only needed when type == libp2p

--- a/platform/view/services/comm/config.go
+++ b/platform/view/services/comm/config.go
@@ -11,8 +11,8 @@ const (
 	DefaultIncomingMessagesBufferSize = 1024
 	// DefaultStreamReaderBufferSize is the default buffer size for stream readers
 	DefaultStreamReaderBufferSize = 4096
-	// DefaultMaxMessageSize is the default max message size limit (100 MiB)
-	DefaultMaxMessageSize = 100 * 1024 * 1024
+	// DefaultMaxMessageSize is the default max message size limit (10 MiB)
+	DefaultMaxMessageSize = 10 * 1024 * 1024
 )
 
 type configService interface {
@@ -40,6 +40,9 @@ func NewConfig(cs configService) *config {
 	maxMessageSize := DefaultMaxMessageSize
 	if cs.IsSet("fsc.p2p.maxMessageSize") {
 		maxMessageSize = cs.GetInt("fsc.p2p.maxMessageSize")
+	}
+	if maxMessageSize < 0 {
+		maxMessageSize = DefaultMaxMessageSize
 	}
 
 	return &config{

--- a/platform/view/services/comm/config.go
+++ b/platform/view/services/comm/config.go
@@ -11,6 +11,8 @@ const (
 	DefaultIncomingMessagesBufferSize = 1024
 	// DefaultStreamReaderBufferSize is the default buffer size for stream readers
 	DefaultStreamReaderBufferSize = 4096
+	// DefaultMaxMessageSize is the default max message size limit (100 MiB)
+	DefaultMaxMessageSize = 100 * 1024 * 1024
 )
 
 type configService interface {
@@ -21,6 +23,7 @@ type configService interface {
 type config struct {
 	incomingMessagesBufferSize int
 	streamReaderBufferSize     int
+	maxMessageSize             int
 }
 
 func NewConfig(cs configService) *config {
@@ -34,8 +37,14 @@ func NewConfig(cs configService) *config {
 		streamReaderBufferSize = cs.GetInt("fsc.p2p.streamReaderBufferSize")
 	}
 
+	maxMessageSize := DefaultMaxMessageSize
+	if cs.IsSet("fsc.p2p.maxMessageSize") {
+		maxMessageSize = cs.GetInt("fsc.p2p.maxMessageSize")
+	}
+
 	return &config{
 		incomingMessagesBufferSize: incomingMessagesBufferSize,
 		streamReaderBufferSize:     streamReaderBufferSize,
+		maxMessageSize:             maxMessageSize,
 	}
 }

--- a/platform/view/services/comm/config.go
+++ b/platform/view/services/comm/config.go
@@ -23,7 +23,7 @@ type configService interface {
 type config struct {
 	incomingMessagesBufferSize int
 	streamReaderBufferSize     int
-	maxMessageSize             int
+	maxRecvMsgSize             int
 }
 
 func NewConfig(cs configService) *config {
@@ -37,17 +37,24 @@ func NewConfig(cs configService) *config {
 		streamReaderBufferSize = cs.GetInt("fsc.p2p.streamReaderBufferSize")
 	}
 
-	maxMessageSize := DefaultMaxMessageSize
-	if cs.IsSet("fsc.p2p.maxMessageSize") {
-		maxMessageSize = cs.GetInt("fsc.p2p.maxMessageSize")
+	maxRecvMsgSize := DefaultMaxMessageSize
+	if cs.IsSet("fsc.p2p.maxRecvMsgSize") {
+		maxRecvMsgSize = cs.GetInt("fsc.p2p.maxRecvMsgSize")
 	}
-	if maxMessageSize < 0 {
-		maxMessageSize = DefaultMaxMessageSize
+
+	if incomingMessagesBufferSize <= 0 {
+		incomingMessagesBufferSize = DefaultIncomingMessagesBufferSize
+	}
+	if streamReaderBufferSize <= 0 {
+		streamReaderBufferSize = DefaultStreamReaderBufferSize
+	}
+	if maxRecvMsgSize < 0 {
+		maxRecvMsgSize = DefaultMaxMessageSize
 	}
 
 	return &config{
 		incomingMessagesBufferSize: incomingMessagesBufferSize,
 		streamReaderBufferSize:     streamReaderBufferSize,
-		maxMessageSize:             maxMessageSize,
+		maxRecvMsgSize:             maxRecvMsgSize,
 	}
 }

--- a/platform/view/services/comm/config_test.go
+++ b/platform/view/services/comm/config_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package comm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockConfigServiceForTesting struct {
+	ints map[string]int
+	sets map[string]bool
+}
+
+func (m *mockConfigServiceForTesting) GetInt(key string) int {
+	return m.ints[key]
+}
+
+func (m *mockConfigServiceForTesting) IsSet(key string) bool {
+	return m.sets[key]
+}
+
+func TestNewConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default values", func(t *testing.T) {
+		t.Parallel()
+		cs := &mockConfigServiceForTesting{
+			ints: make(map[string]int),
+			sets: make(map[string]bool),
+		}
+		cfg := NewConfig(cs)
+		require.Equal(t, DefaultIncomingMessagesBufferSize, cfg.incomingMessagesBufferSize)
+		require.Equal(t, DefaultStreamReaderBufferSize, cfg.streamReaderBufferSize)
+		require.Equal(t, DefaultMaxMessageSize, cfg.maxRecvMsgSize)
+	})
+
+	t.Run("custom values", func(t *testing.T) {
+		t.Parallel()
+		cs := &mockConfigServiceForTesting{
+			ints: map[string]int{
+				"fsc.p2p.incomingMessagesBufferSize": 2048,
+				"fsc.p2p.streamReaderBufferSize":     8192,
+				"fsc.p2p.maxRecvMsgSize":             5000,
+			},
+			sets: map[string]bool{
+				"fsc.p2p.incomingMessagesBufferSize": true,
+				"fsc.p2p.streamReaderBufferSize":     true,
+				"fsc.p2p.maxRecvMsgSize":             true,
+			},
+		}
+		cfg := NewConfig(cs)
+		require.Equal(t, 2048, cfg.incomingMessagesBufferSize)
+		require.Equal(t, 8192, cfg.streamReaderBufferSize)
+		require.Equal(t, 5000, cfg.maxRecvMsgSize)
+	})
+
+	t.Run("clamping invalid values", func(t *testing.T) {
+		t.Parallel()
+		cs := &mockConfigServiceForTesting{
+			ints: map[string]int{
+				"fsc.p2p.incomingMessagesBufferSize": 0,
+				"fsc.p2p.streamReaderBufferSize":     -5,
+				"fsc.p2p.maxRecvMsgSize":             -100,
+			},
+			sets: map[string]bool{
+				"fsc.p2p.incomingMessagesBufferSize": true,
+				"fsc.p2p.streamReaderBufferSize":     true,
+				"fsc.p2p.maxRecvMsgSize":             true,
+			},
+		}
+		cfg := NewConfig(cs)
+		// Should clamp to defaults
+		require.Equal(t, DefaultIncomingMessagesBufferSize, cfg.incomingMessagesBufferSize)
+		require.Equal(t, DefaultStreamReaderBufferSize, cfg.streamReaderBufferSize)
+		require.Equal(t, DefaultMaxMessageSize, cfg.maxRecvMsgSize)
+	})
+
+	t.Run("zero maxRecvMsgSize is allowed", func(t *testing.T) {
+		t.Parallel()
+		cs := &mockConfigServiceForTesting{
+			ints: map[string]int{
+				"fsc.p2p.maxRecvMsgSize": 0,
+			},
+			sets: map[string]bool{
+				"fsc.p2p.maxRecvMsgSize": true,
+			},
+		}
+		cfg := NewConfig(cs)
+		require.Equal(t, 0, cfg.maxRecvMsgSize)
+	})
+}

--- a/platform/view/services/comm/host/websocket/ws/stream_test.go
+++ b/platform/view/services/comm/host/websocket/ws/stream_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/comm/io"
 )
 
+const testMaxMessageSize = 10 * 1024 * 1024
+
 func newMockStream(conn *mockConn) host.P2PStream {
 	return ws.NewWSStream(conn, context.Background(), host.StreamInfo{})
 }
@@ -117,7 +119,7 @@ func TestReader(t *testing.T) { //nolint:paralleltest
 		read:    make(chan []byte, 100),
 	}
 	stream := newMockStream(conn)
-	r := io.NewVarintProtoReader(stream, 2, 104857600)
+	r := io.NewVarintProtoReader(stream, 2, testMaxMessageSize)
 
 	input := []proto.Message{
 		messageOfSize(12),

--- a/platform/view/services/comm/host/websocket/ws/stream_test.go
+++ b/platform/view/services/comm/host/websocket/ws/stream_test.go
@@ -117,7 +117,7 @@ func TestReader(t *testing.T) { //nolint:paralleltest
 		read:    make(chan []byte, 100),
 	}
 	stream := newMockStream(conn)
-	r := io.NewVarintProtoReader(stream, 2)
+	r := io.NewVarintProtoReader(stream, 2, 104857600)
 
 	input := []proto.Message{
 		messageOfSize(12),

--- a/platform/view/services/comm/io/io.go
+++ b/platform/view/services/comm/io/io.go
@@ -20,8 +20,8 @@ type (
 // NewVarintProtoReader creates a reader that uses:
 // - varint delimiting
 // - protobuf message serialization
-func NewVarintProtoReader(reader io.Reader, capacity int) ProtoReaderCloser {
-	return newProtoReader(newVarintReader(reader, capacity))
+func NewVarintProtoReader(reader io.Reader, capacity, maxMessageSize int) ProtoReaderCloser {
+	return newProtoReader(newVarintReader(reader, capacity, maxMessageSize))
 }
 
 // NewVarintProtoWriter creates a writer that uses:

--- a/platform/view/services/comm/io/reader.go
+++ b/platform/view/services/comm/io/reader.go
@@ -50,7 +50,7 @@ func (r *varintReader) ReadData() ([]byte, error) {
 		return nil, err
 	}
 
-	if l > uint64(r.maxMessageSize) {
+	if r.maxMessageSize > 0 && l > uint64(r.maxMessageSize) {
 		return nil, errors.Errorf("message length [%d] exceeds max message size [%d]", l, r.maxMessageSize)
 	}
 

--- a/platform/view/services/comm/io/reader.go
+++ b/platform/view/services/comm/io/reader.go
@@ -29,21 +29,20 @@ type readerCloser[F any] interface {
 	io.Closer
 }
 
-func newVarintReader(reader io.Reader, capacity int) dataReader {
+func newVarintReader(reader io.Reader, capacity, maxMessageSize int) dataReader {
 	var closer io.Closer
 	if c, ok := reader.(io.Closer); ok {
 		closer = c
 	}
-	return &varintReader{r: bufio.NewReaderSize(reader, capacity), closer: closer}
+	return &varintReader{r: bufio.NewReaderSize(reader, capacity), closer: closer, maxMessageSize: maxMessageSize}
 }
 
 // varintReader reads a varint that contains the length of the message to follow (len([]byte)) and then the message
 type varintReader struct {
-	r      *bufio.Reader
-	closer io.Closer
+	r              *bufio.Reader
+	closer         io.Closer
+	maxMessageSize int
 }
-
-const maxMessageSize = 10 * 1024 * 1024
 
 func (r *varintReader) ReadData() ([]byte, error) {
 	l, err := binary.ReadUvarint(r.r)
@@ -51,8 +50,8 @@ func (r *varintReader) ReadData() ([]byte, error) {
 		return nil, err
 	}
 
-	if l > maxMessageSize {
-		return nil, errors.Errorf("message length [%d] exceeds max message size [%d]", l, maxMessageSize)
+	if l > uint64(r.maxMessageSize) {
+		return nil, errors.Errorf("message length [%d] exceeds max message size [%d]", l, r.maxMessageSize)
 	}
 
 	buffer := make([]byte, l) // We can re-use the buffer to avoid allocations

--- a/platform/view/services/comm/io/reader_security_test.go
+++ b/platform/view/services/comm/io/reader_security_test.go
@@ -21,7 +21,7 @@ func TestVarintReader_OOMProtection(t *testing.T) {
 	buf := make([]byte, 10)
 	n := binary.PutUvarint(buf, hugeLength)
 
-	r := newVarintReader(bytes.NewReader(buf[:n]), 1024)
+	r := newVarintReader(bytes.NewReader(buf[:n]), 1024, 104857600)
 
 	data, err := r.ReadData()
 	require.Error(t, err)
@@ -36,7 +36,7 @@ func TestVarintReader_NormalMessage(t *testing.T) {
 	n := binary.PutUvarint(buf, uint64(len(msg)))
 	copy(buf[n:], msg)
 
-	r := newVarintReader(bytes.NewReader(buf[:n+len(msg)]), 1024)
+	r := newVarintReader(bytes.NewReader(buf[:n+len(msg)]), 1024, 104857600)
 
 	data, err := r.ReadData()
 	require.NoError(t, err)

--- a/platform/view/services/comm/io/reader_security_test.go
+++ b/platform/view/services/comm/io/reader_security_test.go
@@ -21,7 +21,7 @@ func TestVarintReader_OOMProtection(t *testing.T) {
 	buf := make([]byte, 10)
 	n := binary.PutUvarint(buf, hugeLength)
 
-	r := newVarintReader(bytes.NewReader(buf[:n]), 1024, 104857600)
+	r := newVarintReader(bytes.NewReader(buf[:n]), 1024, testMaxMessageSize)
 
 	data, err := r.ReadData()
 	require.Error(t, err)
@@ -36,7 +36,7 @@ func TestVarintReader_NormalMessage(t *testing.T) {
 	n := binary.PutUvarint(buf, uint64(len(msg)))
 	copy(buf[n:], msg)
 
-	r := newVarintReader(bytes.NewReader(buf[:n+len(msg)]), 1024, 104857600)
+	r := newVarintReader(bytes.NewReader(buf[:n+len(msg)]), 1024, testMaxMessageSize)
 
 	data, err := r.ReadData()
 	require.NoError(t, err)

--- a/platform/view/services/comm/io/reader_test.go
+++ b/platform/view/services/comm/io/reader_test.go
@@ -17,6 +17,8 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
+const testMaxMessageSize = 10 * 1024 * 1024
+
 func TestVarintReader_ReadData(t *testing.T) {
 	t.Parallel()
 	t.Run("successful read", func(t *testing.T) {
@@ -30,7 +32,7 @@ func TestVarintReader_ReadData(t *testing.T) {
 		buf.Write(lenBuf[:n])
 		buf.Write(data)
 
-		r := newVarintReader(buf, 1024, 104857600)
+		r := newVarintReader(buf, 1024, testMaxMessageSize)
 		readData, err := r.ReadData()
 		require.NoError(t, err)
 		require.Equal(t, data, readData)
@@ -43,7 +45,7 @@ func TestVarintReader_ReadData(t *testing.T) {
 		n := binary.PutUvarint(lenBuf, 0)
 		buf.Write(lenBuf[:n])
 
-		r := newVarintReader(buf, 1024, 104857600)
+		r := newVarintReader(buf, 1024, testMaxMessageSize)
 		readData, err := r.ReadData()
 		require.NoError(t, err)
 		require.Equal(t, []byte{}, readData)
@@ -65,7 +67,7 @@ func TestVarintReader_ReadData(t *testing.T) {
 			buf.Write(msg)
 		}
 
-		r := newVarintReader(buf, 1024, 104857600)
+		r := newVarintReader(buf, 1024, testMaxMessageSize)
 		for i, expected := range messages {
 			readData, err := r.ReadData()
 			require.NoError(t, err, "failed reading message %d", i)
@@ -76,7 +78,7 @@ func TestVarintReader_ReadData(t *testing.T) {
 	t.Run("error on EOF reading length", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
-		r := newVarintReader(buf, 1024, 104857600)
+		r := newVarintReader(buf, 1024, testMaxMessageSize)
 
 		_, err := r.ReadData()
 		require.Error(t, err)
@@ -91,7 +93,7 @@ func TestVarintReader_ReadData(t *testing.T) {
 		buf.Write(lenBuf[:n])
 		buf.Write([]byte("short")) // Only 5 bytes instead of 10
 
-		r := newVarintReader(buf, 1024, 104857600)
+		r := newVarintReader(buf, 1024, testMaxMessageSize)
 		_, err := r.ReadData()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "error reading message")
@@ -103,7 +105,7 @@ func TestVarintReader_Close(t *testing.T) {
 	t.Run("close with closer", func(t *testing.T) {
 		t.Parallel()
 		closer := &mockReadCloser{Buffer: bytes.NewBuffer(nil)}
-		r := newVarintReader(closer, 1024, 104857600)
+		r := newVarintReader(closer, 1024, testMaxMessageSize)
 
 		err := r.Close()
 		require.NoError(t, err)
@@ -113,7 +115,7 @@ func TestVarintReader_Close(t *testing.T) {
 	t.Run("close without closer", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
-		r := newVarintReader(buf, 1024, 104857600)
+		r := newVarintReader(buf, 1024, testMaxMessageSize)
 
 		err := r.Close()
 		require.NoError(t, err)
@@ -125,7 +127,7 @@ func TestVarintReader_Close(t *testing.T) {
 			Buffer:   bytes.NewBuffer(nil),
 			closeErr: assert.AnError,
 		}
-		r := newVarintReader(closer, 1024, 104857600)
+		r := newVarintReader(closer, 1024, testMaxMessageSize)
 
 		err := r.Close()
 		require.Error(t, err)
@@ -147,7 +149,7 @@ func TestProtoReader_ReadMsg(t *testing.T) {
 		err := w.WriteMsg(msg)
 		require.NoError(t, err)
 
-		r := NewVarintProtoReader(buf, 1024, 104857600)
+		r := NewVarintProtoReader(buf, 1024, testMaxMessageSize)
 		readMsg := &anypb.Any{}
 		err = r.ReadMsg(readMsg)
 		require.NoError(t, err)
@@ -170,7 +172,7 @@ func TestProtoReader_ReadMsg(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		r := NewVarintProtoReader(buf, 1024, 104857600)
+		r := NewVarintProtoReader(buf, 1024, testMaxMessageSize)
 		for i, expected := range messages {
 			readMsg := &anypb.Any{}
 			err := r.ReadMsg(readMsg)
@@ -183,7 +185,7 @@ func TestProtoReader_ReadMsg(t *testing.T) {
 	t.Run("error on EOF", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
-		r := NewVarintProtoReader(buf, 1024, 104857600)
+		r := NewVarintProtoReader(buf, 1024, testMaxMessageSize)
 
 		msg := &anypb.Any{}
 		err := r.ReadMsg(msg)
@@ -201,7 +203,7 @@ func TestProtoReader_ReadMsg(t *testing.T) {
 		buf.Write(lenBuf[:n])
 		buf.Write(invalidData)
 
-		r := NewVarintProtoReader(buf, 1024, 104857600)
+		r := NewVarintProtoReader(buf, 1024, testMaxMessageSize)
 		msg := &anypb.Any{}
 		err := r.ReadMsg(msg)
 		require.Error(t, err)
@@ -214,7 +216,7 @@ func TestProtoReader_Close(t *testing.T) {
 	t.Run("close successfully", func(t *testing.T) {
 		t.Parallel()
 		closer := &mockReadCloser{Buffer: bytes.NewBuffer(nil)}
-		r := NewVarintProtoReader(closer, 1024, 104857600)
+		r := NewVarintProtoReader(closer, 1024, testMaxMessageSize)
 
 		err := r.Close()
 		require.NoError(t, err)
@@ -224,7 +226,7 @@ func TestProtoReader_Close(t *testing.T) {
 	t.Run("close without closer", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
-		r := NewVarintProtoReader(buf, 1024, 104857600)
+		r := NewVarintProtoReader(buf, 1024, testMaxMessageSize)
 
 		err := r.Close()
 		require.NoError(t, err)
@@ -234,7 +236,7 @@ func TestProtoReader_Close(t *testing.T) {
 func TestNewVarintProtoReader(t *testing.T) {
 	t.Parallel()
 	buf := &bytes.Buffer{}
-	r := NewVarintProtoReader(buf, 1024, 104857600)
+	r := NewVarintProtoReader(buf, 1024, testMaxMessageSize)
 	require.NotNil(t, r)
 }
 
@@ -257,7 +259,7 @@ func TestRoundTrip(t *testing.T) {
 		}
 
 		// Read messages back
-		r := NewVarintProtoReader(buf, 1024, 104857600)
+		r := NewVarintProtoReader(buf, 1024, testMaxMessageSize)
 		for i, expected := range messages {
 			readMsg := &anypb.Any{}
 			err := r.ReadMsg(readMsg)

--- a/platform/view/services/comm/io/reader_test.go
+++ b/platform/view/services/comm/io/reader_test.go
@@ -30,7 +30,7 @@ func TestVarintReader_ReadData(t *testing.T) {
 		buf.Write(lenBuf[:n])
 		buf.Write(data)
 
-		r := newVarintReader(buf, 1024)
+		r := newVarintReader(buf, 1024, 104857600)
 		readData, err := r.ReadData()
 		require.NoError(t, err)
 		require.Equal(t, data, readData)
@@ -43,7 +43,7 @@ func TestVarintReader_ReadData(t *testing.T) {
 		n := binary.PutUvarint(lenBuf, 0)
 		buf.Write(lenBuf[:n])
 
-		r := newVarintReader(buf, 1024)
+		r := newVarintReader(buf, 1024, 104857600)
 		readData, err := r.ReadData()
 		require.NoError(t, err)
 		require.Equal(t, []byte{}, readData)
@@ -65,7 +65,7 @@ func TestVarintReader_ReadData(t *testing.T) {
 			buf.Write(msg)
 		}
 
-		r := newVarintReader(buf, 1024)
+		r := newVarintReader(buf, 1024, 104857600)
 		for i, expected := range messages {
 			readData, err := r.ReadData()
 			require.NoError(t, err, "failed reading message %d", i)
@@ -76,7 +76,7 @@ func TestVarintReader_ReadData(t *testing.T) {
 	t.Run("error on EOF reading length", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
-		r := newVarintReader(buf, 1024)
+		r := newVarintReader(buf, 1024, 104857600)
 
 		_, err := r.ReadData()
 		require.Error(t, err)
@@ -91,7 +91,7 @@ func TestVarintReader_ReadData(t *testing.T) {
 		buf.Write(lenBuf[:n])
 		buf.Write([]byte("short")) // Only 5 bytes instead of 10
 
-		r := newVarintReader(buf, 1024)
+		r := newVarintReader(buf, 1024, 104857600)
 		_, err := r.ReadData()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "error reading message")
@@ -103,7 +103,7 @@ func TestVarintReader_Close(t *testing.T) {
 	t.Run("close with closer", func(t *testing.T) {
 		t.Parallel()
 		closer := &mockReadCloser{Buffer: bytes.NewBuffer(nil)}
-		r := newVarintReader(closer, 1024)
+		r := newVarintReader(closer, 1024, 104857600)
 
 		err := r.Close()
 		require.NoError(t, err)
@@ -113,7 +113,7 @@ func TestVarintReader_Close(t *testing.T) {
 	t.Run("close without closer", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
-		r := newVarintReader(buf, 1024)
+		r := newVarintReader(buf, 1024, 104857600)
 
 		err := r.Close()
 		require.NoError(t, err)
@@ -125,7 +125,7 @@ func TestVarintReader_Close(t *testing.T) {
 			Buffer:   bytes.NewBuffer(nil),
 			closeErr: assert.AnError,
 		}
-		r := newVarintReader(closer, 1024)
+		r := newVarintReader(closer, 1024, 104857600)
 
 		err := r.Close()
 		require.Error(t, err)
@@ -147,7 +147,7 @@ func TestProtoReader_ReadMsg(t *testing.T) {
 		err := w.WriteMsg(msg)
 		require.NoError(t, err)
 
-		r := NewVarintProtoReader(buf, 1024)
+		r := NewVarintProtoReader(buf, 1024, 104857600)
 		readMsg := &anypb.Any{}
 		err = r.ReadMsg(readMsg)
 		require.NoError(t, err)
@@ -170,7 +170,7 @@ func TestProtoReader_ReadMsg(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		r := NewVarintProtoReader(buf, 1024)
+		r := NewVarintProtoReader(buf, 1024, 104857600)
 		for i, expected := range messages {
 			readMsg := &anypb.Any{}
 			err := r.ReadMsg(readMsg)
@@ -183,7 +183,7 @@ func TestProtoReader_ReadMsg(t *testing.T) {
 	t.Run("error on EOF", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
-		r := NewVarintProtoReader(buf, 1024)
+		r := NewVarintProtoReader(buf, 1024, 104857600)
 
 		msg := &anypb.Any{}
 		err := r.ReadMsg(msg)
@@ -201,7 +201,7 @@ func TestProtoReader_ReadMsg(t *testing.T) {
 		buf.Write(lenBuf[:n])
 		buf.Write(invalidData)
 
-		r := NewVarintProtoReader(buf, 1024)
+		r := NewVarintProtoReader(buf, 1024, 104857600)
 		msg := &anypb.Any{}
 		err := r.ReadMsg(msg)
 		require.Error(t, err)
@@ -214,7 +214,7 @@ func TestProtoReader_Close(t *testing.T) {
 	t.Run("close successfully", func(t *testing.T) {
 		t.Parallel()
 		closer := &mockReadCloser{Buffer: bytes.NewBuffer(nil)}
-		r := NewVarintProtoReader(closer, 1024)
+		r := NewVarintProtoReader(closer, 1024, 104857600)
 
 		err := r.Close()
 		require.NoError(t, err)
@@ -224,7 +224,7 @@ func TestProtoReader_Close(t *testing.T) {
 	t.Run("close without closer", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
-		r := NewVarintProtoReader(buf, 1024)
+		r := NewVarintProtoReader(buf, 1024, 104857600)
 
 		err := r.Close()
 		require.NoError(t, err)
@@ -234,7 +234,7 @@ func TestProtoReader_Close(t *testing.T) {
 func TestNewVarintProtoReader(t *testing.T) {
 	t.Parallel()
 	buf := &bytes.Buffer{}
-	r := NewVarintProtoReader(buf, 1024)
+	r := NewVarintProtoReader(buf, 1024, 104857600)
 	require.NotNil(t, r)
 }
 
@@ -257,7 +257,7 @@ func TestRoundTrip(t *testing.T) {
 		}
 
 		// Read messages back
-		r := NewVarintProtoReader(buf, 1024)
+		r := NewVarintProtoReader(buf, 1024, 104857600)
 		for i, expected := range messages {
 			readMsg := &anypb.Any{}
 			err := r.ReadMsg(readMsg)

--- a/platform/view/services/comm/io/writer_test.go
+++ b/platform/view/services/comm/io/writer_test.go
@@ -137,7 +137,7 @@ func TestProtoWriter_WriteMsg(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify we can read it back
-		r := NewVarintProtoReader(buf, 1024)
+		r := NewVarintProtoReader(buf, 1024, 104857600)
 		readMsg := &anypb.Any{}
 		err = r.ReadMsg(readMsg)
 		require.NoError(t, err)
@@ -162,7 +162,7 @@ func TestProtoWriter_WriteMsg(t *testing.T) {
 		}
 
 		// Read them back
-		r := NewVarintProtoReader(buf, 1024)
+		r := NewVarintProtoReader(buf, 1024, 104857600)
 		for i, expected := range messages {
 			readMsg := &anypb.Any{}
 			err := r.ReadMsg(readMsg)

--- a/platform/view/services/comm/io/writer_test.go
+++ b/platform/view/services/comm/io/writer_test.go
@@ -137,7 +137,7 @@ func TestProtoWriter_WriteMsg(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify we can read it back
-		r := NewVarintProtoReader(buf, 1024, 104857600)
+		r := NewVarintProtoReader(buf, 1024, testMaxMessageSize)
 		readMsg := &anypb.Any{}
 		err = r.ReadMsg(readMsg)
 		require.NoError(t, err)
@@ -162,7 +162,7 @@ func TestProtoWriter_WriteMsg(t *testing.T) {
 		}
 
 		// Read them back
-		r := NewVarintProtoReader(buf, 1024, 104857600)
+		r := NewVarintProtoReader(buf, 1024, testMaxMessageSize)
 		for i, expected := range messages {
 			readMsg := &anypb.Any{}
 			err := r.ReadMsg(readMsg)

--- a/platform/view/services/comm/p2p.go
+++ b/platform/view/services/comm/p2p.go
@@ -63,26 +63,18 @@ type P2PNode struct {
 	numWorkers                 int
 	incomingMessagesBufferSize int
 	streamReaderBufferSize     int
-	maxMessageSize             int
+	maxRecvMsgSize             int
 }
 
 func NewNode(ctx context.Context, h host2.P2PHost, metricsProvider metrics.Provider) (*P2PNode, error) {
 	return NewNodeWithConfig(ctx, h, metricsProvider, &config{
 		incomingMessagesBufferSize: DefaultIncomingMessagesBufferSize,
 		streamReaderBufferSize:     DefaultStreamReaderBufferSize,
+		maxRecvMsgSize:             DefaultMaxMessageSize,
 	})
 }
 
 func NewNodeWithConfig(ctx context.Context, h host2.P2PHost, metricsProvider metrics.Provider, cfg *config) (*P2PNode, error) {
-	if cfg.incomingMessagesBufferSize <= 0 {
-		cfg.incomingMessagesBufferSize = DefaultIncomingMessagesBufferSize
-	}
-	if cfg.streamReaderBufferSize <= 0 {
-		cfg.streamReaderBufferSize = DefaultStreamReaderBufferSize
-	}
-	if cfg.maxMessageSize <= 0 {
-		cfg.maxMessageSize = DefaultMaxMessageSize
-	}
 	nodeCtx, cancel := context.WithCancel(ctx)
 	p := &P2PNode{
 		host:                       h,
@@ -96,7 +88,7 @@ func NewNodeWithConfig(ctx context.Context, h host2.P2PHost, metricsProvider met
 		numWorkers:                 DefaultDispatcherWorkers,
 		incomingMessagesBufferSize: cfg.incomingMessagesBufferSize,
 		streamReaderBufferSize:     cfg.streamReaderBufferSize,
-		maxMessageSize:             cfg.maxMessageSize,
+		maxRecvMsgSize:             cfg.maxRecvMsgSize,
 	}
 	if err := h.Start(p.handleIncomingStream); err != nil {
 		cancel()
@@ -314,7 +306,7 @@ func (p *P2PNode) handleIncomingStream(stream host2.P2PStream) {
 func (p *P2PNode) handleStream(stream host2.P2PStream) *streamHandler {
 	sh := &streamHandler{
 		stream: stream,
-		reader: io.NewVarintProtoReader(stream, p.streamReaderBufferSize, p.maxMessageSize),
+		reader: io.NewVarintProtoReader(stream, p.streamReaderBufferSize, p.maxRecvMsgSize),
 		writer: io.NewVarintProtoWriter(stream),
 		node:   p,
 	}

--- a/platform/view/services/comm/p2p.go
+++ b/platform/view/services/comm/p2p.go
@@ -63,6 +63,7 @@ type P2PNode struct {
 	numWorkers                 int
 	incomingMessagesBufferSize int
 	streamReaderBufferSize     int
+	maxMessageSize             int
 }
 
 func NewNode(ctx context.Context, h host2.P2PHost, metricsProvider metrics.Provider) (*P2PNode, error) {
@@ -79,6 +80,9 @@ func NewNodeWithConfig(ctx context.Context, h host2.P2PHost, metricsProvider met
 	if cfg.streamReaderBufferSize <= 0 {
 		cfg.streamReaderBufferSize = DefaultStreamReaderBufferSize
 	}
+	if cfg.maxMessageSize <= 0 {
+		cfg.maxMessageSize = DefaultMaxMessageSize
+	}
 	nodeCtx, cancel := context.WithCancel(ctx)
 	p := &P2PNode{
 		host:                       h,
@@ -92,6 +96,7 @@ func NewNodeWithConfig(ctx context.Context, h host2.P2PHost, metricsProvider met
 		numWorkers:                 DefaultDispatcherWorkers,
 		incomingMessagesBufferSize: cfg.incomingMessagesBufferSize,
 		streamReaderBufferSize:     cfg.streamReaderBufferSize,
+		maxMessageSize:             cfg.maxMessageSize,
 	}
 	if err := h.Start(p.handleIncomingStream); err != nil {
 		cancel()
@@ -309,7 +314,7 @@ func (p *P2PNode) handleIncomingStream(stream host2.P2PStream) {
 func (p *P2PNode) handleStream(stream host2.P2PStream) *streamHandler {
 	sh := &streamHandler{
 		stream: stream,
-		reader: io.NewVarintProtoReader(stream, p.streamReaderBufferSize),
+		reader: io.NewVarintProtoReader(stream, p.streamReaderBufferSize, p.maxMessageSize),
 		writer: io.NewVarintProtoWriter(stream),
 		node:   p,
 	}

--- a/platform/view/services/comm/stress_test.go
+++ b/platform/view/services/comm/stress_test.go
@@ -187,8 +187,7 @@ func TestRecipientOversizedRejection(t *testing.T) { //nolint:paralleltest
 	p, err := NewNode(t.Context(), h, &disabled.Provider{})
 	require.NoError(t, err)
 	defer p.Stop()
-
-	// Create a mock stream that sends an 11MB length prefix
+	// Create a mock stream that sends a 150MB length prefix
 	done := make(chan struct{})
 	ms := &mockOversizedStream{
 		mockStream: mockStream{ctx: t.Context()},
@@ -212,9 +211,9 @@ type mockOversizedStream struct {
 }
 
 func (m *mockOversizedStream) Read(p []byte) (int, error) {
-	// Send a varint for 11MB (11 * 1024 * 1024 = 11534336)
-	// Varint for 11534336 is [0x80, 0x80, 0xBF, 0x05]
-	oversizedVarint := []byte{0x80, 0x80, 0xBF, 0x05}
+	// Send a varint for 150MB (150 * 1024 * 1024 = 157286400)
+	// Varint for 157286400 is [0x80, 0x80, 0x80, 0x4B]
+	oversizedVarint := []byte{0x80, 0x80, 0x80, 0x4B}
 	n := copy(p, oversizedVarint)
 	return n, nil
 }

--- a/platform/view/services/comm/stress_test.go
+++ b/platform/view/services/comm/stress_test.go
@@ -187,7 +187,7 @@ func TestRecipientOversizedRejection(t *testing.T) { //nolint:paralleltest
 	p, err := NewNode(t.Context(), h, &disabled.Provider{})
 	require.NoError(t, err)
 	defer p.Stop()
-	// Create a mock stream that sends a 150MB length prefix
+	// Create a mock stream that sends an 11MB length prefix
 	done := make(chan struct{})
 	ms := &mockOversizedStream{
 		mockStream: mockStream{ctx: t.Context()},
@@ -211,9 +211,9 @@ type mockOversizedStream struct {
 }
 
 func (m *mockOversizedStream) Read(p []byte) (int, error) {
-	// Send a varint for 150MB (150 * 1024 * 1024 = 157286400)
-	// Varint for 157286400 is [0x80, 0x80, 0x80, 0x4B]
-	oversizedVarint := []byte{0x80, 0x80, 0x80, 0x4B}
+	// Send a varint for 11MB (11 * 1024 * 1024 = 11534336)
+	// Varint for 11534336 is [0x80, 0x80, 0xBF, 0x05]
+	oversizedVarint := []byte{0x80, 0x80, 0xBF, 0x05}
 	n := copy(p, oversizedVarint)
 	return n, nil
 }


### PR DESCRIPTION
Closes #1573 
Adds a configurable `fsc.p2p.maxRecvMsgSize` setting (default 10 MiB) to limit incoming message sizes. The limit is plumbed to the P2P stream reader so it drops oversized payloads before memory allocation and deserialisation. This update also centralises configuration clamping logic into config.go for consistency, adds comprehensive unit tests in `config_test.go`, and updates the corresponding documentation.