### PR TITLE
feat(fabric/config): support adding a new Fabric network at runtime

### DIFF
--- a/platform/fabric/core/config.go
+++ b/platform/fabric/core/config.go
@@ -7,87 +7,323 @@ SPDX-License-Identifier: Apache-2.0
 package core
 
 import (
+	"regexp"
+	"sort"
 	"strings"
+	"sync"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	commondriver "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+	genericconfig "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
+	viewconfig "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/config"
 )
 
+// ConfigProvider is the minimal read surface Config needs to discover and describe Fabric
+// networks: the ability to unmarshal a configuration key into an arbitrary Go value.
 type ConfigProvider interface {
 	UnmarshalKey(key string, rawVal any) error
 }
 
-type FSNConfig struct {
-	Default bool   `yaml:"default,omitempty"`
-	Driver  string `yaml:"driver,omitempty"`
+// DynamicConfigProvider is a ConfigProvider that also supports injecting new
+// configuration into the live configuration tree at runtime.
+type DynamicConfigProvider interface {
+	ConfigProvider
+	// MergeConfig merges the given raw yaml configuration into the current configuration.
+	MergeConfig(raw []byte) error
+	// ProvideFromRaw returns a new, independent provider whose configuration is loaded
+	// from the given raw yaml representation.
+	ProvideFromRaw(raw []byte) (*viewconfig.Provider, error)
 }
 
+// DynamicConfigService is a commondriver.ConfigService that also supports injecting new
+// configuration into the live configuration tree at runtime. It satisfies DynamicConfigProvider.
+type DynamicConfigService interface {
+	commondriver.ConfigService
+	// MergeConfig merges the given raw yaml configuration into the current configuration.
+	MergeConfig(raw []byte) error
+	// ProvideFromRaw returns a new, independent provider whose configuration is loaded
+	// from the given raw yaml representation.
+	ProvideFromRaw(raw []byte) (*viewconfig.Provider, error)
+}
+
+// FSNConfig is the per-network configuration read from the `fabric.<name>` configuration key.
+type FSNConfig struct {
+	// Default marks this network as the default one. At most one network may set this to true.
+	Default bool `yaml:"default,omitempty"`
+	// Driver is the name of the driver.Driver that should be used to instantiate this network.
+	// If empty, every registered driver is tried in turn.
+	Driver string `yaml:"driver,omitempty"`
+}
+
+// Config exposes the set of Fabric networks configured for this node: their names, which one
+// is the default, and their per-network FSNConfig. It is safe for concurrent use; AddNetwork
+// may add new networks to a live Config while other goroutines read from it.
 type Config struct {
+	mu sync.RWMutex
+
+	provider       DynamicConfigProvider
 	configurations map[string]*FSNConfig
 	names          []string
 	defaultName    string
 }
 
-func NewConfig(configProvider ConfigProvider) (*Config, error) {
-	var value any
-	if err := configProvider.UnmarshalKey("fabric", &value); err != nil {
-		return nil, errors.Wrap(err, "failed unmarshalling `fabric` key")
-	}
-	m := value.(map[string]any)
-	var names []string
-	var defaultName string
-	configurations := map[string]*FSNConfig{}
-	for k := range m {
-		name := k
-		if strings.ToLower(name) != "enabled" {
-			names = append(names, name)
-
-			var fsnConfig FSNConfig
-			if err := configProvider.UnmarshalKey("fabric."+name, &fsnConfig); err != nil {
-				return nil, errors.Wrapf(err, "failed unmarshalling `fabric.%s` key", name)
-			}
-			configurations[name] = &fsnConfig
-			logger.Debugf("found fabric network [%s], driver [%s]", name, fsnConfig.Driver)
-
-			// is this default?
-			if fsnConfig.Default || name == "default" {
-				if len(defaultName) != 0 {
-					logger.Warnf("only one network should be set as default, ignoring [%s], default is set to [%s]", name, defaultName)
-					continue
-				}
-				defaultName = name
-			}
-		}
-	}
-	if len(names) == 0 {
-		return nil, errors.New("no fabric network configured")
-	}
-
-	if len(defaultName) == 0 {
-		defaultName = names[0]
-		if len(names) > 1 {
-			logger.Warnf("no default network configured, set it to [%s]", defaultName)
-		}
+// NewConfig builds a Config by scanning the `fabric` key of the given configProvider. It
+// returns an error if no Fabric network is configured.
+func NewConfig(configProvider DynamicConfigProvider) (*Config, error) {
+	configurations, names, defaultName, err := loadNetworks(configProvider)
+	if err != nil {
+		return nil, err
 	}
 
 	return &Config{
+		provider:       configProvider,
 		names:          names,
 		defaultName:    defaultName,
 		configurations: configurations,
 	}, nil
 }
 
+// loadNetworks scans the `fabric` key of the given provider and returns the discovered
+// per-network configurations, the ordered (sorted) list of network names, and the resolved
+// default network name. Every network name and channel name it discovers is validated against
+// the Fabric naming rules, and at most one network may be marked as default (explicitly via
+// FSNConfig.Default, or implicitly by being named "default"); violating either rule is an error.
+func loadNetworks(configProvider ConfigProvider) (map[string]*FSNConfig, []string, string, error) {
+	var value any
+	if err := configProvider.UnmarshalKey("fabric", &value); err != nil {
+		return nil, nil, "", errors.Wrap(err, "failed unmarshalling `fabric` key")
+	}
+	m, ok := value.(map[string]any)
+	if !ok {
+		return nil, nil, "", errors.New("failed unmarshalling `fabric` key: expected a map")
+	}
+
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		if strings.ToLower(k) == "enabled" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var names []string
+	configurations := map[string]*FSNConfig{}
+	for _, name := range keys {
+		if err := validateNetworkName(name); err != nil {
+			return nil, nil, "", errors.Wrapf(err, "invalid fabric network [%s]", name)
+		}
+
+		var fsnConfig FSNConfig
+		if err := configProvider.UnmarshalKey("fabric."+name, &fsnConfig); err != nil {
+			return nil, nil, "", errors.Wrapf(err, "failed unmarshalling `fabric.%s` key", name)
+		}
+		if err := validateChannels(configProvider, name); err != nil {
+			return nil, nil, "", errors.Wrapf(err, "invalid fabric network [%s]", name)
+		}
+
+		names = append(names, name)
+		configurations[name] = &fsnConfig
+		logger.Debugf("found fabric network [%s], driver [%s]", name, fsnConfig.Driver)
+	}
+	if len(names) == 0 {
+		return nil, nil, "", errors.New("no fabric network configured")
+	}
+
+	defaults := explicitDefaults(configurations, names)
+	if len(defaults) > 1 {
+		return nil, nil, "", errors.Errorf("multiple fabric networks are set as default: %v", defaults)
+	}
+
+	var defaultName string
+	if len(defaults) == 1 {
+		defaultName = defaults[0]
+	} else {
+		defaultName = names[0]
+		if len(names) > 1 {
+			logger.Warnf("no default network configured, set it to [%s]", defaultName)
+		}
+	}
+
+	return configurations, names, defaultName, nil
+}
+
+// explicitDefaults returns, in sorted order, the names among names that explicitly request to
+// be the default network: either FSNConfig.Default is set, or the network is named "default".
+func explicitDefaults(configurations map[string]*FSNConfig, names []string) []string {
+	var defaults []string
+	for _, name := range names {
+		if configurations[name].Default || name == "default" {
+			defaults = append(defaults, name)
+		}
+	}
+	sort.Strings(defaults)
+	return defaults
+}
+
+// Names returns the names of every currently configured Fabric network, including any added
+// at runtime via AddNetwork.
 func (c *Config) Names() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.names
 }
 
+// DefaultName returns the name of the default Fabric network.
 func (c *Config) DefaultName() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.defaultName
 }
 
+// Config returns the FSNConfig for the given network name, or an error if no such network is
+// configured.
 func (c *Config) Config(network string) (*FSNConfig, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	conf, ok := c.configurations[network]
 	if !ok {
 		return nil, errors.Errorf("cannot find configuration for network [%s]", network)
 	}
 	return conf, nil
+}
+
+// NetworkConfigValidator validates a candidate Fabric network's configuration before it is
+// merged into the live configuration tree. It is invoked once per network name introduced by
+// an AddNetwork call, with a ConfigProvider scoped to the parsed, not-yet-merged incoming
+// configuration, so a validator can inspect any key under `fabric.<networkName>.*`.
+type NetworkConfigValidator interface {
+	Validate(networkName string, configProvider ConfigProvider) error
+}
+
+// NetworkConfigValidatorFunc adapts a function to a NetworkConfigValidator.
+type NetworkConfigValidatorFunc func(networkName string, configProvider ConfigProvider) error
+
+// Validate calls f.
+func (f NetworkConfigValidatorFunc) Validate(networkName string, configProvider ConfigProvider) error {
+	return f(networkName, configProvider)
+}
+
+// AddNetwork validates the given raw yaml configuration and, if it describes one or more new
+// Fabric networks, merges it into the live configuration tree.
+//
+// The raw configuration must be a valid `fabric` configuration snippet (e.g. `fabric.<name>.*`
+// keys). Every network name and channel name it introduces is validated against the Fabric
+// naming rules (the same rules applied to the configuration loaded at startup), and every
+// network it introduces must be new: adding a network whose name already exists is rejected, as
+// updating an existing network's configuration is not supported. A network requesting to become
+// the default (via FSNConfig.Default or the name "default") is also rejected if doing so would
+// leave more than one network marked as default. Any additional validators are run, per
+// incoming network, after the built-in checks and before anything is merged.
+func (c *Config) AddNetwork(raw []byte, validators ...NetworkConfigValidator) error {
+	temp, err := c.provider.ProvideFromRaw(raw)
+	if err != nil {
+		return errors.Wrap(err, "failed parsing fabric configuration")
+	}
+
+	incomingConfigurations, incomingNames, _, err := loadNetworks(temp)
+	if err != nil {
+		return errors.Wrap(err, "failed loading fabric configuration")
+	}
+
+	for _, name := range incomingNames {
+		for _, v := range validators {
+			if err := v.Validate(name, temp); err != nil {
+				return errors.Wrapf(err, "custom validation failed for fabric network [%s]", name)
+			}
+		}
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, name := range incomingNames {
+		if _, exists := c.configurations[name]; exists {
+			return errors.Errorf("fabric network [%s] already exists, updating an existing network is not supported", name)
+		}
+	}
+
+	defaults := append(explicitDefaults(c.configurations, c.names), explicitDefaults(incomingConfigurations, incomingNames)...)
+	sort.Strings(defaults)
+	if len(defaults) > 1 {
+		return errors.Errorf("multiple fabric networks are set as default: %v", defaults)
+	}
+
+	if err := c.provider.MergeConfig(raw); err != nil {
+		return errors.Wrap(err, "failed merging fabric configuration")
+	}
+
+	configurations, names, defaultName, err := loadNetworks(c.provider)
+	if err != nil {
+		return errors.Wrap(err, "failed reloading fabric configuration after merge")
+	}
+	c.configurations = configurations
+	c.names = names
+	c.defaultName = defaultName
+
+	logger.Infof("added fabric network(s) %v", incomingNames)
+
+	return nil
+}
+
+// identifierAllowedChars matches the Fabric convention for channel/network identifiers: a
+// lowercase letter followed by any number of lowercase alphanumerics, dots, and dashes.
+var identifierAllowedChars = regexp.MustCompile(`^[a-z][a-z0-9.-]*$`)
+
+// maxIdentifierLength is the maximum length allowed for a network or channel name, matching the
+// Fabric channel ID convention.
+const maxIdentifierLength = 249
+
+// validateIdentifier checks that name complies with the Fabric naming rules for identifiers:
+// contains only lowercase ASCII alphanumerics, dots, and dashes; starts with a letter; and is
+// shorter than maxIdentifierLength characters.
+func validateIdentifier(name string) error {
+	if len(name) == 0 {
+		return errors.New("identifier illegal, cannot be empty")
+	}
+	if len(name) > maxIdentifierLength {
+		return errors.Errorf("identifier illegal, cannot be longer than %d", maxIdentifierLength)
+	}
+	if !identifierAllowedChars.MatchString(name) {
+		return errors.Errorf("identifier [%s] contains illegal characters", name)
+	}
+	return nil
+}
+
+// validateNetworkName checks that the given network name complies with the Fabric naming
+// rules for identifiers (lowercase alphanumerics, dots and dashes, starting with a letter).
+func validateNetworkName(name string) error {
+	if err := validateIdentifier(name); err != nil {
+		return errors.Wrapf(err, "invalid network name [%s]", name)
+	}
+	return nil
+}
+
+// validateChannels checks that every channel declared for the given network under the given
+// provider has a name that complies with the Fabric naming rules, and that no two channels of
+// the same network share the same name.
+func validateChannels(configProvider ConfigProvider, network string) error {
+	var channels []*genericconfig.Channel
+	if err := configProvider.UnmarshalKey("fabric."+network+".channels", &channels); err != nil {
+		return errors.Wrapf(err, "failed unmarshalling channels for network [%s]", network)
+	}
+
+	seen := map[string]struct{}{}
+	for _, ch := range channels {
+		if ch == nil || len(ch.Name) == 0 {
+			return errors.Errorf("channel name is empty for network [%s]", network)
+		}
+		if err := validateIdentifier(ch.Name); err != nil {
+			return errors.Wrapf(err, "invalid channel name [%s] for network [%s]", ch.Name, network)
+		}
+		if _, exists := seen[ch.Name]; exists {
+			return errors.Errorf("duplicate channel name [%s] for network [%s]", ch.Name, network)
+		}
+		seen[ch.Name] = struct{}{}
+	}
+
+	return nil
 }

--- a/platform/fabric/core/config_test.go
+++ b/platform/fabric/core/config_test.go
@@ -1,0 +1,325 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	viewconfig "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/config"
+)
+
+const baseYAML = `
+fabric:
+  enabled: true
+  default:
+    default: true
+    driver: generic
+    channels:
+      - Name: default-channel
+`
+
+func newTestProvider(t *testing.T, raw string) *viewconfig.Provider {
+	t.Helper()
+	p, err := (&viewconfig.Provider{}).ProvideFromRaw([]byte(raw))
+	require.NoError(t, err)
+	return p
+}
+
+func TestNewConfig(t *testing.T) {
+	t.Parallel()
+	p := newTestProvider(t, baseYAML)
+	cfg, err := NewConfig(p)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"default"}, cfg.Names())
+	assert.Equal(t, "default", cfg.DefaultName())
+
+	fsnConfig, err := cfg.Config("default")
+	require.NoError(t, err)
+	assert.Equal(t, "generic", fsnConfig.Driver)
+}
+
+func TestNewConfig_RejectsMultipleExplicitDefaults(t *testing.T) {
+	t.Parallel()
+	_, err := NewConfig(newTestProvider(t, `
+fabric:
+  enabled: true
+  network1:
+    default: true
+    driver: generic
+    channels:
+      - Name: mychannel
+  network2:
+    default: true
+    driver: generic
+    channels:
+      - Name: mychannel
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple fabric networks are set as default")
+}
+
+func TestNewConfig_RejectsExplicitDefaultAlongsideNamedDefault(t *testing.T) {
+	t.Parallel()
+	// the network named "default" is implicitly the default, so a second network explicitly
+	// marking itself as default is also ambiguous.
+	_, err := NewConfig(newTestProvider(t, `
+fabric:
+  enabled: true
+  default:
+    driver: generic
+    channels:
+      - Name: default-channel
+  network2:
+    default: true
+    driver: generic
+    channels:
+      - Name: mychannel
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple fabric networks are set as default")
+}
+
+func TestAddNetwork_RejectsSecondDefault(t *testing.T) {
+	t.Parallel()
+	p := newTestProvider(t, baseYAML)
+	cfg, err := NewConfig(p)
+	require.NoError(t, err)
+	require.Equal(t, "default", cfg.DefaultName())
+
+	err = cfg.AddNetwork([]byte(`
+fabric:
+  network2:
+    default: true
+    driver: generic
+    channels:
+      - Name: mychannel
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple fabric networks are set as default")
+	// the live tree must be left untouched
+	assert.ElementsMatch(t, []string{"default"}, cfg.Names())
+	assert.Equal(t, "default", cfg.DefaultName())
+}
+
+func TestAddNetwork_Valid(t *testing.T) {
+	t.Parallel()
+	p := newTestProvider(t, baseYAML)
+	cfg, err := NewConfig(p)
+	require.NoError(t, err)
+
+	err = cfg.AddNetwork([]byte(`
+fabric:
+  network2:
+    driver: generic
+    channels:
+      - Name: mychannel
+`))
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{"default", "network2"}, cfg.Names())
+	// the pre-existing default network is preserved
+	assert.Equal(t, "default", cfg.DefaultName())
+
+	fsnConfig, err := cfg.Config("network2")
+	require.NoError(t, err)
+	assert.Equal(t, "generic", fsnConfig.Driver)
+}
+
+func TestAddNetwork_RejectsExistingNetwork(t *testing.T) {
+	t.Parallel()
+	p := newTestProvider(t, baseYAML)
+	cfg, err := NewConfig(p)
+	require.NoError(t, err)
+
+	err = cfg.AddNetwork([]byte(`
+fabric:
+  default:
+    driver: generic
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+
+	// the live tree must be left untouched
+	assert.ElementsMatch(t, []string{"default"}, cfg.Names())
+}
+
+func TestAddNetwork_RejectsBadNetworkName(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"Bad_Net",  // uppercase and underscore
+		"1network", // must start with a letter
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			p := newTestProvider(t, baseYAML)
+			cfg, err := NewConfig(p)
+			require.NoError(t, err)
+
+			err = cfg.AddNetwork([]byte(`
+fabric:
+  ` + name + `:
+    driver: generic
+`))
+			require.Error(t, err)
+			assert.ElementsMatch(t, []string{"default"}, cfg.Names())
+		})
+	}
+}
+
+func TestAddNetwork_EmptyNetworkName(t *testing.T) {
+	t.Parallel()
+	p := newTestProvider(t, baseYAML)
+	cfg, err := NewConfig(p)
+	require.NoError(t, err)
+
+	err = cfg.AddNetwork([]byte(`
+fabric:
+  "":
+    driver: generic
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be empty")
+	assert.ElementsMatch(t, []string{"default"}, cfg.Names())
+}
+
+func TestAddNetwork_RejectsBadChannelName(t *testing.T) {
+	t.Parallel()
+	p := newTestProvider(t, baseYAML)
+	cfg, err := NewConfig(p)
+	require.NoError(t, err)
+
+	err = cfg.AddNetwork([]byte(`
+fabric:
+  network2:
+    driver: generic
+    channels:
+      - Name: Bad_Channel
+`))
+	require.Error(t, err)
+	assert.ElementsMatch(t, []string{"default"}, cfg.Names())
+}
+
+func TestAddNetwork_RejectsDuplicateChannelWithinNetwork(t *testing.T) {
+	t.Parallel()
+	p := newTestProvider(t, baseYAML)
+	cfg, err := NewConfig(p)
+	require.NoError(t, err)
+
+	err = cfg.AddNetwork([]byte(`
+fabric:
+  network2:
+    driver: generic
+    channels:
+      - Name: mychannel
+      - Name: mychannel
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate channel name")
+	assert.ElementsMatch(t, []string{"default"}, cfg.Names())
+}
+
+func TestAddNetwork_AllowsSameChannelNameAcrossNetworks(t *testing.T) {
+	t.Parallel()
+	p := newTestProvider(t, baseYAML)
+	cfg, err := NewConfig(p)
+	require.NoError(t, err)
+
+	err = cfg.AddNetwork([]byte(`
+fabric:
+  network2:
+    driver: generic
+    channels:
+      - Name: default-channel
+`))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"default", "network2"}, cfg.Names())
+}
+
+func TestAddNetwork_RunsCustomValidators(t *testing.T) {
+	t.Parallel()
+	p := newTestProvider(t, baseYAML)
+	cfg, err := NewConfig(p)
+	require.NoError(t, err)
+
+	var seenNetwork string
+	reject := NetworkConfigValidatorFunc(func(networkName string, configProvider ConfigProvider) error {
+		seenNetwork = networkName
+		var fsnConfig FSNConfig
+		require.NoError(t, configProvider.UnmarshalKey("fabric."+networkName, &fsnConfig))
+		if fsnConfig.Driver != "allowed-driver" {
+			return errors.Errorf("driver [%s] is not allowed", fsnConfig.Driver)
+		}
+		return nil
+	})
+
+	err = cfg.AddNetwork([]byte(`
+fabric:
+  network2:
+    driver: generic
+    channels:
+      - Name: mychannel
+`), reject)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "custom validation failed")
+	assert.Contains(t, err.Error(), "driver [generic] is not allowed")
+	assert.Equal(t, "network2", seenNetwork)
+	// the live tree must be left untouched
+	assert.ElementsMatch(t, []string{"default"}, cfg.Names())
+
+	err = cfg.AddNetwork([]byte(`
+fabric:
+  network3:
+    driver: allowed-driver
+    channels:
+      - Name: mychannel
+`), reject)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"default", "network3"}, cfg.Names())
+}
+
+func TestFSNProvider_AddNetwork(t *testing.T) {
+	t.Parallel()
+	p := newTestProvider(t, baseYAML)
+	provider, err := NewFabricNetworkServiceProvider(p, nil, nil)
+	require.NoError(t, err)
+
+	err = provider.AddNetwork([]byte(`
+fabric:
+  network2:
+    driver: generic
+    channels:
+      - Name: mychannel
+`))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"default", "network2"}, provider.Names())
+}
+
+func TestFSNProvider_AddNetwork_RunsConfiguredValidators(t *testing.T) {
+	t.Parallel()
+	p := newTestProvider(t, baseYAML)
+	reject := NetworkConfigValidatorFunc(func(networkName string, configProvider ConfigProvider) error {
+		return errors.Errorf("network [%s] rejected by policy", networkName)
+	})
+	provider, err := NewFabricNetworkServiceProvider(p, nil, []NetworkConfigValidator{reject})
+	require.NoError(t, err)
+
+	err = provider.AddNetwork([]byte(`
+fabric:
+  network2:
+    driver: generic
+    channels:
+      - Name: mychannel
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rejected by policy")
+	assert.ElementsMatch(t, []string{"default"}, provider.Names())
+}

--- a/platform/fabric/core/generic/driver/config/service.go
+++ b/platform/fabric/core/generic/driver/config/service.go
@@ -15,11 +15,16 @@ import (
 	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 )
 
+// provider is the default Provider implementation. It keeps a reference to the shared
+// configService and to the default network name resolved at construction time, and builds a
+// generic/config.Service on demand for whichever network is requested.
 type provider struct {
 	configService driver.ConfigService
 	defaultName   string
 }
 
+// ConfigService is the per-network configuration surface exposed by the generic Fabric driver:
+// the common driver.ConfigService plus MSP- and resolver-related accessors.
 type ConfigService interface {
 	driver2.ConfigService
 	Resolvers() ([]config.Resolver, error)
@@ -28,15 +33,22 @@ type ConfigService interface {
 	MSPs() ([]config.MSP, error)
 }
 
+// Provider hands out a ConfigService scoped to a given Fabric network name.
 type Provider interface {
 	GetConfig(network string) (ConfigService, error)
 }
 
-func NewCore(config driver.ConfigService) (*core.Config, error) {
+// NewCore builds a *core.Config from config, scanning its `fabric` key for the set of
+// configured Fabric networks. config must also support merging new configuration into the
+// live tree at runtime (core.DynamicConfigService), since the returned *core.Config's
+// AddNetwork relies on it.
+func NewCore(config core.DynamicConfigService) (*core.Config, error) {
 	return core.NewConfig(config)
 }
 
-func NewProvider(config driver.ConfigService) (Provider, error) {
+// NewProvider builds a Provider backed by config, resolving the default network name once at
+// construction time via a *core.Config built from the same config.
+func NewProvider(config core.DynamicConfigService) (Provider, error) {
 	c, err := core.NewConfig(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create config provider")
@@ -47,6 +59,7 @@ func NewProvider(config driver.ConfigService) (Provider, error) {
 	}, nil
 }
 
+// GetConfig returns the ConfigService for the given Fabric network name.
 func (p *provider) GetConfig(network string) (ConfigService, error) {
 	return config.NewService(p.configService, network, p.defaultName == network)
 }

--- a/platform/fabric/core/provider.go
+++ b/platform/fabric/core/provider.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
-	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services"
@@ -26,21 +25,31 @@ var (
 	logger                   = logging.MustGetLogger()
 )
 
+// NamedDriver associates a driver.Driver implementation with the name a network's
+// configuration (FSNConfig.Driver) can reference to select it.
 type NamedDriver struct {
 	Name string
 	driver.Driver
 }
 
+// FSNProvider is the driver.FabricNetworkServiceProvider implementation: it lazily builds and
+// caches, one per network name, the driver.FabricNetworkService for every Fabric network known
+// to its Config, and supports adding further networks at runtime via AddNetwork.
 type FSNProvider struct {
 	config *Config
 
 	networksMutex sync.Mutex
-	configService driver2.ConfigService
+	configService DynamicConfigService
 	networks      map[string]driver.FabricNetworkService
 	drivers       map[string]driver.Driver
+	validators    []NetworkConfigValidator
 }
 
-func NewFabricNetworkServiceProvider(configService driver2.ConfigService, namedDrivers []NamedDriver) (*FSNProvider, error) {
+// NewFabricNetworkServiceProvider builds an FSNProvider from configService (scanned once, at
+// construction time, to seed its Config), the set of named drivers available to instantiate
+// each configured network, and the NetworkConfigValidators (if any) that every subsequent
+// AddNetwork call on the returned provider must satisfy.
+func NewFabricNetworkServiceProvider(configService DynamicConfigService, namedDrivers []NamedDriver, validators []NetworkConfigValidator) (*FSNProvider, error) {
 	fnsConfig, err := NewConfig(configService)
 	if err != nil {
 		return nil, err
@@ -54,11 +63,28 @@ func NewFabricNetworkServiceProvider(configService driver2.ConfigService, namedD
 		configService: configService,
 		networks:      map[string]driver.FabricNetworkService{},
 		drivers:       drivers,
+		validators:    validators,
 	}
 	provider.InitFabricLogging()
 	return provider, nil
 }
 
+// AddNetwork validates the given raw yaml configuration and, if it describes one or more new
+// Fabric networks, merges it into the live configuration tree, making the new network(s)
+// available to subsequent calls to FabricNetworkService. It does not start any committer or
+// delivery service for the new network(s): those are (lazily) created and started the first
+// time FabricNetworkService is called for the new network name.
+//
+// The configuration is checked against the built-in Fabric naming rules for networks and
+// channels, and against every NetworkConfigValidator this provider was configured with.
+func (p *FSNProvider) AddNetwork(raw []byte) error {
+	return p.config.AddNetwork(raw, p.validators...)
+}
+
+// Start instantiates every configured Fabric network and starts the committer and delivery
+// service of each of its channels. It does not start any network added afterwards via
+// AddNetwork; those are instead lazily started via FabricNetworkService/newFNS materialization
+// on first access, without their committer/delivery being started automatically.
 func (p *FSNProvider) Start(ctx context.Context) error {
 	// What's the default network?
 	// TODO: add listener to fabric service when a channel is opened.
@@ -86,6 +112,8 @@ func (p *FSNProvider) Start(ctx context.Context) error {
 	return nil
 }
 
+// Stop closes every channel of every Fabric network that has been instantiated so far (i.e.
+// every network for which FabricNetworkService has been called at least once).
 func (p *FSNProvider) Stop() error {
 	for _, networkName := range p.config.Names() {
 		fns, err := p.FabricNetworkService(networkName)
@@ -105,14 +133,20 @@ func (p *FSNProvider) Stop() error {
 	return nil
 }
 
+// Names returns the names of every currently configured Fabric network, including any added
+// at runtime via AddNetwork.
 func (p *FSNProvider) Names() []string {
 	return p.config.Names()
 }
 
+// DefaultName returns the name of the default Fabric network.
 func (p *FSNProvider) DefaultName() string {
 	return p.config.DefaultName()
 }
 
+// FabricNetworkService returns the driver.FabricNetworkService for the given network name,
+// instantiating and caching it on first access. If network is empty, the default network is
+// used instead.
 func (p *FSNProvider) FabricNetworkService(network string) (driver.FabricNetworkService, error) {
 	p.networksMutex.Lock()
 	defer p.networksMutex.Unlock()
@@ -143,6 +177,10 @@ func (p *FSNProvider) InitFabricLogging() {
 	})
 }
 
+// newFNS instantiates the driver.FabricNetworkService for network by re-reading the live
+// configuration (so that a network added at runtime via AddNetwork is picked up) and
+// delegating to the driver named by its FSNConfig.Driver, or to every registered driver in
+// turn if none is specified.
 func (p *FSNProvider) newFNS(network string) (driver.FabricNetworkService, error) {
 	fnsConfig, err := NewConfig(p.configService)
 	if err != nil {
@@ -183,6 +221,8 @@ func (p *FSNProvider) newFNS(network string) (driver.FabricNetworkService, error
 	return nil, errors.Errorf("no network driver found for [%s]", network)
 }
 
+// GetFabricNetworkServiceProvider retrieves the driver.FabricNetworkServiceProvider registered
+// with the given services.Provider.
 func GetFabricNetworkServiceProvider(sp services.Provider) (driver.FabricNetworkServiceProvider, error) {
 	s, err := sp.GetService(fabricNetworkServiceType)
 	if err != nil {

--- a/platform/fabric/sdk/dig/fns/providers.go
+++ b/platform/fabric/sdk/dig/fns/providers.go
@@ -9,15 +9,18 @@ package fns
 import (
 	"go.uber.org/dig"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core"
 )
 
+// NewProvider is the dig constructor for *core.FSNProvider. Drivers is populated from every
+// value provided into the "fabric-platform-drivers" dig group, and Validators from every value
+// provided into the "fabric-network-config-validators" dig group; either group may be empty.
 func NewProvider(in struct {
 	dig.In
-	ConfigService driver.ConfigService
-	Drivers       []core.NamedDriver `group:"fabric-platform-drivers"`
+	ConfigService core.DynamicConfigService
+	Drivers       []core.NamedDriver            `group:"fabric-platform-drivers"`
+	Validators    []core.NetworkConfigValidator `group:"fabric-network-config-validators"`
 },
 ) (*core.FSNProvider, error) {
-	return core.NewFabricNetworkServiceProvider(in.ConfigService, in.Drivers)
+	return core.NewFabricNetworkServiceProvider(in.ConfigService, in.Drivers, in.Validators)
 }

--- a/platform/fabric/sdk/dig/sdk.go
+++ b/platform/fabric/sdk/dig/sdk.go
@@ -33,34 +33,46 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/state/vault"
 	viewsdk "github.com/hyperledger-labs/fabric-smart-client/platform/view/sdk/dig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services"
+	viewconfig "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/config"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/endpoint"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/id"
 )
 
 var logger = logging.MustGetLogger()
 
+// SDK wires the Fabric platform's dig providers on top of a base dig2.SDK (typically the view
+// SDK) and drives the lifecycle of the resulting *core.FSNProvider.
 type SDK struct {
 	dig2.SDK
 	fnsProvider *core.FSNProvider
 }
 
+// NewSDK builds a Fabric SDK on top of a fresh view SDK for the given services.Registry.
 func NewSDK(registry services.Registry) *SDK {
 	return NewFrom(viewsdk.NewSDK(registry))
 }
 
+// NewFrom builds a Fabric SDK on top of an already-constructed base dig2.SDK.
 func NewFrom(sdk dig2.SDK) *SDK {
 	return &SDK{SDK: sdk}
 }
 
+// FabricEnabled reports whether the `fabric.enabled` configuration key is set.
 func (p *SDK) FabricEnabled() bool {
 	return p.ConfigService().GetBool("fabric.enabled")
 }
 
+// Install registers every dig provider needed by the Fabric platform on top of the base SDK.
+// It is a no-op (delegating straight to the base SDK) if `fabric.enabled` is not set.
 func (p *SDK) Install() error {
 	if !p.FabricEnabled() {
 		return p.SDK.Install()
 	}
 	err := errors.Join(
+		// Re-provide the already-registered *viewconfig.Provider singleton under the
+		// core.DynamicConfigService interface, so that config.NewCore, config.NewProvider and
+		// fns.NewProvider can depend on the narrower interface instead of the concrete type.
+		p.Container().Provide(digutils.Identity[*viewconfig.Provider](), dig.As(new(core.DynamicConfigService))),
 		p.Container().Provide(config.NewCore),
 		p.Container().Provide(config.NewProvider),
 		p.Container().Provide(committer.NewFinalityListenerManagerProvider[driver.ValidationCode], dig.As(new(driver.ListenerManagerProvider))),


### PR DESCRIPTION
## Summary

Adds support for registering a new Fabric network at runtime, scoped to the configuration
tree only (see [Explicitly out of scope](#explicitly-out-of-scope) below).

- `core.Config.AddNetwork(raw []byte, validators ...NetworkConfigValidator) error` — parses the
  given raw yaml, validates every network/channel name it introduces against the existing
  Fabric naming rules, rejects any network name that already exists, runs any supplied
  `NetworkConfigValidator`s, and only then merges it into the live configuration tree (via the
  existing `MergeConfig`/`ProvideFromRaw` primitives on `viewconfig.Provider`) and refreshes
  `Config`'s in-memory state.
- `NetworkConfigValidator` interface + `NetworkConfigValidatorFunc` adapter — a pluggable,
  per-network validation hook that runs before a candidate network's configuration is merged.
- `FSNProvider.AddNetwork(raw []byte) error` — forwards to `Config.AddNetwork` using the
  `[]NetworkConfigValidator` the provider was constructed with.
- `NewFabricNetworkServiceProvider` now takes a `[]NetworkConfigValidator` parameter, wired via a
  new `"fabric-network-config-validators"` dig group in
  `platform/fabric/sdk/dig/fns/providers.go` (mirroring the existing `"fabric-platform-drivers"`
  group), so any SDK can contribute validators without touching `core`.
- Godoc added for every new/changed exported symbol touched by this change.

## Explicitly out of scope

`FSNProvider.newFNS` already re-reads live configuration on first access to a network name, so a
network added via `AddNetwork` becomes lazily instantiable without further changes. This PR does
**not**:
- Auto-start the committer/delivery service for a network added at runtime (`FSNProvider.Start`
  remains a one-shot loop over the networks known at construction time).
- Re-run the one-shot startup registration loops in `platform/fabric/sdk/dig/sdk.go`
  (`registerProcessorsForDrivers`, `registerRWSetLoaderHandlerProviders`) for networks added
  afterwards.

## Test plan

- [x] `make lint-fmt` / `make checks` — clean.
- [x] `go test -race -cover ./platform/fabric/core/... ./platform/fabric/sdk/...` — all pass.
- [x] `go test -race --run '(TestWiring)' ./platform/{common,fabric,fabricx,view}/sdk/dig/...` —
      all pass.
- [x] New unit tests in `platform/fabric/core/config_test.go` cover: valid network addition,
      rejecting an already-existing network, rejecting malformed network/channel names,
      rejecting duplicate channel names within one network, allowing the same channel name
      across different networks, custom validators blocking/allowing a merge, and the same
      behavior exercised through `FSNProvider.AddNetwork`.

Fixes #1602

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>
