### PR TITLE
ci(coverage): integration tests now really contribute to the coverage report

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,18 +77,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tests: ${{ steps.set-itest-tests.outputs.tests }}
-      all-tests: ${{ steps.set-all-tests.outputs.all-tests }}
     steps:
       - uses: actions/checkout@v6
       - name: list itest targets
         id: set-itest-tests
         run: |
           echo "tests=$(make list-integration-tests | jq -R . | jq -s -c .)" >> $GITHUB_OUTPUT
-      - name: build carryforward string
-        id: set-all-tests
-        run: |
-          itests=$(make list-integration-tests | sed 's/^/itest-/' | paste -sd "," -)
-          echo "all-tests=utest,utest-postgres,$itests" >> $GITHUB_OUTPUT
 
   itest:
     needs:
@@ -152,11 +146,15 @@ jobs:
       - utest
       - utest-postgres
       - itest
-      - itest-list
     runs-on: ubuntu-latest
     steps:
+      # Close the parallel Coveralls build. Every test job in this run reports a
+      # flag (the itest matrix has no job-level skips), so all flags are present
+      # and no `carryforward` is needed. Omitting carryforward is deliberate: it
+      # previously masked missing integration-test jobs by silently reusing a
+      # prior build's coverage, so an incomplete run reported a stale-but-
+      # plausible number instead of an obviously low one.
       - uses: coverallsapp/github-action@v2
         with:
           parallel-finished: true
-          carryforward: ${{ needs.itest-list.outputs.all-tests }}
           fail-on-error: false

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -103,8 +103,15 @@ outer:
 	}
 
 	// build with coverage profiling, more details: https://go.dev/doc/build-cover
+	//
+	// -coverpkg is required: without it, `-cover` only instruments each spawned
+	// binary's own packages, which all live under integration/. Those are then
+	// discarded by scripts/filter-coverage.sh (which excludes /integration/), so
+	// the integration tests would report no coverage at all. Instrumenting the
+	// whole module credits the platform/core code the FSC nodes exercise at
+	// runtime, which is the coverage the integration tests are meant to measure.
 	if _, ok := os.LookupEnv("GOCOVERDIR"); ok {
-		params = append(params, "-cover")
+		params = append(params, "-cover", "-coverpkg=github.com/hyperledger-labs/fabric-smart-client/...")
 	}
 
 	buildServer := common.NewBuildServer(params...)


### PR DESCRIPTION
## Problem

The Coveralls coverage number for `main` was misleading. It read ~81%, but that
figure was propped up by stale data — and when that stale data aged out, it
dropped to ~74%.

Two underlying issues:

1. **Integration tests reported no coverage.** In the `Tests` workflow, each of
   the 13 `itest-*` jobs ran, passed, and uploaded to Coveralls — but every
   upload was empty ("Nothing to report"). The FSC node binaries spawned by the
   integration tests were built with `-cover` but **without `-coverpkg`**, so Go
   only instrumented the binaries' own packages, which all live under
   `integration/`. `scripts/filter-coverage.sh` deliberately excludes
   `/integration/` (it is test scaffolding, not product code), so the entire
   integration profile was filtered away to nothing.

2. **`carryforward` hid it.** The Coveralls `parallel-finished` step passed a
   `carryforward` flag list. Because the `itest-*` jobs uploaded nothing,
   Coveralls reused their results from an earlier build. That made the report
   look complete when it was not, and turned a real gap into a silent one.

Net effect: the integration tests never actually contributed coverage, and the
reported percentage reflected stale carried-forward data rather than the current
integration runs.

## When it broke, and why it stayed hidden

**When.** The `-cover` build and the `/integration/` filter were both added in
#1164 (2026-02-19, "Integrate coveralls.io"). At that point `integration/` was
part of the **root** Go module, so `go build -cover` of a node binary also
instrumented the `platform/...` code in that same module — real coverage was
collected and survived the filter. It worked.

The regression was introduced by **#1534 (2026-06-18, "Introduce FSC Multi
module structure")**, which split `integration/` out into its **own Go module**.
`go build -cover` without `-coverpkg` only instruments the build's **main
module**; once `platform/...` lived in a different module from the integration
binaries, it was no longer instrumented. From then on the integration tests
collected coverage only for `integration/...` code — which the filter discards —
so they effectively reported nothing. (#1534 was an intentional module
refactor, marked `refactor!`; the coverage regression was an unintended side
effect of the module boundary change.)

**Why it stayed hidden.** Two things kept it invisible for ~3 weeks:

- **`carryforward`** made Coveralls reuse the `itest-*` results from the last
  build that still had them, so the merged report kept showing integration
  coverage that was really stale, carried-forward data — not the current run.
- **`fail-on-error: false`** on the Coveralls steps meant an empty upload never
  turned CI red; the jobs stayed green and only the reported percentage was
  affected.

The number finally dropped (~81% → ~74%) on 2026-07-09 when the stale
carried-forward source aged out and there was no longer an old build to reuse
`itest-*` results from — exposing the true unit-test-only coverage.

## What we changed

### 1. `integration/integration.go` — instrument the whole module

When a coverage run is active (`GOCOVERDIR` is set), the spawned binaries are now
built with `-coverpkg` for the whole module in addition to `-cover`:

```go
if _, ok := os.LookupEnv("GOCOVERDIR"); ok {
    params = append(params, "-cover", "-coverpkg=github.com/hyperledger-labs/fabric-smart-client/...")
}
```

Now the binaries instrument the `platform/...` code the FSC nodes actually run
at runtime. That coverage survives the `/integration/` filter, so the
integration tests report the coverage they are meant to measure. This is the
single place `-cover` is added, so it applies to every integration-test target,
and it matches the unit tests, which already build with `-coverpkg=./...`.

### 2. `.github/workflows/tests.yml` — remove `carryforward`

Dropped `carryforward` from the `publish-coverage` step, along with the
`itest-list` output that only existed to build its flag list. Every test job
reports a flag on every push/PR (the integration matrix has no job-level skips),
so `carryforward` served no real purpose — it only masked missing coverage. With
it removed and the integration tests now producing real data, the merged report
is both complete and honest: a genuinely missing job shows up as a visible
coverage drop instead of being silently backfilled.

## Result

With both changes, the integration-test jobs upload real coverage of the
`platform/...` code they exercise (view services, comm/libp2p/websocket,
endpoint, grpc, config, storage, tracing, etc.), and it is merged into the final
Coveralls report instead of being filtered to nothing and masked by stale data.
The reported coverage now reflects the actual combined unit- and
integration-test coverage of the current commit.

closes #1592