### PR TITLE
fix(security): harden responder-view input validation and endorsement checks

### DIFF
--- a/platform/fabric/core/generic/transaction/envelope.go
+++ b/platform/fabric/core/generic/transaction/envelope.go
@@ -135,6 +135,9 @@ func UnpackEnvelopePayload(payloadRaw []byte) (*UnpackedEnvelope, int32, error) 
 	if err != nil {
 		return nil, -1, errors.Wrap(err, "failed to unmarshal payload")
 	}
+	if payl.Header == nil {
+		return nil, -1, errors.Errorf("payload header is nil")
+	}
 
 	chdr, err := protoutil.UnmarshalChannelHeader(payl.Header.ChannelHeader)
 	if err != nil {
@@ -157,6 +160,9 @@ func UnpackEnvelopePayload(payloadRaw []byte) (*UnpackedEnvelope, int32, error) 
 		return nil, chdr.Type, errors.Wrap(err, "VSCC error: GetTransaction failed")
 	}
 
+	if len(tx.Actions) == 0 {
+		return nil, chdr.Type, errors.Errorf("VSCC error: transaction has no actions")
+	}
 	cap, err := protoutil.UnmarshalChaincodeActionPayload(tx.Actions[0].Payload)
 	if err != nil {
 		return nil, chdr.Type, errors.Wrap(err, "VSCC error: GetChaincodeActionPayload failed")
@@ -169,7 +175,22 @@ func UnpackEnvelopePayload(payloadRaw []byte) (*UnpackedEnvelope, int32, error) 
 	if err != nil {
 		return nil, chdr.Type, errors.Wrap(err, "VSCC error: UnmarshalChaincodeInvocationSpec failed")
 	}
+	if cis.ChaincodeSpec == nil {
+		return nil, chdr.Type, errors.Errorf("chaincode invocation spec did not contain chaincode spec")
+	}
+	if cis.ChaincodeSpec.Input == nil {
+		return nil, chdr.Type, errors.Errorf("chaincode input did not contain any input")
+	}
+	if len(cis.ChaincodeSpec.Input.Args) == 0 {
+		return nil, chdr.Type, errors.Errorf("chaincode input has no arguments")
+	}
+	if cis.ChaincodeSpec.ChaincodeId == nil {
+		return nil, chdr.Type, errors.Errorf("chaincode invocation spec did not contain chaincode id")
+	}
 
+	if cap.Action == nil {
+		return nil, chdr.Type, errors.Errorf("VSCC error: chaincode action payload has no action")
+	}
 	pRespPayload, err := protoutil.UnmarshalProposalResponsePayload(cap.Action.ProposalResponsePayload)
 	if err != nil {
 		return nil, chdr.Type, errors.Wrap(err, "failed to unmarshal proposal response payload")

--- a/platform/fabric/core/generic/transaction/envelope_test.go
+++ b/platform/fabric/core/generic/transaction/envelope_test.go
@@ -17,8 +17,16 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/transaction"
 )
 
-func createValidEnvelope(t *testing.T) *common.Envelope { //nolint:unparam
-	t.Helper()
+func createValidEnvelope(tb testing.TB) *common.Envelope { //nolint:unparam
+	tb.Helper()
+	return createEnvelopeWithArgs(tb, [][]byte{[]byte("invoke"), []byte("arg1")})
+}
+
+// createEnvelopeWithArgs builds an envelope identical to createValidEnvelope but with
+// a caller-controlled chaincode Args slice, so tests can craft the adversarial "zero
+// arguments" case a malicious peer could send.
+func createEnvelopeWithArgs(tb testing.TB, args [][]byte) *common.Envelope {
+	tb.Helper()
 
 	channelHeader := &common.ChannelHeader{
 		Type:      int32(common.HeaderType_ENDORSER_TRANSACTION),
@@ -26,26 +34,26 @@ func createValidEnvelope(t *testing.T) *common.Envelope { //nolint:unparam
 		ChannelId: "channel",
 	}
 	chBytes, err := proto.Marshal(channelHeader)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	signatureHeader := &common.SignatureHeader{
 		Creator: []byte("creator"),
 		Nonce:   []byte("nonce"),
 	}
 	shBytes, err := proto.Marshal(signatureHeader)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	ccAction := &peer.ChaincodeAction{
 		Results: []byte("results"),
 	}
 	ccActionBytes, err := proto.Marshal(ccAction)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	prp := &peer.ProposalResponsePayload{
 		Extension: ccActionBytes,
 	}
 	prpBytes, err := proto.Marshal(prp)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	cis := &peer.ChaincodeInvocationSpec{
 		ChaincodeSpec: &peer.ChaincodeSpec{
@@ -54,18 +62,18 @@ func createValidEnvelope(t *testing.T) *common.Envelope { //nolint:unparam
 				Version: "1.0",
 			},
 			Input: &peer.ChaincodeInput{
-				Args: [][]byte{[]byte("invoke"), []byte("arg1")},
+				Args: args,
 			},
 		},
 	}
 	cisBytes, err := proto.Marshal(cis)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	cpp := &peer.ChaincodeProposalPayload{
 		Input: cisBytes,
 	}
 	cppBytes, err := proto.Marshal(cpp)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	cap := &peer.ChaincodeActionPayload{
 		ChaincodeProposalPayload: cppBytes,
@@ -77,7 +85,7 @@ func createValidEnvelope(t *testing.T) *common.Envelope { //nolint:unparam
 		},
 	}
 	capBytes, err := proto.Marshal(cap)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	txAction := &peer.TransactionAction{
 		Payload: capBytes,
@@ -86,7 +94,7 @@ func createValidEnvelope(t *testing.T) *common.Envelope { //nolint:unparam
 		Actions: []*peer.TransactionAction{txAction},
 	}
 	txBytes, err := proto.Marshal(tx)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	payload := &common.Payload{
 		Header: &common.Header{
@@ -96,7 +104,7 @@ func createValidEnvelope(t *testing.T) *common.Envelope { //nolint:unparam
 		Data: txBytes,
 	}
 	payloadBytes, err := proto.Marshal(payload)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	return &common.Envelope{
 		Payload: payloadBytes,
@@ -162,6 +170,69 @@ func TestEnvelope(t *testing.T) {
 	err = e2.FromBytes(b)
 	require.NoError(t, err)
 	require.Equal(t, "txid", e2.TxID())
+}
+
+// TestUnpackEnvelopePayload_EmptyArgsReturnsError demonstrates that
+// UnpackEnvelopePayload now rejects a zero-argument ChaincodeInvocationSpec with an
+// error instead of panicking on the unchecked `cis.ChaincodeSpec.Input.Args[0]` index
+// (envelope.go).
+//
+// This is directly responder-reachable: both platform/fabric/services/endorser/flow.go
+// and platform/fabric/services/state/transaction.go's receiveTransactionView.Call read a
+// raw []byte payload off an inbound P2P session and pass it straight into
+// NewTransactionFromEnvelopeBytes / SetFromEnvelopeBytes. A remote peer sending an
+// envelope whose ChaincodeInput has an empty Args slice must get a rejected
+// transaction, not a crashed responder goroutine.
+func TestUnpackEnvelopePayload_EmptyArgsReturnsError(t *testing.T) {
+	t.Parallel()
+
+	env := createEnvelopeWithArgs(t, [][]byte{})
+	payloadBytes := env.Payload
+
+	_, _, err := transaction.UnpackEnvelopePayload(payloadBytes)
+	require.Error(t, err, "UnpackEnvelopePayload must reject a zero-argument ChaincodeInvocationSpec")
+}
+
+// TestTransaction_SetFromEnvelopeBytesReturnsErrorOnEmptyChaincodeArgs proves the fix is
+// reachable through the exact production call chain used by the responder views:
+// Transaction.SetFromEnvelopeBytes -> transaction.NewEnvelopeFromEnv/UnpackEnvelopePayload.
+func TestTransaction_SetFromEnvelopeBytesReturnsErrorOnEmptyChaincodeArgs(t *testing.T) {
+	t.Parallel()
+
+	env := createEnvelopeWithArgs(t, [][]byte{})
+	envBytes, err := proto.Marshal(env)
+	require.NoError(t, err)
+
+	tx := &transaction.Transaction{}
+	err = tx.SetFromEnvelopeBytes(envBytes)
+	require.Error(t, err, "SetFromEnvelopeBytes must reject a zero-argument ChaincodeInvocationSpec")
+}
+
+// TestUnpackEnvelopePayload_NilHeaderReturnsError demonstrates the fix for a
+// nil-pointer-dereference bug found via fuzzing (FuzzUnpackEnvelopeFromBytes):
+// UnpackEnvelopePayload (envelope.go) now checks payl.Header for nil before
+// dereferencing it, instead of panicking with "invalid memory address or nil pointer
+// dereference" the way protoutil.UnmarshalPayload/proto.Unmarshal's zero-value
+// *common.Payload (with a nil Header) used to trigger.
+//
+// Unlike the Args[0] bug, this requires no crafted ChaincodeInvocationSpec at all:
+// an envelope whose Payload is empty (or whose payload bytes simply omit the Header
+// field) is enough. It is reachable through the exact same responder call chain:
+// platform/fabric/services/endorser/flow.go and
+// platform/fabric/services/state/transaction.go's receiveTransactionView.Call feed
+// raw, unvalidated bytes from an inbound P2P session into
+// NewTransactionFromEnvelopeBytes -> SetFromEnvelopeBytes -> UnpackEnvelopeFromBytes
+// -> UnpackEnvelopePayload.
+func TestUnpackEnvelopePayload_NilHeaderReturnsError(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := transaction.UnpackEnvelopeFromBytes([]byte{})
+	require.Error(t, err, "UnpackEnvelopeFromBytes must reject a marshaled payload with no Header")
+
+	// Same fix reachable via the exact production call chain.
+	tx := &transaction.Transaction{}
+	err = tx.SetFromEnvelopeBytes([]byte{})
+	require.Error(t, err, "SetFromEnvelopeBytes must reject an envelope payload with no Header")
 }
 
 func TestEnvelope_Errors(t *testing.T) {

--- a/platform/fabric/core/generic/transaction/fuzz_test.go
+++ b/platform/fabric/core/generic/transaction/fuzz_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package transaction_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	pb "github.com/hyperledger/fabric-protos-go-apiv2/peer"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/transaction"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/transaction/mock"
+)
+
+// This file fuzzes the byte-deserialization entry points that a remote, untrusted
+// peer can reach directly: platform/fabric/services/endorser/flow.go's
+// receiveTransactionView.Call and platform/fabric/services/state/transaction.go's
+// receiveTransactionView.Call both read a raw []byte payload off an inbound P2P
+// session and hand it, unvalidated, to Builder.NewTransactionFromBytes /
+// NewTransactionFromEnvelopeBytes, which bottom out in the functions fuzzed here.
+//
+// Two panics that used to be reachable here are now fixed and covered by dedicated
+// regression tests, so their inputs are seeded below as ordinary (non-panicking)
+// corpus entries:
+//   - empty ChaincodeInput.Args -> now returns an error instead of panicking on
+//     Args[0], see TestUnpackSignedProposal_EmptyArgsReturnsError,
+//     TestTransaction_SetFromBytesReturnsErrorOnEmptyChaincodeArgs,
+//     TestUnpackEnvelopePayload_EmptyArgsReturnsError,
+//     TestTransaction_SetFromEnvelopeBytesReturnsErrorOnEmptyChaincodeArgs.
+//   - empty/header-less envelope payload -> now returns an error instead of a nil
+//     pointer dereference in UnpackEnvelopePayload, see
+//     TestUnpackEnvelopePayload_NilHeaderReturnsError.
+//
+// Running with `go test -fuzz <name>` (see the analysis report) continues to explore
+// further malformed/adversarial mutations looking for other unrecovered panics.
+
+// FuzzUnpackSignedProposal fuzzes transaction.UnpackSignedProposal's ProposalBytes
+// field with arbitrary bytes - this is the payload embedded in every
+// TSignedProposal that reaches SetFromBytes from raw wire bytes.
+func FuzzUnpackSignedProposal(f *testing.F) {
+	validSP := createValidSignedProposal(f)
+	emptyArgsSP := createSignedProposalWithArgs(f, [][]byte{})
+
+	f.Add(validSP.ProposalBytes)
+	f.Add(emptyArgsSP.ProposalBytes)
+	f.Add([]byte(nil))
+	f.Add([]byte(""))
+	f.Add([]byte("not a protobuf message"))
+
+	f.Fuzz(func(t *testing.T, proposalBytes []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("UnpackSignedProposal panicked on input %q: %v", proposalBytes, r)
+			}
+		}()
+		_, _ = transaction.UnpackSignedProposal(&pb.SignedProposal{
+			ProposalBytes: proposalBytes,
+			Signature:     []byte("signature"),
+		})
+	})
+}
+
+// FuzzUnpackEnvelopeFromBytes fuzzes transaction.UnpackEnvelopeFromBytes with
+// arbitrary bytes - this is exactly the raw []byte a responder passes to
+// Transaction.SetFromEnvelopeBytes, which in turn is exactly the payload a remote
+// peer controls end to end via receiveTransactionView.Call.
+func FuzzUnpackEnvelopeFromBytes(f *testing.F) {
+	validEnv := createValidEnvelope(f)
+
+	validEnvBytes, err := proto.Marshal(validEnv)
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	emptyArgsEnv := createEnvelopeWithArgs(f, [][]byte{})
+	emptyArgsEnvBytes, err := proto.Marshal(emptyArgsEnv)
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	f.Add(validEnvBytes)
+	f.Add(emptyArgsEnvBytes)
+	f.Add([]byte("not a protobuf message"))
+	f.Add([]byte(nil))
+	f.Add([]byte(""))
+
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("UnpackEnvelopeFromBytes panicked on input %q: %v", raw, r)
+			}
+		}()
+		_, _, _ = transaction.UnpackEnvelopeFromBytes(raw)
+	})
+}
+
+// FuzzTransactionSetFromBytes fuzzes Transaction.SetFromBytes with arbitrary bytes,
+// exercising the exact production call chain used by receiveTransactionView.Call ->
+// Builder.NewTransactionFromBytes -> Manager.NewTransactionFromBytes ->
+// Transaction.SetFromBytes(txRaw.Raw).
+func FuzzTransactionSetFromBytes(f *testing.F) {
+	mockChannelProvider := &mock.ChannelProvider{}
+	mockSigService := &mock.SignerService{}
+	mockChannel := &mock.Channel{}
+	mockChannelProvider.ChannelReturns(mockChannel, nil)
+	factory := transaction.NewEndorserTransactionFactory("network", mockChannelProvider, mockSigService)
+
+	validTx := &transaction.Transaction{TSignedProposal: createValidSignedProposal(f)}
+	validRaw, err := json.Marshal(validTx)
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	emptyArgsTx := &transaction.Transaction{TSignedProposal: createSignedProposalWithArgs(f, [][]byte{})}
+	emptyArgsRaw, err := json.Marshal(emptyArgsTx)
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	f.Add(validRaw)
+	f.Add(emptyArgsRaw)
+	f.Add([]byte(nil))
+	f.Add([]byte(""))
+	f.Add([]byte("{}"))
+	f.Add([]byte("not json at all"))
+
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		tx, err := factory.NewTransaction(t.Context(), "channel", nil, nil, "", nil)
+		if err != nil {
+			t.Fatalf("factory.NewTransaction failed: %v", err)
+		}
+
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("SetFromBytes panicked on input %q: %v", raw, r)
+			}
+		}()
+		_ = tx.SetFromBytes(raw)
+	})
+}
+
+// FuzzTransactionSetFromEnvelopeBytes fuzzes Transaction.SetFromEnvelopeBytes with
+// arbitrary bytes, exercising the exact production call chain used by
+// receiveTransactionView.Call -> Builder.NewTransactionFromEnvelopeBytes ->
+// Manager.NewTransactionFromEnvelopeBytes -> Transaction.SetFromEnvelopeBytes(raw).
+func FuzzTransactionSetFromEnvelopeBytes(f *testing.F) {
+	mockChannelProvider := &mock.ChannelProvider{}
+	mockSigService := &mock.SignerService{}
+	mockChannel := &mock.Channel{}
+	mockChannelProvider.ChannelReturns(mockChannel, nil)
+	factory := transaction.NewEndorserTransactionFactory("network", mockChannelProvider, mockSigService)
+
+	validEnv := createValidEnvelope(f)
+
+	validEnvBytes, err := proto.Marshal(validEnv)
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	emptyArgsEnv := createEnvelopeWithArgs(f, [][]byte{})
+	emptyArgsEnvBytes, err := proto.Marshal(emptyArgsEnv)
+	if err != nil {
+		f.Fatal(err)
+	}
+
+	f.Add(validEnvBytes)
+	f.Add(emptyArgsEnvBytes)
+	f.Add([]byte("not a protobuf message"))
+
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		tx, err := factory.NewTransaction(t.Context(), "channel", nil, nil, "", nil)
+		if err != nil {
+			t.Fatalf("factory.NewTransaction failed: %v", err)
+		}
+
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("SetFromEnvelopeBytes panicked on input %q: %v", raw, r)
+			}
+		}()
+		_ = tx.SetFromEnvelopeBytes(raw)
+	})
+}

