### PR TITLE
feature(fabric-x): add GetNamespacePolicies to query service

### DIFF
--- a/integration/fabricx/simple/simple_test.go
+++ b/integration/fabricx/simple/simple_test.go
@@ -131,6 +131,15 @@ func RunTest(n *integration.Infrastructure) {
 		Namespace: simple.Namespace,
 	}))
 	Expect(err).ToNot(HaveOccurred())
+
+	// query the namespace policies and make sure our namespace has one registered
+	res, err = n.Client(simple.CreatorNode).CallView("namespacePolicies", nil)
+	Expect(err).ToNot(HaveOccurred())
+	raw, ok = res.([]byte)
+	Expect(ok).To(BeTrue())
+	var policies views.NamespacePoliciesResult
+	nwocommon.JSONUnmarshal(raw, &policies)
+	Expect(policies.Versions).To(HaveKey(simple.Namespace))
 }
 
 func NewTestSuite(commType nwofsc.P2PCommunicationType) *TestSuite {

--- a/integration/fabricx/simple/topo.go
+++ b/integration/fabricx/simple/topo.go
@@ -40,7 +40,8 @@ func Topology(sdk node.SDK, commType fsc.P2PCommunicationType) []api.Topology {
 		AddOptions(fabric.WithOrganization("Org1")).
 		// simple logic
 		RegisterViewFactory("create", &simpleviews.CreateViewFactory{}).
-		RegisterViewFactory("query", &simpleviews.QueryViewFactory{})
+		RegisterViewFactory("query", &simpleviews.QueryViewFactory{}).
+		RegisterViewFactory("namespacePolicies", &simpleviews.NamespacePoliciesViewFactory{})
 
 	fscTopology.AddSDK(sdk)
 

--- a/integration/fabricx/simple/views/policies.go
+++ b/integration/fabricx/simple/views/policies.go
@@ -1,0 +1,55 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package views
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
+
+// NamespacePoliciesResult is the (JSON-serializable) output of NamespacePoliciesView.
+// It reports, per namespace, the version of the registered endorsement policy.
+type NamespacePoliciesResult struct {
+	// Versions maps a namespace to the version of its registered policy.
+	Versions map[string]uint64
+}
+
+// NamespacePoliciesView queries the endorsement policies currently registered
+// for every namespace via the query service and returns their versions keyed
+// by namespace.
+type NamespacePoliciesView struct{}
+
+func (v *NamespacePoliciesView) Call(viewCtx view.Context) (any, error) {
+	network, ch, err := fabric.GetDefaultChannel(viewCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	qs, err := queryservice.GetQueryService(viewCtx, network.Name(), ch.Name())
+	if err != nil {
+		return nil, err
+	}
+
+	policies, err := qs.GetNamespacePolicies()
+	if err != nil {
+		return nil, err
+	}
+
+	res := NamespacePoliciesResult{Versions: make(map[string]uint64, len(policies.GetPolicies()))}
+	for _, p := range policies.GetPolicies() {
+		res.Versions[p.GetNamespace()] = p.GetVersion()
+	}
+
+	return res, nil
+}
+
+type NamespacePoliciesViewFactory struct{}
+
+func (c *NamespacePoliciesViewFactory) NewView([]byte) (view.View, error) {
+	return &NamespacePoliciesView{}, nil
+}

--- a/platform/fabricx/core/committer/queryservice/mock/query_service.go
+++ b/platform/fabricx/core/committer/queryservice/mock/query_service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 )
 
 type QueryService struct {
@@ -19,6 +20,18 @@ type QueryService struct {
 	}
 	getConfigTransactionReturnsOnCall map[int]struct {
 		result1 *queryservice.ConfigTransactionInfo
+		result2 error
+	}
+	GetNamespacePoliciesStub        func() (*applicationpb.NamespacePolicies, error)
+	getNamespacePoliciesMutex       sync.RWMutex
+	getNamespacePoliciesArgsForCall []struct {
+	}
+	getNamespacePoliciesReturns struct {
+		result1 *applicationpb.NamespacePolicies
+		result2 error
+	}
+	getNamespacePoliciesReturnsOnCall map[int]struct {
+		result1 *applicationpb.NamespacePolicies
 		result2 error
 	}
 	GetStateStub        func(driver.Namespace, driver.PKey) (*driver.VaultValue, error)
@@ -130,6 +143,62 @@ func (fake *QueryService) GetConfigTransactionReturnsOnCall(i int, result1 *quer
 	}
 	fake.getConfigTransactionReturnsOnCall[i] = struct {
 		result1 *queryservice.ConfigTransactionInfo
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *QueryService) GetNamespacePolicies() (*applicationpb.NamespacePolicies, error) {
+	fake.getNamespacePoliciesMutex.Lock()
+	ret, specificReturn := fake.getNamespacePoliciesReturnsOnCall[len(fake.getNamespacePoliciesArgsForCall)]
+	fake.getNamespacePoliciesArgsForCall = append(fake.getNamespacePoliciesArgsForCall, struct {
+	}{})
+	stub := fake.GetNamespacePoliciesStub
+	fakeReturns := fake.getNamespacePoliciesReturns
+	fake.recordInvocation("GetNamespacePolicies", []interface{}{})
+	fake.getNamespacePoliciesMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *QueryService) GetNamespacePoliciesCallCount() int {
+	fake.getNamespacePoliciesMutex.RLock()
+	defer fake.getNamespacePoliciesMutex.RUnlock()
+	return len(fake.getNamespacePoliciesArgsForCall)
+}
+
+func (fake *QueryService) GetNamespacePoliciesCalls(stub func() (*applicationpb.NamespacePolicies, error)) {
+	fake.getNamespacePoliciesMutex.Lock()
+	defer fake.getNamespacePoliciesMutex.Unlock()
+	fake.GetNamespacePoliciesStub = stub
+}
+
+func (fake *QueryService) GetNamespacePoliciesReturns(result1 *applicationpb.NamespacePolicies, result2 error) {
+	fake.getNamespacePoliciesMutex.Lock()
+	defer fake.getNamespacePoliciesMutex.Unlock()
+	fake.GetNamespacePoliciesStub = nil
+	fake.getNamespacePoliciesReturns = struct {
+		result1 *applicationpb.NamespacePolicies
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *QueryService) GetNamespacePoliciesReturnsOnCall(i int, result1 *applicationpb.NamespacePolicies, result2 error) {
+	fake.getNamespacePoliciesMutex.Lock()
+	defer fake.getNamespacePoliciesMutex.Unlock()
+	fake.GetNamespacePoliciesStub = nil
+	if fake.getNamespacePoliciesReturnsOnCall == nil {
+		fake.getNamespacePoliciesReturnsOnCall = make(map[int]struct {
+			result1 *applicationpb.NamespacePolicies
+			result2 error
+		})
+	}
+	fake.getNamespacePoliciesReturnsOnCall[i] = struct {
+		result1 *applicationpb.NamespacePolicies
 		result2 error
 	}{result1, result2}
 }

--- a/platform/fabricx/core/committer/queryservice/provider.go
+++ b/platform/fabricx/core/committer/queryservice/provider.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"google.golang.org/grpc"
 
@@ -39,6 +40,7 @@ type QueryService interface {
 	GetTransactionStatus(txID string) (int32, error)
 	GetTransactionStatuses(txIDs []string) (map[string]int32, error)
 	GetConfigTransaction() (*ConfigTransactionInfo, error)
+	GetNamespacePolicies() (*applicationpb.NamespacePolicies, error)
 }
 
 // ServiceConfigProvider provides gRPC configuration for a given network.

--- a/platform/fabricx/core/committer/queryservice/query.go
+++ b/platform/fabricx/core/committer/queryservice/query.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
@@ -152,6 +153,22 @@ func (s *RemoteQueryService) GetConfigTransaction() (*ConfigTransactionInfo, err
 		Envelope: envelope,
 		Version:  res.GetVersion(),
 	}, nil
+}
+
+// GetNamespacePolicies returns the endorsement policies currently registered
+// for every namespace, together with their version.
+func (s *RemoteQueryService) GetNamespacePolicies() (*applicationpb.NamespacePolicies, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), s.config.RequestTimeout)
+	defer cancel()
+
+	now := time.Now()
+	res, err := s.client.GetNamespacePolicies(ctx, &emptypb.Empty{})
+	if err != nil {
+		return nil, errors.Wrap(err, "get namespace policies")
+	}
+	logger.Debugf("QS GetNamespacePolicies: got %d policies in %v", len(res.GetPolicies()), time.Since(now))
+
+	return res, nil
 }
 
 func (s *RemoteQueryService) query(m map[driver.Namespace][]driver.PKey) (map[driver.Namespace]map[driver.PKey]driver.VaultValue, error) {

--- a/platform/fabricx/core/committer/queryservice/query_test.go
+++ b/platform/fabricx/core/committer/queryservice/query_test.go
@@ -544,4 +544,48 @@ func TestQueryService(t *testing.T) {
 			require.ErrorIs(t, err, expectedError)
 		})
 	})
