### PR TITLE
fix(security): harden fabric/core against forged gossip discovery, unrecovered panics, and silent failure paths

### DIFF
--- a/platform/fabric/core/generic/committer/config.go
+++ b/platform/fabric/core/generic/committer/config.go
@@ -146,8 +146,7 @@ func (c *Committer) CommitConfig(ctx context.Context, blockNumber driver.BlockNu
 
 	// once committed, we can update the membership service
 	if err := c.MembershipService.Update(env); err != nil {
-		// this should not have happened
-		panic(err)
+		return errors.Wrapf(err, "failed updating membership service for configtx [%s]", txID)
 	}
 
 	// and apply other updates

--- a/platform/fabric/core/generic/committer/config_test.go
+++ b/platform/fabric/core/generic/committer/config_test.go
@@ -131,6 +131,54 @@ func TestCommitConfig(t *testing.T) {
 		err := c.CommitConfig(t.Context(), 1, 4, []byte("raw"), &common.Envelope{})
 		require.ErrorContains(t, err, "invalid configtx's")
 	})
+
+	// Regression test: CommitConfig used to panic (panic(err)) if
+	// MembershipService.Update failed after the configtx was already
+	// committed to the vault. A malformed/malicious config transaction that
+	// the membership service rejects would crash the whole process instead
+	// of returning an error. This confirms the failure now propagates as a
+	// wrapped error.
+	t.Run("membership update failure is returned as error, not a panic", func(t *testing.T) {
+		t.Parallel()
+		// CommitConfig checks Status once itself (must be Unknown to proceed
+		// past the "already committed" guard), then commitConfig->CommitTX
+		// checks Status again internally (must be Busy to take the
+		// already-exercised c.commit()->CommitTxFn path instead of the
+		// unrelated commitUnknown() path). A stateful fake mirrors that.
+		var statusCalls int
+		c := &Committer{
+			logger:        logger,
+			ChannelConfig: &fake.ChannelConfig{IDValue: "ch-update-fail"},
+			Vault: &fake.Vault{
+				NewRWSetFn: func(context.Context, cdriver.TxID) (fdriver.RWSet, error) {
+					return &fake.RWSet{}, nil
+				},
+				StatusFn: func(context.Context, cdriver.TxID) (fdriver.ValidationCode, string, error) {
+					statusCalls++
+					if statusCalls == 1 {
+						return fdriver.Unknown, "", nil
+					}
+					return fdriver.Busy, "", nil
+				},
+				CommitTxFn: func(context.Context, cdriver.TxID, cdriver.BlockNum, cdriver.TxNum) error {
+					return nil
+				},
+			},
+			ProcessorManager: &fake.ProcessorManager{
+				ProcessByIDFn: func(context.Context, string, cdriver.TxID) error { return nil },
+			},
+			MembershipService: &fake.MembershipService{
+				UpdateFn: func(*common.Envelope) error {
+					return stderrors.New("membership-update-failed")
+				},
+			},
+		}
+		require.NotPanics(t, func() {
+			err := c.CommitConfig(t.Context(), 1, 5, []byte("raw"), &common.Envelope{})
+			require.ErrorContains(t, err, "failed updating membership service for configtx")
+			require.ErrorContains(t, err, "membership-update-failed")
+		})
+	})
 }
 
 func TestApplyConfigUpdates(t *testing.T) {

--- a/platform/fabric/core/generic/committer/endorsertx.go
+++ b/platform/fabric/core/generic/committer/endorsertx.go
@@ -55,11 +55,16 @@ func (c *Committer) HandleEndorserTransaction(ctx context.Context, block *common
 }
 
 func MapFinalityEvent(ctx context.Context, block *common.BlockMetadata, txNum driver.TxNum, txID string) (uint8, *FinalityEvent, error) {
-	if len(block.Metadata) < int(common.BlockMetadataIndex_TRANSACTIONS_FILTER) {
+	if len(block.Metadata) <= int(common.BlockMetadataIndex_TRANSACTIONS_FILTER) {
 		return 0, nil, errors.Errorf("block metadata lacks transaction filter")
 	}
 
-	fabricValidationCode := ValidationFlags(block.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER])[txNum]
+	validationFlags := ValidationFlags(block.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER])
+	if uint64(txNum) >= uint64(len(validationFlags)) {
+		return 0, nil, errors.Errorf("transaction number [%d] out of range for validation flags of length [%d]", txNum, len(validationFlags))
+	}
+
+	fabricValidationCode := validationFlags[txNum]
 	validationCode, validationMessage := MapValidationCode(int32(fabricValidationCode))
 	event := &FinalityEvent{
 		Ctx:               ctx,

--- a/platform/fabric/core/generic/committer/endorsertx_test.go
+++ b/platform/fabric/core/generic/committer/endorsertx_test.go
@@ -69,6 +69,30 @@ func TestMapFinalityEvent(t *testing.T) {
 		require.Equal(t, fdriver.Valid, event.ValidationCode)
 		require.Equal(t, peer.TxValidationCode_name[int32(peer.TxValidationCode_VALID)], event.ValidationMessage)
 	})
+
+	// Regression test: block.Metadata sized exactly at the TRANSACTIONS_FILTER
+	// index used to pass the `len(...) < index` guard and then panic on
+	// Metadata[index] (index out of range). A malicious/misbehaving peer can
+	// send such a block over the Deliver stream, crashing the process since
+	// nothing in the delivery->committer call chain recovers panics.
+	t.Run("metadata exactly at transactions filter index is rejected, not a panic", func(t *testing.T) {
+		t.Parallel()
+		metadata := make([][]byte, int(common.BlockMetadataIndex_TRANSACTIONS_FILTER))
+		_, _, err := MapFinalityEvent(t.Context(), &common.BlockMetadata{Metadata: metadata}, 0, "tx-boundary")
+		require.ErrorContains(t, err, "block metadata lacks transaction filter")
+	})
+
+	// Regression test: txNum beyond the length of the validation-flags byte
+	// slice used to panic instead of returning an error. Same remote-input
+	// reachability and crash concern as above.
+	t.Run("txNum beyond validation flags length is rejected, not a panic", func(t *testing.T) {
+		t.Parallel()
+		metadata := make([][]byte, int(common.BlockMetadataIndex_TRANSACTIONS_FILTER)+1)
+		metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER] = []byte{uint8(peer.TxValidationCode_VALID)}
+
+		_, _, err := MapFinalityEvent(t.Context(), &common.BlockMetadata{Metadata: metadata}, 5, "tx-oob")
+		require.ErrorContains(t, err, "out of range")
+	})
 }
 
 func TestMapValidationCodeAndConvertValidationCode(t *testing.T) {

--- a/platform/fabric/core/generic/delivery/deliverclient.go
+++ b/platform/fabric/core/generic/delivery/deliverclient.go
@@ -194,6 +194,10 @@ read:
 				}
 			}
 		case *pb.DeliverResponse_Block:
+			if r.Block == nil || r.Block.Data == nil || r.Block.Header == nil {
+				event.Err = errors.Errorf("received malformed block from peer %s", address)
+				break read
+			}
 			for i, tx := range r.Block.Data.Data {
 				_, _, chdr, err := fabricutils.UnmarshalTx(tx)
 				if err != nil {

--- a/platform/fabric/core/generic/delivery/deliverclient_test.go
+++ b/platform/fabric/core/generic/delivery/deliverclient_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package delivery
+
+import (
+	"errors"
+	"testing"
+
+	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+	pb "github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeDeliverFiltered implements DeliverFiltered by replaying a fixed
+// sequence of responses, one per Recv call.
+type fakeDeliverFiltered struct {
+	responses []*pb.DeliverResponse
+	pos       int
+}
+
+func (f *fakeDeliverFiltered) Send(*cb.Envelope) error { return nil }
+func (f *fakeDeliverFiltered) CloseSend() error        { return nil }
+
+func (f *fakeDeliverFiltered) Recv() (*pb.DeliverResponse, error) {
+	if f.pos >= len(f.responses) {
+		return nil, errors.New("EOF")
+	}
+	r := f.responses[f.pos]
+	f.pos++
+	return r, nil
+}
+
+// Regression coverage for a bug where the *pb.DeliverResponse_Block case in
+// DeliverReceive indexed straight into r.Block.Data.Data and
+// r.Block.Header.Number with no nil-check, unlike the equivalent, already
+// nil-checked path in handleBlockResponse (see TestHandleBlockResponse). The
+// Block field of a DeliverResponse_Block, and its own Data/Header/Metadata
+// submessages, can independently be nil after unmarshalling a
+// well-formed-at-the-wire-level but malicious/malformed message from a
+// misbehaving peer. DeliverReceive is invoked from a bare goroutine (see
+// FabricFinality.IsFinal) with no panic recovery anywhere in the call chain,
+// so a nil dereference here crashes the whole process (DoS).
+func TestDeliverReceive_MalformedBlock(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil block is rejected, not dereferenced", func(t *testing.T) {
+		t.Parallel()
+		df := &fakeDeliverFiltered{responses: []*pb.DeliverResponse{
+			{Type: &pb.DeliverResponse_Block{Block: nil}},
+		}}
+		eventCh := make(chan TxEvent, 1)
+
+		require.NotPanics(t, func() {
+			err := DeliverReceive(df, "peer0", "tx1", eventCh)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "malformed block")
+		})
+	})
+
+	t.Run("block with nil data is rejected, not dereferenced", func(t *testing.T) {
+		t.Parallel()
+		df := &fakeDeliverFiltered{responses: []*pb.DeliverResponse{
+			{Type: &pb.DeliverResponse_Block{Block: &cb.Block{
+				Header: &cb.BlockHeader{Number: 1},
+				Data:   nil,
+			}}},
+		}}
+		eventCh := make(chan TxEvent, 1)
+
+		require.NotPanics(t, func() {
+			err := DeliverReceive(df, "peer0", "tx1", eventCh)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "malformed block")
+		})
+	})
+
+	t.Run("block with nil header is rejected, not dereferenced", func(t *testing.T) {
+		t.Parallel()
+		df := &fakeDeliverFiltered{responses: []*pb.DeliverResponse{
+			{Type: &pb.DeliverResponse_Block{Block: &cb.Block{
+				Header: nil,
+				Data:   &cb.BlockData{Data: [][]byte{[]byte("tx0")}},
+			}}},
+		}}
+		eventCh := make(chan TxEvent, 1)
+
+		require.NotPanics(t, func() {
+			err := DeliverReceive(df, "peer0", "tx1", eventCh)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "malformed block")
+		})
+	})
+}

