### PR TITLE
fix(fabricx): stop retaining RWSets and tx statuses in the vault

### DIFF
--- a/platform/fabricx/core/vault/marshal.go
+++ b/platform/fabricx/core/vault/marshal.go
@@ -23,28 +23,22 @@ import (
 )
 
 // Marshaller is the custom marshaller for fabricx that handles serialization and deserialization
-// of read-write sets to/from the FabricX protobuf format.
-// It maintains namespace version information (NsInfo) required for proper marshalling.
-type Marshaller struct {
-	// NsInfo maps namespace names to their version information.
-	// This must be populated before calling Marshal.
-	NsInfo map[driver.Namespace]driver.RawVersion
-}
+// of read-write sets to/from the FabricX protobuf format. It is stateless and safe for concurrent
+// use: the namespace version information required for marshalling is passed to Marshal per call
+// rather than stored on the marshaller.
+type Marshaller struct{}
 
-// NewMarshaller creates a new Marshaller instance with an empty namespace info map.
+// NewMarshaller creates a new Marshaller instance.
 func NewMarshaller() *Marshaller {
 	return &Marshaller{}
 }
 
 // Marshal serializes a ReadWriteSet into FabricX protobuf format for the given transaction ID.
-// It uses the namespace version information stored in m.NsInfo to properly encode namespace versions.
-// Returns an error if any namespace in the RWSet is not found in NsInfo or if marshalling fails.
-func (m *Marshaller) Marshal(txID string, rws *vault.ReadWriteSet) ([]byte, error) {
+// nsInfo maps each namespace to its version information and must contain an entry for every
+// namespace present in the RWSet. Returns an error if a namespace is missing from nsInfo or if
+// marshalling fails. Taking nsInfo as a parameter keeps the marshaller stateless and race-free.
+func (m *Marshaller) Marshal(txID string, rws *vault.ReadWriteSet, nsInfo map[driver.Namespace]driver.RawVersion) ([]byte, error) {
 	logger.Debugf("Marshal rws into fabricx proto [txID=%v]", txID)
-	return m.marshal(txID, rws, m.NsInfo)
-}
-
-func (m *Marshaller) marshal(txID string, rws *vault.ReadWriteSet, nsInfo map[driver.Namespace]driver.RawVersion) ([]byte, error) {
 	if logger.IsEnabledFor(zap.DebugLevel) {
 		str, _ := json.MarshalIndent(rws, "", "\t")
 		logger.Debugf("Marshal vault.ReadWriteSet %s", string(str))

--- a/platform/fabricx/core/vault/marshal_test.go
+++ b/platform/fabricx/core/vault/marshal_test.go
@@ -79,14 +79,13 @@ func TestMarshal_Deterministic(t *testing.T) {
 			rws, nsInfo := buildRWSet(t, mode)
 
 			m := vault.NewMarshaller()
-			m.NsInfo = nsInfo
 
-			first, err := m.Marshal("tx1", &rws)
+			first, err := m.Marshal("tx1", &rws, nsInfo)
 			require.NoError(t, err)
 
 			const attempts = 30
 			for i := range attempts {
-				out, err := m.Marshal("tx1", &rws)
+				out, err := m.Marshal("tx1", &rws, nsInfo)
 				require.NoError(t, err)
 				require.Equal(t, first, out,
 					"Marshal produced different bytes for the exact same ReadWriteSet on attempt %d/%d; "+

--- a/platform/fabricx/core/vault/vault.go
+++ b/platform/fabricx/core/vault/vault.go
@@ -8,7 +8,6 @@ package vault
 
 import (
 	"context"
-	"sync"
 
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 
@@ -19,31 +18,13 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
 )
 
-// txStatusInfo holds local transaction status information including validation code,
-// error message, and block/transaction index for committed transactions.
-type txStatusInfo struct {
-	code    fdriver.ValidationCode // Validation code (Valid, Invalid, Unknown, etc.)
-	message string                 // Error or status message
-	block   cdriver.BlockNum       // Block number where transaction was committed
-	index   cdriver.TxNum          // Transaction index within the block
-}
-
-// Vault is a vault implementation that uses QueryService for remote state queries
-// and manages read-write sets (RWSets) and transaction statuses locally.
-//
-// It provides a hybrid architecture where:
-//   - Read operations are delegated to a remote QueryService
-//   - RWSets are managed in-memory for performance
-//   - Transaction statuses are cached locally with remote fallback
-//   - All operations are thread-safe using RWMutex
-//
-// Vault implements the fdriver.Vault interface for FabricX.
+// Vault implements the fdriver.Vault interface for FabricX. Several interface methods
+// (CommitTX/DiscardTx/SetDiscarded/Match/RWSExists) exist only to satisfy that contract; FabricX
+// has no local commit pipeline, so they are never invoked in the FabricX wiring and panic if
+// reached (which would indicate the vault was wired into a generic committer by mistake).
 type Vault struct {
-	queryService queryservice.QueryService            // Remote query service for state queries
-	marshaller   *Marshaller                          // Marshaller for RWSet serialization
-	rwsets       map[cdriver.TxID]*vault.ReadWriteSet // Local RWSet storage
-	txStatuses   map[cdriver.TxID]*txStatusInfo       // Local transaction status cache
-	mu           sync.RWMutex                         // Mutex for thread-safe access
+	queryService queryservice.QueryService // Remote query service for state and status queries
+	marshaller   *Marshaller               // Marshaller for RWSet serialization
 }
 
 // NewVault creates a new Vault instance with the given QueryService.
@@ -58,8 +39,6 @@ func NewVault(qs queryservice.QueryService) *Vault {
 	return &Vault{
 		queryService: qs,
 		marshaller:   NewMarshaller(),
-		rwsets:       make(map[cdriver.TxID]*vault.ReadWriteSet),
-		txStatuses:   make(map[cdriver.TxID]*txStatusInfo),
 	}
 }
 
@@ -349,15 +328,13 @@ func (r *rwSetWrapper) Bytes() ([]byte, error) {
 		}
 	}
 
-	// Set nsInfo in marshaller before marshalling
-	r.v.marshaller.NsInfo = nsInfo
-
-	return r.v.marshaller.Marshal(string(r.txID), r.rws)
+	// Pass nsInfo per call rather than through shared marshaller state, so concurrent
+	// Bytes() calls on different RWSets from the same vault do not race.
+	return r.v.marshaller.Marshal(string(r.txID), r.rws, nsInfo)
 }
 
-// Done performs cleanup for this RWSet. Currently a no-op as no cleanup is needed.
+// Done is a no-op. The vault does not retain the ReadWriteSet.
 func (r *rwSetWrapper) Done() {
-	// No cleanup needed
 }
 
 // Equals compares this RWSet with another RWSet for equality.
@@ -382,13 +359,9 @@ func (r *rwSetWrapper) Equals(rws any, nss ...cdriver.Namespace) error {
 }
 
 // NewRWSet creates a new empty RWSet for the given transaction ID.
-// The RWSet is stored locally and can be used to track reads and writes.
+// The returned wrapper owns the ReadWriteSet; the vault does not retain a reference to it.
 func (v *Vault) NewRWSet(ctx context.Context, txID cdriver.TxID) (cdriver.RWSet, error) {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-
 	rws := vault.EmptyRWSet()
-	v.rwsets[txID] = &rws
 
 	qe, err := v.NewQueryExecutor(ctx)
 	if err != nil {
@@ -404,17 +377,12 @@ func (v *Vault) NewRWSet(ctx context.Context, txID cdriver.TxID) (cdriver.RWSet,
 }
 
 // NewRWSetFromBytes creates a new RWSet by deserializing it from bytes.
-// The RWSet is stored locally with the given transaction ID.
+// The returned wrapper owns the ReadWriteSet; the vault does not retain a reference to it.
 func (v *Vault) NewRWSetFromBytes(ctx context.Context, txID cdriver.TxID, rwset []byte) (cdriver.RWSet, error) {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-
 	rws, err := v.marshaller.RWSetFromBytes(rwset)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal rwset")
 	}
-
-	v.rwsets[txID] = rws
 
 	qe, err := v.NewQueryExecutor(ctx)
 	if err != nil {
@@ -429,89 +397,66 @@ func (v *Vault) NewRWSetFromBytes(ctx context.Context, txID cdriver.TxID, rwset 
 	}, nil
 }
 
-// SetDiscarded marks a transaction as discarded (invalid) with the given error message.
-// The status is stored locally.
-func (v *Vault) SetDiscarded(ctx context.Context, txID cdriver.TxID, message string) error {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-
-	v.txStatuses[txID] = &txStatusInfo{
-		code:    fdriver.Invalid,
-		message: message,
-	}
-	return nil
+// SetDiscarded is not supported: the fabricx wiring has no local commit pipeline
+// (see platform/fabricx/core/channel/provider.go). Reaching this method means the
+// vault was wired into a generic committer, which is a programming error.
+func (v *Vault) SetDiscarded(context.Context, cdriver.TxID, string) error {
+	panic("fabricx vault: SetDiscarded called; fabricx has no local commit pipeline")
 }
 
-// Status returns the validation status of a transaction.
-// It first checks the local cache, then queries the remote QueryService if not found locally.
-// The result from the remote service is cached for future queries.
+// Status returns the validation status of a single transaction. It delegates to Statuses so that
+// the two methods answer the same question the same way: a txID the committer does not yet know is
+// reported as Unknown ("not final yet") rather than as an error, which matters for callers polling
+// an in-flight transaction through the public vault facade (platform/fabric/vault.go).
 func (v *Vault) Status(ctx context.Context, txID cdriver.TxID) (fdriver.ValidationCode, string, error) {
-	v.mu.RLock()
-	// Check local cache first
-	if status, exists := v.txStatuses[txID]; exists {
-		v.mu.RUnlock()
-		return status.code, status.message, nil
-	}
-	v.mu.RUnlock()
-
-	// Query remote service
-	statusCode, err := v.queryService.GetTransactionStatus(string(txID))
+	statuses, err := v.Statuses(ctx, txID)
 	if err != nil {
-		return fdriver.Unknown, "", errors.Wrapf(err, "failed to get transaction status for txID=%s", txID)
+		return fdriver.Unknown, "", err
 	}
-
-	// Map status code to ValidationCode
-	validationCode := v.mapStatusToValidationCode(statusCode)
-
-	// Cache the result
-	v.mu.Lock()
-	v.txStatuses[txID] = &txStatusInfo{
-		code:    validationCode,
-		message: "",
-	}
-	v.mu.Unlock()
-
-	return validationCode, "", nil
+	return statuses[0].ValidationCode, statuses[0].Message, nil
 }
 
-// Statuses returns the validation statuses for multiple transactions.
-// Each transaction status is retrieved using the Status method.
+// Statuses returns the validation statuses for multiple transactions, resolving them from the
+// remote QueryService in a single batched query. A txID that the committer does not know
+// is omitted from the batched result and is reported here as Unknown
+// ("not final yet"). The result preserves the order of the input txIDs.
 func (v *Vault) Statuses(ctx context.Context, txIDs ...cdriver.TxID) ([]cdriver.TxValidationStatus[fdriver.ValidationCode], error) {
-	statuses := make([]cdriver.TxValidationStatus[fdriver.ValidationCode], len(txIDs))
-
+	ids := make([]string, len(txIDs))
 	for i, txID := range txIDs {
-		code, message, err := v.Status(ctx, txID)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get status for txID=%s", txID)
+		ids[i] = string(txID)
+	}
+
+	codes, err := v.queryService.GetTransactionStatuses(ids)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get transaction statuses")
+	}
+
+	statuses := make([]cdriver.TxValidationStatus[fdriver.ValidationCode], len(txIDs))
+	for i, txID := range txIDs {
+		code := fdriver.Unknown // omitted from the batched result => not final yet
+		if statusCode, ok := codes[string(txID)]; ok {
+			code = v.mapStatusToValidationCode(statusCode)
 		}
 		statuses[i] = cdriver.TxValidationStatus[fdriver.ValidationCode]{
 			TxID:           txID,
 			ValidationCode: code,
-			Message:        message,
 		}
 	}
-
 	return statuses, nil
 }
 
-// DiscardTx marks a transaction as discarded. This is an alias for SetDiscarded.
-func (v *Vault) DiscardTx(ctx context.Context, txID cdriver.TxID, message string) error {
-	return v.SetDiscarded(ctx, txID, message)
+// DiscardTx is not supported: the fabricx wiring has no local commit pipeline
+// (see platform/fabricx/core/channel/provider.go). Reaching this method means the
+// vault was wired into a generic committer, which is a programming error.
+func (v *Vault) DiscardTx(context.Context, cdriver.TxID, string) error {
+	panic("fabricx vault: DiscardTx called; fabricx has no local commit pipeline")
 }
 
-// CommitTX marks a transaction as committed (valid) and records its block number and index.
-// The status is stored locally.
-func (v *Vault) CommitTX(ctx context.Context, txID cdriver.TxID, block cdriver.BlockNum, index cdriver.TxNum) error {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-
-	v.txStatuses[txID] = &txStatusInfo{
-		code:    fdriver.Valid,
-		message: "",
-		block:   block,
-		index:   index,
-	}
-	return nil
+// CommitTX is not supported: the fabricx wiring has no local commit pipeline
+// (see platform/fabricx/core/channel/provider.go). Reaching this method means the
+// vault was wired into a generic committer, which is a programming error.
+func (v *Vault) CommitTX(context.Context, cdriver.TxID, cdriver.BlockNum, cdriver.TxNum) error {
+	panic("fabricx vault: CommitTX called; fabricx has no local commit pipeline")
 }
 
 // InspectRWSet creates an ephemeral RWSet from bytes for inspection purposes.
@@ -537,55 +482,22 @@ func (v *Vault) InspectRWSet(ctx context.Context, rwset []byte, namespaces ...cd
 	}, nil
 }
 
-// RWSExists checks whether an RWSet exists locally for the given transaction ID.
-func (v *Vault) RWSExists(ctx context.Context, id cdriver.TxID) bool {
-	v.mu.RLock()
-	defer v.mu.RUnlock()
-	_, exists := v.rwsets[id]
-	return exists
+// RWSExists is not supported: the fabricx wiring has no local commit pipeline
+// (see platform/fabricx/core/channel/provider.go). Reaching this method means the
+// vault was wired into a generic committer, which is a programming error.
+func (v *Vault) RWSExists(context.Context, cdriver.TxID) bool {
+	panic("fabricx vault: RWSExists called; fabricx has no local commit pipeline")
 }
 
-// Match compares a stored RWSet with provided bytes to verify they match.
-// Returns an error if the RWSet doesn't exist, or if the bytes don't match.
-func (v *Vault) Match(ctx context.Context, id cdriver.TxID, results []byte) error {
-	v.mu.RLock()
-	rws, exists := v.rwsets[id]
-	v.mu.RUnlock()
-
-	if !exists {
-		return errors.Errorf("rwset not found for txID=%s", id)
-	}
-
-	// Marshal the stored RWSet
-	storedBytes, err := v.marshaller.Marshal(string(id), rws)
-	if err != nil {
-		return errors.Wrap(err, "failed to marshal stored rwset")
-	}
-
-	// Compare bytes
-	if len(storedBytes) != len(results) {
-		return errors.Errorf("rwset mismatch: length differs (stored=%d, provided=%d)", len(storedBytes), len(results))
-	}
-
-	for i := range storedBytes {
-		if storedBytes[i] != results[i] {
-			return errors.Errorf("rwset mismatch at byte %d", i)
-		}
-	}
-
-	return nil
+// Match is not supported: the fabricx wiring has no local commit pipeline
+// (see platform/fabricx/core/channel/provider.go). Reaching this method means the
+// vault was wired into a generic committer, which is a programming error.
+func (v *Vault) Match(context.Context, cdriver.TxID, []byte) error {
+	panic("fabricx vault: Match called; fabricx has no local commit pipeline")
 }
 
-// Close clears all local storage (RWSets and transaction statuses).
-// After closing, the vault can still be used but all cached data is lost.
+// Close is a no-op. The vault holds no per-transaction state to release.
 func (v *Vault) Close() error {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-
-	// Clear local storage
-	v.rwsets = make(map[cdriver.TxID]*vault.ReadWriteSet)
-	v.txStatuses = make(map[cdriver.TxID]*txStatusInfo)
-
 	return nil
 }
 

--- a/platform/fabricx/core/vault/vault.go
+++ b/platform/fabricx/core/vault/vault.go
@@ -411,7 +411,7 @@ func (v *Vault) SetDiscarded(context.Context, cdriver.TxID, string) error {
 func (v *Vault) Status(ctx context.Context, txID cdriver.TxID) (fdriver.ValidationCode, string, error) {
 	statuses, err := v.Statuses(ctx, txID)
 	if err != nil {
-		return fdriver.Unknown, "", err
+		return fdriver.Unknown, "", errors.Wrapf(err, "failed to get transaction status for txID=%s", txID)
 	}
 	return statuses[0].ValidationCode, statuses[0].Message, nil
 }

--- a/platform/fabricx/core/vault/vault_test.go
+++ b/platform/fabricx/core/vault/vault_test.go
@@ -8,6 +8,7 @@ package vault_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
@@ -195,25 +196,52 @@ func TestVaultX_Status(t *testing.T) {
 	require.Empty(t, msg)
 }
 
+// TestVaultX_Status_Unknown asserts that Status agrees with Statuses on the "committer doesn't know
+// this tx" case: it reports Unknown ("not final yet") without an error, rather than surfacing the
+// unknown-tx condition as a failure to a caller polling an in-flight transaction.
+func TestVaultX_Status_Unknown(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	// tx1 intentionally left unset => committer does not know it yet.
+
+	v := vault.NewVault(qs)
+	ctx := context.Background()
+
+	code, msg, err := v.Status(ctx, "tx1")
+	require.NoError(t, err)
+	require.Equal(t, fdriver.Unknown, code)
+	require.Empty(t, msg)
+}
+
 func TestVaultX_Statuses(t *testing.T) {
 	t.Parallel()
 	qs := newMockQueryService()
 	qs.setTxStatus("tx1", 1) // COMMITTED
 	qs.setTxStatus("tx2", 0) // UNSPECIFIED
+	// tx3 is intentionally left unset: the batched query omits transactions the committer does not
+	// know, and Statuses must report those as Unknown ("not final yet") in the right position.
 
 	v := vault.NewVault(qs)
 	ctx := context.Background()
 
-	statuses, err := v.Statuses(ctx, "tx1", "tx2")
+	statuses, err := v.Statuses(ctx, "tx1", "tx3", "tx2")
 	require.NoError(t, err)
-	require.Len(t, statuses, 2)
+	require.Len(t, statuses, 3)
 
+	// Order matches the input, not the (unordered) map returned by the batched query.
 	require.Equal(t, driver.TxID("tx1"), statuses[0].TxID)
 	require.Equal(t, fdriver.Valid, statuses[0].ValidationCode)
 
-	require.Equal(t, driver.TxID("tx2"), statuses[1].TxID)
+	require.Equal(t, driver.TxID("tx3"), statuses[1].TxID)
 	require.Equal(t, fdriver.Unknown, statuses[1].ValidationCode)
+
+	require.Equal(t, driver.TxID("tx2"), statuses[2].TxID)
+	require.Equal(t, fdriver.Unknown, statuses[2].ValidationCode)
 }
+
+// The commit-pipeline methods (SetDiscarded/DiscardTx/CommitTX/Match/RWSExists) are unreachable in
+// the fabricx wiring, which has no local commit pipeline. They panic if called, so that wiring the
+// vault into a generic committer by mistake fails loudly rather than silently misbehaving.
 
 func TestVaultX_SetDiscarded(t *testing.T) {
 	t.Parallel()
@@ -221,14 +249,9 @@ func TestVaultX_SetDiscarded(t *testing.T) {
 	v := vault.NewVault(qs)
 	ctx := context.Background()
 
-	err := v.SetDiscarded(ctx, "tx1", "test error")
-	require.NoError(t, err)
-
-	// Verify status is set to Invalid
-	code, msg, err := v.Status(ctx, "tx1")
-	require.NoError(t, err)
-	require.Equal(t, fdriver.Invalid, code)
-	require.Equal(t, "test error", msg)
+	require.PanicsWithValue(t,
+		"fabricx vault: SetDiscarded called; fabricx has no local commit pipeline",
+		func() { _ = v.SetDiscarded(ctx, "tx1", "test error") })
 }
 
 func TestVaultX_DiscardTx(t *testing.T) {
@@ -237,14 +260,9 @@ func TestVaultX_DiscardTx(t *testing.T) {
 	v := vault.NewVault(qs)
 	ctx := context.Background()
 
-	err := v.DiscardTx(ctx, "tx1", "discard reason")
-	require.NoError(t, err)
-
-	// Verify status
-	code, msg, err := v.Status(ctx, "tx1")
-	require.NoError(t, err)
-	require.Equal(t, fdriver.Invalid, code)
-	require.Equal(t, "discard reason", msg)
+	require.PanicsWithValue(t,
+		"fabricx vault: DiscardTx called; fabricx has no local commit pipeline",
+		func() { _ = v.DiscardTx(ctx, "tx1", "discard reason") })
 }
 
 func TestVaultX_CommitTX(t *testing.T) {
@@ -253,14 +271,9 @@ func TestVaultX_CommitTX(t *testing.T) {
 	v := vault.NewVault(qs)
 	ctx := context.Background()
 
-	err := v.CommitTX(ctx, "tx1", 10, 5)
-	require.NoError(t, err)
-
-	// Verify status is set to Valid
-	code, msg, err := v.Status(ctx, "tx1")
-	require.NoError(t, err)
-	require.Equal(t, fdriver.Valid, code)
-	require.Empty(t, msg)
+	require.PanicsWithValue(t,
+		"fabricx vault: CommitTX called; fabricx has no local commit pipeline",
+		func() { _ = v.CommitTX(ctx, "tx1", 10, 5) })
 }
 
 func TestVaultX_InspectRWSet(t *testing.T) {
@@ -298,15 +311,10 @@ func TestVaultX_RWSExists(t *testing.T) {
 	v := vault.NewVault(qs)
 	ctx := context.Background()
 
-	// Initially should not exist
-	require.False(t, v.RWSExists(ctx, "tx1"))
-
-	// Create RWSet
-	_, err := v.NewRWSet(ctx, "tx1")
-	require.NoError(t, err)
-
-	// Now should exist
-	require.True(t, v.RWSExists(ctx, "tx1"))
+	// RWSExists has no error channel, so returning a value would be a misleading answer; it panics.
+	require.PanicsWithValue(t,
+		"fabricx vault: RWSExists called; fabricx has no local commit pipeline",
+		func() { _ = v.RWSExists(ctx, "tx1") })
 }
 
 func TestVaultX_Match(t *testing.T) {
@@ -315,7 +323,8 @@ func TestVaultX_Match(t *testing.T) {
 	v := vault.NewVault(qs)
 	ctx := context.Background()
 
-	// Create an RWSet
+	// The vault retains no RWSet to match against, and Match is unreachable in the fabricx wiring,
+	// so it panics — including for a txID whose RWSet was just created and marshalled.
 	rws, err := v.NewRWSet(ctx, "tx1")
 	require.NoError(t, err)
 
@@ -325,17 +334,9 @@ func TestVaultX_Match(t *testing.T) {
 	bytes, err := rws.Bytes()
 	require.NoError(t, err)
 
-	// Match should succeed with same bytes
-	err = v.Match(ctx, "tx1", bytes)
-	require.NoError(t, err)
-
-	// Match should fail with different bytes
-	err = v.Match(ctx, "tx1", []byte("different"))
-	require.Error(t, err)
-
-	// Match should fail for non-existent tx
-	err = v.Match(ctx, "nonexistent", bytes)
-	require.Error(t, err)
+	require.PanicsWithValue(t,
+		"fabricx vault: Match called; fabricx has no local commit pipeline",
+		func() { _ = v.Match(ctx, "tx1", bytes) })
 }
 
 func TestVaultX_Close(t *testing.T) {
@@ -344,19 +345,12 @@ func TestVaultX_Close(t *testing.T) {
 	v := vault.NewVault(qs)
 	ctx := context.Background()
 
-	// Create some data
+	// The vault holds no per-transaction state, so Close is a no-op that always succeeds.
 	_, err := v.NewRWSet(ctx, "tx1")
 	require.NoError(t, err)
 
-	err = v.SetDiscarded(ctx, "tx2", "test")
-	require.NoError(t, err)
-
-	// Close should clear everything
 	err = v.Close()
 	require.NoError(t, err)
-
-	// Verify data is cleared
-	require.False(t, v.RWSExists(ctx, "tx1"))
 }
 
 func TestRWSet_Operations(t *testing.T) {
@@ -461,4 +455,41 @@ func TestRWSet_GetWriteAt(t *testing.T) {
 	// Test out of bounds
 	_, _, err = rws.GetWriteAt("ns1", 100)
 	require.Error(t, err)
+}
+
+// TestRWSet_ConcurrentBytes exercises many goroutines calling Bytes() on different RWSets created
+// from the same vault. All those wrappers share the vault's single Marshaller, so before Bytes()
+// stopped writing the marshaller's namespace-info through shared state, this raced. Run under
+// -race, it fails on the old code and locks the fix in.
+func TestRWSet_ConcurrentBytes(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	// Give the namespaces a non-default _meta version so Bytes() builds a populated nsInfo map.
+	qs.setState("_meta", "ns1", nil, 7)
+	qs.setState("_meta", "ns2", nil, 9)
+
+	v := vault.NewVault(qs)
+	ctx := context.Background()
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := range goroutines {
+		go func(g int) {
+			defer wg.Done()
+			// Each goroutine gets its own RWSet, but they all share v.marshaller.
+			rws, err := v.NewRWSet(ctx, driver.TxID("tx"))
+			require.NoError(t, err)
+			// Vary the namespace per goroutine so the nsInfo maps differ between concurrent calls.
+			ns := driver.Namespace("ns1")
+			if g%2 == 0 {
+				ns = "ns2"
+			}
+			require.NoError(t, rws.SetState(ns, "key", []byte("value")))
+
+			_, err = rws.Bytes()
+			require.NoError(t, err)
+		}(g)
+	}
+	wg.Wait()
 }

--- a/platform/fabricx/core/vault/vault_test.go
+++ b/platform/fabricx/core/vault/vault_test.go
@@ -8,13 +8,14 @@ package vault_test
 
 import (
 	"context"
-	"sync"
 	"testing"
 
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/encoding/protowire"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
@@ -472,24 +473,29 @@ func TestRWSet_ConcurrentBytes(t *testing.T) {
 	ctx := context.Background()
 
 	const goroutines = 16
-	var wg sync.WaitGroup
-	wg.Add(goroutines)
+	// Assertions must not run off the test goroutine (require.* calls t.FailNow, which is only
+	// valid from the goroutine running the test), so errors are collected and checked below.
+	var eg errgroup.Group
 	for g := range goroutines {
-		go func(g int) {
-			defer wg.Done()
+		eg.Go(func() error {
 			// Each goroutine gets its own RWSet, but they all share v.marshaller.
 			rws, err := v.NewRWSet(ctx, driver.TxID("tx"))
-			require.NoError(t, err)
+			if err != nil {
+				return errors.Wrapf(err, "goroutine %d: NewRWSet", g)
+			}
 			// Vary the namespace per goroutine so the nsInfo maps differ between concurrent calls.
 			ns := driver.Namespace("ns1")
 			if g%2 == 0 {
 				ns = "ns2"
 			}
-			require.NoError(t, rws.SetState(ns, "key", []byte("value")))
-
-			_, err = rws.Bytes()
-			require.NoError(t, err)
-		}(g)
+			if err := rws.SetState(ns, "key", []byte("value")); err != nil {
+				return errors.Wrapf(err, "goroutine %d: SetState", g)
+			}
+			if _, err := rws.Bytes(); err != nil {
+				return errors.Wrapf(err, "goroutine %d: Bytes", g)
+			}
+			return nil
+		})
 	}
-	wg.Wait()
+	require.NoError(t, eg.Wait())
 }


### PR DESCRIPTION
closes #1599
The FabricX vault held two in-memory maps (rwsets, txStatuses) that grew
unboundedly: nothing on the FabricX path ever pruned or read them. FabricX has
no local commit pipeline — commit/validation happens in the external
fabric-x-committer, and finality is delivered by the gRPC notifier — so the
vault methods that populated or read those maps (CommitTX/DiscardTx/
SetDiscarded/Match/RWSExists) are never invoked in the FabricX wiring. Endorse-
only nodes were pinning ~1.5 GB of RWSets at rest as a result (PR #1206).

Changes:
- Remove the rwsets and txStatuses maps, the txStatusInfo struct, and the mutex.
  NewRWSet/NewRWSetFromBytes no longer retain the RWSet; the wrapper owns it.
- The five commit-pipeline interface methods now panic instead of returning a
  value. They exist only to satisfy fdriver.Vault; reaching one means the vault
  was wired into a generic committer by mistake, which is a programming error,
  not a runtime condition. Panicking fails loudly and cannot be silently
  swallowed — RWSExists in particular has no error channel, so its old `false`
  return was an actively misleading answer.
- Status now delegates to the batched Statuses so both report a tx unknown to
  the committer as Unknown ("not final yet") rather than as an error — the
  condition a caller polling an in-flight tx will hit.
- Bytes() passes namespace-version info to the marshaller per call instead of
  through a shared mutable field, fixing a data race between concurrent Bytes()
  calls. The marshaller is now stateless; the racy field and its exported
  wrapper are removed. Covered by a new -race test.
