### PR TITLE
ci(coverage): honour caller -coverpkg from GOFLAGS in integration builds

### DIFF
--- a/integration/integration.go
+++ b/integration/integration.go
@@ -110,8 +110,19 @@ outer:
 	// the integration tests would report no coverage at all. Instrumenting the
 	// whole module credits the platform/core code the FSC nodes exercise at
 	// runtime, which is the coverage the integration tests are meant to measure.
+	//
+	// Downstream modules that embed FSC nodes (e.g. fabric-token-sdk) run their
+	// own code inside these node binaries and need their packages instrumented
+	// instead of — or in addition to — FSC's. Go's standard channel for that is
+	// -coverpkg supplied via GOFLAGS. Respect it: only fall back to instrumenting
+	// the FSC module when the caller has not set -coverpkg, so a consumer that
+	// exports GOFLAGS=-coverpkg=<their-module>/... has it honoured rather than
+	// silently overridden, while FSC's own coverage build is unchanged.
 	if _, ok := os.LookupEnv("GOCOVERDIR"); ok {
-		params = append(params, "-cover", "-coverpkg=github.com/hyperledger-labs/fabric-smart-client/...")
+		params = append(params, "-cover")
+		if !goflagsHasCoverpkg() {
+			params = append(params, "-coverpkg=github.com/hyperledger-labs/fabric-smart-client/...")
+		}
 	}
 
 	buildServer := common.NewBuildServer(params...)
@@ -131,6 +142,20 @@ outer:
 		},
 	}
 	return n, nil
+}
+
+// goflagsHasCoverpkg reports whether the caller has already supplied a -coverpkg
+// flag through the GOFLAGS environment variable. GOFLAGS is a space-separated
+// list of flags that every go command merges into its own; an explicit -coverpkg
+// there is the standard way for a consumer to select the packages instrumented
+// in the cover-built node binaries.
+func goflagsHasCoverpkg() bool {
+	for _, f := range strings.Fields(os.Getenv("GOFLAGS")) {
+		if strings.HasPrefix(f, "-coverpkg") || strings.HasPrefix(f, "--coverpkg") {
+			return true
+		}
+	}
+	return false
 }
 
 func Generate(startPort int, race bool, topologies ...api.Topology) (*Infrastructure, error) {


### PR DESCRIPTION
Fixes #1595

### Problem

When building cover-instrumented integration node binaries (`GOCOVERDIR` set), `integration/integration.go` hardcoded `-coverpkg=github.com/hyperledger-labs/fabric-smart-client/...`. An explicit `-coverpkg` on the `go build` command line takes precedence over one supplied via `GOFLAGS`, so a consumer that embeds FSC nodes could not instrument its own packages — the flag silently overrode theirs. Their integration tests then credited FSC packages instead of their own code, collapsing the consumer's reported coverage.

### Why the consumer must use GOFLAGS

A downstream project's code runs inside the node binaries FSC compiles, not in `go test`. Go's `go build -cover` only instruments a binary's own main module unless `-coverpkg` names other packages, and only the consumer knows its module path. Since the consumer doesn't invoke the build, `GOFLAGS=-coverpkg=<their-module>/...` is the standard channel to pass that flag into FSC's `go build`. FSC just needs to stop overriding it.

### Change

Respect a `-coverpkg` the caller supplied via `GOFLAGS`; only fall back to instrumenting the FSC module when none is set.

```go
if _, ok := os.LookupEnv("GOCOVERDIR"); ok {
    params = append(params, "-cover")
    if !goflagsHasCoverpkg() {
        params = append(params, "-coverpkg=github.com/hyperledger-labs/fabric-smart-client/...")
    }
}
```

- **FSC's own coverage build is unchanged** — it sets no `-coverpkg`, so the default still applies.
- **Downstream consumers** get their existing `GOFLAGS=-coverpkg=...` honoured instead of silently overridden — no bespoke setting required. This restores the standard-Go behaviour that predated the hardcoded flag.

Why respect GOFLAGS instead of adding an FSC_COVERPKG variable: GOFLAGS=-coverpkg=... is the standard Go mechanism consumers already use to select instrumented packages. Honoring it needs no new, FSC-specific variable to learn, requires no extra config (an existing GOFLAGS export just works), and restores standard Go behaviour rather than layering a bespoke knob on top of it.

### Testing

- `go build ./...` and `go vet .` pass in the `integration` module.
- With no `GOFLAGS` `-coverpkg`, the emitted flags are identical to before.
