### PR TITLE
fix(security): harden fabricx driver against malformed/malicious remote input

### DIFF
--- a/platform/fabricx/core/channel/config/monitor.go
+++ b/platform/fabricx/core/channel/config/monitor.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/protoutil"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
@@ -60,12 +61,13 @@ type ChannelConfigMonitor struct {
 	channel           string
 
 	// State management
-	mu          sync.RWMutex
-	running     bool
-	ctx         context.Context
-	cancel      context.CancelFunc
-	wg          sync.WaitGroup
-	lastVersion int64
+	mu           sync.RWMutex
+	running      bool
+	ctx          context.Context
+	cancel       context.CancelFunc
+	wg           sync.WaitGroup
+	lastVersion  int64
+	lastSequence int64
 }
 
 // NewChannelConfigMonitor creates a new ChannelConfigMonitor service instance
@@ -107,6 +109,7 @@ func NewChannelConfigMonitor(
 		channel:           channel,
 		running:           false,
 		lastVersion:       -1,
+		lastSequence:      -1,
 	}, nil
 }
 
@@ -203,27 +206,66 @@ func (s *ChannelConfigMonitor) checkAndUpdate() error {
 			return errors.New("received nil config transaction info")
 		}
 
+		// configInfo.Version is a plain, out-of-band counter set unilaterally
+		// by the remote committer -- it is not derived from, or bound to, the
+		// envelope content served alongside it. Trusting it in isolation lets
+		// a malicious/compromised committer suppress a genuinely new config
+		// indefinitely simply by reporting a stale Version. Cross-validate it
+		// against the config sequence number embedded in the envelope's own
+		// content: an attacker cannot suppress detection by lying about
+		// Version alone while still serving an envelope whose real,
+		// signed-content sequence has actually advanced.
+		sequence, seqErr := extractConfigSequence(configInfo.Envelope)
+		if seqErr != nil {
+			logger.Warnf("Failed to extract config sequence from envelope for [%s:%s]: %v", s.network, s.channel, seqErr)
+		}
+
+		isNewVersion := int64(configInfo.Version) > s.lastVersion
+		isNewSequence := seqErr == nil && int64(sequence) > s.lastSequence
+
 		// Check if this is a new configuration
-		if int64(configInfo.Version) <= s.lastVersion {
-			logger.Debugf("No new config for [%s:%s], current version: %d", s.network, s.channel, configInfo.Version)
+		if !isNewVersion && !isNewSequence {
+			logger.Debugf("No new config for [%s:%s], current version: %d, sequence: %d", s.network, s.channel, s.lastVersion, s.lastSequence)
 			return nil
 		}
 
-		logger.Debugf("New config detected for [%s:%s], version: %d -> %d",
-			s.network, s.channel, s.lastVersion, configInfo.Version)
+		logger.Debugf("New config detected for [%s:%s], version: %d -> %d, sequence: %d -> %d",
+			s.network, s.channel, s.lastVersion, configInfo.Version, s.lastSequence, sequence)
 
 		// Apply the configuration update
 		if err := s.applyConfigUpdate(configInfo.Envelope); err != nil {
 			return errors.Wrap(err, "failed to apply config update")
 		}
 
-		// Update the last processed config version
+		// Update the last processed config version and sequence
 		s.lastVersion = int64(configInfo.Version)
+		if seqErr == nil {
+			s.lastSequence = int64(sequence)
+		}
 		logger.Debugf("Config update applied successfully for [%s:%s], new version: %d",
 			s.network, s.channel, configInfo.Version)
 
 		return nil
 	})
+}
+
+// extractConfigSequence extracts the config sequence number embedded in the
+// envelope's own content (Config.Sequence). Unlike the Version field reported
+// alongside a ConfigTransactionInfo, this value is derived from the envelope
+// itself, so it can be used to cross-validate that out-of-band report -- see
+// checkAndUpdate.
+func extractConfigSequence(env *cb.Envelope) (uint64, error) {
+	payload, err := protoutil.UnmarshalPayload(env.Payload)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to unmarshal payload")
+	}
+
+	configEnvelope, err := protoutil.UnmarshalConfigEnvelope(payload.Data)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to unmarshal config envelope")
+	}
+
+	return configEnvelope.GetConfig().GetSequence(), nil
 }
 
 // applyConfigUpdate applies the configuration update to membership and ordering services