+
+	// New tests for GetNamespacePolicies
+	t.Run("GetNamespacePolicies", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("happy path", func(t *testing.T) {
+			t.Parallel()
+			qs, fake := setupTest(t)
+			expected := &applicationpb.NamespacePolicies{
+				Policies: []*applicationpb.PolicyItem{
+					{Namespace: "ns1", Policy: []byte("policy1"), Version: 0},
+					{Namespace: "ns2", Policy: []byte("policy2"), Version: 3},
+				},
+			}
+			fake.GetNamespacePoliciesReturns(expected, nil)
+
+			resp, err := qs.GetNamespacePolicies()
+			require.NoError(t, err)
+			require.Equal(t, expected, resp)
+			require.Equal(t, 1, fake.GetNamespacePoliciesCallCount())
+		})
+
+		t.Run("empty policies", func(t *testing.T) {
+			t.Parallel()
+			qs, fake := setupTest(t)
+			expected := &applicationpb.NamespacePolicies{}
+			fake.GetNamespacePoliciesReturns(expected, nil)
+
+			resp, err := qs.GetNamespacePolicies()
+			require.NoError(t, err)
+			require.Equal(t, expected, resp)
+			require.Empty(t, resp.GetPolicies())
+		})
+
+		t.Run("client error", func(t *testing.T) {
+			t.Parallel()
+			qs, fake := setupTest(t)
+			expectedError := errors.New("some error")
+			fake.GetNamespacePoliciesReturns(nil, expectedError)
+
+			_, err := qs.GetNamespacePolicies()
+			require.ErrorIs(t, err, expectedError)
+		})
+	})
 }

