### PR TITLE
Add configurable size limit for outgoing P2P messages

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,6 +110,9 @@ fsc:
     # This protects the node from memory exhaustion by rejecting oversized payloads before deserialization.
     # Set to 0 to disable the limit (allow arbitrarily large messages - not recommended).
     maxRecvMsgSize: 10485760
+    # Maximum allowed size (in bytes) for outgoing P2P messages. Default: 10485760 (10 MiB)
+    # Set to 0 to disable the limit (allow arbitrarily large messages - not recommended).
+    maxSendMsgSize: 10485760
     opts:
       # ------------------- libp2p specific options -------------------------
       # Only needed when type == libp2p

--- a/platform/view/services/comm/config.go
+++ b/platform/view/services/comm/config.go
@@ -24,6 +24,7 @@ type config struct {
 	incomingMessagesBufferSize int
 	streamReaderBufferSize     int
 	maxRecvMsgSize             int
+	maxSendMsgSize             int
 }
 
 func NewConfig(cs configService) *config {
@@ -42,6 +43,11 @@ func NewConfig(cs configService) *config {
 		maxRecvMsgSize = cs.GetInt("fsc.p2p.maxRecvMsgSize")
 	}
 
+	maxSendMsgSize := DefaultMaxMessageSize
+	if cs.IsSet("fsc.p2p.maxSendMsgSize") {
+		maxSendMsgSize = cs.GetInt("fsc.p2p.maxSendMsgSize")
+	}
+
 	if incomingMessagesBufferSize <= 0 {
 		incomingMessagesBufferSize = DefaultIncomingMessagesBufferSize
 	}
@@ -51,10 +57,14 @@ func NewConfig(cs configService) *config {
 	if maxRecvMsgSize < 0 {
 		maxRecvMsgSize = DefaultMaxMessageSize
 	}
+	if maxSendMsgSize < 0 {
+		maxSendMsgSize = DefaultMaxMessageSize
+	}
 
 	return &config{
 		incomingMessagesBufferSize: incomingMessagesBufferSize,
 		streamReaderBufferSize:     streamReaderBufferSize,
 		maxRecvMsgSize:             maxRecvMsgSize,
+		maxSendMsgSize:             maxSendMsgSize,
 	}
 }

--- a/platform/view/services/comm/config_test.go
+++ b/platform/view/services/comm/config_test.go
@@ -38,6 +38,7 @@ func TestNewConfig(t *testing.T) {
 		require.Equal(t, DefaultIncomingMessagesBufferSize, cfg.incomingMessagesBufferSize)
 		require.Equal(t, DefaultStreamReaderBufferSize, cfg.streamReaderBufferSize)
 		require.Equal(t, DefaultMaxMessageSize, cfg.maxRecvMsgSize)
+		require.Equal(t, DefaultMaxMessageSize, cfg.maxSendMsgSize)
 	})
 
 	t.Run("custom values", func(t *testing.T) {
@@ -47,17 +48,20 @@ func TestNewConfig(t *testing.T) {
 				"fsc.p2p.incomingMessagesBufferSize": 2048,
 				"fsc.p2p.streamReaderBufferSize":     8192,
 				"fsc.p2p.maxRecvMsgSize":             5000,
+				"fsc.p2p.maxSendMsgSize":             6000,
 			},
 			sets: map[string]bool{
 				"fsc.p2p.incomingMessagesBufferSize": true,
 				"fsc.p2p.streamReaderBufferSize":     true,
 				"fsc.p2p.maxRecvMsgSize":             true,
+				"fsc.p2p.maxSendMsgSize":             true,
 			},
 		}
 		cfg := NewConfig(cs)
 		require.Equal(t, 2048, cfg.incomingMessagesBufferSize)
 		require.Equal(t, 8192, cfg.streamReaderBufferSize)
 		require.Equal(t, 5000, cfg.maxRecvMsgSize)
+		require.Equal(t, 6000, cfg.maxSendMsgSize)
 	})
 
 	t.Run("clamping invalid values", func(t *testing.T) {
@@ -67,11 +71,13 @@ func TestNewConfig(t *testing.T) {
 				"fsc.p2p.incomingMessagesBufferSize": 0,
 				"fsc.p2p.streamReaderBufferSize":     -5,
 				"fsc.p2p.maxRecvMsgSize":             -100,
+				"fsc.p2p.maxSendMsgSize":             -200,
 			},
 			sets: map[string]bool{
 				"fsc.p2p.incomingMessagesBufferSize": true,
 				"fsc.p2p.streamReaderBufferSize":     true,
 				"fsc.p2p.maxRecvMsgSize":             true,
+				"fsc.p2p.maxSendMsgSize":             true,
 			},
 		}
 		cfg := NewConfig(cs)
@@ -79,19 +85,23 @@ func TestNewConfig(t *testing.T) {
 		require.Equal(t, DefaultIncomingMessagesBufferSize, cfg.incomingMessagesBufferSize)
 		require.Equal(t, DefaultStreamReaderBufferSize, cfg.streamReaderBufferSize)
 		require.Equal(t, DefaultMaxMessageSize, cfg.maxRecvMsgSize)
+		require.Equal(t, DefaultMaxMessageSize, cfg.maxSendMsgSize)
 	})
 