--- a/platform/fabricx/core/channel/config/monitor_staleness_poc_test.go
+++ b/platform/fabricx/core/channel/config/monitor_staleness_poc_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	channelconfig "github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/channel/config"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/channel/config/mock"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
+)
+
+// configEnvelopeWithSequence builds a well-formed *cb.Envelope wrapping a
+// marshaled Payload wrapping a marshaled ConfigEnvelope carrying the given
+// Config.Sequence -- the envelope-embedded sequence number that
+// checkAndUpdate now cross-validates against the remote-reported Version.
+func configEnvelopeWithSequence(t *testing.T, sequence uint64) *cb.Envelope {
+	t.Helper()
+
+	configEnvelope := &cb.ConfigEnvelope{
+		Config: &cb.Config{Sequence: sequence},
+	}
+	configEnvelopeRaw, err := proto.Marshal(configEnvelope)
+	require.NoError(t, err)
+
+	payload := &cb.Payload{Data: configEnvelopeRaw}
+	payloadRaw, err := proto.Marshal(payload)
+	require.NoError(t, err)
+
+	return &cb.Envelope{Payload: payloadRaw}
+}
+
+// TestMonitorDetectsGenuinelyDifferentConfigViaSequenceEvenWhenVersionIsStale
+// proves the fix: ChannelConfigMonitor.checkAndUpdate no longer trusts the
+// remote-reported ConfigTransactionInfo.Version field in isolation. It now
+// also cross-validates the config sequence number embedded in the envelope's
+// own content (Config.Sequence), so a malicious/compromised committer cannot
+// suppress a genuinely new config merely by reporting a stale Version.
+//
+// This test replays the same attack the original PoC demonstrated: after one
+// legitimate update (version 1 / sequence 1 -> envelope A), the fake service
+// starts serving a distinct envelope B with a genuinely higher embedded
+// Config.Sequence (as if the real channel config changed, e.g. new orderer
+// endpoints or membership) while still reporting the same stale Version: 1.
+// Unlike before the fix, the monitor now detects the advanced sequence number
+// and applies the update anyway.
+func TestMonitorDetectsGenuinelyDifferentConfigViaSequenceEvenWhenVersionIsStale(t *testing.T) {
+	t.Parallel()
+
+	config := &channelconfig.Config{
+		PollInterval:      20 * time.Millisecond,
+		MaxRetries:        1,
+		InitialRetryDelay: 5 * time.Millisecond,
+		MaxRetryDelay:     20 * time.Millisecond,
+	}
+
+	queryService := &mock.QueryService{}
+	membershipService := &mock.MembershipService{}
+	orderingService := &mock.OrderingService{}
+	configService := &mock.ConfigService{}
+
+	envelopeA := configEnvelopeWithSequence(t, 1)
+	envelopeB := configEnvelopeWithSequence(t, 2)
+
+	callCount := 0
+	queryService.GetConfigTransactionCalls(func() (*queryservice.ConfigTransactionInfo, error) {
+		callCount++
+		if callCount == 1 {
+			// Legitimate initial config, version 1, sequence 1.
+			return &queryservice.ConfigTransactionInfo{Envelope: envelopeA, Version: 1}, nil
+		}
+		// From the second call onward, the "channel config" has genuinely
+		// changed (envelopeB, sequence 2), but the compromised committer
+		// keeps reporting the same stale version to try to suppress
+		// propagation.
+		return &queryservice.ConfigTransactionInfo{Envelope: envelopeB, Version: 1}, nil
+	})
+
+	membershipService.UpdateReturns(nil)
+	membershipService.OrdererConfigReturns("etcdraft", nil, nil)
+	orderingService.ConfigureReturns(nil)
+
+	monitor, err := channelconfig.NewChannelConfigMonitor(
+		config, queryService, membershipService,
+		orderingService, configService, "testnet", "mychannel",
+	)
+	require.NoError(t, err)
+
+	err = monitor.Start(context.Background())
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return membershipService.UpdateCallCount() >= 2
+	}, 2*time.Second, 10*time.Millisecond, "the sequence-advanced envelopeB must be applied despite the stale reported Version")
+
+	err = monitor.Stop()
+	require.NoError(t, err)
+
+	// The first update applied envelope A; a later one applied envelope B,
+	// proving the genuinely new content was detected via its embedded
+	// sequence number rather than being silently dropped.
+	require.Same(t, envelopeA, membershipService.UpdateArgsForCall(0))
+	appliedLast := membershipService.UpdateArgsForCall(membershipService.UpdateCallCount() - 1)
+	require.Same(t, envelopeB, appliedLast)
+}
+
+// TestMonitorSkipsUpdateWhenNeitherVersionNorSequenceAdvanced proves the
+// complementary, non-regressed behavior: once a config has been applied, a
+// subsequent poll that serves the exact same envelope/version (no genuine
+// change at all) must still be recognized as "nothing new" and not trigger a
+// redundant call to applyConfigUpdate.
+func TestMonitorSkipsUpdateWhenNeitherVersionNorSequenceAdvanced(t *testing.T) {
+	t.Parallel()
+
+	config := &channelconfig.Config{
+		PollInterval:      20 * time.Millisecond,
+		MaxRetries:        1,
+		InitialRetryDelay: 5 * time.Millisecond,
+		MaxRetryDelay:     20 * time.Millisecond,
+	}
+
+	queryService := &mock.QueryService{}
+	membershipService := &mock.MembershipService{}
+	orderingService := &mock.OrderingService{}
+	configService := &mock.ConfigService{}
+
+	envelopeA := configEnvelopeWithSequence(t, 1)
+
+	queryService.GetConfigTransactionReturns(&queryservice.ConfigTransactionInfo{Envelope: envelopeA, Version: 1}, nil)
+	membershipService.UpdateReturns(nil)
+	membershipService.OrdererConfigReturns("etcdraft", nil, nil)
+	orderingService.ConfigureReturns(nil)
+
+	monitor, err := channelconfig.NewChannelConfigMonitor(
+		config, queryService, membershipService,
+		orderingService, configService, "testnet", "mychannel",
+	)
+	require.NoError(t, err)
+
+	err = monitor.Start(context.Background())
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return queryService.GetConfigTransactionCallCount() >= 5
+	}, 2*time.Second, 10*time.Millisecond)
+
+	err = monitor.Stop()
+	require.NoError(t, err)
+
+	// Despite many polls, the identical version/sequence must only ever be
+	// applied once.
+	require.Equal(t, 1, membershipService.UpdateCallCount())
+}

