### PR TITLE
refactor(metrics): drop version gauge caching workaround

### DIFF
--- a/platform/view/services/metrics/operations/metrics.go
+++ b/platform/view/services/metrics/operations/metrics.go
@@ -7,37 +7,19 @@ SPDX-License-Identifier: Apache-2.0
 package operations
 
 import (
-	"sync"
-
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics/disabled"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics/prometheus"
 )
 
-var (
-	fscVersion = metrics.GaugeOpts{
-		Name:       "fsc_version",
-		Help:       "The active version of Fabric Smart Client.",
-		LabelNames: []string{"version"},
-	}
-
-	gaugeLock        sync.Mutex
-	promVersionGauge metrics.Gauge
-)
+var fscVersion = metrics.GaugeOpts{
+	Name:       "fsc_version",
+	Help:       "The active version of Fabric Smart Client.",
+	LabelNames: []string{"version"},
+}
 
 func versionGauge(provider metrics.Provider) metrics.Gauge {
-	switch provider.(type) {
-	case *prometheus.Provider:
-		gaugeLock.Lock()
-		defer gaugeLock.Unlock()
-		if promVersionGauge == nil {
-			promVersionGauge = provider.NewGauge(fscVersion)
-		}
-		return promVersionGauge
-
-	default:
-		return provider.NewGauge(fscVersion)
-	}
+	return provider.NewGauge(fscVersion)
 }
 
 func NewMetricsProvider(m MetricsOptions) metrics.Provider {


### PR DESCRIPTION
## Motivation

`operations/metrics.go` guards `fsc_version` against duplicate registration with a package-level singleton (`gaugeLock`/`promVersionGauge`), special-casing `*prometheus.Provider`. Since #1582 the prometheus provider caches collectors itself, so this workaround is redundant — the follow-up cleanup suggested by @mbrandenburger in the #1582 review.

## Changes

- `versionGauge` reduces to `provider.NewGauge(fscVersion)`; the provider-type switch, the lock, and the cached gauge are removed.
- `versionGauge` stays in place, so the caller-package-based namespace/subsystem inference is unaffected.

## Tests

Covered by the existing suites: `operations` (the system tests run through `versionGauge` on startup) and `prometheus` (the provider caching semantics from #1582). All pass with `-race`.

Fixes #1586