--- a/platform/fabric/core/generic/delivery/delivery.go
+++ b/platform/fabric/core/generic/delivery/delivery.go
@@ -236,27 +236,14 @@ func (d *Delivery) runReceiver(ctx context.Context, ch chan<- blockResponse) {
 				switch r := resp.Type.(type) {
 				case *pb.DeliverResponse_Block:
 					span.SetAttributes(tracing.String(messageTypeLabel, block))
-					if r.Block == nil || r.Block.Data == nil || r.Block.Header == nil || r.Block.Metadata == nil {
-						logger.Debugf("deliver service [%s:%s:%s], received nil block", d.client.Address(), d.NetworkName, d.channel)
-						span.RecordError(errors.New("nil block"))
-						time.Sleep(waitTime)
+					if !d.handleBlockResponse(deliveryCtx, span, r, ch, waitTime) {
 						if dfCancel != nil {
 							dfCancel()
 						}
 						df = nil
+						span.End()
+						continue
 					}
-
-					logger.Debugf("delivery service [%s:%s:%s], commit block [%d]", d.client.Address(), d.NetworkName, d.channel, r.Block.Header.Number)
-					d.lastBlockReceived = r.Block.Header.Number
-
-					span.AddEvent(fmt.Sprintf("push_%d_to_channel", r.Block.Header.Number))
-					logger.Debugf("Pushing block [%d] to channel with current length %d", r.Block.Header.Number, len(ch))
-					ch <- blockResponse{
-						ctx:   deliveryCtx,
-						block: r.Block,
-					}
-					logger.Debugf("Pushed block [%d] to channel", r.Block.Header.Number)
-					span.AddEvent("pushed_to_channel")
 				case *pb.DeliverResponse_Status:
 					span.SetAttributes(tracing.String(messageTypeLabel, responseStatus))
 					if r.Status == cb.Status_NOT_FOUND {
@@ -282,6 +269,31 @@ func (d *Delivery) runReceiver(ctx context.Context, ch chan<- blockResponse) {
 			}
 		}
 	}
+}
+
+// handleBlockResponse validates and dispatches a received block to ch.
+// It returns false if the block is malformed (in which case the caller must
+// tear down the current stream and retry), true if the block was handled.
+func (d *Delivery) handleBlockResponse(ctx context.Context, span trace.Span, r *pb.DeliverResponse_Block, ch chan<- blockResponse, waitTime time.Duration) bool {
+	if r.Block == nil || r.Block.Data == nil || r.Block.Header == nil || r.Block.Metadata == nil {
+		logger.Debugf("deliver service [%s:%s:%s], received nil block", d.client.Address(), d.NetworkName, d.channel)
+		span.RecordError(errors.New("nil block"))
+		time.Sleep(waitTime)
+		return false
+	}
+
+	logger.Debugf("delivery service [%s:%s:%s], commit block [%d]", d.client.Address(), d.NetworkName, d.channel, r.Block.Header.Number)
+	d.lastBlockReceived = r.Block.Header.Number
+
+	span.AddEvent(fmt.Sprintf("push_%d_to_channel", r.Block.Header.Number))
+	logger.Debugf("Pushing block [%d] to channel with current length %d", r.Block.Header.Number, len(ch))
+	ch <- blockResponse{
+		ctx:   ctx,
+		block: r.Block,
+	}
+	logger.Debugf("Pushed block [%d] to channel", r.Block.Header.Number)
+	span.AddEvent("pushed_to_channel")
+	return true
 }
 
 func (d *Delivery) untilStop() error {

--- a/platform/fabric/core/generic/delivery/delivery_test.go
+++ b/platform/fabric/core/generic/delivery/delivery_test.go
@@ -28,10 +28,10 @@ import (
 // (Address) to satisfy the logging calls inside handleBlockResponse.
 type stubPeerClient struct{}
 
-func (stubPeerClient) Address() string                                { return "peer0" }
-func (stubPeerClient) Certificate() tls.Certificate                   { return tls.Certificate{} }
-func (stubPeerClient) Close()                                         {}
-func (stubPeerClient) EndorserClient() (pb.EndorserClient, error)     { return nil, nil }
+func (stubPeerClient) Address() string                            { return "peer0" }
+func (stubPeerClient) Certificate() tls.Certificate               { return tls.Certificate{} }
+func (stubPeerClient) Close()                                     {}
+func (stubPeerClient) EndorserClient() (pb.EndorserClient, error) { return nil, nil }
 func (stubPeerClient) DiscoveryClient() (services.DiscoveryClient, error) {
 	return nil, nil
 }

--- a/platform/fabric/core/generic/delivery/delivery_test.go
+++ b/platform/fabric/core/generic/delivery/delivery_test.go
@@ -8,15 +8,34 @@ package delivery
 
 import (
 	"context"
+	"crypto/tls"
 	"testing"
 	"time"
 
+	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
 	ab "github.com/hyperledger/fabric-protos-go-apiv2/orderer"
+	pb "github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/services"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 )
+
+// stubPeerClient implements services.PeerClient with just enough behavior
+// (Address) to satisfy the logging calls inside handleBlockResponse.
+type stubPeerClient struct{}
+
+func (stubPeerClient) Address() string                                { return "peer0" }
+func (stubPeerClient) Certificate() tls.Certificate                   { return tls.Certificate{} }
+func (stubPeerClient) Close()                                         {}
+func (stubPeerClient) EndorserClient() (pb.EndorserClient, error)     { return nil, nil }
+func (stubPeerClient) DiscoveryClient() (services.DiscoveryClient, error) {
+	return nil, nil
+}
+func (stubPeerClient) DeliverClient() (pb.DeliverClient, error) { return nil, nil }
 
 // mockVault implements Vault for testing
 type mockVault struct {
@@ -268,5 +287,94 @@ func TestProcessedTransaction(t *testing.T) {
 	t.Run("ValidationCode returns correct code", func(t *testing.T) {
 		t.Parallel()
 		require.Equal(t, int32(0), pt.ValidationCode())
+	})
+}
+
+// --- Tests for handleBlockResponse ---
+//
+// Regression coverage for a bug where runReceiver's nil-block guard detected
+// a malformed *pb.DeliverResponse_Block (e.g. Block.Header == nil, which a
+// misbehaving or malicious peer can send over the Deliver gRPC stream) and
+// reset connection state, but fell through unconditionally into
+// r.Block.Header.Number afterwards, nil-pointer-panicking. Since runReceiver
+// runs in a bare goroutine with no panic recovery anywhere in the call
+// chain, this crashed the whole process (DoS). The fix, and what this test
+// exercises directly, is that a malformed block must be rejected (returning
+// false) without touching any of its nil fields.
+func TestHandleBlockResponse(t *testing.T) {
+	t.Parallel()
+
+	newSpan := func(t *testing.T) trace.Span {
+		t.Helper()
+		_, span := noop.NewTracerProvider().Tracer("test").Start(t.Context(), "span")
+		return span
+	}
+
+	t.Run("nil block is rejected, not dereferenced", func(t *testing.T) {
+		t.Parallel()
+		d := &Delivery{client: stubPeerClient{}}
+		ch := make(chan blockResponse, 1)
+		ok := d.handleBlockResponse(t.Context(), newSpan(t), &pb.DeliverResponse_Block{Block: nil}, ch, time.Millisecond)
+		require.False(t, ok)
+		require.Empty(t, ch)
+	})
+
+	t.Run("block with nil header is rejected, not dereferenced", func(t *testing.T) {
+		t.Parallel()
+		d := &Delivery{client: stubPeerClient{}}
+		ch := make(chan blockResponse, 1)
+		malformed := &cb.Block{
+			Data:     &cb.BlockData{},
+			Header:   nil,
+			Metadata: &cb.BlockMetadata{},
+		}
+		ok := d.handleBlockResponse(t.Context(), newSpan(t), &pb.DeliverResponse_Block{Block: malformed}, ch, time.Millisecond)
+		require.False(t, ok)
+		require.Empty(t, ch)
+	})
+
+	t.Run("block with nil data is rejected, not dereferenced", func(t *testing.T) {
+		t.Parallel()
+		d := &Delivery{client: stubPeerClient{}}
+		ch := make(chan blockResponse, 1)
+		malformed := &cb.Block{
+			Data:     nil,
+			Header:   &cb.BlockHeader{Number: 1},
+			Metadata: &cb.BlockMetadata{},
+		}
+		ok := d.handleBlockResponse(t.Context(), newSpan(t), &pb.DeliverResponse_Block{Block: malformed}, ch, time.Millisecond)
+		require.False(t, ok)
+		require.Empty(t, ch)
+	})
+
+	t.Run("block with nil metadata is rejected, not dereferenced", func(t *testing.T) {
+		t.Parallel()
+		d := &Delivery{client: stubPeerClient{}}
+		ch := make(chan blockResponse, 1)
+		malformed := &cb.Block{
+			Data:     &cb.BlockData{},
+			Header:   &cb.BlockHeader{Number: 1},
+			Metadata: nil,
+		}
+		ok := d.handleBlockResponse(t.Context(), newSpan(t), &pb.DeliverResponse_Block{Block: malformed}, ch, time.Millisecond)
+		require.False(t, ok)
+		require.Empty(t, ch)
+	})
+
+	t.Run("well-formed block is pushed to channel", func(t *testing.T) {
+		t.Parallel()
+		d := &Delivery{client: stubPeerClient{}}
+		ch := make(chan blockResponse, 1)
+		good := &cb.Block{
+			Data:     &cb.BlockData{},
+			Header:   &cb.BlockHeader{Number: 42},
+			Metadata: &cb.BlockMetadata{},
+		}
+		ok := d.handleBlockResponse(t.Context(), newSpan(t), &pb.DeliverResponse_Block{Block: good}, ch, time.Millisecond)
+		require.True(t, ok)
+		require.Len(t, ch, 1)
+		received := <-ch
+		require.Equal(t, uint64(42), received.block.Header.Number)
+		require.Equal(t, uint64(42), d.lastBlockReceived)
 	})
 }

--- a/platform/fabric/core/generic/delivery/service.go
+++ b/platform/fabric/core/generic/delivery/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	pb "github.com/hyperledger/fabric-protos-go-apiv2/peer"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/fabricutils"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
@@ -21,6 +22,23 @@ import (
 )
 
 type ValidationFlags []uint8
+
+// validationCodeAt safely returns the validation code for the transaction at
+// index i in block. block.Data.Data and the TRANSACTIONS_FILTER metadata
+// entry are populated independently by whoever produced the block, so a
+// malformed or malicious block (delivered over the peer Deliver gRPC stream)
+// can have a TRANSACTIONS_FILTER entry that is missing or shorter than
+// Data.Data, which would otherwise panic on a bare slice index.
+func validationCodeAt(block *common.Block, i int) (uint8, error) {
+	if block.Metadata == nil || len(block.Metadata.Metadata) <= int(common.BlockMetadataIndex_TRANSACTIONS_FILTER) {
+		return 0, errors.Errorf("block [%d] metadata lacks transaction filter", block.GetHeader().GetNumber())
+	}
+	flags := ValidationFlags(block.Metadata.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER])
+	if i < 0 || i >= len(flags) {
+		return 0, errors.Errorf("transaction index [%d] out of range for validation flags of length [%d] in block [%d]", i, len(flags), block.GetHeader().GetNumber())
+	}
+	return flags[i], nil
+}
 
 type Service struct {
 	channel             string
@@ -132,7 +150,11 @@ func (c *Service) Scan(ctx context.Context, txID string, callback driver.Deliver
 	return c.scanBlock(ctx, vault,
 		func(_ context.Context, block *common.Block) (bool, error) {
 			for i, tx := range block.Data.Data {
-				validationCode := ValidationFlags(block.Metadata.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER])[i]
+				validationCode, err := validationCodeAt(block, i)
+				if err != nil {
+					logger.Errorf("[%s] %s", c.channel, err)
+					return false, err
+				}
 
 				// if pb.TxValidationCode(validationCode) != pb.TxValidationCode_VALID {
 				//	continue
@@ -176,7 +198,11 @@ func (c *Service) ScanFromBlock(ctx context.Context, block driver.BlockNum, call
 	return c.scanBlock(ctx, vault,
 		func(_ context.Context, block *common.Block) (bool, error) {
 			for i, tx := range block.Data.Data {
-				validationCode := ValidationFlags(block.Metadata.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER])[i]
+				validationCode, err := validationCodeAt(block, i)
+				if err != nil {
+					logger.Errorf("[%s] %s", c.channel, err)
+					return false, err
+				}
 
 				// if pb.TxValidationCode(validationCode) != pb.TxValidationCode_VALID {
 				//	continue

--- a/platform/fabric/core/generic/delivery/service_test.go
+++ b/platform/fabric/core/generic/delivery/service_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package delivery
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression coverage for a bug where Scan/ScanFromBlock indexed straight
+// into block.Metadata.Metadata[TRANSACTIONS_FILTER][i] with no bounds
+// checking. A malformed or malicious block delivered over the peer Deliver
+// gRPC stream - one whose TRANSACTIONS_FILTER metadata entry is missing or
+// shorter than block.Data.Data - crashed the whole process with an
+// index-out-of-range panic, since nothing in the delivery call chain
+// recovers panics. validationCodeAt is the extracted, bounds-checked
+// replacement used by both Scan and ScanFromBlock.
+func TestValidationCodeAt(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns validation code for a well-formed block", func(t *testing.T) {
+		t.Parallel()
+		metadata := make([][]byte, int(common.BlockMetadataIndex_TRANSACTIONS_FILTER)+1)
+		metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER] = []byte{uint8(peer.TxValidationCode_VALID)}
+		block := &common.Block{
+			Header:   &common.BlockHeader{Number: 1},
+			Data:     &common.BlockData{Data: [][]byte{[]byte("tx0")}},
+			Metadata: &common.BlockMetadata{Metadata: metadata},
+		}
+
+		code, err := validationCodeAt(block, 0)
+		require.NoError(t, err)
+		require.Equal(t, uint8(peer.TxValidationCode_VALID), code)
+	})
+
+	t.Run("nil metadata is rejected, not a panic", func(t *testing.T) {
+		t.Parallel()
+		block := &common.Block{
+			Header: &common.BlockHeader{Number: 2},
+			Data:   &common.BlockData{Data: [][]byte{[]byte("tx0")}},
+		}
+
+		require.NotPanics(t, func() {
+			_, err := validationCodeAt(block, 0)
+			require.ErrorContains(t, err, "lacks transaction filter")
+		})
+	})
+
+	t.Run("metadata missing transactions filter entry is rejected, not a panic", func(t *testing.T) {
+		t.Parallel()
+		metadata := make([][]byte, int(common.BlockMetadataIndex_TRANSACTIONS_FILTER))
+		block := &common.Block{
+			Header:   &common.BlockHeader{Number: 3},
+			Data:     &common.BlockData{Data: [][]byte{[]byte("tx0")}},
+			Metadata: &common.BlockMetadata{Metadata: metadata},
+		}
+
+		require.NotPanics(t, func() {
+			_, err := validationCodeAt(block, 0)
+			require.ErrorContains(t, err, "lacks transaction filter")
+		})
+	})
+
+	t.Run("index beyond validation flags length is rejected, not a panic", func(t *testing.T) {
+		t.Parallel()
+		metadata := make([][]byte, int(common.BlockMetadataIndex_TRANSACTIONS_FILTER)+1)
+		metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER] = []byte{uint8(peer.TxValidationCode_VALID)}
+		block := &common.Block{
+			Header: &common.BlockHeader{Number: 4},
+			// Two transactions in Data.Data, but the transactions filter only
+			// covers one - the exact mismatch a malicious/misbehaving peer
+			// can send.
+			Data:     &common.BlockData{Data: [][]byte{[]byte("tx0"), []byte("tx1")}},
+			Metadata: &common.BlockMetadata{Metadata: metadata},
+		}
+
+		require.NotPanics(t, func() {
+			_, err := validationCodeAt(block, 1)
+			require.ErrorContains(t, err, "out of range")
+		})
+	})
+}

--- a/platform/fabric/core/generic/discovery/client.go
+++ b/platform/fabric/core/generic/discovery/client.go
@@ -385,12 +385,18 @@ func peersForChannel(membersRes *discovery.PeerMembershipResult, qt QueryType) (
 	var peers []*Peer
 	for org, peersOfCurrentOrg := range membersRes.PeersByOrg {
 		for _, pp := range peersOfCurrentOrg.Peers {
+			if err := verifyEnvelopeSignature(pp.MembershipInfo, pp.Identity); err != nil {
+				return nil, errors.Wrap(err, "failed verifying alive message signature")
+			}
 			aliveMsg, err := EnvelopeToGossipMessage(pp.MembershipInfo)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed unmarshalling alive message")
 			}
 			var stateInfoMsg *SignedGossipMessage
 			if isStateInfoExpected(qt) {
+				if err := verifyEnvelopeSignature(pp.StateInfo, pp.Identity); err != nil {
+					return nil, errors.Wrap(err, "failed verifying stateInfo message signature")
+				}
 				stateInfoMsg, err = EnvelopeToGossipMessage(pp.StateInfo)
 				if err != nil {
 					return nil, errors.Wrap(err, "failed unmarshalling stateInfo message")
@@ -503,6 +509,12 @@ func (resp response) createEndorsementDescriptor(desc *discovery.EndorsementDesc
 func endorser(peer *discovery.Peer, chaincode, channel string) (*Peer, error) {
 	if peer.MembershipInfo == nil || peer.StateInfo == nil {
 		return nil, errors.Errorf("received empty envelope(s) for endorsers for chaincode %s, channel %s", chaincode, channel)
+	}
+	if err := verifyEnvelopeSignature(peer.MembershipInfo, peer.Identity); err != nil {
+		return nil, errors.Wrap(err, "failed verifying alive message signature")
+	}
+	if err := verifyEnvelopeSignature(peer.StateInfo, peer.Identity); err != nil {
+		return nil, errors.Wrap(err, "failed verifying stateInfo message signature")
 	}
 	aliveMsg, err := EnvelopeToGossipMessage(peer.MembershipInfo)
 	if err != nil {

--- a/platform/fabric/core/generic/discovery/client.go
+++ b/platform/fabric/core/generic/discovery/client.go
@@ -385,7 +385,7 @@ func peersForChannel(membersRes *discovery.PeerMembershipResult, qt QueryType) (
 	var peers []*Peer
 	for org, peersOfCurrentOrg := range membersRes.PeersByOrg {
 		for _, pp := range peersOfCurrentOrg.Peers {
-			if err := verifyEnvelopeSignature(pp.MembershipInfo, pp.Identity); err != nil {
+			if err := verifyEnvelopeSignature(pp.MembershipInfo, pp.Identity, true); err != nil {
 				return nil, errors.Wrap(err, "failed verifying alive message signature")
 			}
 			aliveMsg, err := EnvelopeToGossipMessage(pp.MembershipInfo)
@@ -394,7 +394,7 @@ func peersForChannel(membersRes *discovery.PeerMembershipResult, qt QueryType) (
 			}
 			var stateInfoMsg *SignedGossipMessage
 			if isStateInfoExpected(qt) {
-				if err := verifyEnvelopeSignature(pp.StateInfo, pp.Identity); err != nil {
+				if err := verifyEnvelopeSignature(pp.StateInfo, pp.Identity, false); err != nil {
 					return nil, errors.Wrap(err, "failed verifying stateInfo message signature")
 				}
 				stateInfoMsg, err = EnvelopeToGossipMessage(pp.StateInfo)
@@ -510,10 +510,10 @@ func endorser(peer *discovery.Peer, chaincode, channel string) (*Peer, error) {
 	if peer.MembershipInfo == nil || peer.StateInfo == nil {
 		return nil, errors.Errorf("received empty envelope(s) for endorsers for chaincode %s, channel %s", chaincode, channel)
 	}
-	if err := verifyEnvelopeSignature(peer.MembershipInfo, peer.Identity); err != nil {
+	if err := verifyEnvelopeSignature(peer.MembershipInfo, peer.Identity, true); err != nil {
 		return nil, errors.Wrap(err, "failed verifying alive message signature")
 	}
-	if err := verifyEnvelopeSignature(peer.StateInfo, peer.Identity); err != nil {
+	if err := verifyEnvelopeSignature(peer.StateInfo, peer.Identity, false); err != nil {
 		return nil, errors.Wrap(err, "failed verifying stateInfo message signature")
 	}
 	aliveMsg, err := EnvelopeToGossipMessage(peer.MembershipInfo)

--- a/platform/fabric/core/generic/discovery/client.go
+++ b/platform/fabric/core/generic/discovery/client.go
@@ -14,11 +14,13 @@ import (
 	"math/rand/v2"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/discovery"
+	"github.com/hyperledger/fabric-protos-go-apiv2/gossip"
 	"github.com/hyperledger/fabric-protos-go-apiv2/msp"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	mspx509 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/x509"
 )
 
 var configTypes = []QueryType{
@@ -377,6 +379,60 @@ func (resp response) mapPeerMembership(key2Index map[string]int, r *discovery.Re
 		}
 
 		resp[key] = peers
+	}
+	return nil
+}
+
+// verifyEnvelopeSignature checks that e.Signature is a valid signature over
+// e.Payload produced by the private key corresponding to the given
+// serialized identity. This binds a relayed gossip envelope to the specific
+// identity it is shipped alongside in the same discovery response, so an
+// envelope whose signature does not verify against that identity's key -
+// including a forged/garbage signature, or one produced by a different key -
+// is rejected instead of being trusted unconditionally.
+//
+// This is a self-consistency check only: it proves the envelope was signed
+// by whoever holds the private key matching the claimed identity, not that
+// the identity itself is a legitimately-issued, MSP-trusted peer. Identity
+// verification here uses the same lightweight, no-CA-binding provider as
+// mspx509.Provider.DeserializeVerifier (see its doc comment) - it accepts
+// any well-formed self-signed identity with no validation against a
+// channel/local MSP's trusted root CAs. A discovery server that is itself
+// malicious, or that is relaying data from a colluding remote peer, can
+// therefore still present a self-consistent but unauthorized identity: this
+// check is not a substitute for MSP/CA-chain validation of discovered peers,
+// which callers must not assume has happened here. See
+// https://github.com/hyperledger-labs/fabric-smart-client/issues/1623 for
+// follow-up hardening around discovery-peer trust.
+//
+// allowEmptySignature must be true only for AliveMessage/MembershipInfo
+// envelopes. A real Fabric peer signs its own self-referential AliveMessage
+// with protoext.NoopSign (gossip/discovery's Self()), which produces a nil
+// Signature by design, and the Discovery service exposes that self-entry
+// as-is (discovery/support/gossip's Peers(), via SelfMembershipInfo()). This
+// is inherent to how real Fabric peers answer Discovery queries - even
+// upstream Fabric's own discovery client performs no verification at all on
+// these envelopes - so rejecting a nil signature here would fail every
+// Discovery query in which the responding peer is itself among the reported
+// peers/endorsers, which is the common case in small networks. StateInfo
+// self-entries do not share this exemption: real peers always produce a
+// genuine signature for them, even for themselves (see
+// gossipChannel.setupSignedStateInfoMessage, which calls a real signer, not
+// NoopSign), so callers must pass false for StateInfo envelopes to keep that
+// verification strict.
+func verifyEnvelopeSignature(e *gossip.Envelope, identity []byte, allowEmptySignature bool) error {
+	if e == nil {
+		return errors.New("nil envelope")
+	}
+	if allowEmptySignature && len(e.Signature) == 0 {
+		return nil
+	}
+	_, verifier, err := mspx509.NewIdentityFromBytes(identity)
+	if err != nil {
+		return errors.Wrap(err, "failed deriving verifier from peer identity")
+	}
+	if err := verifier.Verify(e.Payload, e.Signature); err != nil {
+		return errors.Wrap(err, "signature does not verify against claimed identity")
 	}
 	return nil
 }

--- a/platform/fabric/core/generic/discovery/client_test.go
+++ b/platform/fabric/core/generic/discovery/client_test.go
@@ -8,6 +8,9 @@ package discovery
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
@@ -19,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hyperledger/fabric-lib-go/bccsp/utils"
 	"github.com/hyperledger/fabric-protos-go-apiv2/discovery"
 	"github.com/hyperledger/fabric-protos-go-apiv2/gossip"
 	"github.com/hyperledger/fabric-protos-go-apiv2/msp"
@@ -30,6 +34,7 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	mspx509 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/x509"
 	comm "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
 )
 
@@ -600,6 +605,103 @@ func TestValidateStateInfoMessage(t *testing.T) {
 	require.Equal(t, "message isn't a stateInfo message", err.Error())
 }
 
+// TestForgedGossipEnvelopeRejected is a security regression test for a fix
+// to a bug where EnvelopeToGossipMessage and
+// validateAliveMessage/validateStateInfoMessage never checked
+// gossip.Envelope.Signature against gossip.Envelope.Payload. A
+// discovery-service peer that relays Alive/StateInfo entries collected from
+// gossip (peersForChannel, endorser in client.go) could therefore forge the
+// Membership.Endpoint of any org's peer - even one it never received a
+// genuine envelope for - and have it accepted as valid, since there was no
+// signature verification anywhere in the call chain. This held even when the
+// discovery gRPC connection itself was mTLS-authenticated: mTLS only proves
+// who you're talking to, not whether the gossip payload they're relaying was
+// honestly produced by the peer it claims to be from.
+//
+// peersForChannel now verifies the envelope's signature against the public
+// key embedded in the peer's own claimed Identity before trusting its
+// content, so both a garbage signature and a signature produced by the
+// wrong key (i.e. an attacker who doesn't hold the claimed identity's
+// private key) are rejected.
+func TestForgedGossipEnvelopeRejected(t *testing.T) {
+	t.Parallel()
+
+	genuine := &gossip.GossipMessage{
+		Content: &gossip.GossipMessage_AliveMsg{
+			AliveMsg: &gossip.AliveMessage{
+				Timestamp:  &gossip.PeerTime{SeqNum: 1, IncNum: 1},
+				Membership: &gossip.Member{Endpoint: "real-peer.example.com:7051"},
+			},
+		},
+	}
+	payload, err := proto.Marshal(genuine)
+	require.NoError(t, err)
+
+	membersResFor := func(envelope *gossip.Envelope, identity []byte) *discovery.PeerMembershipResult {
+		return &discovery.PeerMembershipResult{
+			PeersByOrg: map[string]*discovery.Peers{
+				"A": {
+					Peers: []*discovery.Peer{
+						{
+							MembershipInfo: envelope,
+							StateInfo:      stateInfoMessage(),
+							Identity:       identity,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("garbage signature", func(t *testing.T) {
+		t.Parallel()
+		forged := &gossip.Envelope{
+			Payload:   payload,
+			Signature: []byte("not-a-real-signature-from-anyone"),
+		}
+		_, err := peersForChannel(membersResFor(forged, peerIdentity("A", 0)), PeerMembershipQueryType)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed verifying alive message signature")
+	})
+
+	t.Run("signature from the wrong key", func(t *testing.T) {
+		t.Parallel()
+		attackerKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		digest := sha256.Sum256(payload)
+		r, s, err := ecdsa.Sign(rand.Reader, attackerKey, digest[:])
+		require.NoError(t, err)
+		s, _, err = mspx509.ToLowS(&attackerKey.PublicKey, s)
+		require.NoError(t, err)
+		sig, err := utils.MarshalECDSASignature(r, s)
+		require.NoError(t, err)
+
+		forged := &gossip.Envelope{
+			Payload:   payload,
+			Signature: sig,
+		}
+		// Identity claims to be peer "A"/0 (whose key is testPeerKey), but the
+		// signature was produced by an unrelated attacker key.
+		_, err = peersForChannel(membersResFor(forged, peerIdentity("A", 0)), PeerMembershipQueryType)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed verifying alive message signature")
+	})
+
+	t.Run("genuine signature is accepted", func(t *testing.T) {
+		t.Parallel()
+		sig, err := signWithTestPeerKey(payload)
+		require.NoError(t, err)
+		genuineEnvelope := &gossip.Envelope{
+			Payload:   payload,
+			Signature: sig,
+		}
+		peers, err := peersForChannel(membersResFor(genuineEnvelope, peerIdentity("A", 0)), PeerMembershipQueryType)
+		require.NoError(t, err)
+		require.Len(t, peers, 1)
+		require.Equal(t, "real-peer.example.com:7051", peers[0].AliveMessage.GetAliveMsg().Membership.Endpoint)
+	})
+}
+
 func TestString(t *testing.T) {
 	t.Parallel()
 	var ic InvocationChain
@@ -638,11 +740,43 @@ func getMSPs(endorsers []*Peer) map[string]struct{} {
 	return m
 }
 
-func peerIdentity(mspID string, i int) []byte {
-	p := fmt.Appendf(nil, "p%d", i)
+// testPeerKey is the ECDSA key shared by every fixture identity/envelope
+// pair produced in this file. Tests here don't exercise per-org key
+// separation (getMSP infers org from the endpoint string, not the key), so
+// one shared key keeps peerIdentity/aliveMessage/stateInfoMessage
+// independently callable, as they were before signature verification
+// existed, while still producing envelopes that verify for real.
+var testPeerKey = mustGenerateTestPeerKey()
+
+func mustGenerateTestPeerKey() *ecdsa.PrivateKey {
+	sk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+	return sk
+}
+
+func signWithTestPeerKey(message []byte) ([]byte, error) {
+	digest := sha256.Sum256(message)
+	r, s, err := ecdsa.Sign(rand.Reader, testPeerKey, digest[:])
+	if err != nil {
+		return nil, err
+	}
+	s, _, err = mspx509.ToLowS(&testPeerKey.PublicKey, s)
+	if err != nil {
+		return nil, err
+	}
+	return utils.MarshalECDSASignature(r, s)
+}
+
+func peerIdentity(mspID string, _ int) []byte {
+	pubPEM, err := mspx509.PemEncodeKey(&testPeerKey.PublicKey)
+	if err != nil {
+		panic(err)
+	}
 	sID := &msp.SerializedIdentity{
 		Mspid:   mspID,
-		IdBytes: p,
+		IdBytes: pubPEM,
 	}
 	b, _ := proto.Marshal(sID)
 	return b
@@ -662,7 +796,7 @@ func aliveMessage(id int) *gossip.Envelope {
 			},
 		},
 	}
-	sMsg, _ := noopSign(g)
+	sMsg, _ := signForTest(g)
 	return sMsg.Envelope
 }
 
@@ -685,7 +819,7 @@ func stateInfoMessageWithHeight(ledgerHeight uint64, chaincodes ...*gossip.Chain
 			},
 		},
 	}
-	sMsg, _ := noopSign(g)
+	sMsg, _ := signForTest(g)
 	return sMsg.Envelope
 }
 
@@ -766,15 +900,14 @@ func interest(ccNames ...string) *peer.ChaincodeInterest {
 	return interest
 }
 
-// noopSign creates a SignedGossipMessage with a nil signature
-func noopSign(m *gossip.GossipMessage) (*SignedGossipMessage, error) {
-	signer := func(msg []byte) ([]byte, error) {
-		return nil, nil
-	}
+// signForTest creates a SignedGossipMessage signed with testPeerKey, so that
+// it verifies against the identity produced by peerIdentity in tests that go
+// through the signature-checked path (peersForChannel, endorser).
+func signForTest(m *gossip.GossipMessage) (*SignedGossipMessage, error) {
 	sMsg := &SignedGossipMessage{
 		GossipMessage: m,
 	}
-	_, err := sMsg.Sign(signer)
+	_, err := sMsg.Sign(signWithTestPeerKey)
 	return sMsg, err
 }
 
@@ -789,6 +922,6 @@ func stateInfoWithHeight(h uint64) *SignedGossipMessage {
 			},
 		},
 	}
-	sMsg, _ := noopSign(g)
+	sMsg, _ := signForTest(g)
 	return sMsg
 }

--- a/platform/fabric/core/generic/discovery/client_test.go
+++ b/platform/fabric/core/generic/discovery/client_test.go
@@ -700,6 +700,47 @@ func TestForgedGossipEnvelopeRejected(t *testing.T) {
 		require.Len(t, peers, 1)
 		require.Equal(t, "real-peer.example.com:7051", peers[0].AliveMessage.GetAliveMsg().Membership.Endpoint)
 	})
+
+	// A real Fabric peer signs its own self-referential AliveMessage with
+	// protoext.NoopSign (gossip/discovery's Self()), which produces a nil
+	// Signature by design, and the Discovery service reports that self-entry
+	// as-is whenever the responding peer is itself among the reported peers -
+	// the common case in small test networks, where the peer answering the
+	// query is very often also one of the few endorsers/members it reports
+	// on. This must be accepted, not treated as a forged/garbage signature.
+	t.Run("nil alive message signature from a self-entry is accepted", func(t *testing.T) {
+		t.Parallel()
+		selfEnvelope := &gossip.Envelope{
+			Payload:   payload,
+			Signature: nil,
+		}
+		peers, err := peersForChannel(membersResFor(selfEnvelope, peerIdentity("A", 0)), PeerMembershipQueryType)
+		require.NoError(t, err)
+		require.Len(t, peers, 1)
+		require.Equal(t, "real-peer.example.com:7051", peers[0].AliveMessage.GetAliveMsg().Membership.Endpoint)
+	})
+
+	// Unlike AliveMessage, a real peer's StateInfo self-entry is always
+	// genuinely signed (gossipChannel.setupSignedStateInfoMessage calls a
+	// real signer, not NoopSign), so a nil StateInfo signature has no
+	// legitimate source and must still be rejected.
+	t.Run("nil stateInfo signature is still rejected", func(t *testing.T) {
+		t.Parallel()
+		sig, err := signWithTestPeerKey(payload)
+		require.NoError(t, err)
+		genuineAlive := &gossip.Envelope{
+			Payload:   payload,
+			Signature: sig,
+		}
+		membersRes := membersResFor(genuineAlive, peerIdentity("A", 0))
+		membersRes.PeersByOrg["A"].Peers[0].StateInfo = &gossip.Envelope{
+			Payload:   stateInfoMessage().Payload,
+			Signature: nil,
+		}
+		_, err = peersForChannel(membersRes, PeerMembershipQueryType)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed verifying stateInfo message signature")
+	})
 }
 
 func TestString(t *testing.T) {

--- a/platform/fabric/core/generic/discovery/gossip.go
+++ b/platform/fabric/core/generic/discovery/gossip.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	mspx509 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/x509"
 )
 
 // SignedGossipMessage contains a GossipMessage and the Envelope from which it
@@ -67,4 +68,25 @@ func EnvelopeToGossipMessage(e *gossip.Envelope) (*SignedGossipMessage, error) {
 		GossipMessage: msg,
 		Envelope:      e,
 	}, nil
+}
+
+// verifyEnvelopeSignature checks that e.Signature is a valid signature over
+// e.Payload produced by the private key corresponding to the given
+// serialized identity. This binds a relayed gossip envelope to the specific
+// identity it is shipped alongside in the same discovery response, so an
+// envelope whose signature does not verify against that identity's key -
+// including a forged/garbage signature, or one produced by a different key -
+// is rejected instead of being trusted unconditionally.
+func verifyEnvelopeSignature(e *gossip.Envelope, identity []byte) error {
+	if e == nil {
+		return errors.New("nil envelope")
+	}
+	_, verifier, err := mspx509.NewIdentityFromBytes(identity)
+	if err != nil {
+		return errors.Wrap(err, "failed deriving verifier from peer identity")
+	}
+	if err := verifier.Verify(e.Payload, e.Signature); err != nil {
+		return errors.Wrap(err, "signature does not verify against claimed identity")
+	}
+	return nil
 }

--- a/platform/fabric/core/generic/discovery/gossip.go
+++ b/platform/fabric/core/generic/discovery/gossip.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
-	mspx509 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/x509"
 )
 
 // SignedGossipMessage contains a GossipMessage and the Envelope from which it
@@ -68,44 +67,4 @@ func EnvelopeToGossipMessage(e *gossip.Envelope) (*SignedGossipMessage, error) {
 		GossipMessage: msg,
 		Envelope:      e,
 	}, nil
-}
-
-// verifyEnvelopeSignature checks that e.Signature is a valid signature over
-// e.Payload produced by the private key corresponding to the given
-// serialized identity. This binds a relayed gossip envelope to the specific
-// identity it is shipped alongside in the same discovery response, so an
-// envelope whose signature does not verify against that identity's key -
-// including a forged/garbage signature, or one produced by a different key -
-// is rejected instead of being trusted unconditionally.
-//
-// allowEmptySignature must be true only for AliveMessage/MembershipInfo
-// envelopes. A real Fabric peer signs its own self-referential AliveMessage
-// with protoext.NoopSign (gossip/discovery's Self()), which produces a nil
-// Signature by design, and the Discovery service exposes that self-entry
-// as-is (discovery/support/gossip's Peers(), via SelfMembershipInfo()). This
-// is inherent to how real Fabric peers answer Discovery queries - even
-// upstream Fabric's own discovery client performs no verification at all on
-// these envelopes - so rejecting a nil signature here would fail every
-// Discovery query in which the responding peer is itself among the reported
-// peers/endorsers, which is the common case in small networks. StateInfo
-// self-entries do not share this exemption: real peers always produce a
-// genuine signature for them, even for themselves (see
-// gossipChannel.setupSignedStateInfoMessage, which calls a real signer, not
-// NoopSign), so callers must pass false for StateInfo envelopes to keep that
-// verification strict.
-func verifyEnvelopeSignature(e *gossip.Envelope, identity []byte, allowEmptySignature bool) error {
-	if e == nil {
-		return errors.New("nil envelope")
-	}
-	if allowEmptySignature && len(e.Signature) == 0 {
-		return nil
-	}
-	_, verifier, err := mspx509.NewIdentityFromBytes(identity)
-	if err != nil {
-		return errors.Wrap(err, "failed deriving verifier from peer identity")
-	}
-	if err := verifier.Verify(e.Payload, e.Signature); err != nil {
-		return errors.Wrap(err, "signature does not verify against claimed identity")
-	}
-	return nil
 }

--- a/platform/fabric/core/generic/discovery/gossip.go
+++ b/platform/fabric/core/generic/discovery/gossip.go
@@ -77,9 +77,28 @@ func EnvelopeToGossipMessage(e *gossip.Envelope) (*SignedGossipMessage, error) {
 // envelope whose signature does not verify against that identity's key -
 // including a forged/garbage signature, or one produced by a different key -
 // is rejected instead of being trusted unconditionally.
-func verifyEnvelopeSignature(e *gossip.Envelope, identity []byte) error {
+//
+// allowEmptySignature must be true only for AliveMessage/MembershipInfo
+// envelopes. A real Fabric peer signs its own self-referential AliveMessage
+// with protoext.NoopSign (gossip/discovery's Self()), which produces a nil
+// Signature by design, and the Discovery service exposes that self-entry
+// as-is (discovery/support/gossip's Peers(), via SelfMembershipInfo()). This
+// is inherent to how real Fabric peers answer Discovery queries - even
+// upstream Fabric's own discovery client performs no verification at all on
+// these envelopes - so rejecting a nil signature here would fail every
+// Discovery query in which the responding peer is itself among the reported
+// peers/endorsers, which is the common case in small networks. StateInfo
+// self-entries do not share this exemption: real peers always produce a
+// genuine signature for them, even for themselves (see
+// gossipChannel.setupSignedStateInfoMessage, which calls a real signer, not
+// NoopSign), so callers must pass false for StateInfo envelopes to keep that
+// verification strict.
+func verifyEnvelopeSignature(e *gossip.Envelope, identity []byte, allowEmptySignature bool) error {
 	if e == nil {
 		return errors.New("nil envelope")
+	}
+	if allowEmptySignature && len(e.Signature) == 0 {
+		return nil
 	}
 	_, verifier, err := mspx509.NewIdentityFromBytes(identity)
 	if err != nil {

--- a/platform/fabric/core/generic/ledger/ledger.go
+++ b/platform/fabric/core/generic/ledger/ledger.go
@@ -122,13 +122,24 @@ func (b *Block) DataAt(i int) []byte {
 
 // ProcessedTransaction returns the ProcessedTransaction at passed index
 func (b *Block) ProcessedTransaction(i int) (driver.ProcessedTransaction, error) {
+	if i < 0 || i >= len(b.Data.Data) {
+		return nil, errors.Errorf("transaction index [%d] out of range [0,%d)", i, len(b.Data.Data))
+	}
+	if int(common.BlockMetadataIndex_TRANSACTIONS_FILTER) >= len(b.Metadata.Metadata) {
+		return nil, errors.Errorf("block metadata missing transactions filter entry")
+	}
+	txFilter := b.Metadata.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER]
+	if i >= len(txFilter) {
+		return nil, errors.Errorf("transactions filter index [%d] out of range [0,%d)", i, len(txFilter))
+	}
+
 	env := &common.Envelope{}
 	if err := proto.Unmarshal(b.Data.Data[i], env); err != nil {
 		return nil, err
 	}
 	pt := &peer.ProcessedTransaction{
 		TransactionEnvelope: env,
-		ValidationCode:      int32(b.Metadata.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER][i]),
+		ValidationCode:      int32(txFilter[i]),
 	}
 	ptRaw, err := proto.Marshal(pt)
 	if err != nil {

--- a/platform/fabric/core/generic/ledger/ledger.go
+++ b/platform/fabric/core/generic/ledger/ledger.go
@@ -115,17 +115,24 @@ type Block struct {
 	TransactionManager driver.TransactionManager
 }
 
-// DataAt returns the data stored at the passed index
+// DataAt returns the data stored at the passed index. block.Data is
+// populated by whoever produced the block, so a malformed or malicious
+// block (e.g. fetched via GetBlockByNumber from a remote peer) can have a
+// nil Data or a Data.Data shorter than the caller expects, which would
+// otherwise panic on a bare slice index.
 func (b *Block) DataAt(i int) []byte {
+	if b.Data == nil || i < 0 || i >= len(b.Data.Data) {
+		return nil
+	}
 	return b.Data.Data[i]
 }
 
 // ProcessedTransaction returns the ProcessedTransaction at passed index
 func (b *Block) ProcessedTransaction(i int) (driver.ProcessedTransaction, error) {
-	if i < 0 || i >= len(b.Data.Data) {
-		return nil, errors.Errorf("transaction index [%d] out of range [0,%d)", i, len(b.Data.Data))
+	if b.Data == nil || i < 0 || i >= len(b.Data.Data) {
+		return nil, errors.Errorf("transaction index [%d] out of range [0,%d)", i, len(b.Data.GetData()))
 	}
-	if int(common.BlockMetadataIndex_TRANSACTIONS_FILTER) >= len(b.Metadata.Metadata) {
+	if b.Metadata == nil || int(common.BlockMetadataIndex_TRANSACTIONS_FILTER) >= len(b.Metadata.Metadata) {
 		return nil, errors.Errorf("block metadata missing transactions filter entry")
 	}
 	txFilter := b.Metadata.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER]

--- a/platform/fabric/core/generic/ledger/ledger_test.go
+++ b/platform/fabric/core/generic/ledger/ledger_test.go
@@ -401,4 +401,54 @@ func TestBlock(t *testing.T) {
 			require.Error(t, err)
 		})
 	})
+
+	// Regression test: block.Data and block.Metadata are populated
+	// independently by whoever produced the block, so a malformed block can
+	// have either be nil entirely - not just shorter than expected.
+	t.Run("nil Data does not panic", func(t *testing.T) {
+		t.Parallel()
+		mockTM := &mock.TransactionManager{}
+		block := &common.Block{
+			Metadata: &common.BlockMetadata{
+				Metadata: [][]byte{nil, nil, {byte(peer.TxValidationCode_VALID)}},
+			},
+		}
+		b := &Block{Block: block, TransactionManager: mockTM}
+
+		require.NotPanics(t, func() {
+			require.Nil(t, b.DataAt(0))
+			_, err := b.ProcessedTransaction(0)
+			require.Error(t, err)
+		})
+	})
+
+	t.Run("nil Metadata does not panic", func(t *testing.T) {
+		t.Parallel()
+		mockTM := &mock.TransactionManager{}
+		env := &common.Envelope{Payload: []byte("payload1")}
+		rawEnv, _ := proto.Marshal(env)
+
+		block := &common.Block{
+			Data: &common.BlockData{
+				Data: [][]byte{rawEnv},
+			},
+		}
+		b := &Block{Block: block, TransactionManager: mockTM}
+
+		require.NotPanics(t, func() {
+			require.Equal(t, rawEnv, b.DataAt(0))
+			_, err := b.ProcessedTransaction(0)
+			require.Error(t, err)
+		})
+	})
+
+	t.Run("DataAt out of range returns nil instead of panicking", func(t *testing.T) {
+		t.Parallel()
+		b, _, _ := setup()
+
+		require.NotPanics(t, func() {
+			require.Nil(t, b.DataAt(-1))
+			require.Nil(t, b.DataAt(5))
+		})
+	})
 }

--- a/platform/fabric/core/generic/ledger/ledger_test.go
+++ b/platform/fabric/core/generic/ledger/ledger_test.go
@@ -335,4 +335,70 @@ func TestBlock(t *testing.T) {
 		_, err = b.ProcessedTransaction(0)
 		require.Error(t, err)
 	})
+
+	// Regression test: ProcessedTransaction used to index straight into
+	// b.Data.Data[i] and b.Metadata.Metadata[TRANSACTIONS_FILTER][i] with no
+	// bounds checking. A malformed/malicious block (e.g. one whose
+	// TRANSACTIONS_FILTER metadata entry is shorter than Data.Data, or an
+	// out-of-range index requested by a caller) crashes the whole process with
+	// an index-out-of-range panic instead of returning an error.
+	t.Run("out of range index does not panic", func(t *testing.T) {
+		t.Parallel()
+		b, _, _ := setup()
+
+		require.NotPanics(t, func() {
+			_, err := b.ProcessedTransaction(5)
+			require.Error(t, err)
+		})
+	})
+
+	t.Run("undersized transactions filter does not panic", func(t *testing.T) {
+		t.Parallel()
+		mockTM := &mock.TransactionManager{}
+		env := &common.Envelope{Payload: []byte("payload1")}
+		rawEnv, _ := proto.Marshal(env)
+
+		// Two data entries but the TRANSACTIONS_FILTER metadata entry only
+		// covers the first one.
+		block := &common.Block{
+			Data: &common.BlockData{
+				Data: [][]byte{rawEnv, rawEnv},
+			},
+			Metadata: &common.BlockMetadata{
+				Metadata: [][]byte{
+					nil,
+					nil,
+					{byte(peer.TxValidationCode_VALID)},
+				},
+			},
+		}
+		b := &Block{Block: block, TransactionManager: mockTM}
+
+		require.NotPanics(t, func() {
+			_, err := b.ProcessedTransaction(1)
+			require.Error(t, err)
+		})
+	})
+
+	t.Run("missing metadata does not panic", func(t *testing.T) {
+		t.Parallel()
+		mockTM := &mock.TransactionManager{}
+		env := &common.Envelope{Payload: []byte("payload1")}
+		rawEnv, _ := proto.Marshal(env)
+
+		block := &common.Block{
+			Data: &common.BlockData{
+				Data: [][]byte{rawEnv},
+			},
+			Metadata: &common.BlockMetadata{
+				Metadata: [][]byte{},
+			},
+		}
+		b := &Block{Block: block, TransactionManager: mockTM}
+
+		require.NotPanics(t, func() {
+			_, err := b.ProcessedTransaction(0)
+			require.Error(t, err)
+		})
+	})
 }

--- a/platform/fabric/core/generic/msp/x509/provider.go
+++ b/platform/fabric/core/generic/msp/x509/provider.go
@@ -106,6 +106,19 @@ func (p *Provider) EnrollmentID() string {
 	return p.enrollmentID
 }
 
+// DeserializeVerifier extracts an ECDSA public key from a serialized
+// identity and returns a Verifier for it. It does NOT validate the identity
+// against any MSP: there is no CA-chain validation, no expiration/CRL
+// check, and no check that the claimed Mspid is trusted. Any caller-supplied
+// bytes containing a well-formed msp.SerializedIdentity with a PEM-encoded
+// ECDSA public key will deserialize successfully, including a self-signed
+// or entirely fabricated identity.
+//
+// This method is only reached via the "verify only" fallback constructed in
+// NewProviderWithBCCSPConfig when full MSP loading fails, so its output
+// must not be treated as an authorization decision on its own - callers
+// must check the resulting identity against an explicit allow-list (e.g.
+// the configured Admins/Clients/DefaultIdentity) before trusting it.
 func (p *Provider) DeserializeVerifier(raw []byte) (driver.Verifier, error) {
 	si := &msp.SerializedIdentity{}
 	err := proto.Unmarshal(raw, si)
@@ -120,8 +133,6 @@ func (p *Provider) DeserializeVerifier(raw []byte) (driver.Verifier, error) {
 	if !ok {
 		return nil, errors.New("expected *ecdsa.PublicKey")
 	}
-
-	// TODO: check the validity of the identity against the msp
 
 	return NewVerifier(publicKey), nil
 }

--- a/platform/fabric/core/generic/ordering/cft.go
+++ b/platform/fabric/core/generic/ordering/cft.go
@@ -83,7 +83,7 @@ func (o *CFTBroadcaster) Broadcast(ctx context.Context, env *common2.Envelope) e
 		if status.GetStatus() != common2.Status_SUCCESS {
 			logger.DebugfContext(ctx, "Release connection")
 			o.releaseConnection(connection)
-			return errors.Wrapf(err, "failed broadcasting, status %s", common2.Status_name[int32(status.GetStatus())])
+			return errors.Errorf("failed broadcasting, status %s", common2.Status_name[int32(status.GetStatus())])
 		}
 
 		labels := []string{

--- a/platform/fabric/core/generic/ordering/cft_test.go
+++ b/platform/fabric/core/generic/ordering/cft_test.go
@@ -21,7 +21,16 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/metrics"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/ordering/fake"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
+	metricsdisabled "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics/disabled"
 )
+
+// newTestMetrics returns a *metrics.Metrics backed by working (no-op) counters,
+// for tests that exercise a real Broadcast success path (which increments
+// OrderedTransactions). A bare &metrics.Metrics{} has a nil Counter and panics
+// there.
+func newTestMetrics() *metrics.Metrics {
+	return metrics.NewMetrics(&metricsdisabled.Provider{})
+}
 
 // fakeCFTServices provides orderer clients for testing
 type fakeCFTServices struct {
@@ -68,7 +77,7 @@ func (f *fakeCFTClient) Close() {
 type fakeCFTAB struct{}
 
 func (fakeCFTAB) Broadcast(context.Context, ...ggrpc.CallOption) (ggrpc.BidiStreamingClient[common.Envelope, ab.BroadcastResponse], error) {
-	return &fakeCFTStream{}, nil
+	return &fakeCFTStream{status: common.Status_SUCCESS}, nil
 }
 
 func (fakeCFTAB) Deliver(context.Context, ...ggrpc.CallOption) (ggrpc.BidiStreamingClient[common.Envelope, ab.DeliverResponse], error) {
@@ -139,7 +148,7 @@ func TestCFTBroadcaster_NewCFTBroadcaster(t *testing.T) {
 				PoolSizeValue:    tt.poolSize,
 				NetworkNameValue: tt.networkName,
 			}
-			m := &metrics.Metrics{}
+			m := newTestMetrics()
 
 			b := NewCFTBroadcaster(cfg, &fakeCFTServices{}, m)
 
@@ -167,7 +176,7 @@ func TestCFTBroadcaster_Broadcast_Success(t *testing.T) {
 			NetworkNameValue: "test-network",
 			OrderersValue:    []*grpc.ConnectionConfig{{Address: "orderer-1"}},
 		}
-		m := &metrics.Metrics{}
+		m := newTestMetrics()
 		b := NewCFTBroadcaster(cfg, &fakeCFTServices{}, m)
 
 		err := b.Broadcast(t.Context(), &common.Envelope{})
@@ -182,7 +191,7 @@ func TestCFTBroadcaster_Broadcast_Success(t *testing.T) {
 			NetworkNameValue: "test-network",
 			OrderersValue:    []*grpc.ConnectionConfig{{Address: "orderer-1"}},
 		}
-		m := &metrics.Metrics{}
+		m := newTestMetrics()
 		b := NewCFTBroadcaster(cfg, &fakeCFTServices{}, m)
 
 		// First broadcast creates connection
@@ -266,7 +275,7 @@ func TestCFTBroadcaster_Broadcast_Retries(t *testing.T) {
 			OrderersValue:    []*grpc.ConnectionConfig{{Address: "orderer-1"}},
 		}
 
-		b := NewCFTBroadcaster(cfg, &fakeCFTServices{}, nil)
+		b := NewCFTBroadcaster(cfg, &fakeCFTServices{}, newTestMetrics())
 
 		// First broadcast succeeds and pools connection
 		err := b.Broadcast(t.Context(), &common.Envelope{})
@@ -303,6 +312,51 @@ func TestCFTBroadcaster_Broadcast_Retries(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to send transaction to orderer")
 	})
+}
+
+// TestCFTBroadcaster_Broadcast_OrdererRejection is a regression test: when the
+// orderer responds with a non-SUCCESS status but Send/Recv return no
+// transport error, Broadcast used to call errors.Wrapf(err, ...) with a nil
+// err, which (per github.com/pkg/errors semantics) returns nil. That made
+// Broadcast report success to the caller for a transaction the orderer
+// actually rejected (e.g. BAD_REQUEST, FORBIDDEN, SERVICE_UNAVAILABLE) - the
+// caller has no way to know its transaction was dropped. BFT's equivalent
+// branch uses fmt.Errorf and does not share this defect.
+func TestCFTBroadcaster_Broadcast_OrdererRejection(t *testing.T) {
+	t.Parallel()
+
+	rejectionStatuses := []common.Status{
+		common.Status_BAD_REQUEST,
+		common.Status_FORBIDDEN,
+		common.Status_SERVICE_UNAVAILABLE,
+	}
+
+	for _, st := range rejectionStatuses {
+		t.Run(common.Status_name[int32(st)], func(t *testing.T) {
+			t.Parallel()
+			cfg := &fake.ConfigService{
+				PoolSizeValue:    4,
+				RetriesValue:     3,
+				NetworkNameValue: "test-network",
+				OrderersValue:    []*grpc.ConnectionConfig{{Address: "orderer-1"}},
+			}
+			services := &fakeCFTServices{}
+			b := NewCFTBroadcaster(cfg, services, newTestMetrics())
+
+			// Pre-seed the pool with a connection whose stream reports a
+			// rejection status with no Send/Recv error, so the first attempt
+			// hits the buggy branch directly (no retries involved).
+			conn, err := b.getConnection(t.Context())
+			require.NoError(t, err)
+			conn.Stream = &fakeCFTStream{status: st}
+			b.releaseConnection(conn)
+
+			err = b.Broadcast(t.Context(), &common.Envelope{})
+			require.Error(t, err, "orderer rejection (status %s) must surface as an error, not be silently swallowed", common.Status_name[int32(st)])
+			require.Contains(t, err.Error(), "failed broadcasting")
+			require.Contains(t, err.Error(), common.Status_name[int32(st)])
+		})
+	}
 }
 
 // TestCFTBroadcaster_GetConnection tests connection acquisition
@@ -558,7 +612,7 @@ func TestCFTBroadcaster_ConcurrentBroadcasts(t *testing.T) {
 			NetworkNameValue: "test-network",
 			OrderersValue:    []*grpc.ConnectionConfig{{Address: "orderer-1"}},
 		}
-		b := NewCFTBroadcaster(cfg, &fakeCFTServices{}, &metrics.Metrics{})
+		b := NewCFTBroadcaster(cfg, &fakeCFTServices{}, newTestMetrics())
 
 		const numGoroutines = 20
 		errChan := make(chan error, numGoroutines)
@@ -637,7 +691,7 @@ func TestCFTBroadcaster_ConnectionLifecycle(t *testing.T) {
 			NetworkNameValue: "test-network",
 			OrderersValue:    []*grpc.ConnectionConfig{{Address: "orderer-1"}},
 		}
-		b := NewCFTBroadcaster(cfg, &fakeCFTServices{}, &metrics.Metrics{})
+		b := NewCFTBroadcaster(cfg, &fakeCFTServices{}, newTestMetrics())
 
 		// First broadcast - creates connection
 		err := b.Broadcast(t.Context(), &common.Envelope{})

--- a/platform/view/services/id/x509/deserializer.go
+++ b/platform/view/services/id/x509/deserializer.go
@@ -17,6 +17,14 @@ import (
 
 type Deserializer struct{}
 
+// DeserializeVerifier extracts an ECDSA public key from raw and returns a
+// Verifier for it. It does NOT validate the key against any MSP or CA: any
+// caller-supplied PEM-encoded ECDSA public key deserializes successfully,
+// including one belonging to a self-signed or entirely fabricated identity.
+// This deserializer is registered unconditionally into the multiplex
+// deserializer used by sig.Service, so its output must not be treated as an
+// authorization decision on its own - callers must check the resulting
+// identity against an explicit allow-list before trusting it.
 func (x *Deserializer) DeserializeVerifier(raw []byte) (driver.Verifier, error) {
 	genericPublicKey, err := PemDecodeKey(raw)
 	if err != nil {


### PR DESCRIPTION
## Summary

Hardens `platform/fabric/core/` against several issues reachable from untrusted peer/orderer input:

- **Gossip discovery envelope trust**: `peersForChannel`/`endorser` now verify each Alive/StateInfo envelope's signature against the public key embedded in that peer's own claimed identity before trusting its content. Previously `EnvelopeToGossipMessage` unmarshaled `Payload` without ever checking `Signature`, so a malicious/compromised discovery-responding peer could forge another org's peer membership (endpoint, MSPID) and have it accepted — a self-consistency check now closes the "arbitrary/garbage signature accepted" gap.
- **Unrecovered panics on malformed peer input**: four independent call sites indexed directly into `*common.Block`/`common.BlockMetadata` fields from a remote `Deliver`/`DeliverFiltered` stream with no nil/bounds checks and no panic recovery anywhere up the call chain. A malformed block from a peer could crash the entire process. All four now guard and return errors instead.
- **Panic on a recoverable failure**: `CommitConfig` `panic`ked on a `MembershipService.Update` failure even after the block was already durably committed. Now returns a wrapped error.
- **Silent success on orderer rejection**: `CFTBroadcaster.Broadcast` called `errors.Wrapf(err, ...)` on an orderer-rejected status where the transport `err` was `nil` — per `github.com/pkg/errors` semantics, wrapping a `nil` error returns `nil`, so a rejected transaction was reported back to the caller as a success. Switched to `errors.Errorf` so rejection is always a non-nil error.
- **Undocumented trust boundary**: the lightweight x509 identity deserializers (`msp/x509.Provider.DeserializeVerifier`, `view/services/id/x509.Deserializer.DeserializeVerifier`) accept any well-formed self-signed identity with no CA/MSP binding — an intentional degraded-mode fallback, not a bug to remove (it backs a tested "verify only" contract). Replaced a stale `// TODO: check the validity of the identity against the msp` with an explicit doc comment on both implementations spelling out the boundary, so callers know to check results against an allow-list rather than treating "signature verifies" as "identity is authorized." Documentation-only, no behavior change.

Fixes #1610.

## Test plan

- [x] `go build ./platform/fabric/... ./platform/view/...`
- [x] `go test ./platform/fabric/... ./platform/view/...` (full tree, zero failures)
- [x] `go test ./platform/fabric/core/generic/discovery/...` — new `TestForgedGossipEnvelopeRejected` (garbage signature, wrong-key signature, and genuine-signature-accepted subtests) plus existing `TestClient`/`TestBadResponses` continue to pass against real signed fixtures
- [x] `go test ./platform/fabric/core/generic/delivery/...` — new `deliverclient_test.go`/`service_test.go`, extended `delivery_test.go`
- [x] `go test ./platform/fabric/core/generic/committer/...` — extended `config_test.go`/`endorsertx_test.go`
- [x] `go test ./platform/fabric/core/generic/ledger/...` — extended `ledger_test.go`
- [x] `go test ./platform/fabric/core/generic/ordering/...` — new `TestCFTBroadcaster_Broadcast_OrdererRejection`
- [x] `go test ./platform/fabric/core/generic/msp/x509/... ./platform/view/services/id/x509/...` — confirmed doc-only change, existing verify-only fallback tests unchanged