### PR TITLE
revert(security): stop redacting responder-view errors sent to remote callers

### DIFF
--- a/docs/platform/view/services/view-service.md
+++ b/docs/platform/view/services/view-service.md
@@ -407,6 +407,8 @@ The View Service integrates with the P2P Service for handling incoming messages:
 4. **View Execution**: Runs the responder view in the context
 5. **Error Handling**: Sends error messages back to the initiator on failure
 
+The text sent is the raw error returned by the responder view (`err.Error()`), forwarded unmodified via `Session().SendError(...)`. The runtime does not inspect or filter it — deciding what information is safe to disclose to a remote, potentially untrusted caller is the responder view's responsibility, not the P2P service's. See the [View API](../view-api.md#send-and-receive) for guidance on what responder views should and shouldn't return as errors.
+
 ### Message Flow
 
 ```mermaid

--- a/docs/platform/view/view-api.md
+++ b/docs/platform/view/view-api.md
@@ -217,6 +217,8 @@ type Session interface {
 
 `SendError` and `SendErrorWithContext` transmit an error response. These methods set the message status to `view.ERROR`, allowing the recipient to distinguish protocol failures from normal payloads.
 
+The payload passed to `SendError` is transmitted as-is. When a responder view returns an error from `Call`, the P2P runtime forwards `err.Error()` verbatim to the remote caller via `SendError` — it does not inspect, wrap, or redact it. The runtime's job is only to decide *that* an error gets returned; deciding *what* information that error is allowed to contain is the application's responsibility. Since the remote party may be untrusted, responder views should return business-logic errors verbatim (callers legitimately need that detail to react, and tests rely on it), but should wrap or replace errors that could carry internal detail (stack-adjacent context, file paths, credentials) with a sanitized message before returning them.
+
 `Receive()` returns a channel of incoming `Message` values. Views typically consume it with a `select` and an explicit timeout rather than waiting indefinitely.
 
 `Close()` releases resources associated with the logical session.

--- a/platform/view/services/view/p2p/service.go
+++ b/platform/view/services/view/p2p/service.go
@@ -159,9 +159,8 @@ func (s *Service) respond(responder view.View, id view.Identity, msg *view.Messa
 	if err != nil {
 		logger.DebugfContext(viewCtx.Context(), "[%s] Respond Failure [from:%s], [sessionID:%s], [contextID:%s] [%s]\n", id, msg.FromEndpoint, msg.SessionID, msg.ContextID, err)
 
-		// send a generic, non-identifying error back to the remote caller; the
-		// detailed error (which may contain internal error/panic text) stays local.
-		if serr := viewCtx.Session().SendError([]byte("responder failed")); serr != nil {
+		// send the error back to the caller
+		if serr := viewCtx.Session().SendError([]byte(err.Error())); serr != nil {
 			logger.Error(serr.Error())
 		}
 	}

--- a/platform/view/services/view/p2p/service_test.go
+++ b/platform/view/services/view/p2p/service_test.go
@@ -122,16 +122,12 @@ func TestService_MasterSessionError(t *testing.T) {
 	require.Contains(t, err.Error(), "failed getting master session")
 }
 
-// TestService_PanicDoesNotLeakInternalErrorToRemoteCaller demonstrates that when a
-// responder view panics (e.g. endorser.Transaction.Namespaces() panics with
+// TestService_PanicIsReturnedToRemoteCaller demonstrates that when a responder view
+// panics (e.g. endorser.Transaction.Namespaces() panics with
 // `panic(errors.Wrap(err, "failed getting rw set").Error())` when the local RWSet cannot be
-// read), Service.respond now sends a generic, non-identifying error back to the remote,
-// untrusted caller via Session.SendError instead of the raw panic/error text. The
-// detailed error stays local (logged by the recover() in Service.respond), so a remote
-// peer can no longer learn internal error detail (e.g. local storage/db error strings,
-// stack-adjacent context) about the responder's internals by causing a responder view
-// to panic.
-func TestService_PanicDoesNotLeakInternalErrorToRemoteCaller(t *testing.T) {
+// read), Service.respond sends the resulting error back to the remote caller via
+// Session.SendError, exactly as it would for any other responder-view error.
+func TestService_PanicIsReturnedToRemoteCaller(t *testing.T) {
 	t.Parallel()
 
 	sensitivePanicText := "failed getting rw set: could not open /var/lib/fabric/kvs/vault.db: permission denied"
@@ -203,12 +199,8 @@ func TestService_PanicDoesNotLeakInternalErrorToRemoteCaller(t *testing.T) {
 		return respSession.SendErrorCallCount() > 0
 	}, 5*time.Second, 10*time.Millisecond, "SendError was never called with the panic's error text")
 
-	// FIXED: a generic message is sent back to the remote peer; the sensitive
-	// internal panic text stays local.
 	sentPayload := respSession.SendErrorArgsForCall(0)
-	require.Equal(t, "responder failed", string(sentPayload))
-	require.NotContains(t, string(sentPayload), sensitivePanicText,
-		"internal panic detail must not be leaked to the remote caller via SendError")
+	require.Contains(t, string(sentPayload), sensitivePanicText)
 }
 
 func TestService_HandleResponderError(t *testing.T) {


### PR DESCRIPTION
## Summary

#1594 changed `Service.respond` to send a hardcoded `"responder failed"` string back to the remote caller instead of the responder view's actual error, to avoid leaking internal error/panic detail across the wire.

That decision belongs one layer up. The P2P runner's job is to decide *that* an error gets returned to the remote caller, not *what* it may contain — deciding what information is safe to disclose to a remote, potentially untrusted party is the responder application's decision to make, not the runtime's. `respond()` calls `SendError` for **every** responder-view error, not just panics — including ordinary business-logic errors (e.g. an auditor view rejecting a transfer for exceeding a payment/holding limit, or a `TokenService` validation failure). Hardcoding the runtime's response erases information legitimate callers rely on to react to (and tests rely on to assert against) the specific rejection reason, and takes away the application's ability to choose what to disclose.

This surfaced downstream in Fabric Token SDK / Panurus: bumping to a commit that included #1594 broke integration tests that check the auditor's specific rejection message returned across a P2P session (see [LFDT-Panurus/panurus#1969](https://github.com/LFDT-Panurus/panurus/pull/1969)).

This PR reverts just the redaction: `respond()` sends back the responder's actual `err.Error()` again, matching pre-#1594 behavior, and leaves it to the application/view layer to wrap or sanitize errors that could carry internal detail before returning them. The rest of #1594 (wire-deserialization validation at proposal/transaction boundaries, endorsement signature/binding verification hardening) is untouched and stays in place — only the generic-error substitution in `platform/view/services/view/p2p/service.go` is reverted.

Documentation updated to describe this responsibility split: [`docs/platform/view/view-api.md`](docs/platform/view/view-api.md) (`SendError` semantics) and [`docs/platform/view/services/view-service.md`](docs/platform/view/services/view-service.md) (P2P Service error-forwarding behavior) now state that the runtime forwards `err.Error()` verbatim and that filtering/redaction is the responder view's responsibility.

## Test plan
- [x] `go build ./...`
- [x] `go vet -all ./platform/view/...`
- [x] `go test ./platform/view/services/view/p2p/...` — updated `TestService_PanicDoesNotLeakInternalErrorToRemoteCaller` → `TestService_PanicIsReturnedToRemoteCaller` to assert the panic text *is* forwarded again, matching the reverted behavior.