--- a/platform/fabric/core/generic/transaction/proposal.go
+++ b/platform/fabric/core/generic/transaction/proposal.go
@@ -106,6 +106,10 @@ func UnpackProposal(prop *pb.Proposal) (*UnpackedProposal, error) {
 		return nil, errors.Errorf("chaincode input did not contain any input")
 	}
 
+	if len(cis.ChaincodeSpec.Input.Args) == 0 {
+		return nil, errors.Errorf("chaincode input has no arguments")
+	}
+
 	cppNoTransient := &pb.ChaincodeProposalPayload{Input: cpp.Input, TransientMap: nil}
 	ppBytes, err := proto.Marshal(cppNoTransient)
 	if err != nil {

--- a/platform/fabric/core/generic/transaction/proposal_test.go
+++ b/platform/fabric/core/generic/transaction/proposal_test.go
@@ -21,8 +21,16 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/protoutil"
 )
 
-func createValidSignedProposal(t *testing.T) *pb.SignedProposal { //nolint:unparam
-	t.Helper()
+func createValidSignedProposal(tb testing.TB) *pb.SignedProposal { //nolint:unparam
+	tb.Helper()
+	return createSignedProposalWithArgs(tb, [][]byte{[]byte("invoke"), []byte("arg1")})
+}
+
+// createSignedProposalWithArgs builds a signed proposal identical to
+// createValidSignedProposal but with a caller-controlled Args slice, so tests can
+// craft the adversarial "zero arguments" case a malicious peer could send.
+func createSignedProposalWithArgs(tb testing.TB, args [][]byte) *pb.SignedProposal {
+	tb.Helper()
 
 	cis := &pb.ChaincodeInvocationSpec{
 		ChaincodeSpec: &pb.ChaincodeSpec{
@@ -31,28 +39,28 @@ func createValidSignedProposal(t *testing.T) *pb.SignedProposal { //nolint:unpar
 				Version: "1.0",
 			},
 			Input: &pb.ChaincodeInput{
-				Args: [][]byte{[]byte("invoke"), []byte("arg1")},
+				Args: args,
 			},
 		},
 	}
 	cisBytes, err := proto.Marshal(cis)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	cpp := &pb.ChaincodeProposalPayload{
 		Input: cisBytes,
 	}
 	cppBytes, err := proto.Marshal(cpp)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	nonce := []byte("nonce")
-	creatorBytes := mustMarshal(t, &mspPb.SerializedIdentity{Mspid: "Org1MSP", IdBytes: []byte("creator")})
+	creatorBytes := mustMarshal(tb, &mspPb.SerializedIdentity{Mspid: "Org1MSP", IdBytes: []byte("creator")})
 	txID := protoutil.ComputeTxID(nonce, creatorBytes)
 
 	channelHeader := &cb.ChannelHeader{
 		Type:      int32(cb.HeaderType_ENDORSER_TRANSACTION),
 		TxId:      txID,
 		ChannelId: "channel",
-		Extension: mustMarshal(t, &pb.ChaincodeHeaderExtension{
+		Extension: mustMarshal(tb, &pb.ChaincodeHeaderExtension{
 			ChaincodeId: &pb.ChaincodeID{
 				Name:    "mycc",
 				Version: "1.0",
@@ -60,28 +68,28 @@ func createValidSignedProposal(t *testing.T) *pb.SignedProposal { //nolint:unpar
 		}),
 	}
 	chBytes, err := proto.Marshal(channelHeader)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	signatureHeader := &cb.SignatureHeader{
 		Creator: creatorBytes,
 		Nonce:   nonce,
 	}
 	shBytes, err := proto.Marshal(signatureHeader)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	header := &cb.Header{
 		ChannelHeader:   chBytes,
 		SignatureHeader: shBytes,
 	}
 	headerBytes, err := proto.Marshal(header)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	proposal := &pb.Proposal{
 		Header:  headerBytes,
 		Payload: cppBytes,
 	}
 	proposalBytes, err := proto.Marshal(proposal)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	return &pb.SignedProposal{
 		ProposalBytes: proposalBytes,
@@ -89,10 +97,10 @@ func createValidSignedProposal(t *testing.T) *pb.SignedProposal { //nolint:unpar
 	}
 }
 
-func mustMarshal(t *testing.T, msg proto.Message) []byte {
-	t.Helper()
+func mustMarshal(tb testing.TB, msg proto.Message) []byte {
+	tb.Helper()
 	b, err := proto.Marshal(msg)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	return b
 }
 
@@ -108,6 +116,30 @@ func TestUnpackSignedProposal(t *testing.T) {
 	require.NotEmpty(t, up.TxID())
 	require.Equal(t, []byte("nonce"), up.Nonce())
 	require.NotEmpty(t, up.ProposalHash)
+}
+
+// TestUnpackSignedProposal_EmptyArgsReturnsError demonstrates that UnpackProposal now
+// rejects a zero-argument ChaincodeInvocationSpec with an error, instead of succeeding
+// and leaving every consumer that reconstructs a transaction from raw bytes to index
+// Args[0] without a length check:
+//   - Transaction.SetFromBytes (transaction.go): t.TFunction = string(up.Input.Args[0])
+//   - UnpackEnvelopePayload (envelope.go): Function: string(cis.ChaincodeSpec.Input.Args[0])
+//
+// Both of these are reached directly from raw, attacker-controlled bytes coming off
+// the wire: platform/fabric/services/endorser/flow.go's receiveTransactionView.Call
+// and platform/fabric/services/state/transaction.go's receiveTransactionView.Call
+// both read a []byte payload from a P2P session and pass it straight into
+// NewTransactionFromBytes. A remote peer sending a proposal/transaction payload whose
+// ChaincodeInput has an empty Args slice must get a rejected transaction, not a
+// crashed responder goroutine.
+func TestUnpackSignedProposal_EmptyArgsReturnsError(t *testing.T) {
+	t.Parallel()
+
+	sp := createSignedProposalWithArgs(t, [][]byte{})
+
+	up, err := transaction.UnpackSignedProposal(sp)
+	require.Error(t, err, "UnpackSignedProposal must reject a zero-argument ChaincodeInvocationSpec")
+	require.Nil(t, up)
 }
 
 func TestUnpackSignedProposal_Validate(t *testing.T) {

--- a/platform/fabric/core/generic/transaction/transaction.go
+++ b/platform/fabric/core/generic/transaction/transaction.go
@@ -152,6 +152,9 @@ func (t *Transaction) ChaincodeVersion() string {
 }
 
 func (t *Transaction) Results() ([]byte, error) {
+	if len(t.TProposalResponses) == 0 {
+		return nil, errors.Errorf("no proposal responses available")
+	}
 	upr, err := UnpackProposalResponse(t.TProposalResponses[0])
 	if err != nil {
 		return nil, err

--- a/platform/fabric/core/generic/transaction/transaction_test.go
+++ b/platform/fabric/core/generic/transaction/transaction_test.go
@@ -146,6 +146,26 @@ func TestTransaction_RWSet(t *testing.T) {
 	require.Nil(t, tx.RWS())
 }
 
+// TestTransaction_ResultsReturnsErrorOnEmptyProposalResponses demonstrates that
+// Transaction.Results() now rejects an empty TProposalResponses slice with an error
+// instead of indexing t.TProposalResponses[0] and panicking with an
+// index-out-of-range runtime error.
+//
+// TProposalResponses is an exported field and is populated directly from
+// attacker-controlled envelope bytes by SetFromEnvelopeBytes (which sets
+// t.TProposalResponses = upe.ProposalResponses with no length check), so a
+// transaction reconstructed from a crafted envelope with zero proposal responses
+// carries an empty TProposalResponses.
+func TestTransaction_ResultsReturnsErrorOnEmptyProposalResponses(t *testing.T) {
+	t.Parallel()
+
+	tx := &transaction.Transaction{}
+	require.Empty(t, tx.TProposalResponses)
+
+	_, err := tx.Results()
+	require.Error(t, err, "Results() must reject an empty TProposalResponses slice")
+}
+
 func TestProcessedTransaction(t *testing.T) {
 	t.Parallel()
 	env := createValidEnvelope(t)
@@ -249,6 +269,43 @@ func TestTransaction_SetFromBytes(t *testing.T) {
 	mockChannelProvider.ChannelReturns(nil, contextError("channel fail"))
 	err = tx2.SetFromBytes(b)
 	require.ErrorContains(t, err, "channel fail")
+}
+
+// TestTransaction_SetFromBytesReturnsErrorOnEmptyChaincodeArgs demonstrates that
+// Transaction.SetFromBytes now rejects a TSignedProposal whose ChaincodeInput.Args is
+// empty with an error, instead of indexing Args[0] and panicking with an
+// index-out-of-range runtime error.
+//
+// This is directly attacker-reachable: platform/fabric/services/endorser/flow.go's
+// receiveTransactionView.Call and platform/fabric/services/state/transaction.go's
+// receiveTransactionView.Call both read a raw []byte payload off an inbound P2P
+// session and pass it straight to Builder.NewTransactionFromBytes ->
+// Manager.NewTransactionFromBytes -> Transaction.SetFromBytes. A remote peer sending
+// a transaction payload whose embedded proposal has zero chaincode arguments must get
+// a rejected transaction, not a crashed responder goroutine.
+func TestTransaction_SetFromBytesReturnsErrorOnEmptyChaincodeArgs(t *testing.T) {
+	t.Parallel()
+	mockChannelProvider := &mock.ChannelProvider{}
+	mockSigService := &mock.SignerService{}
+	mockChannel := &mock.Channel{}
+	mockChannelProvider.ChannelReturns(mockChannel, nil)
+
+	factory := transaction.NewEndorserTransactionFactory("network", mockChannelProvider, mockSigService)
+	tx2, err := factory.NewTransaction(t.Context(), "channel", nil, nil, "", nil)
+	require.NoError(t, err)
+
+	maliciousSignedProposal := createSignedProposalWithArgs(t, [][]byte{})
+
+	txWithEmptyArgs := &transaction.Transaction{}
+	txWithEmptyArgs.TSignedProposal = &pb.SignedProposal{
+		ProposalBytes: maliciousSignedProposal.ProposalBytes,
+		Signature:     maliciousSignedProposal.Signature,
+	}
+	raw, err := json.Marshal(txWithEmptyArgs)
+	require.NoError(t, err)
+
+	err = tx2.SetFromBytes(raw)
+	require.Error(t, err, "SetFromBytes must reject a zero-argument chaincode input")
 }
 
 func TestTransaction_SetFromEnvelopeBytes(t *testing.T) {

--- a/platform/fabric/services/endorser/endorsement.go
+++ b/platform/fabric/services/endorser/endorsement.go
@@ -116,7 +116,7 @@ func (c *collectEndorsementsView) Call(viewCtx view.Context) (any, error) {
 			return nil, errors.Wrapf(err, "failed unmarshalling response")
 		}
 
-		found := true
+		found := false
 		fns, err := fabric.GetFabricNetworkService(viewCtx, c.tx.Network())
 		if err != nil {
 			return nil, errors.WithMessagef(err, "fabric network service [%s] not found", c.tx.Network())
@@ -133,7 +133,7 @@ func (c *collectEndorsementsView) Call(viewCtx view.Context) (any, error) {
 
 			// Check the validity of the response
 			logger.DebugfContext(viewCtx.Context(), "Check response validity")
-			if endpoint.GetService(viewCtx).IsBoundTo(viewCtx.Context(), endorser, party) {
+			if endorser.Equal(party) || endpoint.GetService(viewCtx).IsBoundTo(viewCtx.Context(), endorser, party) {
 				found = true
 			}
 

--- a/platform/fabric/services/endorser/endorsement_proposal.go
+++ b/platform/fabric/services/endorser/endorsement_proposal.go
@@ -38,6 +38,14 @@ type answer struct {
 	party view.Identity
 }
 
+// defaultParallelEndorsementTimeout bounds, in aggregate, how long the initiator waits for
+// all contacted parties to answer when no explicit timeout has been configured via
+// WithTimeout. It matters beyond just the final receive step: session establishment and
+// sending the proposal to each party (both done inside collectEndorsement, before its own
+// receive-timeout kicks in) are not otherwise bounded, so an unresponsive or malicious party
+// could park its goroutine indefinitely and, with it, this view's wait on answerChannel.
+const defaultParallelEndorsementTimeout = 30 * time.Second
+
 type parallelCollectEndorsementsOnProposalView struct {
 	tx      EndorsementsOnProposalTransaction
 	parties []view.Identity
@@ -57,9 +65,14 @@ func (c *parallelCollectEndorsementsOnProposalView) Call(viewCtx view.Context) (
 	}
 	answerChannel := make(chan *answer, len(c.parties))
 
+	timeout := c.timeout
+	if timeout <= 0 {
+		timeout = defaultParallelEndorsementTimeout
+	}
+
 	logger.DebugfContext(viewCtx.Context(), "Collect endorsements from %d parties for TX [%s]", len(c.parties), c.tx.ID())
 	for _, party := range c.parties {
-		go c.collectEndorsement(viewCtx, party, stateRaw, answerChannel)
+		go c.collectEndorsement(viewCtx, party, stateRaw, timeout, answerChannel)
 	}
 
 	fns, err := fabric.GetFabricNetworkService(viewCtx, c.tx.Network())
@@ -74,10 +87,17 @@ func (c *parallelCollectEndorsementsOnProposalView) Call(viewCtx view.Context) (
 	}
 	vProviders := []fabric.VerifierProvider{&verifierProviderWrapper{m: ch.MSPManager()}}
 
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+
 	for i := 0; i < len(c.parties); i++ {
 		logger.DebugfContext(viewCtx.Context(), "Wait for endorsement")
-		// TODO: put a timeout
-		a := <-answerChannel
+		var a *answer
+		select {
+		case a = <-answerChannel:
+		case <-deadline.C:
+			return nil, errors.Errorf("timeout waiting for endorsement from [%d] parties", len(c.parties)-i)
+		}
 		logger.DebugfContext(viewCtx.Context(), "Received endorsement")
 		if a.err != nil {
 			return nil, errors.Wrapf(a.err, "got failure [%s] from [%s]", a.party.String(), a.err)
@@ -127,6 +147,7 @@ func (c *parallelCollectEndorsementsOnProposalView) collectEndorsement(
 	viewCtx view.Context,
 	party view.Identity,
 	raw []byte,
+	timeout time.Duration,
 	answerChan chan *answer,
 ) {
 	defer logger.Debugf("Received answer for endorsement of TX [%s] from [%v]", c.tx.ID(), party)
@@ -145,7 +166,7 @@ func (c *parallelCollectEndorsementsOnProposalView) collectEndorsement(
 		return
 	}
 	r := &Response{}
-	if err := s.ReceiveWithTimeout(r, c.timeout); err != nil {
+	if err := s.ReceiveWithTimeout(r, timeout); err != nil {
 		answerChan <- &answer{err: err, party: party}
 		return
 	}

--- a/platform/fabric/services/endorser/endorsement_proposal.go
+++ b/platform/fabric/services/endorser/endorsement_proposal.go
@@ -12,17 +12,20 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/comm/session"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/endpoint"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
 // EndorsementsOnProposalTransaction models a transaction on which to collect endorsements on the transaction's proposal
 type EndorsementsOnProposalTransaction interface {
 	Network() string
+	Channel() string
 	EndorseProposalResponseWithIdentity(id view.Identity) error
 	ProposalResponses() ([][]byte, error)
 	Bytes() ([]byte, error)
 	ID() string
 	AppendProposalResponse(response *fabric.ProposalResponse) error
+	FabricNetworkService() *fabric.NetworkService
 }
 
 type Response struct {
@@ -64,6 +67,13 @@ func (c *parallelCollectEndorsementsOnProposalView) Call(viewCtx view.Context) (
 		return nil, errors.WithMessagef(err, "fabric network service [%s] not found", c.tx.Network())
 	}
 	tm := fns.TransactionManager()
+
+	ch, err := fns.Channel(c.tx.Channel())
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed getting channel [%s:%s]", c.tx.Network(), c.tx.Channel())
+	}
+	vProviders := []fabric.VerifierProvider{&verifierProviderWrapper{m: ch.MSPManager()}}
+
 	for i := 0; i < len(c.parties); i++ {
 		logger.DebugfContext(viewCtx.Context(), "Wait for endorsement")
 		// TODO: put a timeout
@@ -82,7 +92,21 @@ func (c *parallelCollectEndorsementsOnProposalView) Call(viewCtx view.Context) (
 				return nil, errors.Wrap(err, "failed unmarshalling received proposal response")
 			}
 
-			// TODO: check the validity of the response
+			endorserID := view.Identity(proposalResponse.Endorser())
+			if !endorserID.Equal(a.party) && !endpoint.GetService(viewCtx).IsBoundTo(viewCtx.Context(), endorserID, a.party) {
+				return nil, errors.Errorf("invalid endorsement, expected one signed by [%s]", a.party.String())
+			}
+
+			verified := false
+			for _, provider := range vProviders {
+				if err := proposalResponse.VerifyEndorsement(provider); err == nil {
+					verified = true
+					break
+				}
+			}
+			if !verified {
+				return nil, errors.Errorf("failed to verify signature for party [%s]", a.party.String())
+			}
 
 			logger.DebugfContext(viewCtx.Context(), "Appended proposal")
 			err = c.tx.AppendProposalResponse(proposalResponse)

--- a/platform/fabric/services/endorser/endorsement_test.go
+++ b/platform/fabric/services/endorser/endorsement_test.go
@@ -694,6 +694,83 @@ func TestParallelCollectEndorsementsOnProposalView_RejectsUnverifiedResponse(t *
 	require.Equal(t, 0, fakeTx.AppendProposalResponseCallCount())
 }
 
+// TestParallelCollectEndorsementsOnProposalView_TimesOutOnSilentParty demonstrates that
+// parallelCollectEndorsementsOnProposalView.Call (endorsement_proposal.go) no longer blocks
+// forever on <-answerChannel when a contacted party never answers. Each per-party goroutine's
+// own ReceiveWithTimeout only bounds the final receive step of collectEndorsement - it does
+// not bound session setup/send, and (per WithTimeout's doc) is zero unless the caller
+// explicitly opts in, which the only production call site (state.NewParallelCollectEndorsementsOnProposalView)
+// never does. Call now applies an aggregate deadline around the wait itself, so the view
+// returns a timeout error instead of hanging indefinitely.
+func TestParallelCollectEndorsementsOnProposalView_TimesOutOnSilentParty(t *testing.T) {
+	t.Parallel()
+	fakeCtx := &mock.Context{}
+	fakeCtx.ContextReturns(context.Background())
+	fakeSP := &mock.Provider{}
+	fakeCtx.GetServiceCalls(func(v any) (any, error) {
+		return fakeSP.GetService(v)
+	})
+
+	fakeFNSP := &mock.FabricNetworkServiceProvider{}
+	fakeFNS := &mock.FabricNetworkService{}
+	fakeFNS.NameReturns("net1")
+	fakeFNSP.FabricNetworkServiceReturns(fakeFNS, nil)
+	fakeNSP := fabric.NewNetworkServiceProvider(fakeFNSP, nil)
+	networkServiceProviderType := reflect.TypeFor[*fabric.NetworkServiceProvider]()
+	fakeSP.GetServiceCalls(func(v any) (any, error) {
+		if v == networkServiceProviderType {
+			return fakeNSP, nil
+		}
+		return nil, nil
+	})
+
+	fakeTM := &mock.TransactionManager{}
+	fakeFNS.TransactionManagerReturns(fakeTM)
+
+	fakeCH := &mock.Channel{}
+	fakeCH.NameReturns("ch1")
+	fakeFNS.ChannelReturns(fakeCH, nil)
+	fakeCM := &mock.ChannelMembership{}
+	fakeCH.ChannelMembershipReturns(fakeCM)
+
+	fakeTx := &mock.Transaction{}
+	fakeTx.NetworkReturns("net1")
+	fakeTx.ChannelReturns("ch1")
+	fakeTx.BytesReturns([]byte("raw"), nil)
+	fakeTx.IDReturns("tx1")
+
+	ft := &Transaction{
+		Transaction: fabric.NewTransaction(fabric.NewNetworkService(nil, fakeFNS, "net1"), fakeTx),
+	}
+
+	// A short timeout so the test doesn't wait out defaultParallelEndorsementTimeout; the
+	// party's session never delivers a response (empty, never-fed channel), simulating a
+	// silent/unresponsive remote peer.
+	v := NewParallelCollectEndorsementsOnProposalView(ft, []byte("bob"))
+	v.WithTimeout(50 * time.Millisecond)
+
+	fakeSession := &mock.Session{}
+	fakeCtx.GetSessionReturns(fakeSession, nil)
+	fakeCtx.InitiatorReturns(&fakeView{})
+	fakeSession.ReceiveReturns(make(chan *view.Message))
+
+	done := make(chan struct{})
+	var err error
+	go func() {
+		_, err = v.Call(fakeCtx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Call did not return - it appears to be blocking forever on the silent party")
+	}
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timeout")
+}
+
 func TestEndorsementOnProposalResponderViewInternal(t *testing.T) {
 	t.Parallel()
 	fakeCtx := &mock.Context{}

--- a/platform/fabric/services/endorser/endorsement_test.go
+++ b/platform/fabric/services/endorser/endorsement_test.go
@@ -9,6 +9,7 @@ package endorser
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -451,6 +452,36 @@ func TestReceiveView(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestReceiveView_TimesOutWhenSilent demonstrates the fix for the DoS in flow.go's
+// receiveView.Call: it now bounds the wait on <-ch with a 10-second timeout instead
+// of blocking forever. A remote peer that opens a session and never sends anything
+// (and never sends an error) no longer parks the responder's view-execution
+// goroutine indefinitely.
+func TestReceiveView_TimesOutWhenSilent(t *testing.T) {
+	t.Parallel()
+	fakeCtx := &mock.Context{}
+	fakeSession := &mock.Session{}
+	fakeCtx.SessionReturns(fakeSession)
+
+	// A malicious/silent remote peer: the channel never receives a message.
+	msgCh := make(chan *view.Message)
+	fakeSession.ReceiveReturns(msgCh)
+
+	rv := &receiveView{}
+	done := make(chan error, 1)
+	go func() {
+		_, err := rv.Call(fakeCtx)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "receiveView.Call must return a timeout error when the remote peer stays silent")
+	case <-time.After(15 * time.Second):
+		t.Fatal("receiveView.Call did not return within the expected 10-second timeout window")
+	}
+}
+
 func TestReceiveTransactionView(t *testing.T) {
 	t.Parallel()
 	fakeCtx := &mock.Context{}
@@ -518,8 +549,15 @@ func TestParallelCollectEndorsementsOnProposalViewInternal(t *testing.T) {
 	fakeTM := &mock.TransactionManager{}
 	fakeFNS.TransactionManagerReturns(fakeTM)
 
+	fakeCH := &mock.Channel{}
+	fakeCH.NameReturns("ch1")
+	fakeFNS.ChannelReturns(fakeCH, nil)
+	fakeCM := &mock.ChannelMembership{}
+	fakeCH.ChannelMembershipReturns(fakeCM)
+
 	fakeTx := &mock.Transaction{}
 	fakeTx.NetworkReturns("net1")
+	fakeTx.ChannelReturns("ch1")
 	fakeTx.BytesReturns([]byte("raw"), nil)
 	fakeTx.IDReturns("tx1")
 
@@ -543,6 +581,8 @@ func TestParallelCollectEndorsementsOnProposalViewInternal(t *testing.T) {
 	fakeSession.ReceiveReturns(msgCh)
 
 	fakeResp := &mock.ProposalResponse{}
+	fakeResp.EndorserReturns([]byte("bob"))
+	fakeResp.VerifyEndorsementReturns(nil)
 	fakeTM.NewProposalResponseFromBytesReturns(fakeResp, nil)
 
 	_, err := v.Call(fakeCtx)
@@ -567,6 +607,91 @@ func TestParallelCollectEndorsementsOnProposalViewInternal(t *testing.T) {
 	fakeSession.ReceiveReturns(msgCh)
 	_, err = v.Call(fakeCtx)
 	require.Error(t, err)
+}
+
+// TestParallelCollectEndorsementsOnProposalView_RejectsUnverifiedResponse demonstrates
+// that parallelCollectEndorsementsOnProposalView.Call (endorsement_proposal.go) now
+// calls ProposalResponse.VerifyEndorsement, and checks that the endorser is bound to
+// the contacted party, before appending a remote-supplied proposal response to the
+// transaction - mirroring the sequential collectEndorsementsView.Call, which verifies
+// signatures against a set of VerifierProviders.
+func TestParallelCollectEndorsementsOnProposalView_RejectsUnverifiedResponse(t *testing.T) {
+	t.Parallel()
+	fakeCtx := &mock.Context{}
+	fakeCtx.ContextReturns(context.Background())
+	fakeSP := &mock.Provider{}
+	fakeCtx.GetServiceCalls(func(v any) (any, error) {
+		return fakeSP.GetService(v)
+	})
+
+	fakeFNSP := &mock.FabricNetworkServiceProvider{}
+	fakeFNS := &mock.FabricNetworkService{}
+	fakeFNS.NameReturns("net1")
+	fakeFNSP.FabricNetworkServiceReturns(fakeFNS, nil)
+	fakeNSP := fabric.NewNetworkServiceProvider(fakeFNSP, nil)
+	networkServiceProviderType := reflect.TypeFor[*fabric.NetworkServiceProvider]()
+	endpointServiceType := reflect.TypeFor[*endpoint.Service]()
+
+	fakeBindingStore := &mock.BindingStore{}
+	fakeBindingStore.HaveSameBindingReturns(false, nil)
+	endpointService, _ := endpoint.NewService(fakeBindingStore)
+
+	fakeSP.GetServiceCalls(func(v any) (any, error) {
+		if v == networkServiceProviderType {
+			return fakeNSP, nil
+		}
+		if v == endpointServiceType {
+			return endpointService, nil
+		}
+		return nil, nil
+	})
+
+	fakeTM := &mock.TransactionManager{}
+	fakeFNS.TransactionManagerReturns(fakeTM)
+
+	fakeCH := &mock.Channel{}
+	fakeCH.NameReturns("ch1")
+	fakeFNS.ChannelReturns(fakeCH, nil)
+	fakeCM := &mock.ChannelMembership{}
+	fakeCH.ChannelMembershipReturns(fakeCM)
+
+	fakeTx := &mock.Transaction{}
+	fakeTx.NetworkReturns("net1")
+	fakeTx.ChannelReturns("ch1")
+	fakeTx.BytesReturns([]byte("raw"), nil)
+	fakeTx.IDReturns("tx1")
+
+	ft := &Transaction{
+		Transaction: fabric.NewTransaction(fabric.NewNetworkService(nil, fakeFNS, "net1"), fakeTx),
+	}
+
+	// Party contacted is "bob", but the returned response claims to be endorsed by
+	// "mallory" - an identity with no relationship to "bob" whatsoever.
+	v := NewParallelCollectEndorsementsOnProposalView(ft, []byte("bob"))
+	v.WithTimeout(1 * time.Second)
+
+	fakeSession := &mock.Session{}
+	fakeCtx.GetSessionReturns(fakeSession, nil)
+	fakeCtx.InitiatorReturns(&fakeView{})
+
+	respPayload, _ := json.Marshal(&Response{
+		ProposalResponses: [][]byte{[]byte("resp-from-mallory")},
+	})
+	msgCh := make(chan *view.Message, 1)
+	msgCh <- &view.Message{Payload: respPayload}
+	fakeSession.ReceiveReturns(msgCh)
+
+	// This response is neither signed by "bob" nor bound to "bob", so it must be
+	// rejected regardless of what VerifyEndorsement would say.
+	fakeResp := &mock.ProposalResponse{}
+	fakeResp.EndorserReturns([]byte("mallory"))
+	fakeResp.VerifyEndorsementReturns(errors.New("signature verification failed"))
+	fakeTM.NewProposalResponseFromBytesReturns(fakeResp, nil)
+
+	_, err := v.Call(fakeCtx)
+
+	require.Error(t, err, "unverified proposal response from an unrelated identity must be rejected")
+	require.Equal(t, 0, fakeTx.AppendProposalResponseCallCount())
 }
 
 func TestEndorsementOnProposalResponderViewInternal(t *testing.T) {
@@ -631,6 +756,103 @@ func TestEndorsementOnProposalResponderViewInternal(t *testing.T) {
 	fakeTx.EndorseProposalResponseWithIdentityReturns(fmt.Errorf("err"))
 	_, err = ev.Call(fakeCtx)
 	require.Error(t, err)
+}
+
+// TestCollectEndorsementsView_RejectsEndorsementFromUnboundParty demonstrates that
+// collectEndorsementsView.Call rejects a cryptographically-valid endorsement from an
+// identity that is NOT bound to the expected party. `found` is now initialized to
+// `false` before the IsBoundTo check (endorsement.go), so the final
+// `if !found { return error }` guard correctly rejects a response whose signer is
+// neither the contacted party nor bound to it.
+func TestCollectEndorsementsView_RejectsEndorsementFromUnboundParty(t *testing.T) {
+	t.Parallel()
+	fakeCtx := &mock.Context{}
+	fakeSP := &mock.Provider{}
+	fakeCtx.GetServiceCalls(func(v any) (any, error) {
+		return fakeSP.GetService(v)
+	})
+
+	fakeTx := &mock.Transaction{}
+	fakeTx.ChannelReturns("ch1")
+	fakeTx.NetworkReturns("net1")
+
+	fakeRWS := &mock.RWSet{}
+	fakeRWS.BytesReturns([]byte("results"), nil)
+	fakeTx.GetRWSetReturns(fakeRWS, nil)
+	fakeTx.BytesReturns([]byte("bytes"), nil)
+	fakeTx.ResultsReturns([]byte("results"), nil)
+
+	fakeFNS := &mock.FabricNetworkService{}
+	fakeFNS.NameReturns("net1")
+	fakeCH := &mock.Channel{}
+	fakeCH.NameReturns("ch1")
+	fakeFNS.ChannelReturns(fakeCH, nil)
+
+	fakeCM := &mock.ChannelMembership{}
+	fakeCH.ChannelMembershipReturns(fakeCM)
+
+	fakeTM := &mock.TransactionManager{}
+	fakeFNS.TransactionManagerReturns(fakeTM)
+
+	fakeFNSP := &mock.FabricNetworkServiceProvider{}
+	fakeFNSP.FabricNetworkServiceReturns(fakeFNS, nil)
+	fakeNSP := fabric.NewNetworkServiceProvider(fakeFNSP, nil)
+
+	// A real endpoint.Service backed by a BindingStore that reports the endorser
+	// identity is NOT bound to the party we asked to endorse.
+	fakeBindingStore := &mock.BindingStore{}
+	fakeBindingStore.HaveSameBindingReturns(false, nil)
+	endpointService, _ := endpoint.NewService(fakeBindingStore)
+
+	networkServiceProviderType := reflect.TypeFor[*fabric.NetworkServiceProvider]()
+	endpointServiceType := reflect.TypeFor[*endpoint.Service]()
+
+	fakeSP.GetServiceCalls(func(v any) (any, error) {
+		if v == networkServiceProviderType {
+			return fakeNSP, nil
+		}
+		if v == endpointServiceType {
+			return endpointService, nil
+		}
+		return nil, nil
+	})
+
+	fns := fabric.NewNetworkService(nil, fakeFNS, "net1")
+	ft := fabric.NewTransaction(fns, fakeTx)
+	et := &Transaction{
+		Transaction: ft,
+	}
+
+	party := view.Identity("expected-party")
+	ev := NewCollectEndorsementsView(et, party)
+
+	fakeCtx.IsMeReturns(false)
+	fakeSession := &mock.Session{}
+	fakeCtx.GetSessionReturns(fakeSession, nil)
+	msgCh := make(chan *view.Message, 1)
+	fakeSession.ReceiveReturns(msgCh)
+
+	// The response is endorsed by "attacker", a completely different identity than
+	// "expected-party", and the binding store confirms they are not bound together.
+	resp := &mock.ProposalResponse{}
+	resp.EndorserReturns([]byte("attacker"))
+	resp.ResultsReturns([]byte("results"))
+	// VerifyEndorsement succeeds unconditionally here: in a real deployment this
+	// would succeed whenever "attacker" is any validly-enrolled MSP member, since
+	// verification only checks the signature was produced by whoever `Endorser()`
+	// claims to be - it says nothing about whether that signer is `party`.
+	resp.VerifyEndorsementReturns(nil)
+	fakeTM.NewProposalResponseFromBytesReturns(resp, nil)
+
+	payload, _ := json.Marshal([][]byte{[]byte("resp-from-attacker")})
+	msgCh <- &view.Message{Payload: payload}
+
+	_, err := ev.Call(fakeCtx)
+
+	// The overall Call must fail because the endorser is neither the contacted
+	// party nor bound to it, even though the individual response passed signature
+	// verification and was provisionally appended before the post-loop binding check.
+	require.ErrorContains(t, err, "invalid endorsement, expected one signed by", "endorsement from an unbound identity must be rejected")
 }
 
 func TestVerifierProviderWrapper(t *testing.T) {

--- a/platform/fabric/services/endorser/flow.go
+++ b/platform/fabric/services/endorser/flow.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package endorser
 
 import (
+	"time"
+
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
@@ -39,8 +41,15 @@ func (s receiveView) Call(viewCtx view.Context) (any, error) {
 	// Wait to receive a state
 	ch := session.Receive()
 
-	// TODO: add timeout
-	msg := <-ch
+	timeout := time.NewTimer(time.Second * 10)
+	defer timeout.Stop()
+
+	var msg *view.Message
+	select {
+	case msg = <-ch:
+	case <-timeout.C:
+		return nil, errors.New("timeout reached")
+	}
 
 	if msg.Status == view.ERROR {
 		return nil, errors.New(string(msg.Payload))

--- a/platform/fabric/services/endorser/flow.go
+++ b/platform/fabric/services/endorser/flow.go
@@ -33,6 +33,12 @@ func NewReceiveTransactionView() *receiveTransactionView {
 	return &receiveTransactionView{}
 }
 
+// receiveTimeout bounds how long a responder waits for the initiator to send
+// its next message, so a silent/unresponsive remote peer cannot park this
+// goroutine indefinitely. It matches the default receive timeout used
+// elsewhere for session-level reads (see session.defaultReceiveTimeout).
+const receiveTimeout = 10 * time.Second
+
 type receiveView struct{}
 
 func (s receiveView) Call(viewCtx view.Context) (any, error) {
@@ -41,7 +47,7 @@ func (s receiveView) Call(viewCtx view.Context) (any, error) {
 	// Wait to receive a state
 	ch := session.Receive()
 
-	timeout := time.NewTimer(time.Second * 10)
+	timeout := time.NewTimer(receiveTimeout)
 	defer timeout.Stop()
 
 	var msg *view.Message

--- a/platform/fabric/services/endorser/transaction.go
+++ b/platform/fabric/services/endorser/transaction.go
@@ -185,7 +185,7 @@ func (t *Transaction) GetSignatureOf(party view.Identity) ([]byte, error) {
 func (t *Transaction) Namespaces() Namespaces {
 	rwSet, err := t.RWSet()
 	if err != nil {
-		panic(errors.Wrap(err, "filed getting rw set").Error())
+		panic(errors.Wrap(err, "failed getting rw set").Error())
 	}
 
 	return rwSet.Namespaces()

--- a/platform/view/services/view/p2p/service.go
+++ b/platform/view/services/view/p2p/service.go
@@ -159,8 +159,9 @@ func (s *Service) respond(responder view.View, id view.Identity, msg *view.Messa
 	if err != nil {
 		logger.DebugfContext(viewCtx.Context(), "[%s] Respond Failure [from:%s], [sessionID:%s], [contextID:%s] [%s]\n", id, msg.FromEndpoint, msg.SessionID, msg.ContextID, err)
 
-		// try to send error back to caller
-		if serr := viewCtx.Session().SendError([]byte(err.Error())); serr != nil {
+		// send a generic, non-identifying error back to the remote caller; the
+		// detailed error (which may contain internal error/panic text) stays local.
+		if serr := viewCtx.Session().SendError([]byte("responder failed")); serr != nil {
 			logger.Error(serr.Error())
 		}
 	}

--- a/platform/view/services/view/p2p/service_test.go
+++ b/platform/view/services/view/p2p/service_test.go
@@ -124,7 +124,7 @@ func TestService_MasterSessionError(t *testing.T) {
 
 // TestService_PanicDoesNotLeakInternalErrorToRemoteCaller demonstrates that when a
 // responder view panics (e.g. endorser.Transaction.Namespaces() panics with
-// `panic(errors.Wrap(err, "filed getting rw set").Error())` when the local RWSet cannot be
+// `panic(errors.Wrap(err, "failed getting rw set").Error())` when the local RWSet cannot be
 // read), Service.respond now sends a generic, non-identifying error back to the remote,
 // untrusted caller via Session.SendError instead of the raw panic/error text. The
 // detailed error stays local (logged by the recover() in Service.respond), so a remote
@@ -134,7 +134,7 @@ func TestService_MasterSessionError(t *testing.T) {
 func TestService_PanicDoesNotLeakInternalErrorToRemoteCaller(t *testing.T) {
 	t.Parallel()
 
-	sensitivePanicText := "filed getting rw set: could not open /var/lib/fabric/kvs/vault.db: permission denied"
+	sensitivePanicText := "failed getting rw set: could not open /var/lib/fabric/kvs/vault.db: permission denied"
 
 	panicView := &mock.View{}
 	panicView.CallStub = func(view.Context) (any, error) {

--- a/platform/view/services/view/p2p/service_test.go
+++ b/platform/view/services/view/p2p/service_test.go
@@ -9,6 +9,7 @@ package p2p_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -119,6 +120,95 @@ func TestService_MasterSessionError(t *testing.T) {
 	err := service.Start(context.Background())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed getting master session")
+}
+
+// TestService_PanicDoesNotLeakInternalErrorToRemoteCaller demonstrates that when a
+// responder view panics (e.g. endorser.Transaction.Namespaces() panics with
+// `panic(errors.Wrap(err, "filed getting rw set").Error())` when the local RWSet cannot be
+// read), Service.respond now sends a generic, non-identifying error back to the remote,
+// untrusted caller via Session.SendError instead of the raw panic/error text. The
+// detailed error stays local (logged by the recover() in Service.respond), so a remote
+// peer can no longer learn internal error detail (e.g. local storage/db error strings,
+// stack-adjacent context) about the responder's internals by causing a responder view
+// to panic.
+func TestService_PanicDoesNotLeakInternalErrorToRemoteCaller(t *testing.T) {
+	t.Parallel()
+
+	sensitivePanicText := "filed getting rw set: could not open /var/lib/fabric/kvs/vault.db: permission denied"
+
+	panicView := &mock.View{}
+	panicView.CallStub = func(view.Context) (any, error) {
+		panic(sensitivePanicText)
+	}
+
+	vm := &viewManagerMock{
+		HandleResponderCalled: make(chan struct{}, 10),
+	}
+	vm.ExistResponderForCallerFunc = func(caller string) (view.View, view.Identity, error) {
+		return panicView, nil, nil
+	}
+
+	respSession := &mock.Session{}
+	respSession.SendErrorReturns(nil)
+
+	respCtx := &mock.Context{}
+	respCtx.SessionReturns(respSession)
+	// The default Runner (p2p.NewDefaultRunner) just delegates to viewCtx.RunView(responder).
+	// The real implementation (viewpkg.RunViewNow) recovers any panic raised by the
+	// responder's Call and turns it into an error (wrapping ErrViewExecutionFailed with the
+	// panic value) rather than letting it propagate - mirror that here.
+	respCtx.RunViewStub = func(v view.View, _ ...view.RunViewOption) (res any, err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("caught panic: %v", r)
+			}
+		}()
+		return v.Call(respCtx)
+	}
+	vm.NewSessionContextFunc = func(ctx context.Context, contextID string, session view.Session, party view.Identity) (view.Context, bool, error) {
+		vm.HandleResponderCalled <- struct{}{}
+		return respCtx, true, nil
+	}
+
+	cl := &mock2.CommLayer{}
+	masterSess := &mock.Session{}
+	ch := make(chan *view.Message, 10)
+	cl.MasterSessionReturns(masterSess, nil)
+	masterSess.ReceiveReturns(ch)
+
+	service := p2p.NewService(vm, vm, cl, vm, p2p.NewDefaultRunner())
+	ctx := t.Context()
+
+	err := service.Start(ctx)
+	require.NoError(t, err)
+
+	ch <- &view.Message{
+		ContextID:    "ctx1",
+		SessionID:    "sess1",
+		Caller:       "caller1",
+		FromEndpoint: "endpoint1",
+		FromPKID:     []byte("pkid1"),
+		Ctx:          ctx,
+	}
+
+	select {
+	case <-vm.HandleResponderCalled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("NewResponderContext was not called")
+	}
+
+	// respond() runs the panicking view asynchronously (handleMessage is invoked via
+	// `go s.handleMessage(msg)`); poll briefly for the resulting SendError call.
+	require.Eventually(t, func() bool {
+		return respSession.SendErrorCallCount() > 0
+	}, 5*time.Second, 10*time.Millisecond, "SendError was never called with the panic's error text")
+
+	// FIXED: a generic message is sent back to the remote peer; the sensitive
+	// internal panic text stays local.
+	sentPayload := respSession.SendErrorArgsForCall(0)
+	require.Equal(t, "responder failed", string(sentPayload))
+	require.NotContains(t, string(sentPayload), sensitivePanicText,
+		"internal panic detail must not be leaked to the remote caller via SendError")
 }
 
 func TestService_HandleResponderError(t *testing.T) {


### PR DESCRIPTION
## Summary

Hardens the responder-view attack surface — code reachable when this node
answers a remote, untrusted peer over a P2P session — against malformed
input and endorsement-verification bypass.

- Validate wire-deserialized proposals/envelopes/transactions (nil/length
  checks on protobuf-decoded fields) instead of panicking on malformed
  input from a remote peer.
- Stop leaking internal panic/error detail to the remote caller via
  `Session.SendError`; full detail is still logged locally.
- Enforce endorsement signature and party-binding verification on both the
  sequential and parallel endorsement-collection paths.
- Add a timeout to the responder's message-receive wait so a silent peer
  can no longer block a goroutine indefinitely.
- Guard an unindexed access when no proposal responses are present.

All existing tests that previously asserted the vulnerable/buggy behavior
(`require.Panics`, accept-without-verification) have been updated to assert
the fixed/secure behavior. Fuzz seed corpora were extended with the
previously-crashing inputs, now exercised as ordinary non-panicking cases.

Refs #1593.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./platform/...`
- [x] `go test ./platform/fabric/core/generic/transaction/...`
- [x] `go test ./platform/fabric/services/endorser/...`
- [x] `go test ./platform/view/services/view/p2p/...`
- [x] `go test ./platform/fabric/services/state/...` (downstream consumer)
- [x] 15s live fuzz run of `FuzzUnpackEnvelopeFromBytes` — no new panics