-	t.Run("zero maxRecvMsgSize is allowed", func(t *testing.T) {
+	t.Run("zero maxRecvMsgSize and maxSendMsgSize are allowed", func(t *testing.T) {
 		t.Parallel()
 		cs := &mockConfigServiceForTesting{
 			ints: map[string]int{
 				"fsc.p2p.maxRecvMsgSize": 0,
+				"fsc.p2p.maxSendMsgSize": 0,
 			},
 			sets: map[string]bool{
 				"fsc.p2p.maxRecvMsgSize": true,
+				"fsc.p2p.maxSendMsgSize": true,
 			},
 		}
 		cfg := NewConfig(cs)
 		require.Equal(t, 0, cfg.maxRecvMsgSize)
+		require.Equal(t, 0, cfg.maxSendMsgSize)
 	})
 }

--- a/platform/view/services/comm/host/websocket/ws/stream_test.go
+++ b/platform/view/services/comm/host/websocket/ws/stream_test.go
@@ -81,7 +81,7 @@ func TestWriter(t *testing.T) { //nolint:paralleltest
 		read:    make(chan []byte, 100),
 	}
 	stream := newMockStream(conn)
-	w := io.NewVarintProtoWriter(stream)
+	w := io.NewVarintProtoWriter(stream, 1024*1024)
 
 	input := []proto.Message{
 		messageOfSize(12),

--- a/platform/view/services/comm/io/io.go
+++ b/platform/view/services/comm/io/io.go
@@ -27,6 +27,6 @@ func NewVarintProtoReader(reader io.Reader, capacity, maxMessageSize int) ProtoR
 // NewVarintProtoWriter creates a writer that uses:
 // - varint delimiting
 // - protobuf message serialization
-func NewVarintProtoWriter(writer io.Writer) ProtoWriterCloser {
-	return newProtoWriter(newVarintWriter(writer))
+func NewVarintProtoWriter(writer io.Writer, maxSendMsgSize int) ProtoWriterCloser {
+	return newProtoWriter(newVarintWriter(writer), maxSendMsgSize)
 }

--- a/platform/view/services/comm/io/reader_security_test.go
+++ b/platform/view/services/comm/io/reader_security_test.go
@@ -21,7 +21,7 @@ func TestVarintReader_OOMProtection(t *testing.T) {
 	buf := make([]byte, 10)
 	n := binary.PutUvarint(buf, hugeLength)
 
-	r := newVarintReader(bytes.NewReader(buf[:n]), 1024, testMaxMessageSize)
+	r := newVarintReader(bytes.NewReader(buf[:n]), testBufferSize, testMaxMessageSize)
 
 	data, err := r.ReadData()
 	require.Error(t, err)
@@ -36,7 +36,7 @@ func TestVarintReader_NormalMessage(t *testing.T) {
 	n := binary.PutUvarint(buf, uint64(len(msg)))
 	copy(buf[n:], msg)
 
-	r := newVarintReader(bytes.NewReader(buf[:n+len(msg)]), 1024, testMaxMessageSize)
+	r := newVarintReader(bytes.NewReader(buf[:n+len(msg)]), testBufferSize, testMaxMessageSize)
 
 	data, err := r.ReadData()
 	require.NoError(t, err)

--- a/platform/view/services/comm/io/reader_test.go
+++ b/platform/view/services/comm/io/reader_test.go
@@ -145,7 +145,7 @@ func TestProtoReader_ReadMsg(t *testing.T) {
 		}
 
 		buf := &bytes.Buffer{}
-		w := NewVarintProtoWriter(buf)
+		w := NewVarintProtoWriter(buf, 1024)
 		err := w.WriteMsg(msg)
 		require.NoError(t, err)
 
@@ -166,7 +166,7 @@ func TestProtoReader_ReadMsg(t *testing.T) {
 		}
 
 		buf := &bytes.Buffer{}
-		w := NewVarintProtoWriter(buf)
+		w := NewVarintProtoWriter(buf, 1024)
 		for _, msg := range messages {
 			err := w.WriteMsg(msg)
 			require.NoError(t, err)
@@ -247,7 +247,7 @@ func TestRoundTrip(t *testing.T) {
 		buf := &bytes.Buffer{}
 
 		// Write messages
-		w := NewVarintProtoWriter(buf)
+		w := NewVarintProtoWriter(buf, 1024)
 		messages := []*anypb.Any{
 			{TypeUrl: "type1", Value: []byte("value1")},
 			{TypeUrl: "type2", Value: []byte("value2")},

--- a/platform/view/services/comm/io/reader_test.go
+++ b/platform/view/services/comm/io/reader_test.go
@@ -17,7 +17,10 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
-const testMaxMessageSize = 10 * 1024 * 1024
+const (
+	testMaxMessageSize = 10 * 1024 * 1024
+	testBufferSize     = 1024
+)
 
 func TestVarintReader_ReadData(t *testing.T) {
 	t.Parallel()
@@ -32,7 +35,7 @@ func TestVarintReader_ReadData(t *testing.T) {
 		buf.Write(lenBuf[:n])
 		buf.Write(data)
 
-		r := newVarintReader(buf, 1024, testMaxMessageSize)
+		r := newVarintReader(buf, testBufferSize, testMaxMessageSize)
 		readData, err := r.ReadData()
 		require.NoError(t, err)
 		require.Equal(t, data, readData)
@@ -45,7 +48,7 @@ func TestVarintReader_ReadData(t *testing.T) {
 		n := binary.PutUvarint(lenBuf, 0)
 		buf.Write(lenBuf[:n])
 
-		r := newVarintReader(buf, 1024, testMaxMessageSize)
+		r := newVarintReader(buf, testBufferSize, testMaxMessageSize)
 		readData, err := r.ReadData()
 		require.NoError(t, err)
 		require.Equal(t, []byte{}, readData)
@@ -67,7 +70,7 @@ func TestVarintReader_ReadData(t *testing.T) {
 			buf.Write(msg)
 		}
 
-		r := newVarintReader(buf, 1024, testMaxMessageSize)
+		r := newVarintReader(buf, testBufferSize, testMaxMessageSize)
 		for i, expected := range messages {
 			readData, err := r.ReadData()
 			require.NoError(t, err, "failed reading message %d", i)
@@ -78,7 +81,7 @@ func TestVarintReader_ReadData(t *testing.T) {
 	t.Run("error on EOF reading length", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
-		r := newVarintReader(buf, 1024, testMaxMessageSize)
+		r := newVarintReader(buf, testBufferSize, testMaxMessageSize)
 
 		_, err := r.ReadData()
 		require.Error(t, err)
@@ -93,7 +96,7 @@ func TestVarintReader_ReadData(t *testing.T) {
 		buf.Write(lenBuf[:n])
 		buf.Write([]byte("short")) // Only 5 bytes instead of 10
 
-		r := newVarintReader(buf, 1024, testMaxMessageSize)
+		r := newVarintReader(buf, testBufferSize, testMaxMessageSize)
 		_, err := r.ReadData()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "error reading message")
@@ -105,7 +108,7 @@ func TestVarintReader_Close(t *testing.T) {
 	t.Run("close with closer", func(t *testing.T) {
 		t.Parallel()
 		closer := &mockReadCloser{Buffer: bytes.NewBuffer(nil)}
-		r := newVarintReader(closer, 1024, testMaxMessageSize)
+		r := newVarintReader(closer, testBufferSize, testMaxMessageSize)
 
 		err := r.Close()
 		require.NoError(t, err)
@@ -115,7 +118,7 @@ func TestVarintReader_Close(t *testing.T) {
 	t.Run("close without closer", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
-		r := newVarintReader(buf, 1024, testMaxMessageSize)
+		r := newVarintReader(buf, testBufferSize, testMaxMessageSize)
 
 		err := r.Close()
 		require.NoError(t, err)
@@ -127,7 +130,7 @@ func TestVarintReader_Close(t *testing.T) {
 			Buffer:   bytes.NewBuffer(nil),
 			closeErr: assert.AnError,
 		}
-		r := newVarintReader(closer, 1024, testMaxMessageSize)
+		r := newVarintReader(closer, testBufferSize, testMaxMessageSize)
 
 		err := r.Close()
 		require.Error(t, err)
@@ -145,11 +148,11 @@ func TestProtoReader_ReadMsg(t *testing.T) {
 		}
 
 		buf := &bytes.Buffer{}
-		w := NewVarintProtoWriter(buf, 1024)
+		w := NewVarintProtoWriter(buf, testMaxMessageSize)
 		err := w.WriteMsg(msg)
 		require.NoError(t, err)
 
-		r := NewVarintProtoReader(buf, 1024, testMaxMessageSize)
+		r := NewVarintProtoReader(buf, testBufferSize, testMaxMessageSize)
 		readMsg := &anypb.Any{}
 		err = r.ReadMsg(readMsg)
 		require.NoError(t, err)
@@ -166,13 +169,13 @@ func TestProtoReader_ReadMsg(t *testing.T) {
 		}
 
 		buf := &bytes.Buffer{}
-		w := NewVarintProtoWriter(buf, 1024)
+		w := NewVarintProtoWriter(buf, testMaxMessageSize)
 		for _, msg := range messages {
 			err := w.WriteMsg(msg)
 			require.NoError(t, err)
 		}
 
-		r := NewVarintProtoReader(buf, 1024, testMaxMessageSize)
+		r := NewVarintProtoReader(buf, testBufferSize, testMaxMessageSize)
 		for i, expected := range messages {
 			readMsg := &anypb.Any{}
 			err := r.ReadMsg(readMsg)
@@ -185,7 +188,7 @@ func TestProtoReader_ReadMsg(t *testing.T) {
 	t.Run("error on EOF", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
-		r := NewVarintProtoReader(buf, 1024, testMaxMessageSize)
+		r := NewVarintProtoReader(buf, testBufferSize, testMaxMessageSize)
 
 		msg := &anypb.Any{}
 		err := r.ReadMsg(msg)
@@ -203,7 +206,7 @@ func TestProtoReader_ReadMsg(t *testing.T) {
 		buf.Write(lenBuf[:n])
 		buf.Write(invalidData)
 
-		r := NewVarintProtoReader(buf, 1024, testMaxMessageSize)
+		r := NewVarintProtoReader(buf, testBufferSize, testMaxMessageSize)
 		msg := &anypb.Any{}
 		err := r.ReadMsg(msg)
 		require.Error(t, err)
@@ -216,7 +219,7 @@ func TestProtoReader_Close(t *testing.T) {
 	t.Run("close successfully", func(t *testing.T) {
 		t.Parallel()
 		closer := &mockReadCloser{Buffer: bytes.NewBuffer(nil)}
-		r := NewVarintProtoReader(closer, 1024, testMaxMessageSize)
+		r := NewVarintProtoReader(closer, testBufferSize, testMaxMessageSize)
 
 		err := r.Close()
 		require.NoError(t, err)
@@ -226,7 +229,7 @@ func TestProtoReader_Close(t *testing.T) {
 	t.Run("close without closer", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
-		r := NewVarintProtoReader(buf, 1024, testMaxMessageSize)
+		r := NewVarintProtoReader(buf, testBufferSize, testMaxMessageSize)
 
 		err := r.Close()
 		require.NoError(t, err)
@@ -236,7 +239,7 @@ func TestProtoReader_Close(t *testing.T) {
 func TestNewVarintProtoReader(t *testing.T) {
 	t.Parallel()
 	buf := &bytes.Buffer{}
-	r := NewVarintProtoReader(buf, 1024, testMaxMessageSize)
+	r := NewVarintProtoReader(buf, testBufferSize, testMaxMessageSize)
 	require.NotNil(t, r)
 }
 
@@ -247,7 +250,7 @@ func TestRoundTrip(t *testing.T) {
 		buf := &bytes.Buffer{}
 
 		// Write messages
-		w := NewVarintProtoWriter(buf, 1024)
+		w := NewVarintProtoWriter(buf, testMaxMessageSize)
 		messages := []*anypb.Any{
 			{TypeUrl: "type1", Value: []byte("value1")},
 			{TypeUrl: "type2", Value: []byte("value2")},
@@ -259,7 +262,7 @@ func TestRoundTrip(t *testing.T) {
 		}
 
 		// Read messages back
-		r := NewVarintProtoReader(buf, 1024, testMaxMessageSize)
+		r := NewVarintProtoReader(buf, testBufferSize, testMaxMessageSize)
 		for i, expected := range messages {
 			readMsg := &anypb.Any{}
 			err := r.ReadMsg(readMsg)

--- a/platform/view/services/comm/io/writer.go
+++ b/platform/view/services/comm/io/writer.go
@@ -61,19 +61,23 @@ func (w *varintWriter) Close() error {
 	return nil
 }
 
-func newProtoWriter(w dataWriter) writerCloser[proto.Message] {
-	return &protoWriter{w: w}
+func newProtoWriter(w dataWriter, maxSendMsgSize int) writerCloser[proto.Message] {
+	return &protoWriter{w: w, maxSendMsgSize: maxSendMsgSize}
 }
 
 // protoWriter uses proto.Message as data container
 type protoWriter struct {
-	w dataWriter
+	w              dataWriter
+	maxSendMsgSize int
 }
 
 func (w *protoWriter) WriteMsg(msg proto.Message) error {
 	data, err := proto.Marshal(msg)
 	if err != nil {
 		return errors.Wrapf(err, "failed to marshal the message: [%s]", msg)
+	}
+	if w.maxSendMsgSize > 0 && len(data) > w.maxSendMsgSize {
+		return errors.Errorf("message size %d exceeds maximum send size %d", len(data), w.maxSendMsgSize)
 	}
 	return w.w.WriteData(data)
 }

--- a/platform/view/services/comm/io/writer_test.go
+++ b/platform/view/services/comm/io/writer_test.go
@@ -126,7 +126,7 @@ func TestProtoWriter_WriteMsg(t *testing.T) {
 	t.Run("successful write", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
-		w := NewVarintProtoWriter(buf, 1024)
+		w := NewVarintProtoWriter(buf, testMaxMessageSize)
 
 		msg := &anypb.Any{
 			TypeUrl: "test.type",
@@ -137,7 +137,7 @@ func TestProtoWriter_WriteMsg(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify we can read it back
-		r := NewVarintProtoReader(buf, 1024, testMaxMessageSize)
+		r := NewVarintProtoReader(buf, testBufferSize, testMaxMessageSize)
 		readMsg := &anypb.Any{}
 		err = r.ReadMsg(readMsg)
 		require.NoError(t, err)
@@ -148,7 +148,7 @@ func TestProtoWriter_WriteMsg(t *testing.T) {
 	t.Run("write multiple messages", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
-		w := NewVarintProtoWriter(buf, 1024)
+		w := NewVarintProtoWriter(buf, testMaxMessageSize)
 
 		messages := []*anypb.Any{
 			{TypeUrl: "type1", Value: []byte("value1")},
@@ -162,7 +162,7 @@ func TestProtoWriter_WriteMsg(t *testing.T) {
 		}
 
 		// Read them back
-		r := NewVarintProtoReader(buf, 1024, testMaxMessageSize)
+		r := NewVarintProtoReader(buf, testBufferSize, testMaxMessageSize)
 		for i, expected := range messages {
 			readMsg := &anypb.Any{}
 			err := r.ReadMsg(readMsg)
@@ -178,7 +178,7 @@ func TestProtoWriter_Close(t *testing.T) {
 	t.Run("close successfully", func(t *testing.T) {
 		t.Parallel()
 		closer := &mockCloser{Buffer: &bytes.Buffer{}}
-		w := NewVarintProtoWriter(closer, 1024)
+		w := NewVarintProtoWriter(closer, testMaxMessageSize)
 
 		err := w.Close()
 		require.NoError(t, err)
@@ -188,7 +188,7 @@ func TestProtoWriter_Close(t *testing.T) {
 	t.Run("close without closer", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
-		w := NewVarintProtoWriter(buf, 1024)
+		w := NewVarintProtoWriter(buf, testMaxMessageSize)
 
 		err := w.Close()
 		require.NoError(t, err)
@@ -198,7 +198,7 @@ func TestProtoWriter_Close(t *testing.T) {
 func TestNewVarintProtoWriter(t *testing.T) {
 	t.Parallel()
 	buf := &bytes.Buffer{}
-	w := NewVarintProtoWriter(buf, 1024)
+	w := NewVarintProtoWriter(buf, testMaxMessageSize)
 	require.NotNil(t, w)
 
 	// Verify it's functional

--- a/platform/view/services/comm/io/writer_test.go
+++ b/platform/view/services/comm/io/writer_test.go
@@ -126,7 +126,7 @@ func TestProtoWriter_WriteMsg(t *testing.T) {
 	t.Run("successful write", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
-		w := NewVarintProtoWriter(buf)
+		w := NewVarintProtoWriter(buf, 1024)
 
 		msg := &anypb.Any{
 			TypeUrl: "test.type",
@@ -148,7 +148,7 @@ func TestProtoWriter_WriteMsg(t *testing.T) {
 	t.Run("write multiple messages", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
-		w := NewVarintProtoWriter(buf)
+		w := NewVarintProtoWriter(buf, 1024)
 
 		messages := []*anypb.Any{
 			{TypeUrl: "type1", Value: []byte("value1")},
@@ -178,7 +178,7 @@ func TestProtoWriter_Close(t *testing.T) {
 	t.Run("close successfully", func(t *testing.T) {
 		t.Parallel()
 		closer := &mockCloser{Buffer: &bytes.Buffer{}}
-		w := NewVarintProtoWriter(closer)
+		w := NewVarintProtoWriter(closer, 1024)
 
 		err := w.Close()
 		require.NoError(t, err)
@@ -188,7 +188,7 @@ func TestProtoWriter_Close(t *testing.T) {
 	t.Run("close without closer", func(t *testing.T) {
 		t.Parallel()
 		buf := &bytes.Buffer{}
-		w := NewVarintProtoWriter(buf)
+		w := NewVarintProtoWriter(buf, 1024)
 
 		err := w.Close()
 		require.NoError(t, err)
@@ -198,7 +198,7 @@ func TestProtoWriter_Close(t *testing.T) {
 func TestNewVarintProtoWriter(t *testing.T) {
 	t.Parallel()
 	buf := &bytes.Buffer{}
-	w := NewVarintProtoWriter(buf)
+	w := NewVarintProtoWriter(buf, 1024)
 	require.NotNil(t, w)
 
 	// Verify it's functional
@@ -238,4 +238,15 @@ func (m *mockCloser) Write(p []byte) (n int, err error) {
 		return 0, io.ErrClosedPipe
 	}
 	return m.Buffer.Write(p)
+}
+
+func TestProtoWriter_Oversize(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	w := NewVarintProtoWriter(buf, 5) // max size 5 bytes
+
+	msg := &anypb.Any{TypeUrl: "test", Value: []byte("too large payload here")}
+	err := w.WriteMsg(msg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum send size")
 }

--- a/platform/view/services/comm/p2p.go
+++ b/platform/view/services/comm/p2p.go
@@ -64,6 +64,7 @@ type P2PNode struct {
 	incomingMessagesBufferSize int
 	streamReaderBufferSize     int
 	maxRecvMsgSize             int
+	maxSendMsgSize             int
 }
 
 func NewNode(ctx context.Context, h host2.P2PHost, metricsProvider metrics.Provider) (*P2PNode, error) {
@@ -71,6 +72,7 @@ func NewNode(ctx context.Context, h host2.P2PHost, metricsProvider metrics.Provi
 		incomingMessagesBufferSize: DefaultIncomingMessagesBufferSize,
 		streamReaderBufferSize:     DefaultStreamReaderBufferSize,
 		maxRecvMsgSize:             DefaultMaxMessageSize,
+		maxSendMsgSize:             DefaultMaxMessageSize,
 	})
 }
 
@@ -89,6 +91,7 @@ func NewNodeWithConfig(ctx context.Context, h host2.P2PHost, metricsProvider met
 		incomingMessagesBufferSize: cfg.incomingMessagesBufferSize,
 		streamReaderBufferSize:     cfg.streamReaderBufferSize,
 		maxRecvMsgSize:             cfg.maxRecvMsgSize,
+		maxSendMsgSize:             cfg.maxSendMsgSize,
 	}
 	if err := h.Start(p.handleIncomingStream); err != nil {
 		cancel()
@@ -307,7 +310,7 @@ func (p *P2PNode) handleStream(stream host2.P2PStream) *streamHandler {
 	sh := &streamHandler{
 		stream: stream,
 		reader: io.NewVarintProtoReader(stream, p.streamReaderBufferSize, p.maxRecvMsgSize),
-		writer: io.NewVarintProtoWriter(stream),
+		writer: io.NewVarintProtoWriter(stream, p.maxSendMsgSize),
 		node:   p,
 	}
 


### PR DESCRIPTION
Closes #1579
Following up on the incoming message limits (#1575), this PR adds a configurable size limit for *outgoing* P2P messages to prevent wasting network bandwidth and resources on sending oversized payloads. 

It introduces the `fsc.p2p.maxSendMsgSize` configuration (defaulting to 10 MiB) and enforces this limit directly at the P2P stream writer level, ensuring that messages exceeding the limit are dropped before being written to the wire.

Additionally, configuration bounds are validated and unit tests (`config_test.go`, `reader_test.go`, `writer_test.go`) have been updated to ensure the limit is strictly respected.
