### PR TITLE
feat(logging): extract context values into context-aware log lines as zap fields

### DIFF
--- a/platform/common/services/logging/bench_test.go
+++ b/platform/common/services/logging/bench_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package logging
+
+import (
+	"context"
+	"testing"
+
+	"github.com/uptrace/opentelemetry-go-extra/otelzap"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func observerCore(lvl zapcore.Level) (zapcore.Core, *observer.ObservedLogs) {
+	return observer.New(lvl)
+}
+
+type benchKey struct{ n int }
+
+var benchRegCounter int
+
+func setupBenchRegistry(n int) context.Context {
+	ctx := context.Background()
+	gen := benchRegCounter
+	benchRegCounter++
+	for i := range n {
+		k := benchKey{gen*1000 + i}
+		RegisterContextLogField(benchFieldName(gen, i), k)
+		ctx = context.WithValue(ctx, k, i)
+	}
+	return ctx
+}
+
+func benchFieldName(gen, i int) string {
+	return "bench.field." + string(rune('a'+gen)) + string(rune('a'+i))
+}
+
+func BenchmarkDebugfContext_Disabled_NoFields(b *testing.B) {
+	// NopCore is always disabled; use an Info-level core with debug calls instead for a realistic "disabled but real core" case.
+	core, _ := observerCore(zapcore.InfoLevel)
+	zl := zap.New(core)
+	l := newLogger(zl)
+	ctx := context.Background()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		l.DebugfContext(ctx, "msg %d", i)
+	}
+}
+
+func BenchmarkDebugfContext_Disabled_With3Fields(b *testing.B) {
+	core, _ := observerCore(zapcore.InfoLevel)
+	zl := zap.New(core)
+	l := newLogger(zl)
+	ctx := setupBenchRegistry(3)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		l.DebugfContext(ctx, "msg %d", i)
+	}
+}
+
+func BenchmarkInfowContext_Enabled_NoFields(b *testing.B) {
+	core, _ := observerCore(zapcore.InfoLevel)
+	zl := zap.New(core)
+	l := newLogger(zl)
+	ctx := context.Background()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		l.InfowContext(ctx, "msg", "i", i)
+	}
+}
+
+func BenchmarkInfowContext_Enabled_With3Fields(b *testing.B) {
+	core, _ := observerCore(zapcore.InfoLevel)
+	zl := zap.New(core)
+	l := newLogger(zl)
+	ctx := setupBenchRegistry(3)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		l.InfowContext(ctx, "msg", "i", i)
+	}
+}
+
+// Baseline: raw otelzap.SugaredLogger with no ctxFieldLogger decorator at all, to isolate
+// the decorator's own overhead from otelzap's baseline cost.
+func BenchmarkInfowContext_RawOtelzap_NoDecorator(b *testing.B) {
+	core, _ := observerCore(zapcore.InfoLevel)
+	zl := zap.New(core)
+	sugared := otelzap.New(zl, otelzap.WithMinLevel(zl.Level())).Sugar()
+	ctx := context.Background()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		sugared.InfowContext(ctx, "msg", "i", i)
+	}
+}

--- a/platform/common/services/logging/bench_test.go
+++ b/platform/common/services/logging/bench_test.go
@@ -24,6 +24,9 @@ type benchKey struct{ n int }
 
 var benchRegCounter int
 