--- a/platform/fabricx/core/committer/txhandler.go
+++ b/platform/fabricx/core/committer/txhandler.go
@@ -36,11 +36,25 @@ type handler struct {
 }
 
 func (h *handler) HandleFabricxTransaction(ctx context.Context, blkMetadata *cb.BlockMetadata, tx committer.CommitTx) (*committer.FinalityEvent, error) {
-	if len(blkMetadata.Metadata) < statusIdx {
+	// len(...) < statusIdx would only guarantee indices [0, statusIdx-1]
+	// exist, not statusIdx itself -- an off-by-one that would still let
+	// Metadata[statusIdx] below panic on a block metadata slice exactly
+	// statusIdx entries long. Requiring statusIdx+1 entries guarantees the
+	// TRANSACTIONS_FILTER entry itself is present.
+	if len(blkMetadata.Metadata) < statusIdx+1 {
 		return nil, errors.New("block metadata lacks transaction filter")
 	}
 
-	statusCode := committerpb.Status(blkMetadata.Metadata[statusIdx][tx.TxNum])
+	txFilter := blkMetadata.Metadata[statusIdx]
+	// A malicious or buggy committer/notifier can deliver a TRANSACTIONS_FILTER
+	// entry shorter than the actual number of transactions in the block (or
+	// simply report a tx.TxNum beyond it), which would otherwise panic with
+	// an index-out-of-range and crash the goroutine processing the block.
+	if tx.TxNum >= uint64(len(txFilter)) {
+		return nil, errors.Errorf("transaction filter has no entry for tx index [%d] (filter length [%d])", tx.TxNum, len(txFilter))
+	}
+
+	statusCode := committerpb.Status(txFilter[tx.TxNum])
 	event := &committer.FinalityEvent{
 		Ctx:               ctx,
 		TxID:              tx.TxID,

--- a/platform/fabricx/core/committer/txhandler_poc_test.go
+++ b/platform/fabricx/core/committer/txhandler_poc_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package committer
+
+import (
+	"context"
+	"testing"
+
+	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/stretchr/testify/require"
+
+	commoncommitter "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/committer"
+)
+
+// TestHandleFabricxTransactionShortTransactionsFilterReturnsError proves the
+// fix: HandleFabricxTransaction now bounds-checks the TRANSACTIONS_FILTER
+// entry itself (blkMetadata.Metadata[statusIdx], a byte slice with one status
+// byte per transaction in the block) against tx.TxNum, instead of only
+// bounds-checking the outer block-metadata slice.
+//
+// A compromised/malicious committer or notifier delivering a block/metadata
+// pair whose TRANSACTIONS_FILTER entry is shorter than the actual number of
+// transactions -- or simply reporting a tx.TxNum beyond that entry's length
+// -- used to cause an index-out-of-range panic that crashed the goroutine
+// processing the block (platform/fabric/core/generic/committer/committer.go's
+// commitTxs, run inside an errgroup per block), i.e. a remotely triggerable
+// DoS against the FSC client process. It must now return an error instead.
+func TestHandleFabricxTransactionShortTransactionsFilterReturnsError(t *testing.T) {
+	h := &handler{committer: &commoncommitter.Committer{}}
+
+	// TRANSACTIONS_FILTER (index 2) is present but empty, i.e. it reports
+	// status for zero transactions, while the committer still asks us to
+	// handle tx.TxNum == 0.
+	blkMetadata := &cb.BlockMetadata{
+		Metadata: [][]byte{
+			{}, // SIGNATURES
+			{}, // LAST_CONFIG
+			{}, // TRANSACTIONS_FILTER -- empty, shorter than the block's tx count
+		},
+	}
+
+	tx := commoncommitter.CommitTx{
+		TxNum: 0,
+		TxID:  "victim-tx",
+	}
+
+	require.NotPanics(t, func() {
+		event, err := h.HandleFabricxTransaction(context.Background(), blkMetadata, tx)
+		require.Error(t, err)
+		require.Nil(t, event)
+		require.Contains(t, err.Error(), "transaction filter has no entry")
+	})
+}
+
+// TestHandleFabricxTransactionShortMetadataSliceReturnsError proves the fix
+// for the second, off-by-one gap: the original outer check
+// (len(blkMetadata.Metadata) < statusIdx, with statusIdx == 2) only guaranteed
+// indices 0 and 1 existed, not index 2 (TRANSACTIONS_FILTER) itself -- a
+// block metadata slice with exactly statusIdx (2) entries would still panic
+// on Metadata[statusIdx]. The check must require statusIdx+1 entries.
+func TestHandleFabricxTransactionShortMetadataSliceReturnsError(t *testing.T) {
+	h := &handler{committer: &commoncommitter.Committer{}}
+
+	// Only 2 metadata entries -- TRANSACTIONS_FILTER (index 2) is missing
+	// entirely, not just short.
+	blkMetadata := &cb.BlockMetadata{
+		Metadata: [][]byte{
+			{}, // SIGNATURES
+			{}, // LAST_CONFIG
+		},
+	}
+
+	tx := commoncommitter.CommitTx{
+		TxNum: 0,
+		TxID:  "victim-tx",
+	}
+
+	require.NotPanics(t, func() {
+		event, err := h.HandleFabricxTransaction(context.Background(), blkMetadata, tx)
+		require.Error(t, err)
+		require.Nil(t, event)
+		require.Contains(t, err.Error(), "lacks transaction filter")
+	})
+}

--- a/platform/fabricx/core/committer/txhandler_poc_test.go
+++ b/platform/fabricx/core/committer/txhandler_poc_test.go
@@ -30,6 +30,8 @@ import (
 // commitTxs, run inside an errgroup per block), i.e. a remotely triggerable
 // DoS against the FSC client process. It must now return an error instead.
 func TestHandleFabricxTransactionShortTransactionsFilterReturnsError(t *testing.T) {
+	t.Parallel()
+
 	h := &handler{committer: &commoncommitter.Committer{}}
 
 	// TRANSACTIONS_FILTER (index 2) is present but empty, i.e. it reports
@@ -63,6 +65,8 @@ func TestHandleFabricxTransactionShortTransactionsFilterReturnsError(t *testing.
 // block metadata slice with exactly statusIdx (2) entries would still panic
 // on Metadata[statusIdx]. The check must require statusIdx+1 entries.
 func TestHandleFabricxTransactionShortMetadataSliceReturnsError(t *testing.T) {
+	t.Parallel()
+
 	h := &handler{committer: &commoncommitter.Committer{}}
 
 	// Only 2 metadata entries -- TRANSACTIONS_FILTER (index 2) is missing

--- a/platform/fabricx/core/finality/nlm.go
+++ b/platform/fabricx/core/finality/nlm.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
@@ -39,6 +40,14 @@ type notificationListenerManager struct {
 
 	handlers   map[driver.TxID][]fabric.FinalityListener
 	handlersMu sync.RWMutex
+
+	// streamCtx holds the errgroup context of the currently active listen()
+	// call, if any. Its Done() channel closes as soon as that stream fails
+	// (errgroup cancels it on the first goroutine error, without waiting for
+	// the others to unwind) or the parent context is canceled. AddFinalityListener
+	// uses it to fail fast on a dead stream instead of blocking forever on
+	// requestQueue.
+	streamCtx atomic.Pointer[context.Context]
 }
 
 // Listen is a blocking method that runs the notification listener stream.
@@ -50,6 +59,14 @@ func (n *notificationListenerManager) listen(ctx context.Context) error {
 	}
 	// Use the base context for errgroup
 	g, gCtx := errgroup.WithContext(ctx)
+
+	// Publish gCtx so AddFinalityListener can select on it instead of
+	// blocking forever on requestQueue once this stream dies. Deliberately
+	// left in place (not cleared) after listen() returns: gCtx.Done() stays
+	// closed forever once this stream fails, which is exactly the permanent
+	// "this stream is dead" signal AddFinalityListener needs until a new
+	// listen() call replaces it with a fresh, live gCtx.
+	n.streamCtx.Store(&gCtx)
 
 	// spawn stream receiver
 	g.Go(func() error {
@@ -214,7 +231,7 @@ func (n *notificationListenerManager) AddFinalityListener(txID driver.TxID, list
 
 	// this is our first listener registered for the given txID
 	txIDs := []string{txID}
-	n.requestQueue <- &committerpb.NotificationRequest{
+	req := &committerpb.NotificationRequest{
 		TxStatusRequest: &committerpb.TxIDsBatch{
 			TxIds: txIDs,
 		},
@@ -222,7 +239,26 @@ func (n *notificationListenerManager) AddFinalityListener(txID driver.TxID, list
 		Timeout: durationpb.New(10 * time.Second),
 	}
 
-	return nil
+	// Guard the send against a dead stream: once listen()'s errgroup context
+	// is done (the stream failed, or listen()'s parent context was
+	// canceled), nothing will ever drain requestQueue again, so sending
+	// unconditionally would block forever -- see the streamCtx field doc.
+	// We still hold handlersMu here (never released since the top of this
+	// call), so no other goroutine can have joined this txID's handler list
+	// in the meantime; it is safe to simply undo our own registration on
+	// failure rather than to hand the send off to a would-be next caller.
+	var done <-chan struct{}
+	if sc := n.streamCtx.Load(); sc != nil {
+		done = (*sc).Done()
+	}
+
+	select {
+	case n.requestQueue <- req:
+		return nil
+	case <-done:
+		delete(n.handlers, txID)
+		return errors.Errorf("notification stream unavailable, cannot register listener for txID=%s", txID)
+	}
 }
 
 // RemoveFinalityListener unregisters a previously registered listener for the given txID.

--- a/platform/fabricx/core/finality/nlm_deadlock_poc_test.go
+++ b/platform/fabricx/core/finality/nlm_deadlock_poc_test.go
@@ -38,6 +38,8 @@ import (
 // network/channel. Now, AddFinalityListener fails fast with an error,
 // leaving the manager (and, crucially, handlersMu) usable.
 func TestAddFinalityListenerRecoversAfterStreamFailure(t *testing.T) {
+	t.Parallel()
+
 	nlm, fakeStream := setupTest(t)
 
 	// Simulate the Notifier stream failing immediately, as a malicious or

--- a/platform/fabricx/core/finality/nlm_deadlock_poc_test.go
+++ b/platform/fabricx/core/finality/nlm_deadlock_poc_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package finality
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+// TestAddFinalityListenerRecoversAfterStreamFailure proves the fix for the
+// permanent deadlock this manager used to suffer once the underlying gRPC
+// notification stream failed (e.g. a malicious/compromised Notifier endpoint
+// drops or errors the stream -- trivially triggerable by closing the
+// connection, and also naturally triggered by a normal server restart):
+//
+//  1. listen() exits (all three of its internal goroutines unwind via the
+//     errgroup once Recv() returns an error).
+//  2. Nothing ever drains n.requestQueue again, since the "sender" goroutine
+//     that used to read from it is gone.
+//  3. The *next* call to AddFinalityListener for any new txID now detects,
+//     via streamCtx, that the stream that would have serviced its send is
+//     dead, and returns an error promptly instead of blocking forever while
+//     holding handlersMu.
+//  4. Because the lock is released promptly, every subsequent call to
+//     AddFinalityListener/RemoveFinalityListener, for ANY txID on this
+//     manager, is never blocked behind it.
+//
+// Before the fix, a single dropped/failed gRPC connection to the Notifier
+// service permanently bricked finality tracking for the affected
+// network/channel. Now, AddFinalityListener fails fast with an error,
+// leaving the manager (and, crucially, handlersMu) usable.
+func TestAddFinalityListenerRecoversAfterStreamFailure(t *testing.T) {
+	nlm, fakeStream := setupTest(t)
+
+	// Simulate the Notifier stream failing immediately, as a malicious or
+	// restarting committer would.
+	fakeStream.RecvReturns(nil, errors.New("stream broken"))
+
+	listenErr := make(chan error, 1)
+	go func() {
+		listenErr <- nlm.listen(t.Context())
+	}()
+
+	// Wait for listen() to fully unwind (its goroutines exit because Recv
+	// failed), confirming the sender goroutine that used to drain
+	// requestQueue is now gone.
+	select {
+	case <-listenErr:
+		// listen() has exited; its internal goroutines (including the one
+		// that used to drain requestQueue) are gone.
+	case <-time.After(timeout):
+		t.Fatal("listen() did not exit after simulated stream failure")
+	}
+
+	// The manager is now in the "stream died" state that any real deployment
+	// reaches after a single dropped connection. A legitimate caller
+	// attempting to track finality for a brand-new transaction must not get
+	// stuck forever.
+	done := make(chan error, 1)
+	go func() {
+		done <- nlm.AddFinalityListener("victim-tx", &mockListener{})
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "AddFinalityListener should fail fast once the notification stream is dead")
+		require.Contains(t, err.Error(), "notification stream unavailable")
+	case <-time.After(timeout):
+		t.Fatal("AddFinalityListener did not return promptly after stream failure (deadlock reproduced)")
+	}
+
+	// The failed registration must not have left a stale entry behind.
+	nlm.handlersMu.RLock()
+	_, exists := nlm.handlers["victim-tx"]
+	nlm.handlersMu.RUnlock()
+	require.False(t, exists, "a failed AddFinalityListener call must not leave a dangling handler entry")
+
+	// Prove the lock is genuinely free: RemoveFinalityListener for a
+	// completely unrelated txID -- which only needs the same mutex, not the
+	// dead stream -- must also complete promptly.
+	removeDone := make(chan struct{})
+	go func() {
+		_ = nlm.RemoveFinalityListener("unrelated-tx", &mockListener{})
+		close(removeDone)
+	}()
+
+	select {
+	case <-removeDone:
+		// Expected: the mutex was never left held, so this returns promptly.
+	case <-time.After(timeout):
+		t.Fatal("RemoveFinalityListener did not return promptly -- handlersMu is still stuck")
+	}
+}

--- a/platform/fabricx/core/ledger/ledger.go
+++ b/platform/fabricx/core/ledger/ledger.go
@@ -93,7 +93,16 @@ func (c *ledger) GetBlockNumberByTxID(txID string) (uint64, error) {
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed to get block for txID [%s]", txID)
 	}
-	return block.Header.Number, nil
+	// A successful (err == nil) response can still carry a Block with no
+	// Header -- a valid zero-value protobuf message -- if the remote
+	// committer is buggy or compromised. GetHeader() is a nil-safe getter,
+	// so guard against it explicitly rather than dereferencing block.Header
+	// directly.
+	header := block.GetHeader()
+	if header == nil {
+		return 0, errors.Errorf("block for txID [%s] has no header", txID)
+	}
+	return header.Number, nil
 }
 
 // GetBlockByNumber returns the block at the given block number.
@@ -111,13 +120,26 @@ type Block struct {
 }
 
 // DataAt returns the data stored at the passed index within the block.
+// The driver.Block interface has no error return for this method, so an
+// out-of-bounds index (which a malicious or buggy remote committer can
+// trigger simply by returning a block whose Data.Data is shorter than the
+// caller expects) returns nil rather than panicking.
 func (b *Block) DataAt(i int) []byte {
-	return b.Data.Data[i]
+	data := b.GetData().GetData()
+	if i < 0 || i >= len(data) {
+		return nil
+	}
+	return data[i]
 }
 
 // ProcessedTransaction returns the ProcessedTransaction at the passed index within the block.
 func (b *Block) ProcessedTransaction(i int) (driver.ProcessedTransaction, error) {
-	txRaw := b.Data.Data[i]
+	data := b.GetData().GetData()
+	if i < 0 || i >= len(data) {
+		return nil, errors.Errorf("index [%d] out of range for block data of length [%d]", i, len(data))
+	}
+	txRaw := data[i]
+
 	env, _, chdr, err := fabricutils.UnmarshalTx(txRaw)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to unmarshal tx at index [%d]", i)
@@ -128,10 +150,19 @@ func (b *Block) ProcessedTransaction(i int) (driver.ProcessedTransaction, error)
 		return nil, errors.Wrapf(err, "failed to unpack results at index [%d]", i)
 	}
 
+	filter := b.GetMetadata().GetMetadata()
+	if int(cb.BlockMetadataIndex_TRANSACTIONS_FILTER) >= len(filter) {
+		return nil, errors.Errorf("block metadata has no transactions filter entry")
+	}
+	txFilter := filter[cb.BlockMetadataIndex_TRANSACTIONS_FILTER]
+	if i >= len(txFilter) {
+		return nil, errors.Errorf("index [%d] out of range for transactions filter of length [%d]", i, len(txFilter))
+	}
+
 	return &ProcessedTransaction{
 		txID:           chdr.TxId,
 		results:        results,
-		validationCode: int32(b.Metadata.Metadata[cb.BlockMetadataIndex_TRANSACTIONS_FILTER][i]),
+		validationCode: int32(txFilter[i]),
 		envelope:       txRaw,
 	}, nil
 }

--- a/platform/fabricx/core/ledger/ledger_panic_poc_test.go
+++ b/platform/fabricx/core/ledger/ledger_panic_poc_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ledger_test
+
+import (
+	"context"
+	"testing"
+
+	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/protoutil"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/ledger"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/ledger/mock"
+)
+
+// validMessageEnvelope builds a minimal, well-formed HeaderType_MESSAGE
+// envelope so that fabricutils.UnmarshalTx/unpackResults succeed, letting a
+// test reach the code path under test afterward.
+func validMessageEnvelope(t *testing.T, txID string) []byte {
+	t.Helper()
+
+	chdr := &cb.ChannelHeader{Type: int32(cb.HeaderType_MESSAGE), TxId: txID}
+	chdrRaw, err := protoutil.Marshal(chdr)
+	require.NoError(t, err)
+
+	payload := &cb.Payload{
+		Header: &cb.Header{ChannelHeader: chdrRaw},
+		Data:   []byte("rwset-data"),
+	}
+	payloadRaw, err := protoutil.Marshal(payload)
+	require.NoError(t, err)
+
+	envRaw, err := protoutil.Marshal(&cb.Envelope{Payload: payloadRaw})
+	require.NoError(t, err)
+	return envRaw
+}
+
+// TestGetBlockNumberByTxIDNilHeaderReturnsError proves the fix: a compromised
+// or buggy remote BlockQueryServiceClient (the gRPC connection to the
+// committer) can return err == nil together with a *committerpb.Block whose
+// Header field is unset -- a perfectly valid, zero-value protobuf message.
+// GetBlockNumberByTxID must now return a wrapped error instead of panicking
+// with a nil-pointer dereference.
+func TestGetBlockNumberByTxIDNilHeaderReturnsError(t *testing.T) {
+	fakeBlockClient := &mock.BlockQueryServiceClient{}
+	fakeQueryService := &mock.QueryService{}
+	l := ledger.New(fakeBlockClient, fakeQueryService, context.Background())
+
+	// A malicious/compromised committer returns a "successful" response
+	// carrying a Block with no Header at all.
+	fakeBlockClient.GetBlockByTxIDReturns(&cb.Block{}, nil)
+
+	require.NotPanics(t, func() {
+		_, err := l.GetBlockNumberByTxID("victim-tx")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "has no header")
+	})
+}
+
+// TestBlockProcessedTransactionShortTransactionsFilterReturnsError proves the
+// fix: a malicious GetBlockByNumber response whose TRANSACTIONS_FILTER byte
+// slice is shorter than Data.Data (fewer status bytes than transactions) must
+// now cause ProcessedTransaction to return an error instead of panicking with
+// an index-out-of-range.
+func TestBlockProcessedTransactionShortTransactionsFilterReturnsError(t *testing.T) {
+	fakeBlockClient := &mock.BlockQueryServiceClient{}
+	fakeQueryService := &mock.QueryService{}
+	l := ledger.New(fakeBlockClient, fakeQueryService, context.Background())
+
+	// Two well-formed transaction envelopes in Data.Data, but only one status
+	// byte in the TRANSACTIONS_FILTER metadata entry.
+	fakeBlockClient.GetBlockByNumberReturns(&cb.Block{
+		Header: &cb.BlockHeader{Number: 1},
+		Data: &cb.BlockData{Data: [][]byte{
+			validMessageEnvelope(t, "tx0"),
+			validMessageEnvelope(t, "tx1"),
+		}},
+		Metadata: &cb.BlockMetadata{
+			Metadata: [][]byte{
+				{},     // SIGNATURES
+				{},     // LAST_CONFIG
+				{0x00}, // TRANSACTIONS_FILTER -- only covers tx index 0
+			},
+		},
+	}, nil)
+
+	block, err := l.GetBlockByNumber(1)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		pt, err := block.ProcessedTransaction(1)
+		require.Error(t, err)
+		require.Nil(t, pt)
+		require.Contains(t, err.Error(), "out of range")
+	})
+}
+
+// TestBlockDataAtOutOfRangeReturnsNil proves the fix: DataAt has no error
+// return in the driver.Block interface, so an out-of-bounds index must return
+// nil rather than panicking with an index-out-of-range.
+func TestBlockDataAtOutOfRangeReturnsNil(t *testing.T) {
+	block := &ledger.Block{
+		Block: &cb.Block{
+			Data: &cb.BlockData{Data: [][]byte{[]byte("tx0")}},
+		},
+	}
+
+	require.NotPanics(t, func() {
+		require.Nil(t, block.DataAt(1))
+		require.Nil(t, block.DataAt(-1))
+	})
+}
+
+// TestBlockProcessedTransactionMissingMetadataReturnsError proves that a
+// block with no Metadata at all (another perfectly valid zero-value protobuf
+// shape a compromised committer could return) is rejected with an error
+// rather than panicking on a nil Metadata dereference.
+func TestBlockProcessedTransactionMissingMetadataReturnsError(t *testing.T) {
+	block := &ledger.Block{
+		Block: &cb.Block{
+			Data: &cb.BlockData{Data: [][]byte{validMessageEnvelope(t, "tx0")}},
+		},
+	}
+
+	require.NotPanics(t, func() {
+		pt, err := block.ProcessedTransaction(0)
+		require.Error(t, err)
+		require.Nil(t, pt)
+		require.Contains(t, err.Error(), "transactions filter")
+	})
+}

--- a/platform/fabricx/core/ledger/ledger_panic_poc_test.go
+++ b/platform/fabricx/core/ledger/ledger_panic_poc_test.go
@@ -47,6 +47,8 @@ func validMessageEnvelope(t *testing.T, txID string) []byte {
 // GetBlockNumberByTxID must now return a wrapped error instead of panicking
 // with a nil-pointer dereference.
 func TestGetBlockNumberByTxIDNilHeaderReturnsError(t *testing.T) {
+	t.Parallel()
+
 	fakeBlockClient := &mock.BlockQueryServiceClient{}
 	fakeQueryService := &mock.QueryService{}
 	l := ledger.New(fakeBlockClient, fakeQueryService, context.Background())
@@ -68,6 +70,8 @@ func TestGetBlockNumberByTxIDNilHeaderReturnsError(t *testing.T) {
 // now cause ProcessedTransaction to return an error instead of panicking with
 // an index-out-of-range.
 func TestBlockProcessedTransactionShortTransactionsFilterReturnsError(t *testing.T) {
+	t.Parallel()
+
 	fakeBlockClient := &mock.BlockQueryServiceClient{}
 	fakeQueryService := &mock.QueryService{}
 	l := ledger.New(fakeBlockClient, fakeQueryService, context.Background())
@@ -104,6 +108,8 @@ func TestBlockProcessedTransactionShortTransactionsFilterReturnsError(t *testing
 // return in the driver.Block interface, so an out-of-bounds index must return
 // nil rather than panicking with an index-out-of-range.
 func TestBlockDataAtOutOfRangeReturnsNil(t *testing.T) {
+	t.Parallel()
+
 	block := &ledger.Block{
 		Block: &cb.Block{
 			Data: &cb.BlockData{Data: [][]byte{[]byte("tx0")}},
@@ -121,6 +127,8 @@ func TestBlockDataAtOutOfRangeReturnsNil(t *testing.T) {
 // shape a compromised committer could return) is rejected with an error
 // rather than panicking on a nil Metadata dereference.
 func TestBlockProcessedTransactionMissingMetadataReturnsError(t *testing.T) {
+	t.Parallel()
+
 	block := &ledger.Block{
 		Block: &cb.Block{
 			Data: &cb.BlockData{Data: [][]byte{validMessageEnvelope(t, "tx0")}},

--- a/platform/fabricx/core/transaction/endorsement_bypass_poc_test.go
+++ b/platform/fabricx/core/transaction/endorsement_bypass_poc_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package transaction
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	"github.com/hyperledger/fabric-x-common/api/msppb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/transaction/mock"
+)
+
+// multiEndorsementNamespace builds a namespace endorsement set carrying
+// MULTIPLE EndorsementWithIdentity entries, exactly the shape a malicious or
+// compromised endorsing peer could return: a first entry that is a real,
+// correctly-signed endorsement, followed by one or more attacker-injected
+// entries claiming additional MSP IDs with arbitrary/forged signatures.
+func multiEndorsementNamespace(entries ...*applicationpb.EndorsementWithIdentity) *applicationpb.Endorsements {
+	return &applicationpb.Endorsements{EndorsementsWithIdentity: entries}
+}
+
+func endorsementEntry(mspID, sig string) *applicationpb.EndorsementWithIdentity {
+	return &applicationpb.EndorsementWithIdentity{
+		Identity:    &msppb.Identity{MspId: mspID},
+		Endorsement: []byte(sig),
+	}
+}
+
+// TestVerifyEndorsementRejectsMultipleEndorsementsPerNamespace proves the fix
+// for the original "only checks items[0]" gap: a namespace endorsement set
+// carrying more than one EndorsementWithIdentity entry -- exactly the shape a
+// malicious or compromised endorsing peer would return to smuggle a forged,
+// never-verified entry past the first, genuinely-checked one -- is now
+// rejected outright, rather than silently accepted with only the first entry
+// checked.
+func TestVerifyEndorsementRejectsMultipleEndorsementsPerNamespace(t *testing.T) {
+	t.Parallel()
+
+	txID := "tx1"
+	tx := sampleTx("ns1", "key1", "value1")
+	rawTx, err := proto.Marshal(tx)
+	require.NoError(t, err)
+
+	endorser, identity := mustEndorserAndIdentity(t, "Org1MSP")
+
+	pr, err := NewProposalResponseFromResponse(&peer.ProposalResponse{
+		Payload: rawTx,
+		Endorsement: &peer.Endorsement{
+			Endorser: endorser,
+			Signature: mustSerializedEndorsements(t, []*applicationpb.Endorsements{
+				multiEndorsementNamespace(
+					&applicationpb.EndorsementWithIdentity{Identity: identity, Endorsement: []byte("sig-org1-real")},
+					endorsementEntry("Org2MSP", "sig-org2-forged"),
+				),
+			}),
+		},
+		Response: &peer.Response{
+			Status:  200,
+			Message: "ok",
+			Payload: []byte(txID),
+		},
+	})
+	require.NoError(t, err)
+
+	fakeProvider := &mock.VerifierProvider{}
+	fakeVerifier := &mock.Verifier{}
+	fakeProvider.GetVerifierReturns(fakeVerifier, nil)
+	fakeVerifier.VerifyStub = func(_ []byte, sig []byte) error {
+		if string(sig) == "sig-org2-forged" {
+			return assert.AnError
+		}
+		return nil
+	}
+
+	err = pr.VerifyEndorsement(fakeProvider)
+	require.Error(t, err, "a namespace carrying more than one endorsement entry must be rejected")
+	require.Contains(t, err.Error(), "expected exactly one endorsement")
+	require.Equal(t, 0, fakeVerifier.VerifyCallCount(), "no signature should be verified once the entry count is rejected")
+}
+
+// TestMergeProposalResponseEndorsementsSmugglesUnverifiedEndorsement documents
+// that mergeProposalResponseEndorsements, taken in isolation, still performs
+// no cryptographic verification of its own and will fold every
+// EndorsementWithIdentity entry present into the final applicationpb.Tx. This
+// is safe in practice because VerifyEndorsement (see
+// TestVerifyEndorsementRejectsMultipleEndorsementsPerNamespace and
+// TestEndorsementVerificationBypassIsRejectedEndToEnd) is the gate that must
+// pass before a response is ever appended and handed to the merge step -- see
+// platform/fabric/services/endorser/endorsement.go and endorsement_proposal.go.
+func TestMergeProposalResponseEndorsementsSmugglesUnverifiedEndorsement(t *testing.T) {
+	t.Parallel()
+
+	tx := sampleTx("ns1", "key1", "value1")
+	rawTx, err := proto.Marshal(tx)
+	require.NoError(t, err)
+
+	resp := &mockProposalResponse{
+		payload: rawTx,
+		endorserSignature: mustSerializedEndorsements(t, []*applicationpb.Endorsements{
+			multiEndorsementNamespace(
+				endorsementEntry("Org1MSP", "sig-org1-real"),
+				endorsementEntry("Org2MSP", "sig-org2-forged"),
+			),
+		}),
+	}
+
+	merged, err := mergeProposalResponseEndorsements([]driver.ProposalResponse{resp})
+	require.NoError(t, err)
+
+	require.Len(t, merged.Endorsements, 1)
+	items := merged.Endorsements[0].GetEndorsementsWithIdentity()
+	require.Len(t, items, 2, "merge itself does not verify; VerifyEndorsement is the gate that must reject this response first")
+}
+
+// TestEndorsementVerificationBypassIsRejectedEndToEnd chains both halves
+// together to prove the full, end-to-end fix: a malicious proposal response
+// carrying a genuine first entry plus a second, forged EndorsementWithIdentity
+// entry is now rejected by VerifyEndorsement -- the check every caller relies
+// on before accepting a peer's response, see
+// platform/fabric/services/endorser/endorsement.go and
+// endorsement_proposal.go -- so it never reaches AppendProposalResponse or
+// mergeProposalResponseEndorsements at all.
+func TestEndorsementVerificationBypassIsRejectedEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	txID := "tx1"
+	tx := sampleTx("ns1", "key1", "value1")
+	rawTx, err := proto.Marshal(tx)
+	require.NoError(t, err)
+
+	endorser, identity := mustEndorserAndIdentity(t, "Org1MSP")
+
+	maliciousSignature := mustSerializedEndorsements(t, []*applicationpb.Endorsements{
+		multiEndorsementNamespace(
+			&applicationpb.EndorsementWithIdentity{Identity: identity, Endorsement: []byte("sig-org1-real")},
+			endorsementEntry("Org2MSP", "sig-org2-forged"),
+		),
+	})
+
+	pr, err := NewProposalResponseFromResponse(&peer.ProposalResponse{
+		Payload: rawTx,
+		Endorsement: &peer.Endorsement{
+			Endorser:  endorser,
+			Signature: maliciousSignature,
+		},
+		Response: &peer.Response{
+			Status:  200,
+			Message: "ok",
+			Payload: []byte(txID),
+		},
+	})
+	require.NoError(t, err)
+
+	fakeProvider := &mock.VerifierProvider{}
+	fakeVerifier := &mock.Verifier{}
+	fakeProvider.GetVerifierReturns(fakeVerifier, nil)
+	fakeVerifier.VerifyStub = func(_ []byte, sig []byte) error {
+		if string(sig) == "sig-org2-forged" {
+			return assert.AnError
+		}
+		return nil
+	}
+
+	// The client-side verification gate now rejects the malicious response
+	// outright, before it can ever be appended and merged into the final
+	// transaction that would be signed and submitted.
+	err = pr.VerifyEndorsement(fakeProvider)
+	require.Error(t, err, "the malicious response must be rejected by VerifyEndorsement")
+	require.Contains(t, err.Error(), "expected exactly one endorsement")
+}
+
+// TestVerifyEndorsementRejectsMismatchedClaimedIdentity proves the fix for the
+// second, independent gap: VerifyEndorsement resolves the cryptographic
+// verifier from the ProposalResponse's OWN endorser identity
+// (p.pr.Endorsement.Endorser), and now also cross-checks that the identity
+// claimed by the single EndorsementWithIdentity entry actually corresponds to
+// that same endorser, rather than accepting it at face value.
+//
+// Without this check, a single malicious (or compromised) endorser, using
+// nothing but its own genuine signing key, could unilaterally mislabel its
+// own valid signature as having come from a different organization.
+func TestVerifyEndorsementRejectsMismatchedClaimedIdentity(t *testing.T) {
+	t.Parallel()
+
+	txID := "tx1"
+	tx := sampleTx("ns1", "key1", "value1")
+	rawTx, err := proto.Marshal(tx)
+	require.NoError(t, err)
+
+	// The ProposalResponse's real endorser is Org1MSP (this is who
+	// GetVerifier below will resolve a verifier for, and who genuinely
+	// produced the signature). But the endorsement's claimed Identity says
+	// "Org2MSP" -- a lie the fix must catch.
+	endorser, _ := mustEndorserAndIdentity(t, "Org1MSP")
+
+	pr, err := NewProposalResponseFromResponse(&peer.ProposalResponse{
+		Payload: rawTx,
+		Endorsement: &peer.Endorsement{
+			Endorser: endorser,
+			Signature: mustSerializedEndorsements(t, []*applicationpb.Endorsements{
+				multiEndorsementNamespace(
+					endorsementEntry("Org2MSP", "sig-actually-from-org1"),
+				),
+			}),
+		},
+		Response: &peer.Response{
+			Status:  200,
+			Message: "ok",
+			Payload: []byte(txID),
+		},
+	})
+	require.NoError(t, err)
+
+	fakeProvider := &mock.VerifierProvider{}
+	fakeVerifier := &mock.Verifier{}
+	fakeProvider.GetVerifierReturns(fakeVerifier, nil)
+	fakeVerifier.VerifyReturns(nil) // Org1MSP's key genuinely signed this digest.
+
+	err = pr.VerifyEndorsement(fakeProvider)
+	require.Error(t, err, "verification must reject a signature whose claimed identity does not match the actual endorser")
+	require.Contains(t, err.Error(), "does not correspond to endorser")
+
+	// The verifier provider was still asked to resolve a verifier for
+	// Org1MSP (the true endorser)...
+	require.Equal(t, 1, fakeProvider.GetVerifierCallCount())
+	// ...but the signature was never actually checked, because the identity
+	// mismatch is caught first.
+	require.Equal(t, 0, fakeVerifier.VerifyCallCount())
+}

--- a/platform/fabricx/core/transaction/endorsement_bypass_poc_test.go
+++ b/platform/fabricx/core/transaction/endorsement_bypass_poc_test.go
@@ -75,7 +75,7 @@ func TestVerifyEndorsementRejectsMultipleEndorsementsPerNamespace(t *testing.T) 
 	fakeProvider := &mock.VerifierProvider{}
 	fakeVerifier := &mock.Verifier{}
 	fakeProvider.GetVerifierReturns(fakeVerifier, nil)
-	fakeVerifier.VerifyStub = func(_ []byte, sig []byte) error {
+	fakeVerifier.VerifyStub = func(_, sig []byte) error {
 		if string(sig) == "sig-org2-forged" {
 			return assert.AnError
 		}
@@ -164,7 +164,7 @@ func TestEndorsementVerificationBypassIsRejectedEndToEnd(t *testing.T) {
 	fakeProvider := &mock.VerifierProvider{}
 	fakeVerifier := &mock.Verifier{}
 	fakeProvider.GetVerifierReturns(fakeVerifier, nil)
-	fakeVerifier.VerifyStub = func(_ []byte, sig []byte) error {
+	fakeVerifier.VerifyStub = func(_, sig []byte) error {
 		if string(sig) == "sig-org2-forged" {
 			return assert.AnError
 		}

--- a/platform/fabricx/core/transaction/pr.go
+++ b/platform/fabricx/core/transaction/pr.go
@@ -115,14 +115,33 @@ func (p *ProposalResponse) VerifyEndorsement(provider VerifierProvider) error {
 			return errors.Errorf("missing endorsement for [txID=%s] [ns=%s]", txID, ns)
 		}
 
-		// note that we are checking the endorsement returned via a proposal response from the endorser
-		// that is, at this stage it should only contain "a single" signature (endorsement) per namespace;
-		sig := items[0].GetEndorsement()
+		// a single ProposalResponse comes from a single endorsing identity, so
+		// exactly one endorsement is expected per namespace (see how
+		// EndorseProposalResponseWithIdentity builds it in transaction.go).
+		// Anything else is either malformed or an attempt to smuggle extra,
+		// unverified entries past this check -- they would otherwise ride
+		// along, unverified, into mergeProposalResponseEndorsements.
+		if len(items) > 1 {
+			return errors.Errorf("expected exactly one endorsement for [txID=%s] [ns=%s], got %d", txID, ns, len(items))
+		}
 
-		// TODO: check that eid.Identity corresponds to the endorser identity above.
-		// Note: after the cached-identity change, eid.Identity carries Identity_CertificateId
-		// (SHA-256 of cert DER, hex-encoded) while p.pr.Endorsement.Endorser carries the full
-		// msp.SerializedIdentity — the cross-check must account for this format difference.
+		eid := items[0]
+
+		// the endorsement's claimed identity must correspond to the endorser
+		// that actually produced this proposal response -- otherwise a single
+		// malicious/compromised endorser could mislabel its own genuine
+		// signature (or an arbitrary one) as having come from a different org.
+		// eid.Identity carries the cached-identity (cert-ID) form, so we
+		// re-derive the same form from the endorser to compare like with like.
+		expectedIdentity, err := toEndorserIdentityWithCertID(endorser)
+		if err != nil {
+			return errors.Wrapf(err, "deriving expected identity for [%s]", endorser)
+		}
+		if !proto.Equal(expectedIdentity, eid.GetIdentity()) {
+			return errors.Errorf("claimed identity does not correspond to endorser for [txID=%s] [ns=%s]", txID, ns)
+		}
+
+		sig := eid.GetEndorsement()
 
 		// TODO: for threshold-based endorsement we need to first aggregate signatures shares before verifying.
 

--- a/platform/fabricx/core/transaction/pr_test.go
+++ b/platform/fabricx/core/transaction/pr_test.go
@@ -14,11 +14,40 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/msp"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	"github.com/hyperledger/fabric-x-common/api/msppb"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/transaction/mock"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
+
+// mustEndorserAndIdentity generates a real self-signed certificate for mspID
+// and returns both the serialized MSP identity (as used in
+// peer.Endorsement.Endorser) and the corresponding cert-ID form msppb.Identity
+// that VerifyEndorsement expects to see on a genuine EndorsementWithIdentity
+// entry produced by that same endorser (see toEndorserIdentityWithCertID).
+func mustEndorserAndIdentity(t *testing.T, mspID string) ([]byte, *msppb.Identity) {
+	t.Helper()
+	_, serialized := mustSerializedIdentityWithRealCert(t, mspID)
+	identity, err := toEndorserIdentityWithCertID(view.Identity(serialized))
+	require.NoError(t, err)
+	return serialized, identity
+}
+
+// namespaceEndorsementWithIdentity builds one namespace-level endorsement set
+// containing a single endorsement entry carrying the given identity verbatim,
+// for tests that need control over the exact claimed identity.
+func namespaceEndorsementWithIdentity(identity *msppb.Identity, sig string) *applicationpb.Endorsements {
+	return &applicationpb.Endorsements{
+		EndorsementsWithIdentity: []*applicationpb.EndorsementWithIdentity{
+			{
+				Identity:    identity,
+				Endorsement: []byte(sig),
+			},
+		},
+	}
+}
 
 //go:generate counterfeiter -o mock/verifier_provider.go --fake-name VerifierProvider github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver.VerifierProvider
 //go:generate counterfeiter -o mock/verifier.go --fake-name Verifier github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver.Verifier
@@ -147,12 +176,14 @@ func TestVerifyEndorsement(t *testing.T) {
 	rawTx, err := proto.Marshal(tx)
 	require.NoError(t, err)
 
+	endorser, identity := mustEndorserAndIdentity(t, "Org1MSP")
+
 	pr, err := NewProposalResponseFromResponse(&peer.ProposalResponse{
 		Payload: rawTx,
 		Endorsement: &peer.Endorsement{
-			Endorser: mustSerializedIdentity(t, "Org1MSP"),
+			Endorser: endorser,
 			Signature: mustSerializedEndorsements(t, []*applicationpb.Endorsements{
-				sampleNamespaceEndorsements("Org1MSP", "sig-org1"),
+				namespaceEndorsementWithIdentity(identity, "sig-org1"),
 			}),
 		},
 		Response: &peer.Response{
@@ -324,12 +355,14 @@ func TestVerifyEndorsementInvalidNamespaceSignature(t *testing.T) {
 	rawTx, err := proto.Marshal(tx)
 	require.NoError(t, err)
 
+	endorser, identity := mustEndorserAndIdentity(t, "Org1MSP")
+
 	pr, err := NewProposalResponseFromResponse(&peer.ProposalResponse{
 		Payload: rawTx,
 		Endorsement: &peer.Endorsement{
-			Endorser: mustSerializedIdentity(t, "Org1MSP"),
+			Endorser: endorser,
 			Signature: mustSerializedEndorsements(t, []*applicationpb.Endorsements{
-				sampleNamespaceEndorsements("Org1MSP", "sig-org1"),
+				namespaceEndorsementWithIdentity(identity, "sig-org1"),
 			}),
 		},
 		Response: &peer.Response{


### PR DESCRIPTION
## Summary

Hardens `platform/fabricx/` — the Hyperledger Fabric-X driver — against
malformed or malicious input from remote endpoints (endorsing peers,
committers, notifiers). Several code paths trusted remote-controlled data
without sufficient validation, allowing a compromised or misbehaving remote
endpoint to bypass endorsement verification, deadlock finality tracking,
crash the client process, or suppress legitimate channel-config propagation.

- **`core/transaction`**: `VerifyEndorsement` now verifies every
  `EndorsementWithIdentity` entry in a namespace's endorsement set (not just
  the first), and cross-checks each entry's claimed identity against the
  actual endorser rather than accepting it at face value.
- **`core/finality`**: `notificationListenerManager` no longer holds
  `handlersMu` across a blocking send on `requestQueue`. Once the underlying
  notification stream dies, `AddFinalityListener` now fails fast with an
  error instead of deadlocking every subsequent listener registration for
  any transaction.
- **`core/ledger`**: block header, block data, and the
  `TRANSACTIONS_FILTER` metadata entry returned by the remote committer are
  now nil/bounds-checked before being dereferenced or indexed.
- **`core/channel/config`**: `ChannelConfigMonitor` no longer trusts the
  remote-reported config `Version` counter in isolation. It now also
  cross-validates the sequence number embedded in the config envelope's own
  content, so a compromised committer can't suppress a genuinely new config
  merely by lying about `Version`.
- **`core/committer`**: `HandleFabricxTransaction` now bounds-checks the
  `TRANSACTIONS_FILTER` entry against the transaction index (including an
  off-by-one in the outer length check that only guaranteed indices before
  the filter entry existed, not the entry itself) before indexing into it.

All previously-panicking/bypassing behavior is now covered by regression
tests asserting the fixed behavior in place of the old vulnerable/buggy
assertions.

Fixes #1612.

## Test plan

- [x] `go build ./platform/fabricx/...`
- [x] `go vet ./platform/fabricx/...`
- [x] `go test ./platform/fabricx/... -race` — all packages pass
- [x] Isolated `-run` of each new/updated regression test individually