--- a/platform/fabricx/core/ledger/mock/query_service.go
+++ b/platform/fabricx/core/ledger/mock/query_service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 )
 
 type QueryService struct {
@@ -19,6 +20,18 @@ type QueryService struct {
 	}
 	getConfigTransactionReturnsOnCall map[int]struct {
 		result1 *queryservice.ConfigTransactionInfo
+		result2 error
+	}
+	GetNamespacePoliciesStub        func() (*applicationpb.NamespacePolicies, error)
+	getNamespacePoliciesMutex       sync.RWMutex
+	getNamespacePoliciesArgsForCall []struct {
+	}
+	getNamespacePoliciesReturns struct {
+		result1 *applicationpb.NamespacePolicies
+		result2 error
+	}
+	getNamespacePoliciesReturnsOnCall map[int]struct {
+		result1 *applicationpb.NamespacePolicies
 		result2 error
 	}
 	GetStateStub        func(driver.Namespace, driver.PKey) (*driver.VaultValue, error)
@@ -130,6 +143,62 @@ func (fake *QueryService) GetConfigTransactionReturnsOnCall(i int, result1 *quer
 	}
 	fake.getConfigTransactionReturnsOnCall[i] = struct {
 		result1 *queryservice.ConfigTransactionInfo
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *QueryService) GetNamespacePolicies() (*applicationpb.NamespacePolicies, error) {
+	fake.getNamespacePoliciesMutex.Lock()
+	ret, specificReturn := fake.getNamespacePoliciesReturnsOnCall[len(fake.getNamespacePoliciesArgsForCall)]
+	fake.getNamespacePoliciesArgsForCall = append(fake.getNamespacePoliciesArgsForCall, struct {
+	}{})
+	stub := fake.GetNamespacePoliciesStub
+	fakeReturns := fake.getNamespacePoliciesReturns
+	fake.recordInvocation("GetNamespacePolicies", []interface{}{})
+	fake.getNamespacePoliciesMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *QueryService) GetNamespacePoliciesCallCount() int {
+	fake.getNamespacePoliciesMutex.RLock()
+	defer fake.getNamespacePoliciesMutex.RUnlock()
+	return len(fake.getNamespacePoliciesArgsForCall)
+}
+
+func (fake *QueryService) GetNamespacePoliciesCalls(stub func() (*applicationpb.NamespacePolicies, error)) {
+	fake.getNamespacePoliciesMutex.Lock()
+	defer fake.getNamespacePoliciesMutex.Unlock()
+	fake.GetNamespacePoliciesStub = stub
+}
+
+func (fake *QueryService) GetNamespacePoliciesReturns(result1 *applicationpb.NamespacePolicies, result2 error) {
+	fake.getNamespacePoliciesMutex.Lock()
+	defer fake.getNamespacePoliciesMutex.Unlock()
+	fake.GetNamespacePoliciesStub = nil
+	fake.getNamespacePoliciesReturns = struct {
+		result1 *applicationpb.NamespacePolicies
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *QueryService) GetNamespacePoliciesReturnsOnCall(i int, result1 *applicationpb.NamespacePolicies, result2 error) {
+	fake.getNamespacePoliciesMutex.Lock()
+	defer fake.getNamespacePoliciesMutex.Unlock()
+	fake.GetNamespacePoliciesStub = nil
+	if fake.getNamespacePoliciesReturnsOnCall == nil {
+		fake.getNamespacePoliciesReturnsOnCall = make(map[int]struct {
+			result1 *applicationpb.NamespacePolicies
+			result2 error
+		})
+	}
+	fake.getNamespacePoliciesReturnsOnCall[i] = struct {
+		result1 *applicationpb.NamespacePolicies
 		result2 error
 	}{result1, result2}
 }

--- a/platform/fabricx/core/vault/vault_test.go
+++ b/platform/fabricx/core/vault/vault_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protowire"
 
@@ -72,6 +73,10 @@ func (m *mockQueryService) GetTransactionStatuses(txIDs []string) (map[string]in
 }
 
 func (m *mockQueryService) GetConfigTransaction() (*queryservice.ConfigTransactionInfo, error) {
+	return nil, nil
+}
+
+func (m *mockQueryService) GetNamespacePolicies() (*applicationpb.NamespacePolicies, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
Expose GetNamespacePolicies() on RemoteQueryService and the QueryService
interface, returning the raw *applicationpb.NamespacePolicies (lossless,
matches the gRPC contract). Regenerate the QueryService mocks and add
unit tests covering the happy path, empty policies, and client error.

Closes #1228