+// setupBenchRegistry registers n new context log fields (each call uses a fresh generation
+// of keys, so repeated calls across benchmarks in this file keep growing the shared global
+// registry rather than colliding) and returns a context carrying values for all of them.
 func setupBenchRegistry(n int) context.Context {
 	ctx := context.Background()
 	gen := benchRegCounter
@@ -38,6 +41,17 @@ func setupBenchRegistry(n int) context.Context {
 
 func benchFieldName(gen, i int) string {
 	return "bench.field." + string(rune('a'+gen)) + string(rune('a'+i))
+}
+
+// registerBenchFields registers n new context log fields (a fresh generation of keys, as in
+// setupBenchRegistry) without putting any of them into a context, for benchmarks that need a
+// populated registry but an otherwise plain context (e.g. context.Background()).
+func registerBenchFields(n int) {
+	gen := benchRegCounter
+	benchRegCounter++
+	for i := range n {
+		RegisterContextLogField(benchFieldName(gen, i), benchKey{gen*1000 + i})
+	}
 }
 
 func BenchmarkDebugfContext_Disabled_NoFields(b *testing.B) {
@@ -79,6 +93,91 @@ func BenchmarkInfowContext_Enabled_With3Fields(b *testing.B) {
 	zl := zap.New(core)
 	l := newLogger(zl)
 	ctx := setupBenchRegistry(3)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		l.InfowContext(ctx, "msg", "i", i)
+	}
+}
+
+// BenchmarkInfowContext_Enabled_3FieldsRegistered_NoneInContext measures the case where
+// fields are registered globally but the request's context carries none of them (e.g. a
+// background job, or a request that never populated the optional fields). This is expected
+// to be the common case in a real deployment with several optional context fields, so it
+// must not pay for the fields it doesn't have.
+func BenchmarkInfowContext_Enabled_3FieldsRegistered_NoneInContext(b *testing.B) {
+	core, _ := observerCore(zapcore.InfoLevel)
+	zl := zap.New(core)
+	l := newLogger(zl)
+	registerBenchFields(3)
+	ctx := context.Background()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		l.InfowContext(ctx, "msg", "i", i)
+	}
+}
+
+// BenchmarkInfowContext_Enabled_3FieldsRegistered_OneInContext measures the mixed case where
+// only some of the registered fields are present in ctx.
+func BenchmarkInfowContext_Enabled_3FieldsRegistered_OneInContext(b *testing.B) {
+	core, _ := observerCore(zapcore.InfoLevel)
+	zl := zap.New(core)
+	l := newLogger(zl)
+	gen := benchRegCounter
+	benchRegCounter++
+	keys := make([]benchKey, 3)
+	for i := range keys {
+		keys[i] = benchKey{gen*1000 + i}
+		RegisterContextLogField(benchFieldName(gen, i), keys[i])
+	}
+	ctx := context.WithValue(context.Background(), keys[0], 0)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		l.InfowContext(ctx, "msg", "i", i)
+	}
+}
+
+func BenchmarkInfowContext_Disabled_With3Fields(b *testing.B) {
+	core, _ := observerCore(zapcore.InfoLevel)
+	zl := zap.New(core)
+	l := newLogger(zl)
+	ctx := setupBenchRegistry(3)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		l.DebugwContext(ctx, "msg", "i", i)
+	}
+}
+
+func BenchmarkInfofContext_Enabled_With3Fields(b *testing.B) {
+	core, _ := observerCore(zapcore.InfoLevel)
+	zl := zap.New(core)
+	l := newLogger(zl)
+	ctx := setupBenchRegistry(3)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		l.InfofContext(ctx, "msg %d", i)
+	}
+}
+
+// BenchmarkInfowContext_Enabled_With10Fields and With30Fields measure how the cost of
+// context-field extraction scales with the size of the global registry, since real
+// deployments may register many optional fields (request id, tenant, session, ...) even
+// though a given log call's context will typically carry only a handful of them.
+func BenchmarkInfowContext_Enabled_With10Fields(b *testing.B) {
+	core, _ := observerCore(zapcore.InfoLevel)
+	zl := zap.New(core)
+	l := newLogger(zl)
+	ctx := setupBenchRegistry(10)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		l.InfowContext(ctx, "msg", "i", i)
+	}
+}
+
+func BenchmarkInfowContext_Enabled_With30Fields(b *testing.B) {
+	core, _ := observerCore(zapcore.InfoLevel)
+	zl := zap.New(core)
+	l := newLogger(zl)
+	ctx := setupBenchRegistry(30)
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		l.InfowContext(ctx, "msg", "i", i)

--- a/platform/common/services/logging/config.go
+++ b/platform/common/services/logging/config.go
@@ -36,6 +36,20 @@ type Config struct {
 	// Sanitization means that any non-printable character is removed.
 	// This protects the traces from undesired behaviours like missing tracing.
 	OtelSanitize bool
+
+	// ContextLogFields lists context keys to extract as zap fields on every context-aware
+	// log call (e.g. InfowContext, ErrorfContext). Merged into the global registry; see
+	// RegisterContextLogField.
+	ContextLogFields []ContextLogField
+}
+
+// ContextLogField maps a context key to the zap field name used when the value is found
+// in the context and added to a log line.
+type ContextLogField struct {
+	// Key is looked up via ctx.Value(Key).
+	Key any
+	// Name is the zap field name the value is logged under.
+	Name string
 }
 
 var (
@@ -52,8 +66,12 @@ func Init(c Config) {
 
 	// set local configurations
 	configMutex.Lock()
-	defer configMutex.Unlock()
 	config.OtelSanitize = c.OtelSanitize
+	configMutex.Unlock()
+
+	for _, f := range c.ContextLogFields {
+		registerContextLogField(f.Name, f.Key, true)
+	}
 }
 
 func OtelSanitize() bool {
@@ -87,4 +105,46 @@ func Replacers() map[string]string {
 	replacersMutex.RLock()
 	defer replacersMutex.RUnlock()
 	return replacers
+}
+
+var (
+	ctxFieldsMutex sync.RWMutex
+	ctxFieldNames  []string
+	ctxLogFields   = map[string]any{}
+)
+
+// RegisterContextLogField registers a context key to extract as a zap field, under the
+// given field name, on every context-aware log call. Panics if name is already
+// registered.
+func RegisterContextLogField(name string, key any) {
+	registerContextLogField(name, key, false)
+}
+
+func registerContextLogField(name string, key any, overwrite bool) {
+	ctxFieldsMutex.Lock()
+	defer ctxFieldsMutex.Unlock()
+
+	if _, ok := ctxLogFields[name]; ok {
+		if overwrite {
+			ctxLogFields[name] = key
+			return
+		}
+		panic("context log field already exists")
+	}
+
+	ctxLogFields[name] = key
+	ctxFieldNames = append(ctxFieldNames, name)
+}
+
+// ContextLogFields returns the current context log field registrations, in
+// registration order.
+func ContextLogFields() []ContextLogField {
+	ctxFieldsMutex.RLock()
+	defer ctxFieldsMutex.RUnlock()
+
+	fields := make([]ContextLogField, len(ctxFieldNames))
+	for i, name := range ctxFieldNames {
+		fields[i] = ContextLogField{Key: ctxLogFields[name], Name: name}
+	}
+	return fields
 }

--- a/platform/common/services/logging/config.go
+++ b/platform/common/services/logging/config.go
@@ -168,6 +168,8 @@ func ContextLogFields() []ContextLogField {
 // each test start from an empty registry (e.g. via t.Cleanup) instead of relying on
 // globally-unique field names to avoid colliding with registrations left behind by
 // other tests.
+//
+//lint:ignore U1000 used for testing
 func resetContextLogFields() {
 	ctxFieldsMutex.Lock()
 	defer ctxFieldsMutex.Unlock()

--- a/platform/common/services/logging/config.go
+++ b/platform/common/services/logging/config.go
@@ -9,6 +9,7 @@ package logging
 import (
 	"io"
 	"sync"
+	"sync/atomic"
 
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 )
@@ -108,9 +109,14 @@ func Replacers() map[string]string {
 }
 
 var (
-	ctxFieldsMutex sync.RWMutex
+	// ctxFieldsMutex guards registration (rare, startup-time) writes to ctxFieldNames and
+	// ctxLogFields below. The hot read path, ContextLogFields, never takes it: it loads the
+	// immutable snapshot published in ctxFieldsSnap instead, so every context-aware log call
+	// avoids both lock contention and a per-call copy of the registry.
+	ctxFieldsMutex sync.Mutex
 	ctxFieldNames  []string
 	ctxLogFields   = map[string]any{}
+	ctxFieldsSnap  atomic.Pointer[[]ContextLogField]
 )
 
 // RegisterContextLogField registers a context key to extract as a zap field, under the
@@ -125,26 +131,28 @@ func registerContextLogField(name string, key any, overwrite bool) {
 	defer ctxFieldsMutex.Unlock()
 
 	if _, ok := ctxLogFields[name]; ok {
-		if overwrite {
-			ctxLogFields[name] = key
-			return
+		if !overwrite {
+			panic("context log field already exists")
 		}
-		panic("context log field already exists")
+		ctxLogFields[name] = key
+	} else {
+		ctxLogFields[name] = key
+		ctxFieldNames = append(ctxFieldNames, name)
 	}
 
-	ctxLogFields[name] = key
-	ctxFieldNames = append(ctxFieldNames, name)
+	fields := make([]ContextLogField, len(ctxFieldNames))
+	for i, n := range ctxFieldNames {
+		fields[i] = ContextLogField{Key: ctxLogFields[n], Name: n}
+	}
+	ctxFieldsSnap.Store(&fields)
 }
 
 // ContextLogFields returns the current context log field registrations, in
-// registration order.
+// registration order. The returned slice is an immutable snapshot and must not be
+// mutated by the caller.
 func ContextLogFields() []ContextLogField {
-	ctxFieldsMutex.RLock()
-	defer ctxFieldsMutex.RUnlock()
-
-	fields := make([]ContextLogField, len(ctxFieldNames))
-	for i, name := range ctxFieldNames {
-		fields[i] = ContextLogField{Key: ctxLogFields[name], Name: name}
+	if p := ctxFieldsSnap.Load(); p != nil {
+		return *p
 	}
-	return fields
+	return nil
 }

--- a/platform/common/services/logging/config.go
+++ b/platform/common/services/logging/config.go
@@ -58,6 +58,13 @@ var (
 	configMutex = sync.RWMutex{}
 )
 
+// Init (re-)initializes the logging system. Like the rest of Config, it is idempotent:
+// calling it again fully replaces the previous Format/LogSpec/OtelSanitize/Writer, and
+// merges ContextLogFields into the global registry with later calls overwriting the key
+// registered under a given Name. This differs from RegisterContextLogField, which panics
+// on a duplicate Name: Init models "(re-)apply this whole configuration", where a repeated
+// Name is expected on every call after the first, whereas RegisterContextLogField models a
+// one-off, imperative registration, where a duplicate Name is almost always a bug.
 func Init(c Config) {
 	flogging.Init(flogging.Config{
 		Format:  c.Format,
@@ -155,4 +162,17 @@ func ContextLogFields() []ContextLogField {
 		return *p
 	}
 	return nil
+}
+
+// resetContextLogFields clears the global context-log-field registry. Test-only: lets
+// each test start from an empty registry (e.g. via t.Cleanup) instead of relying on
+// globally-unique field names to avoid colliding with registrations left behind by
+// other tests.
+func resetContextLogFields() {
+	ctxFieldsMutex.Lock()
+	defer ctxFieldsMutex.Unlock()
+
+	ctxFieldNames = nil
+	ctxLogFields = map[string]any{}
+	ctxFieldsSnap.Store(&[]ContextLogField{})
 }

--- a/platform/common/services/logging/context_fields_test.go
+++ b/platform/common/services/logging/context_fields_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package logging
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// ctxKey is a distinct comparable type used as a context key in these tests, following
+// the pattern used elsewhere in the repo (e.g. grpc/logging, web/server/middleware).
+type ctxKey struct{ name string }
+
+func newObservedLogger() (Logger, *observer.ObservedLogs) {
+	core, observed := observer.New(zapcore.DebugLevel)
+	zl := zap.New(core, zap.AddCaller())
+	return newLogger(zl), observed
+}
+
+func findField(fields []zapcore.Field, name string) (zapcore.Field, bool) {
+	for _, f := range fields {
+		if f.Key == name {
+			return f, true
+		}
+	}
+	return zapcore.Field{}, false
+}
+
+func TestContextLogFields_ExtractedIntoLogLine(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	key := ctxKey{"present"}
+	Init(Config{ContextLogFields: []ContextLogField{{Key: key, Name: "test.present"}}})
+
+	logger, observed := newObservedLogger()
+	ctx := context.WithValue(context.Background(), key, "some-value")
+
+	logger.InfowContext(ctx, "hello")
+
+	entries := observed.All()
+	require.Len(t, entries, 1)
+	field, ok := findField(entries[0].Context, "test.present")
+	require.True(t, ok, "expected field %q in %+v", "test.present", entries[0].Context)
+	require.Equal(t, "some-value", field.String)
+}
+
+func TestContextLogFields_AbsentKeyNoField(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	key := ctxKey{"absent"}
+	Init(Config{ContextLogFields: []ContextLogField{{Key: key, Name: "test.absent"}}})
+
+	logger, observed := newObservedLogger()
+
+	logger.InfowContext(context.Background(), "hello")
+
+	entries := observed.All()
+	require.Len(t, entries, 1)
+	_, ok := findField(entries[0].Context, "test.absent")
+	require.False(t, ok, "did not expect field %q in %+v", "test.absent", entries[0].Context)
+}
+
+func TestContextLogFieldArgs_NilContextNoPanic(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	key := ctxKey{"nilctx"}
+	Init(Config{ContextLogFields: []ContextLogField{{Key: key, Name: "test.nilctx"}}})
+
+	var nilCtx context.Context
+	require.NotPanics(t, func() {
+		args := contextLogFieldArgs(nilCtx)
+		require.Nil(t, args)
+	})
+}
+
+func TestContextLogFields_OnlyPresentKeysAdded(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	presentKey := ctxKey{"multi.present"}
+	absentKey := ctxKey{"multi.absent"}
+	Init(Config{ContextLogFields: []ContextLogField{
+		{Key: presentKey, Name: "test.multi.present"},
+		{Key: absentKey, Name: "test.multi.absent"},
+	}})
+
+	logger, observed := newObservedLogger()
+	ctx := context.WithValue(context.Background(), presentKey, "value")
+
+	logger.InfowContext(ctx, "hello")
+
+	entries := observed.All()
+	require.Len(t, entries, 1)
+
+	_, ok := findField(entries[0].Context, "test.multi.present")
+	require.True(t, ok)
+	_, ok = findField(entries[0].Context, "test.multi.absent")
+	require.False(t, ok)
+}
+
+func TestContextLogFields_SurviveWithAndNamed(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	key := ctxKey{"survive"}
+	// Register the field only after the loggers below have already been created and
+	// derived, proving extraction is dynamic (read at call time, not construction time).
+	core, observed := observer.New(zapcore.DebugLevel)
+	zl := zap.New(core, zap.AddCaller())
+	base := newLogger(zl)
+	derived := base.Named("child").With("k", "v")
+
+	Init(Config{ContextLogFields: []ContextLogField{{Key: key, Name: "test.survive"}}})
+
+	ctx := context.WithValue(context.Background(), key, "still-works")
+	derived.InfowContext(ctx, "hello")
+
+	entries := observed.All()
+	require.Len(t, entries, 1)
+	field, ok := findField(entries[0].Context, "test.survive")
+	require.True(t, ok)
+	require.Equal(t, "still-works", field.String)
+}
+
+func TestRegisterContextLogField_DuplicatePanics(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	key1 := ctxKey{"dup1"}
+	key2 := ctxKey{"dup2"}
+	RegisterContextLogField("test.dup.unique", key1)
+
+	require.Panics(t, func() {
+		RegisterContextLogField("test.dup.unique", key2)
+	})
+}
+
+func TestInit_ContextLogFields_Idempotent(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	firstKey := ctxKey{"idempotent.first"}
+	secondKey := ctxKey{"idempotent.second"}
+
+	require.NotPanics(t, func() {
+		Init(Config{ContextLogFields: []ContextLogField{{Key: firstKey, Name: "test.idempotent"}}})
+		Init(Config{ContextLogFields: []ContextLogField{{Key: secondKey, Name: "test.idempotent"}}})
+	})
+
+	logger, observed := newObservedLogger()
+	ctx := context.WithValue(context.Background(), secondKey, "second-value")
+	logger.InfowContext(ctx, "hello")
+
+	entries := observed.All()
+	require.Len(t, entries, 1)
+	field, ok := findField(entries[0].Context, "test.idempotent")
+	require.True(t, ok)
+	require.Equal(t, "second-value", field.String)
+}
+
+func TestContextLogFields_CallerAccuracy(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	key := ctxKey{"caller"}
+	Init(Config{ContextLogFields: []ContextLogField{{Key: key, Name: "test.caller"}}})
+
+	logger, observed := newObservedLogger()
+	ctx := context.WithValue(context.Background(), key, "value")
+
+	logger.InfowContext(ctx, "hello") // the call site under test
+
+	entries := observed.All()
+	require.Len(t, entries, 1)
+	require.True(t, entries[0].Caller.Defined)
+	require.True(t, strings.HasSuffix(entries[0].Caller.File, "context_fields_test.go"),
+		"expected caller in context_fields_test.go, got %s", entries[0].Caller.File)
+}

--- a/platform/common/services/logging/context_fields_test.go
+++ b/platform/common/services/logging/context_fields_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -140,6 +141,59 @@ func TestContextLogFields_SurviveWithAndNamed(t *testing.T) { //nolint:parallelt
 	require.Equal(t, "still-works", field.String)
 }
 
+func TestRegisterContextLogField_AddedToExistingLogger(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	// Create the logger (and a context already carrying the value) before the key is
+	// registered, proving RegisterContextLogField takes effect on loggers that already
+	// exist rather than only ones constructed after registration.
+	logger, observed := newObservedLogger()
+	key := ctxKey{"register.existing"}
+	ctx := context.WithValue(context.Background(), key, "late-registered-value")
+
+	RegisterContextLogField("test.register.existing", key)
+
+	logger.InfowContext(ctx, "hello")
+
+	entries := observed.All()
+	require.Len(t, entries, 1)
+	field, ok := findField(entries[0].Context, "test.register.existing")
+	require.True(t, ok, "expected field %q in %+v", "test.register.existing", entries[0].Context)
+	require.Equal(t, "late-registered-value", field.String)
+}
+
+func TestRegisterContextLogField_SecondCallAddsBoth(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	// A second RegisterContextLogField call for a different key must extend the registry
+	// rather than replace it: the first log call (after only the first key is registered)
+	// should carry only the first field, and the second log call (after the second key is
+	// also registered) should carry both.
+	logger, observed := newObservedLogger()
+	firstKey := ctxKey{"register.multi.first"}
+	secondKey := ctxKey{"register.multi.second"}
+	ctx := context.WithValue(context.Background(), firstKey, "first-value")
+	ctx = context.WithValue(ctx, secondKey, "second-value")
+
+	RegisterContextLogField("test.register.multi.first", firstKey)
+	logger.InfowContext(ctx, "hello")
+
+	RegisterContextLogField("test.register.multi.second", secondKey)
+	logger.InfowContext(ctx, "hello")
+
+	entries := observed.All()
+	require.Len(t, entries, 2)
+
+	field, ok := findField(entries[0].Context, "test.register.multi.first")
+	require.True(t, ok, "expected field %q in %+v", "test.register.multi.first", entries[0].Context)
+	require.Equal(t, "first-value", field.String)
+	_, ok = findField(entries[0].Context, "test.register.multi.second")
+	require.False(t, ok, "did not expect field %q in %+v", "test.register.multi.second", entries[0].Context)
+
+	field, ok = findField(entries[1].Context, "test.register.multi.first")
+	require.True(t, ok, "expected field %q in %+v", "test.register.multi.first", entries[1].Context)
+	require.Equal(t, "first-value", field.String)
+	field, ok = findField(entries[1].Context, "test.register.multi.second")
+	require.True(t, ok, "expected field %q in %+v", "test.register.multi.second", entries[1].Context)
+	require.Equal(t, "second-value", field.String)
+}
+
 func TestRegisterContextLogField_DuplicatePanics(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
 	key1 := ctxKey{"dup1"}
 	key2 := ctxKey{"dup2"}
@@ -168,6 +222,32 @@ func TestInit_ContextLogFields_Idempotent(t *testing.T) { //nolint:paralleltest 
 	field, ok := findField(entries[0].Context, "test.idempotent")
 	require.True(t, ok)
 	require.Equal(t, "second-value", field.String)
+}
+
+func TestContextLogFields_SurviveMultipleContextWrapping(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	// ctx.Value walks up the parent chain, so the registered key must still resolve however
+	// deep it sits under further wrapping (WithValue, WithCancel, WithTimeout, ...) layered on
+	// top by unrelated code between where the value was set and where the log call happens.
+	key := ctxKey{"wrapped"}
+	Init(Config{ContextLogFields: []ContextLogField{{Key: key, Name: "test.wrapped"}}})
+
+	logger, observed := newObservedLogger()
+
+	ctx := context.WithValue(context.Background(), key, "wrapped-value")
+	ctx = context.WithValue(ctx, ctxKey{"unrelated.1"}, "noise-1")
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	ctx, cancelTimeout := context.WithTimeout(ctx, time.Hour)
+	defer cancelTimeout()
+	ctx = context.WithValue(ctx, ctxKey{"unrelated.2"}, "noise-2")
+
+	logger.InfowContext(ctx, "hello")
+
+	entries := observed.All()
+	require.Len(t, entries, 1)
+	field, ok := findField(entries[0].Context, "test.wrapped")
+	require.True(t, ok, "expected field %q in %+v", "test.wrapped", entries[0].Context)
+	require.Equal(t, "wrapped-value", field.String)
 }
 
 func TestContextLogFields_CallerAccuracy(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry

--- a/platform/common/services/logging/context_fields_test.go
+++ b/platform/common/services/logging/context_fields_test.go
@@ -38,6 +38,7 @@ func findField(fields []zapcore.Field, name string) (zapcore.Field, bool) {
 }
 
 func TestContextLogFields_ExtractedIntoLogLine(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	t.Cleanup(resetContextLogFields)
 	key := ctxKey{"present"}
 	Init(Config{ContextLogFields: []ContextLogField{{Key: key, Name: "test.present"}}})
 
@@ -58,6 +59,7 @@ func TestContextLogFields_ExtractedIntoLogLine(t *testing.T) { //nolint:parallel
 type ContextKeyType string
 
 func TestContextLogFields_NamedStringKeyType_ExtractedIntoLogLine(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	t.Cleanup(resetContextLogFields)
 	key := ContextKeyType("request-id")
 	Init(Config{ContextLogFields: []ContextLogField{{Key: key, Name: "test.request-id"}}})
 
@@ -74,6 +76,7 @@ func TestContextLogFields_NamedStringKeyType_ExtractedIntoLogLine(t *testing.T) 
 }
 
 func TestContextLogFields_AbsentKeyNoField(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	t.Cleanup(resetContextLogFields)
 	key := ctxKey{"absent"}
 	Init(Config{ContextLogFields: []ContextLogField{{Key: key, Name: "test.absent"}}})
 
@@ -88,6 +91,7 @@ func TestContextLogFields_AbsentKeyNoField(t *testing.T) { //nolint:paralleltest
 }
 
 func TestContextLogFieldArgs_NilContextNoPanic(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	t.Cleanup(resetContextLogFields)
 	key := ctxKey{"nilctx"}
 	Init(Config{ContextLogFields: []ContextLogField{{Key: key, Name: "test.nilctx"}}})
 
@@ -99,6 +103,7 @@ func TestContextLogFieldArgs_NilContextNoPanic(t *testing.T) { //nolint:parallel
 }
 
 func TestContextLogFields_OnlyPresentKeysAdded(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	t.Cleanup(resetContextLogFields)
 	presentKey := ctxKey{"multi.present"}
 	absentKey := ctxKey{"multi.absent"}
 	Init(Config{ContextLogFields: []ContextLogField{
@@ -121,6 +126,7 @@ func TestContextLogFields_OnlyPresentKeysAdded(t *testing.T) { //nolint:parallel
 }
 
 func TestContextLogFields_SurviveWithAndNamed(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	t.Cleanup(resetContextLogFields)
 	key := ctxKey{"survive"}
 	// Register the field only after the loggers below have already been created and
 	// derived, proving extraction is dynamic (read at call time, not construction time).
@@ -142,6 +148,7 @@ func TestContextLogFields_SurviveWithAndNamed(t *testing.T) { //nolint:parallelt
 }
 
 func TestRegisterContextLogField_AddedToExistingLogger(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	t.Cleanup(resetContextLogFields)
 	// Create the logger (and a context already carrying the value) before the key is
 	// registered, proving RegisterContextLogField takes effect on loggers that already
 	// exist rather than only ones constructed after registration.
@@ -165,6 +172,7 @@ func TestRegisterContextLogField_SecondCallAddsBoth(t *testing.T) { //nolint:par
 	// rather than replace it: the first log call (after only the first key is registered)
 	// should carry only the first field, and the second log call (after the second key is
 	// also registered) should carry both.
+	t.Cleanup(resetContextLogFields)
 	logger, observed := newObservedLogger()
 	firstKey := ctxKey{"register.multi.first"}
 	secondKey := ctxKey{"register.multi.second"}
@@ -195,6 +203,7 @@ func TestRegisterContextLogField_SecondCallAddsBoth(t *testing.T) { //nolint:par
 }
 
 func TestRegisterContextLogField_DuplicatePanics(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	t.Cleanup(resetContextLogFields)
 	key1 := ctxKey{"dup1"}
 	key2 := ctxKey{"dup2"}
 	RegisterContextLogField("test.dup.unique", key1)
@@ -205,6 +214,7 @@ func TestRegisterContextLogField_DuplicatePanics(t *testing.T) { //nolint:parall
 }
 
 func TestInit_ContextLogFields_Idempotent(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	t.Cleanup(resetContextLogFields)
 	firstKey := ctxKey{"idempotent.first"}
 	secondKey := ctxKey{"idempotent.second"}
 
@@ -228,6 +238,7 @@ func TestContextLogFields_SurviveMultipleContextWrapping(t *testing.T) { //nolin
 	// ctx.Value walks up the parent chain, so the registered key must still resolve however
 	// deep it sits under further wrapping (WithValue, WithCancel, WithTimeout, ...) layered on
 	// top by unrelated code between where the value was set and where the log call happens.
+	t.Cleanup(resetContextLogFields)
 	key := ctxKey{"wrapped"}
 	Init(Config{ContextLogFields: []ContextLogField{{Key: key, Name: "test.wrapped"}}})
 
@@ -251,6 +262,7 @@ func TestContextLogFields_SurviveMultipleContextWrapping(t *testing.T) { //nolin
 }
 
 func TestContextLogFields_CallerAccuracy(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	t.Cleanup(resetContextLogFields)
 	key := ctxKey{"caller"}
 	Init(Config{ContextLogFields: []ContextLogField{{Key: key, Name: "test.caller"}}})
 

--- a/platform/common/services/logging/context_fields_test.go
+++ b/platform/common/services/logging/context_fields_test.go
@@ -52,6 +52,26 @@ func TestContextLogFields_ExtractedIntoLogLine(t *testing.T) { //nolint:parallel
 	require.Equal(t, "some-value", field.String)
 }
 
+// ContextKeyType is a named string type used as a context key, as an alternative to the
+// struct-based ctxKey above; some callers prefer this style for keys like "request-id".
+type ContextKeyType string
+
+func TestContextLogFields_NamedStringKeyType_ExtractedIntoLogLine(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
+	key := ContextKeyType("request-id")
+	Init(Config{ContextLogFields: []ContextLogField{{Key: key, Name: "test.request-id"}}})
+
+	logger, observed := newObservedLogger()
+	ctx := context.WithValue(context.Background(), key, "abc-123")
+
+	logger.InfowContext(ctx, "hello")
+
+	entries := observed.All()
+	require.Len(t, entries, 1)
+	field, ok := findField(entries[0].Context, "test.request-id")
+	require.True(t, ok, "expected field %q in %+v", "test.request-id", entries[0].Context)
+	require.Equal(t, "abc-123", field.String)
+}
+
 func TestContextLogFields_AbsentKeyNoField(t *testing.T) { //nolint:paralleltest // mutates the shared global context-field registry
 	key := ctxKey{"absent"}
 	Init(Config{ContextLogFields: []ContextLogField{{Key: key, Name: "test.absent"}}})

--- a/platform/common/services/logging/logger.go
+++ b/platform/common/services/logging/logger.go
@@ -64,7 +64,7 @@ type logger struct {
 func newLogger(zapLogger *zap.Logger) *logger {
 	return &logger{
 		fabricLogger: flogging.NewFabricLogger(zapLogger),
-		otelLogger:   NewOtelLogger(zapLogger.WithOptions(zap.AddCallerSkip(1))),
+		otelLogger:   NewOtelLogger(zapLogger.WithOptions(zap.AddCallerSkip(2))),
 	}
 }
 

--- a/platform/common/services/logging/otel.go
+++ b/platform/common/services/logging/otel.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/otel/log/noop"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -35,10 +36,144 @@ type otelLogger interface {
 }
 
 func NewOtelLogger(zapLogger *zap.Logger) otelLogger {
-	return otelzap.New(zapLogger,
+	sugared := otelzap.New(zapLogger,
 		otelzap.WithLoggerProvider(newLoggerProvider(zapLogger.Name(), OtelSanitize())),
 		otelzap.WithMinLevel(zapLogger.Level()),
+		otelzap.WithCallerDepth(1),
 	).Sugar()
+	return ctxFieldLogger{sugared}
+}
+
+// ctxFieldLogger decorates an *otelzap.SugaredLogger so that every context-aware log
+// call also picks up the registered ContextLogFields (see config.go) from ctx and adds
+// them to the zap log line.
+type ctxFieldLogger struct {
+	*otelzap.SugaredLogger
+}
+
+// levelEnabled reports whether lvl would actually be written by the underlying zap core.
+// Only called for DebugLevel..ErrorLevel: Panic/PanicW below always extract unconditionally
+// since, per zap.SugaredLogger.log, Panic/Fatal levels always proceed regardless of the
+// core's enabled level (they may panic/exit). This lets disabled-level calls (the
+// overwhelming majority in production) skip context-field extraction entirely, at the
+// cost of a single cheap comparison (SugaredLogger.Level() is allocation-free).
+func (l ctxFieldLogger) levelEnabled(lvl zapcore.Level) bool {
+	return lvl >= l.Level()
+}
+
+// withContextFields attaches the registered ContextLogFields present in ctx via With,
+// for the *f*Context (printf-style) methods which have no keysAndValues slice to append
+// to directly. Only called once levelEnabled has confirmed the entry will be written.
+func (l ctxFieldLogger) withContextFields(ctx context.Context) *otelzap.SugaredLogger {
+	if fields := contextLogFieldArgs(ctx); len(fields) > 0 {
+		return l.With(fields...)
+	}
+	return l.SugaredLogger
+}
+
+// appendContextLogFields appends the registered ContextLogFields present in ctx to
+// keysAndValues, for the *w*Context (structured) methods. zap.SugaredLogger.sweetenFields
+// natively supports mixing strongly-typed Field values into a keysAndValues slice, so this
+// avoids the extra SugaredLogger clone that With(...) would otherwise allocate. A fresh
+// backing array is always used so the caller's keysAndValues slice (if passed via `...`
+// spread of an existing slice) is never mutated.
+func appendContextLogFields(ctx context.Context, keysAndValues []any) []any {
+	fields := contextLogFieldArgs(ctx)
+	if len(fields) == 0 {
+		return keysAndValues
+	}
+	combined := make([]any, len(keysAndValues), len(keysAndValues)+len(fields))
+	copy(combined, keysAndValues)
+	return append(combined, fields...)
+}
+
+// contextLogFieldArgs extracts the registered ContextLogFields present in ctx, returned
+// as a flat []any of zap.Field values suitable for SugaredLogger.With or a keysAndValues
+// slice.
+func contextLogFieldArgs(ctx context.Context) []any {
+	if ctx == nil {
+		return nil
+	}
+	specs := ContextLogFields()
+	args := make([]any, 0, len(specs))
+	for _, s := range specs {
+		if v := ctx.Value(s.Key); v != nil {
+			args = append(args, zap.Any(s.Name, v))
+		}
+	}
+	return args
+}
+
+func (l ctxFieldLogger) DebugfContext(ctx context.Context, template string, args ...any) {
+	if !l.levelEnabled(zapcore.DebugLevel) {
+		l.SugaredLogger.DebugfContext(ctx, template, args...)
+		return
+	}
+	l.withContextFields(ctx).DebugfContext(ctx, template, args...)
+}
+
+func (l ctxFieldLogger) DebugwContext(ctx context.Context, msg string, keysAndValues ...any) {
+	if !l.levelEnabled(zapcore.DebugLevel) {
+		l.SugaredLogger.DebugwContext(ctx, msg, keysAndValues...)
+		return
+	}
+	l.SugaredLogger.DebugwContext(ctx, msg, appendContextLogFields(ctx, keysAndValues)...)
+}
+
+func (l ctxFieldLogger) InfofContext(ctx context.Context, template string, args ...any) {
+	if !l.levelEnabled(zapcore.InfoLevel) {
+		l.SugaredLogger.InfofContext(ctx, template, args...)
+		return
+	}
+	l.withContextFields(ctx).InfofContext(ctx, template, args...)
+}
+
+func (l ctxFieldLogger) InfowContext(ctx context.Context, msg string, keysAndValues ...any) {
+	if !l.levelEnabled(zapcore.InfoLevel) {
+		l.SugaredLogger.InfowContext(ctx, msg, keysAndValues...)
+		return
+	}
+	l.SugaredLogger.InfowContext(ctx, msg, appendContextLogFields(ctx, keysAndValues)...)
+}
+
+func (l ctxFieldLogger) WarnfContext(ctx context.Context, template string, args ...any) {
+	if !l.levelEnabled(zapcore.WarnLevel) {
+		l.SugaredLogger.WarnfContext(ctx, template, args...)
+		return
+	}
+	l.withContextFields(ctx).WarnfContext(ctx, template, args...)
+}
+
+func (l ctxFieldLogger) WarnwContext(ctx context.Context, msg string, keysAndValues ...any) {
+	if !l.levelEnabled(zapcore.WarnLevel) {
+		l.SugaredLogger.WarnwContext(ctx, msg, keysAndValues...)
+		return
+	}
+	l.SugaredLogger.WarnwContext(ctx, msg, appendContextLogFields(ctx, keysAndValues)...)
+}
+
+func (l ctxFieldLogger) ErrorfContext(ctx context.Context, template string, args ...any) {
+	if !l.levelEnabled(zapcore.ErrorLevel) {
+		l.SugaredLogger.ErrorfContext(ctx, template, args...)
+		return
+	}
+	l.withContextFields(ctx).ErrorfContext(ctx, template, args...)
+}
+
+func (l ctxFieldLogger) ErrorwContext(ctx context.Context, msg string, keysAndValues ...any) {
+	if !l.levelEnabled(zapcore.ErrorLevel) {
+		l.SugaredLogger.ErrorwContext(ctx, msg, keysAndValues...)
+		return
+	}
+	l.SugaredLogger.ErrorwContext(ctx, msg, appendContextLogFields(ctx, keysAndValues)...)
+}
+
+func (l ctxFieldLogger) PanicfContext(ctx context.Context, template string, args ...any) {
+	l.withContextFields(ctx).PanicfContext(ctx, template, args...)
+}
+
+func (l ctxFieldLogger) PanicwContext(ctx context.Context, msg string, keysAndValues ...any) {
+	l.SugaredLogger.PanicwContext(ctx, msg, appendContextLogFields(ctx, keysAndValues)...)
 }
 
 func newLoggerProvider(name string, sanitize bool) *spanLoggerProvider {

--- a/platform/common/services/logging/otel.go
+++ b/platform/common/services/logging/otel.go
@@ -74,32 +74,58 @@ func (l ctxFieldLogger) withContextFields(ctx context.Context) *otelzap.SugaredL
 // appendContextLogFields appends the registered ContextLogFields present in ctx to
 // keysAndValues, for the *w*Context (structured) methods. zap.SugaredLogger.sweetenFields
 // natively supports mixing strongly-typed Field values into a keysAndValues slice, so this
-// avoids the extra SugaredLogger clone that With(...) would otherwise allocate. A fresh
-// backing array is always used so the caller's keysAndValues slice (if passed via `...`
-// spread of an existing slice) is never mutated.
+// avoids the extra SugaredLogger clone that With(...) would otherwise allocate. The combined
+// slice is only allocated once a registered key is actually found in ctx (the common case
+// where ctx carries none, or only some, of the registered keys is otherwise allocation-free);
+// when allocated, a fresh backing array is used so the caller's keysAndValues slice (if
+// passed via `...` spread of an existing slice) is never mutated.
 func appendContextLogFields(ctx context.Context, keysAndValues []any) []any {
-	fields := contextLogFieldArgs(ctx)
-	if len(fields) == 0 {
+	if ctx == nil {
 		return keysAndValues
 	}
-	combined := make([]any, len(keysAndValues), len(keysAndValues)+len(fields))
-	copy(combined, keysAndValues)
-	return append(combined, fields...)
+	specs := ContextLogFields()
+	if len(specs) == 0 {
+		return keysAndValues
+	}
+	var combined []any
+	for _, s := range specs {
+		v := ctx.Value(s.Key)
+		if v == nil {
+			continue
+		}
+		if combined == nil {
+			combined = make([]any, len(keysAndValues), len(keysAndValues)+len(specs))
+			copy(combined, keysAndValues)
+		}
+		combined = append(combined, zap.Any(s.Name, v))
+	}
+	if combined == nil {
+		return keysAndValues
+	}
+	return combined
 }
 
 // contextLogFieldArgs extracts the registered ContextLogFields present in ctx, returned
 // as a flat []any of zap.Field values suitable for SugaredLogger.With or a keysAndValues
-// slice.
+// slice. Returns nil, allocation-free, if ctx carries none of the registered keys.
 func contextLogFieldArgs(ctx context.Context) []any {
 	if ctx == nil {
 		return nil
 	}
 	specs := ContextLogFields()
-	args := make([]any, 0, len(specs))
+	if len(specs) == 0 {
+		return nil
+	}
+	var args []any
 	for _, s := range specs {
-		if v := ctx.Value(s.Key); v != nil {
-			args = append(args, zap.Any(s.Name, v))
+		v := ctx.Value(s.Key)
+		if v == nil {
+			continue
 		}
+		if args == nil {
+			args = make([]any, 0, len(specs))
+		}
+		args = append(args, zap.Any(s.Name, v))
 	}
 	return args
 }


### PR DESCRIPTION
## Summary

- Adds a declarative `(context key -> zap field name)` mechanism so values
  carried in a `context.Context` (request ID, tenant, tx ID, etc.) are
  automatically attached as `zap.Any` fields to every context-aware log call
  (`InfowContext`, `ErrorfContext`, ... — 10 methods total), instead of only
  being used to emit an OTel span event as today.
- Dual configuration surface mirroring the existing `Replacers` pattern:
  `logging.Init(Config{ContextLogFields: [...]})` for bulk config, and
  `logging.RegisterContextLogField(name, key)` for direct registration
  (panics on duplicate name, same as `RegisterReplacer`).
- Values are logged as-is via `zap.Any` — no implicit sanitization; that
  stays scoped to `OtelSanitize`'s existing span-event-body use.
- Performance: the decorator (`ctxFieldLogger` in `otel.go`) level-gates via
  `SugaredLogger.Level()` before touching the registry or the context at
  all, so disabled log calls stay near-zero-cost regardless of how many
  fields are registered anywhere in the process (measured: ~577ns/12-alloc
  regression without the gate vs. ~50ns/1-alloc with it, matching the
  no-fields-registered baseline). The `*w*Context` methods append extracted
  fields directly into the `keysAndValues` slice instead of calling
  `.With()` first, avoiding an extra `SugaredLogger` clone allocation on the
  enabled path.
- Caller-skip bumped by one in `logger.go` to compensate for the new
  decorator frame, so logged caller/file/line still point at the true call
  site (covered by `TestContextLogFields_CallerAccuracy`).

Closes #1607.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./platform/common/services/logging/...`
- [x] `go test ./platform/common/services/logging/...` (new
      `context_fields_test.go`: extraction, absent key, nil context,
      multi-key, survives `With`/`Named`, duplicate-registration panic,
      `Init` idempotency, caller accuracy — all pass)
- [x] `go test ./platform/common/core/generic/committer/... ./platform/common/core/generic/vault/...`
      (spot-check downstream consumers of context-aware logging — no
      behavior change)
- [x] Isolated benchmarks (`bench_test.go`) confirm the disabled-log-call
      cost is independent of registry size after the level-gate fix