### PR TITLE
feat(fabricx): hash-hiding metadata + QueryService certification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,7 @@ HSM_INTEGRATION_TARGETS = fabric-iouhsm
 
 ## fabricx section
 INTEGRATION_TARGETS += fabricx-iou
+INTEGRATION_TARGETS += fabricx-atsa
 INTEGRATION_TARGETS += fabricx-simple
 INTEGRATION_TARGETS += fabricx-deployment
 INTEGRATION_TARGETS += fabricx-multiendorsement

--- a/integration/fabricx/atsa/README.md
+++ b/integration/fabricx/atsa/README.md
@@ -1,0 +1,37 @@
+# FabricX ATSA (idemix) integration test
+
+This suite runs the **A**sset **T**ransfer **S**ecured **A**greement flow
+(`Issue → AgreeToSell → AgreeToBuy → Transfer`) on the **FabricX** platform, reusing the
+`integration/fabric/atsa` views **unmodified** and exercising **idemix** (`alice`/`bob` run with
+`fabric.WithAnonymousIdentity()`, transactions built via `state.NewAnonymousTransaction`).
+
+## What it validates
+
+The Transfer step depends on two state-service features that Fabric provides but FabricX
+historically did not. Both are now supported below the view layer:
+
+1. **Hash-hidden state metadata.** `AgreeToSell`/`AgreeToBuy` write outputs with
+   `state.WithHashHiding()` (whole-state: on-ledger value = `sha256(json)`, preimage kept as
+   off-ledger field-mapping); the `Asset` hides only its `PrivateProperties` field
+   (`state:"hash"`, field-level). FabricX FSC nodes are stateless (reads go to the committer
+   QueryService, which returns only `{Raw, Version}`), so the preimage is persisted **synchronously
+   on the endorsement path** (`Transaction.StoreTransient`) into a new
+   `(network, channel, ns, key, sha256(committed value))`-indexed store and served back on a vault
+   metadata miss.
+
+2. **State certification.** `WithCertification()` / `VerifyCertification()` are backed by a
+   `QueryServiceCertifier` (resolved per network via the `state.Certifier` seam, registered by the
+   fabricx SDK) that trusts the committer QueryService instead of chaincode endorsement.
+
+See `docs/superpowers/specs/2026-07-22-fabricx-hashhiding-certification-design.md` for the full
+design.
+
+## Running
+
+Integration suites shell out to `configtxgen`/`cryptogen`/`fxconfig` from `$FAB_BINS`. The Makefile
+default is `PWD`-relative and resolves incorrectly from a git worktree, so pass an absolute path:
+
+```bash
+make integration-tests-fabricx-atsa \
+  FAB_BINS=/absolute/path/to/hyperledger-labs/fabric/bin
+```

--- a/integration/fabricx/atsa/README.md
+++ b/integration/fabricx/atsa/README.md
@@ -20,8 +20,9 @@ historically did not. Both are now supported below the view layer:
    metadata miss.
 
 2. **State certification.** `WithCertification()` / `VerifyCertification()` are backed by a
-   `QueryServiceCertifier` (resolved per network via the `state.Certifier` seam, registered by the
-   fabricx SDK) that trusts the committer QueryService instead of chaincode endorsement.
+   `TrustedReadCertifier` (resolved per network via the `state.Certifier` seam, registered by the
+   fabricx SDK) that trusts the vault's committed read — served by the committer QueryService —
+   instead of chaincode endorsement.
 
 See `docs/superpowers/specs/2026-07-22-fabricx-hashhiding-certification-design.md` for the full
 design.

--- a/integration/fabricx/atsa/atsa_suite_test.go
+++ b/integration/fabricx/atsa/atsa_suite_test.go
@@ -1,0 +1,19 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package atsa_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndToEnd(t *testing.T) { //nolint:paralleltest
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Fabric-X Asset Transfer Secured Agreement")
+}

--- a/integration/fabricx/atsa/atsa_test.go
+++ b/integration/fabricx/atsa/atsa_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package atsa_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/hyperledger-labs/fabric-smart-client/integration"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/fabric/atsa/client"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/fabric/atsa/states"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/fabricx/atsa"
+	nwofabricx "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabricx"
+	nwofsc "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
+)
+
+var _ = Describe("EndToEnd", func() {
+	for _, c := range []nwofsc.P2PCommunicationType{nwofsc.WebSocket} {
+		Describe("Asset Transfer Secured Agreement", Label(c), func() {
+			s := NewTestSuite(c, integration.NoReplication)
+			BeforeEach(s.Setup)
+			AfterEach(s.TearDown)
+			It("succeeded", s.TestSucceeded)
+		})
+	}
+})
+
+type TestSuite struct {
+	*integration.TestSuite
+}
+
+func NewTestSuite(commType nwofsc.P2PCommunicationType, nodeOpts *integration.ReplicationOptions) *TestSuite {
+	return &TestSuite{integration.NewTestSuite(func() (*integration.Infrastructure, error) {
+		ii, err := integration.New(
+			integration.FabricXAssetTransferPort.StartPortForNode(),
+			"",
+			atsa.Topology(&atsa.SDK{}, commType, nodeOpts)...,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		ii.RegisterPlatformFactory(nwofabricx.NewPlatformFactory())
+
+		ii.Generate()
+
+		return ii, nil
+	})}
+}
+
+func (s *TestSuite) TestSucceeded() {
+	approver := s.II.Identity("approver")
+
+	issuer := client.New(s.II.Client("issuer"), s.II.Identity("issuer"), approver)
+	_, err := issuer.Issue(&states.Asset{
+		ObjectType:        "coin",
+		ID:                "1234",
+		Owner:             s.II.Identity("alice"),
+		PublicDescription: "Coin",
+		PrivateProperties: []byte("Hello World!!!"),
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	// Note: unlike the Fabric variant, we do not issue a standalone client-side
+	// finality check here. Fabric-x finality is delivered once over the committer's
+	// ephemeral notification stream and is already awaited in-view by both the
+	// issuer (NewOrderingAndFinalityView) and alice (AcceptAssetView), so a fresh
+	// post-commit IsFinal for the same txID would time out as "unknown".
+	seller := client.New(s.II.Client("alice"), s.II.Identity("alice"), approver)
+	agreementID, err := seller.AgreeToSell(&states.AgreementToSell{
+		TradeID: "1234",
+		ID:      "1234",
+		Price:   100,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	buyer := client.New(s.II.Client("bob"), s.II.Identity("bob"), approver)
+	_, err = buyer.AgreeToBuy(&states.AgreementToBuy{
+		TradeID: "1234",
+		ID:      "1234",
+		Price:   100,
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	err = seller.Transfer("1234", agreementID, s.II.Identity("bob"))
+	Expect(err).ToNot(HaveOccurred())
+}

--- a/integration/fabricx/atsa/sdk.go
+++ b/integration/fabricx/atsa/sdk.go
@@ -1,0 +1,39 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package atsa
+
+import (
+	"errors"
+
+	common "github.com/hyperledger-labs/fabric-smart-client/platform/common/sdk/dig"
+	digutils "github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/dig"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/state"
+	fabricx "github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/sdk/dig"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services"
+)
+
+type SDK struct {
+	common.SDK
+}
+
+func NewSDK(registry services.Registry) *SDK {
+	return NewFrom(fabricx.NewSDK(registry))
+}
+
+func NewFrom(sdk common.SDK) *SDK {
+	return &SDK{SDK: sdk}
+}
+
+func (p *SDK) Install() error {
+	if err := p.SDK.Install(); err != nil {
+		return err
+	}
+
+	return errors.Join(
+		digutils.Register[state.VaultService](p.Container()),
+	)
+}

--- a/integration/fabricx/atsa/topology.go
+++ b/integration/fabricx/atsa/topology.go
@@ -1,0 +1,76 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package atsa
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/integration"
+	atsa "github.com/hyperledger-labs/fabric-smart-client/integration/fabric/atsa/views"
+	cviews "github.com/hyperledger-labs/fabric-smart-client/integration/fabric/common/views"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric"
+	nwofabricx "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabricx"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/node"
+)
+
+func Topology(sdk node.SDK, commType fsc.P2PCommunicationType, replicationOpts *integration.ReplicationOptions) []api.Topology {
+	// Create an fabric-x topology with idemix enabled
+	fabricTopology := nwofabricx.NewDefaultTopology()
+	fabricTopology.EnableIdemix()
+	fabricTopology.AddOrganizationsByName("Org1", "Org2", "Org3")
+	fabricTopology.SetNamespaceApproverOrgs("Org1")
+	fabricTopology.AddNamespaceWithUnanimity("asset_transfer", "Org1")
+
+	// Create an FSC topology
+	fscTopology := fsc.NewTopology()
+	fscTopology.P2PCommunicationType = commType
+	fscTopology.SetLogging("grpc=error:fabricx=debug:debug", "")
+
+	// Approver
+	fscTopology.AddNodeByName("approver").
+		AddOptions(fabric.WithOrganization("Org1")).
+		AddOptions(replicationOpts.For("approver")...).
+		RegisterResponder(&atsa.ApproverView{}, &atsa.IssueView{}).
+		RegisterResponder(&atsa.ApproverView{}, &atsa.AgreeToSellView{}).
+		RegisterResponder(&atsa.ApproverView{}, &atsa.AgreeToBuyView{}).
+		RegisterResponder(&atsa.ApproverView{}, &atsa.TransferView{}).
+		RegisterViewFactory("finality", &cviews.FinalityViewFactory{})
+
+	// Issuer
+	fscTopology.AddNodeByName("issuer").
+		AddOptions(fabric.WithOrganization("Org3")).
+		AddOptions(replicationOpts.For("issuer")...).
+		RegisterViewFactory("issue", &atsa.IssueViewFactory{}).
+		RegisterViewFactory("finality", &cviews.FinalityViewFactory{})
+
+	// Alice
+	fscTopology.AddNodeByName("alice").
+		AddOptions(fabric.WithOrganization("Org2"), fabric.WithAnonymousIdentity()).
+		AddOptions(replicationOpts.For("alice")...).
+		RegisterViewFactory("transfer", &atsa.TransferViewFactory{}).
+		RegisterViewFactory("agreeToSell", &atsa.AgreeToSellViewFactory{}).
+		RegisterViewFactory("agreeToBuy", &atsa.AgreeToBuyViewFactory{}).
+		RegisterResponder(&atsa.AcceptAssetView{}, &atsa.IssueView{}).
+		RegisterResponder(&atsa.TransferResponderView{}, &atsa.TransferView{}).
+		RegisterViewFactory("finality", &cviews.FinalityViewFactory{})
+
+	// Bob
+	fscTopology.AddNodeByName("bob").
+		AddOptions(fabric.WithOrganization("Org2"), fabric.WithAnonymousIdentity()).
+		AddOptions(replicationOpts.For("bob")...).
+		RegisterViewFactory("transfer", &atsa.TransferViewFactory{}).
+		RegisterViewFactory("agreeToSell", &atsa.AgreeToSellViewFactory{}).
+		RegisterViewFactory("agreeToBuy", &atsa.AgreeToBuyViewFactory{}).
+		RegisterResponder(&atsa.AcceptAssetView{}, &atsa.IssueView{}).
+		RegisterResponder(&atsa.TransferResponderView{}, &atsa.TransferView{}).
+		RegisterViewFactory("finality", &cviews.FinalityViewFactory{})
+
+	// Add app-specific SDK to FSC Nodes
+	fscTopology.AddSDK(sdk)
+
+	return []api.Topology{fabricTopology, fscTopology}
+}

--- a/integration/fabricx/atsa/topology.go
+++ b/integration/fabricx/atsa/topology.go
@@ -28,7 +28,7 @@ func Topology(sdk node.SDK, commType fsc.P2PCommunicationType, replicationOpts *
 	// Create an FSC topology
 	fscTopology := fsc.NewTopology()
 	fscTopology.P2PCommunicationType = commType
-	fscTopology.SetLogging("grpc=error:fabricx=debug:debug", "")
+	fscTopology.SetLogging("grpc=error:fabricx=debug:info", "")
 
 	// Approver
 	fscTopology.AddNodeByName("approver").

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -36,6 +36,7 @@ const (
 	TwoFabricNetworksPort
 	FabricStopRestart
 	RuntimeConfigPort
+	FabricXAssetTransferPort
 )
 
 // StartPortForNode On linux, the default ephemeral port range is 32768-60999 and can be

--- a/platform/fabric/core/generic/transaction/mock/metadata_service.go
+++ b/platform/fabric/core/generic/transaction/mock/metadata_service.go
@@ -21,6 +21,22 @@ type MetadataService struct {
 	existsReturnsOnCall map[int]struct {
 		result1 bool
 	}
+	GetFieldMappingStub        func(context.Context, string, string, []byte) (driver.TransientMap, error)
+	getFieldMappingMutex       sync.RWMutex
+	getFieldMappingArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 []byte
+	}
+	getFieldMappingReturns struct {
+		result1 driver.TransientMap
+		result2 error
+	}
+	getFieldMappingReturnsOnCall map[int]struct {
+		result1 driver.TransientMap
+		result2 error
+	}
 	LoadTransientStub        func(context.Context, string) (driver.TransientMap, error)
 	loadTransientMutex       sync.RWMutex
 	loadTransientArgsForCall []struct {
@@ -34,6 +50,21 @@ type MetadataService struct {
 	loadTransientReturnsOnCall map[int]struct {
 		result1 driver.TransientMap
 		result2 error
+	}
+	PutFieldMappingStub        func(context.Context, string, string, []byte, driver.TransientMap) error
+	putFieldMappingMutex       sync.RWMutex
+	putFieldMappingArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 []byte
+		arg5 driver.TransientMap
+	}
+	putFieldMappingReturns struct {
+		result1 error
+	}
+	putFieldMappingReturnsOnCall map[int]struct {
+		result1 error
 	}
 	StoreTransientStub        func(context.Context, string, driver.TransientMap) error
 	storeTransientMutex       sync.RWMutex
@@ -114,6 +145,78 @@ func (fake *MetadataService) ExistsReturnsOnCall(i int, result1 bool) {
 	}{result1}
 }
 
+func (fake *MetadataService) GetFieldMapping(arg1 context.Context, arg2 string, arg3 string, arg4 []byte) (driver.TransientMap, error) {
+	var arg4Copy []byte
+	if arg4 != nil {
+		arg4Copy = make([]byte, len(arg4))
+		copy(arg4Copy, arg4)
+	}
+	fake.getFieldMappingMutex.Lock()
+	ret, specificReturn := fake.getFieldMappingReturnsOnCall[len(fake.getFieldMappingArgsForCall)]
+	fake.getFieldMappingArgsForCall = append(fake.getFieldMappingArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 []byte
+	}{arg1, arg2, arg3, arg4Copy})
+	stub := fake.GetFieldMappingStub
+	fakeReturns := fake.getFieldMappingReturns
+	fake.recordInvocation("GetFieldMapping", []interface{}{arg1, arg2, arg3, arg4Copy})
+	fake.getFieldMappingMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *MetadataService) GetFieldMappingCallCount() int {
+	fake.getFieldMappingMutex.RLock()
+	defer fake.getFieldMappingMutex.RUnlock()
+	return len(fake.getFieldMappingArgsForCall)
+}
+
+func (fake *MetadataService) GetFieldMappingCalls(stub func(context.Context, string, string, []byte) (driver.TransientMap, error)) {
+	fake.getFieldMappingMutex.Lock()
+	defer fake.getFieldMappingMutex.Unlock()
+	fake.GetFieldMappingStub = stub
+}
+
+func (fake *MetadataService) GetFieldMappingArgsForCall(i int) (context.Context, string, string, []byte) {
+	fake.getFieldMappingMutex.RLock()
+	defer fake.getFieldMappingMutex.RUnlock()
+	argsForCall := fake.getFieldMappingArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *MetadataService) GetFieldMappingReturns(result1 driver.TransientMap, result2 error) {
+	fake.getFieldMappingMutex.Lock()
+	defer fake.getFieldMappingMutex.Unlock()
+	fake.GetFieldMappingStub = nil
+	fake.getFieldMappingReturns = struct {
+		result1 driver.TransientMap
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *MetadataService) GetFieldMappingReturnsOnCall(i int, result1 driver.TransientMap, result2 error) {
+	fake.getFieldMappingMutex.Lock()
+	defer fake.getFieldMappingMutex.Unlock()
+	fake.GetFieldMappingStub = nil
+	if fake.getFieldMappingReturnsOnCall == nil {
+		fake.getFieldMappingReturnsOnCall = make(map[int]struct {
+			result1 driver.TransientMap
+			result2 error
+		})
+	}
+	fake.getFieldMappingReturnsOnCall[i] = struct {
+		result1 driver.TransientMap
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *MetadataService) LoadTransient(arg1 context.Context, arg2 string) (driver.TransientMap, error) {
 	fake.loadTransientMutex.Lock()
 	ret, specificReturn := fake.loadTransientReturnsOnCall[len(fake.loadTransientArgsForCall)]
@@ -177,6 +280,76 @@ func (fake *MetadataService) LoadTransientReturnsOnCall(i int, result1 driver.Tr
 		result1 driver.TransientMap
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *MetadataService) PutFieldMapping(arg1 context.Context, arg2 string, arg3 string, arg4 []byte, arg5 driver.TransientMap) error {
+	var arg4Copy []byte
+	if arg4 != nil {
+		arg4Copy = make([]byte, len(arg4))
+		copy(arg4Copy, arg4)
+	}
+	fake.putFieldMappingMutex.Lock()
+	ret, specificReturn := fake.putFieldMappingReturnsOnCall[len(fake.putFieldMappingArgsForCall)]
+	fake.putFieldMappingArgsForCall = append(fake.putFieldMappingArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 []byte
+		arg5 driver.TransientMap
+	}{arg1, arg2, arg3, arg4Copy, arg5})
+	stub := fake.PutFieldMappingStub
+	fakeReturns := fake.putFieldMappingReturns
+	fake.recordInvocation("PutFieldMapping", []interface{}{arg1, arg2, arg3, arg4Copy, arg5})
+	fake.putFieldMappingMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *MetadataService) PutFieldMappingCallCount() int {
+	fake.putFieldMappingMutex.RLock()
+	defer fake.putFieldMappingMutex.RUnlock()
+	return len(fake.putFieldMappingArgsForCall)
+}
+
+func (fake *MetadataService) PutFieldMappingCalls(stub func(context.Context, string, string, []byte, driver.TransientMap) error) {
+	fake.putFieldMappingMutex.Lock()
+	defer fake.putFieldMappingMutex.Unlock()
+	fake.PutFieldMappingStub = stub
+}
+
+func (fake *MetadataService) PutFieldMappingArgsForCall(i int) (context.Context, string, string, []byte, driver.TransientMap) {
+	fake.putFieldMappingMutex.RLock()
+	defer fake.putFieldMappingMutex.RUnlock()
+	argsForCall := fake.putFieldMappingArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+}
+
+func (fake *MetadataService) PutFieldMappingReturns(result1 error) {
+	fake.putFieldMappingMutex.Lock()
+	defer fake.putFieldMappingMutex.Unlock()
+	fake.PutFieldMappingStub = nil
+	fake.putFieldMappingReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *MetadataService) PutFieldMappingReturnsOnCall(i int, result1 error) {
+	fake.putFieldMappingMutex.Lock()
+	defer fake.putFieldMappingMutex.Unlock()
+	fake.PutFieldMappingStub = nil
+	if fake.putFieldMappingReturnsOnCall == nil {
+		fake.putFieldMappingReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.putFieldMappingReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *MetadataService) StoreTransient(arg1 context.Context, arg2 string, arg3 driver.TransientMap) error {

--- a/platform/fabric/core/generic/transaction/services.go
+++ b/platform/fabric/core/generic/transaction/services.go
@@ -8,6 +8,7 @@ package transaction
 
 import (
 	"context"
+	"encoding/hex"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 
@@ -40,6 +41,22 @@ func (s *mds) StoreTransient(ctx context.Context, txid string, transientMap driv
 
 func (s *mds) LoadTransient(ctx context.Context, txid string) (driver.TransientMap, error) {
 	return s.metadataKVS.GetMetadata(ctx, s.key(txid))
+}
+
+// fieldMappingStoreKey encodes (ns, key, valueDigest) into the TxID slot of driver.Key
+// so field-mapping entries share the metadata KVS without colliding with real txids.
+// The leading NUL-delimited "fieldmap" prefix keeps them disjoint from txid-shaped keys.
+func fieldMappingStoreKey(ns, key string, valueDigest []byte) string {
+	return "\x00fieldmap\x00" + ns + "\x00" + key + "\x00" + hex.EncodeToString(valueDigest)
+}
+
+func (s *mds) PutFieldMapping(ctx context.Context, ns, key string, valueDigest []byte, mapping driver.TransientMap) error {
+	return s.metadataKVS.PutMetadata(ctx, s.key(fieldMappingStoreKey(ns, key, valueDigest)), mapping)
+}
+
+func (s *mds) GetFieldMapping(ctx context.Context, ns, key string, valueDigest []byte) (driver.TransientMap, error) {
+	// GetMetadata is miss-safe (returns an empty map, not an error), mirroring LoadTransient.
+	return s.metadataKVS.GetMetadata(ctx, s.key(fieldMappingStoreKey(ns, key, valueDigest)))
 }
 
 type envs struct {

--- a/platform/fabric/core/generic/transaction/services.go
+++ b/platform/fabric/core/generic/transaction/services.go
@@ -55,7 +55,10 @@ func (s *mds) PutFieldMapping(ctx context.Context, ns, key string, valueDigest [
 }
 
 func (s *mds) GetFieldMapping(ctx context.Context, ns, key string, valueDigest []byte) (driver.TransientMap, error) {
-	// GetMetadata is miss-safe (returns an empty map, not an error), mirroring LoadTransient.
+	// A miss is not silent: the store reads no row, gets back nil bytes, and fails
+	// unmarshalling them ("unexpected end of JSON input"). Callers must treat an
+	// error here as "no mapping" rather than a hard failure. LoadTransient behaves
+	// identically on a miss.
 	return s.metadataKVS.GetMetadata(ctx, s.key(fieldMappingStoreKey(ns, key, valueDigest)))
 }
 

--- a/platform/fabric/core/generic/transaction/services_test.go
+++ b/platform/fabric/core/generic/transaction/services_test.go
@@ -41,6 +41,38 @@ func TestMetadataService(t *testing.T) {
 	require.Equal(t, driver.TransientMap(tm), loaded)
 }
 
+func TestFieldMappingRoundTrip(t *testing.T) {
+	t.Parallel()
+	mockStore := &mock.MetadataStore{}
+	mds := transaction.NewMetadataService(mockStore, "net", "ch")
+	ctx := t.Context()
+
+	digestA := []byte{0xAA}
+	mappingA := driver.TransientMap{"field_mapping|x": []byte("preimage-A")}
+	mockStore.PutMetadataReturns(nil)
+	require.NoError(t, mds.PutFieldMapping(ctx, "ns", "k", digestA, mappingA))
+
+	// Put targets a (net, ch) key and stores the mapping value verbatim.
+	_, keyA, valA := mockStore.PutMetadataArgsForCall(0)
+	require.Equal(t, "net", keyA.Network)
+	require.Equal(t, "ch", keyA.Channel)
+	require.Equal(t, mappingA, valA)
+
+	// A different digest for the same (ns,key) must map to a distinct KVS key
+	// (overwrite-safe: the old preimage stays resolvable under its own digest).
+	digestB := []byte{0xBB}
+	mappingB := driver.TransientMap{"field_mapping|x": []byte("preimage-B")}
+	require.NoError(t, mds.PutFieldMapping(ctx, "ns", "k", digestB, mappingB))
+	_, keyB, _ := mockStore.PutMetadataArgsForCall(1)
+	require.NotEqual(t, keyA.TxID, keyB.TxID, "different digests must map to different KVS keys")
+
+	// GetFieldMapping returns whatever the store holds for that digest.
+	mockStore.GetMetadataReturns(mappingA, nil)
+	got, err := mds.GetFieldMapping(ctx, "ns", "k", digestA)
+	require.NoError(t, err)
+	require.Equal(t, mappingA, got)
+}
+
 func TestEnvelopeService(t *testing.T) {
 	t.Parallel()
 	mockStore := &mock.EnvelopeStore{}

--- a/platform/fabric/core/generic/transaction/services_test.go
+++ b/platform/fabric/core/generic/transaction/services_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/transaction"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/transaction/mock"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	mem "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver/memory"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver/multiplexed"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/storage/metadata"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/sqlite"
 )
 
 func TestMetadataService(t *testing.T) {
@@ -71,6 +75,60 @@ func TestFieldMappingRoundTrip(t *testing.T) {
 	got, err := mds.GetFieldMapping(ctx, "ns", "k", digestA)
 	require.NoError(t, err)
 	require.Equal(t, mappingA, got)
+}
+
+// newRealMetadataStore builds a metadata store backed by the real
+// (in-memory sqlite) persistence rather than a counterfeiter mock, so that
+// miss behaviour of the actual storage stack is exercised.
+func newRealMetadataStore(t *testing.T) driver.MetadataStore {
+	t.Helper()
+	cp := multiplexed.MockTypeConfig(mem.Persistence, struct{}{})
+	d := multiplexed.NewDriver(cp, mem.NewNamedDriver(sqlite.NewDbProvider()))
+	s, err := metadata.NewStore[driver.Key, driver.TransientMap](cp, d, t.Name())
+	require.NoError(t, err)
+	return s
+}
+
+// TestGetFieldMappingHitAgainstRealStore pins the hit path through the real
+// persistence stack, so the miss assertions below cannot be blamed on a
+// mis-wired store.
+func TestGetFieldMappingHitAgainstRealStore(t *testing.T) {
+	t.Parallel()
+	mds := transaction.NewMetadataService(newRealMetadataStore(t), "net", "ch")
+	ctx := t.Context()
+
+	digest := []byte{0xDE, 0xAD}
+	mapping := driver.TransientMap{"field_mapping|x": []byte("preimage")}
+	require.NoError(t, mds.PutFieldMapping(ctx, "ns", "k", digest, mapping))
+
+	got, err := mds.GetFieldMapping(ctx, "ns", "k", digest)
+	require.NoError(t, err)
+	require.Equal(t, mapping, got)
+}
+
+// TestGetFieldMappingOnMissReturnsError documents that a lookup for a
+// (ns, key, digest) that was never stored is *not* miss-safe: the SQL store
+// returns (nil, nil) for a missing row (QueryUniqueContext swallows
+// sql.ErrNoRows), and metadata.store.GetMetadata then json.Unmarshal's those
+// nil bytes, which fails. Callers must treat the error as "no mapping".
+func TestGetFieldMappingOnMissReturnsError(t *testing.T) {
+	t.Parallel()
+	mds := transaction.NewMetadataService(newRealMetadataStore(t), "net", "ch")
+
+	got, err := mds.GetFieldMapping(t.Context(), "ns", "never-stored", []byte{0xDE, 0xAD})
+	require.ErrorContains(t, err, "unexpected end of JSON input")
+	require.Empty(t, got)
+}
+
+// TestLoadTransientOnMissReturnsError shows GetFieldMapping's miss behaviour
+// really does mirror LoadTransient's — both error rather than returning empty.
+func TestLoadTransientOnMissReturnsError(t *testing.T) {
+	t.Parallel()
+	mds := transaction.NewMetadataService(newRealMetadataStore(t), "net", "ch")
+
+	got, err := mds.LoadTransient(t.Context(), "never-stored-txid")
+	require.ErrorContains(t, err, "unexpected end of JSON input")
+	require.Empty(t, got)
 }
 
 func TestEnvelopeService(t *testing.T) {

--- a/platform/fabric/driver/transaction.go
+++ b/platform/fabric/driver/transaction.go
@@ -61,7 +61,9 @@ type MetadataService interface {
 	// does not use it.
 	PutFieldMapping(ctx context.Context, ns, key string, valueDigest []byte, mapping TransientMap) error
 	// GetFieldMapping returns the field-mapping previously persisted for
-	// (ns, key, valueDigest), or an empty map if none exists.
+	// (ns, key, valueDigest). Implementations are not required to be miss-safe:
+	// the default store returns an error when no mapping exists, so callers
+	// should treat an error as "no mapping" rather than a hard failure.
 	GetFieldMapping(ctx context.Context, ns, key string, valueDigest []byte) (TransientMap, error)
 }
 

--- a/platform/fabric/driver/transaction.go
+++ b/platform/fabric/driver/transaction.go
@@ -56,7 +56,9 @@ type MetadataService interface {
 	// (ns, key, valueDigest), where valueDigest = sha256(committed on-ledger value).
 	// Keying by the digest keeps overwrites/deletes unambiguous: a reader resolves
 	// the exact preimage for the value it actually observes on the ledger.
-	// Populated on FabricX (synchronously, at endorsement); Fabric does not use it.
+	// Populated by deployments whose nodes are stateless and resolve hash-hiding from a
+	// trusted committed read rather than local transient; the chaincode-endorsement path
+	// does not use it.
 	PutFieldMapping(ctx context.Context, ns, key string, valueDigest []byte, mapping TransientMap) error
 	// GetFieldMapping returns the field-mapping previously persisted for
 	// (ns, key, valueDigest), or an empty map if none exists.

--- a/platform/fabric/driver/transaction.go
+++ b/platform/fabric/driver/transaction.go
@@ -52,6 +52,15 @@ type MetadataService interface {
 	Exists(ctx context.Context, txid string) bool
 	StoreTransient(ctx context.Context, txid string, transientMap TransientMap) error
 	LoadTransient(ctx context.Context, txid string) (TransientMap, error)
+	// PutFieldMapping persists a hash-hiding field-mapping preimage keyed by
+	// (ns, key, valueDigest), where valueDigest = sha256(committed on-ledger value).
+	// Keying by the digest keeps overwrites/deletes unambiguous: a reader resolves
+	// the exact preimage for the value it actually observes on the ledger.
+	// Populated on FabricX (synchronously, at endorsement); Fabric does not use it.
+	PutFieldMapping(ctx context.Context, ns, key string, valueDigest []byte, mapping TransientMap) error
+	// GetFieldMapping returns the field-mapping previously persisted for
+	// (ns, key, valueDigest), or an empty map if none exists.
+	GetFieldMapping(ctx context.Context, ns, key string, valueDigest []byte) (TransientMap, error)
 }
 
 type EnvelopeService interface {

--- a/platform/fabric/services/state/certification.go
+++ b/platform/fabric/services/state/certification.go
@@ -141,7 +141,7 @@ func (c *ChaincodeCertifier) VerifyInputCertificationAt(n *Namespace, index int,
 	case ChaincodeCertification:
 		rwSet, err := n.tx.RWSet()
 		if err != nil {
-			return errors.Wrap(err, "filed getting rw set")
+			return errors.Wrap(err, "failed getting rw set")
 		}
 		id, err := rwSet.GetReadKeyAt(n.namespace(), index)
 		if err != nil {
@@ -274,8 +274,11 @@ func (c *QueryServiceCertifier) VerifyInputCertificationAt(n *Namespace, index i
 	}
 
 	// Field-level hiding: the committed value IS the marshaled state (the hidden field is
-	// already hashed in place). Integrity of the field is enforced by unmarshalTags during
-	// State(); here we only confirm the state is committed (checked above).
+	// already hashed in place). Integrity of []byte hash fields is enforced by unmarshalTags
+	// during State() (recompute + compare against the committed hash; a missing or tampered
+	// preimage errors there). String hash fields are rejected at (un)marshal time, so no
+	// unverified hiding mode reaches this point. Here we only confirm the state is committed
+	// (checked above).
 	return nil
 }
 

--- a/platform/fabric/services/state/certification.go
+++ b/platform/fabric/services/state/certification.go
@@ -7,8 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package state
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"reflect"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
@@ -90,7 +93,43 @@ func certificationKey(key string) (string, error) {
 	return rwset.CreateCompositeKey(Certification, elems)
 }
 
+// Certifier verifies and (on Fabric) produces certification for input states.
+// The concrete implementation is resolved per node platform: ChaincodeCertifier
+// on Fabric (default), QueryServiceCertifier on FabricX (registered by its SDK).
+type Certifier interface {
+	CertifyInput(n *Namespace, id string) error
+	VerifyInputCertificationAt(n *Namespace, index int, key string) error
+}
+
+// resolveCertifier returns the Certifier registered on the transaction's service
+// provider, falling back to ChaincodeCertifier (the Fabric default) when none is
+// registered. Dispatch is by injected certifier, not by the stored type string.
+func (n *Namespace) resolveCertifier() Certifier {
+	// n.tx.Provider may be nil in unit tests that exercise pure type-checking paths;
+	// guard so resolution degrades to the default rather than panicking.
+	if n.tx.Provider != nil {
+		if s, err := n.tx.GetService(reflect.TypeFor[Certifier]()); err == nil {
+			if c, ok := s.(Certifier); ok {
+				return c
+			}
+		}
+	}
+	return &ChaincodeCertifier{}
+}
+
 func (n *Namespace) VerifyInputCertificationAt(index int, key string) error {
+	return n.resolveCertifier().VerifyInputCertificationAt(n, index, key)
+}
+
+func (n *Namespace) certifyInput(id string) error {
+	return n.resolveCertifier().CertifyInput(n, id)
+}
+
+// ChaincodeCertifier is the default (Fabric) certifier. It certifies input states
+// by invoking the generic state query chaincode and verifying peer endorsements.
+type ChaincodeCertifier struct{}
+
+func (c *ChaincodeCertifier) VerifyInputCertificationAt(n *Namespace, index int, key string) error {
 	typ, _, err := GetCertificationType(n.tx)
 	if err != nil {
 		return errors.Wrapf(err, "failed getting certification type")
@@ -161,7 +200,7 @@ func (n *Namespace) VerifyInputCertificationAt(index int, key string) error {
 	}
 }
 
-func (n *Namespace) certifyInput(id string) error {
+func (c *ChaincodeCertifier) CertifyInput(n *Namespace, id string) error {
 	typ, _, err := GetCertificationType(n.tx)
 	if err != nil {
 		return errors.Wrapf(err, "failed getting certification type")
@@ -194,6 +233,50 @@ func (n *Namespace) certifyInput(id string) error {
 	default:
 		return errors.Errorf("certification type [%s] not recognized", typ)
 	}
+}
+
+// QueryServiceCertifier certifies inputs against the trusted committer QueryService.
+// It is registered by the FabricX SDK. CertifyInput is a no-op — every FabricX node
+// self-reads the committed value via GetReadAt→QueryService, so certifiedInputs stays
+// empty and nothing consumes a produced cert. Verification re-reads the committed value
+// and branches on the hiding mode.
+type QueryServiceCertifier struct{}
+
+func (c *QueryServiceCertifier) CertifyInput(n *Namespace, id string) error {
+	return nil
+}
+
+func (c *QueryServiceCertifier) VerifyInputCertificationAt(n *Namespace, index int, key string) error {
+	rwSet, err := n.tx.RWSet()
+	if err != nil {
+		return errors.Wrap(err, "filed getting rw set")
+	}
+	_, committed, err := rwSet.GetReadAt(n.namespace(), index)
+	if err != nil {
+		return errors.Wrapf(err, "failed reading committed state [%s, %d]", n.namespace(), index)
+	}
+	if len(committed) == 0 {
+		return errors.Errorf("no committed value for [%s, %s]", n.namespace(), key)
+	}
+
+	mapping, err := n.getFieldMapping(n.namespace(), key, true)
+	if err != nil {
+		return errors.Wrapf(err, "failed getting field mapping [%s, %s]", n.namespace(), key)
+	}
+
+	if root, ok := mapping["_root_"]; ok && len(root) != 0 {
+		// Whole-state hiding: the committed value is sha256(preimage).
+		h := sha256.Sum256(root)
+		if !bytes.Equal(h[:], committed) {
+			return errors.Errorf("hash mismatch for [%s, %s]", n.namespace(), key)
+		}
+		return nil
+	}
+
+	// Field-level hiding: the committed value IS the marshaled state (the hidden field is
+	// already hashed in place). Integrity of the field is enforced by unmarshalTags during
+	// State(); here we only confirm the state is committed (checked above).
+	return nil
 }
 
 type CertificationRequest struct {

--- a/platform/fabric/services/state/certification.go
+++ b/platform/fabric/services/state/certification.go
@@ -93,9 +93,10 @@ func certificationKey(key string) (string, error) {
 	return rwset.CreateCompositeKey(Certification, elems)
 }
 
-// Certifier verifies and (on Fabric) produces certification for input states.
-// The concrete implementation is resolved per node platform: ChaincodeCertifier
-// on Fabric (default), QueryServiceCertifier on FabricX (registered by its SDK).
+// Certifier verifies and (on the default path) produces certification for input
+// states. The concrete implementation is resolved per node from the registered
+// Certifier service: ChaincodeCertifier (the default) verifies chaincode
+// endorsements; TrustedReadCertifier trusts the vault's committed read.
 type Certifier interface {
 	CertifyInput(n *Namespace, id string) error
 	VerifyInputCertificationAt(n *Namespace, index int, key string) error
@@ -235,21 +236,23 @@ func (c *ChaincodeCertifier) CertifyInput(n *Namespace, id string) error {
 	}
 }
 
-// QueryServiceCertifier certifies inputs against the trusted committer QueryService.
-// It is registered by the FabricX SDK. CertifyInput is a no-op — every FabricX node
-// self-reads the committed value via GetReadAt→QueryService, so certifiedInputs stays
-// empty and nothing consumes a produced cert. Verification re-reads the committed value
-// and branches on the hiding mode.
-type QueryServiceCertifier struct{}
+// TrustedReadCertifier certifies inputs by trusting the vault's committed read
+// instead of verifying chaincode endorsements. It suits nodes whose vault reads are
+// already authoritative, so no per-input endorsement proof is needed. It is opt-in:
+// a platform registers it as the Certifier service (the default stays
+// ChaincodeCertifier). CertifyInput is a no-op — every node self-reads the committed
+// value via GetReadAt, so certifiedInputs stays empty and nothing consumes a produced
+// cert. Verification re-reads the committed value and branches on the hiding mode.
+type TrustedReadCertifier struct{}
 
-func (c *QueryServiceCertifier) CertifyInput(n *Namespace, id string) error {
+func (c *TrustedReadCertifier) CertifyInput(n *Namespace, id string) error {
 	return nil
 }
 
-func (c *QueryServiceCertifier) VerifyInputCertificationAt(n *Namespace, index int, key string) error {
+func (c *TrustedReadCertifier) VerifyInputCertificationAt(n *Namespace, index int, key string) error {
 	rwSet, err := n.tx.RWSet()
 	if err != nil {
-		return errors.Wrap(err, "filed getting rw set")
+		return errors.Wrap(err, "failed getting rw set")
 	}
 	_, committed, err := rwSet.GetReadAt(n.namespace(), index)
 	if err != nil {

--- a/platform/fabric/services/state/certification_test.go
+++ b/platform/fabric/services/state/certification_test.go
@@ -8,6 +8,8 @@ package state
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"testing"
@@ -37,6 +39,104 @@ func (t *transientStore) SetTransient(key string, raw []byte) error {
 
 func (t *transientStore) GetTransient(key string) []byte {
 	return append([]byte(nil), t.store[key]...)
+}
+
+func TestResolveCertifierDefaultsToChaincode(t *testing.T) {
+	t.Parallel()
+
+	// A Namespace whose tx.Provider resolves no Certifier service must fall back
+	// to ChaincodeCertifier.
+	tx, _, _ := newTestStateTransaction("assetns")
+	tx.Provider = &mockServiceProvider{
+		getFn: func(any) (any, error) { return nil, errors.New("not found") },
+	}
+
+	c := tx.resolveCertifier()
+	_, ok := c.(*ChaincodeCertifier)
+	require.True(t, ok, "expected default ChaincodeCertifier, got %T", c)
+}
+
+type stubCertifier struct{}
+
+func (s *stubCertifier) CertifyInput(*Namespace, string) error                    { return nil }
+func (s *stubCertifier) VerifyInputCertificationAt(*Namespace, int, string) error { return nil }
+
+func TestResolveCertifierUsesRegistered(t *testing.T) {
+	t.Parallel()
+
+	// When a Certifier is registered on the provider, it is resolved (not the default).
+	registered := &stubCertifier{}
+	tx, _, _ := newTestStateTransaction("assetns")
+	tx.Provider = &mockServiceProvider{
+		getFn: func(v any) (any, error) {
+			if rt, ok := v.(reflect.Type); ok && rt == reflect.TypeFor[Certifier]() {
+				return registered, nil
+			}
+			return nil, errors.New("not found")
+		},
+	}
+
+	c := tx.resolveCertifier()
+	require.Same(t, registered, c)
+}
+
+// newCertifierNamespace builds a Namespace whose input at index 0 reads `committed` from the
+// ledger, optionally with a transient field-mapping (for whole-state hiding). Returns the key.
+func newCertifierNamespace(t *testing.T, ns, key string, committed []byte, mapping map[string][]byte) *Namespace {
+	t.Helper()
+	tx, rwset, driverTx := newTestStateTransaction(ns)
+	require.NoError(t, rwset.SetState(cdriver.Namespace(ns), cdriver.PKey(key), committed))
+	require.NoError(t, rwset.AddReadAt(cdriver.Namespace(ns), key, nil))
+	if mapping != nil {
+		fmKey, err := fieldMappingKey(ns, key)
+		require.NoError(t, err)
+		raw, err := json.Marshal(mapping)
+		require.NoError(t, err)
+		driverTx.transient[fmKey] = raw
+	}
+	return tx.Namespace
+}
+
+func TestQueryServiceCertifier_WholeState_OK(t *testing.T) {
+	t.Parallel()
+	root := []byte(`{"asset_id":"1234","price":10}`)
+	h := sha256.Sum256(root)
+	key, err := CreateCompositeKey("S", []string{"1234"})
+	require.NoError(t, err)
+	n := newCertifierNamespace(t, "asset_transfer", key, h[:], map[string][]byte{"_root_": root})
+	require.NoError(t, (&QueryServiceCertifier{}).VerifyInputCertificationAt(n, 0, key))
+}
+
+func TestQueryServiceCertifier_WholeState_Tampered(t *testing.T) {
+	t.Parallel()
+	root := []byte(`{"asset_id":"1234"}`)
+	wrong := sha256.Sum256([]byte("different"))
+	key, err := CreateCompositeKey("S", []string{"1234"})
+	require.NoError(t, err)
+	n := newCertifierNamespace(t, "asset_transfer", key, wrong[:], map[string][]byte{"_root_": root})
+	err = (&QueryServiceCertifier{}).VerifyInputCertificationAt(n, 0, key)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "hash mismatch")
+}
+
+func TestQueryServiceCertifier_FieldLevel_OK(t *testing.T) {
+	t.Parallel()
+	committed := []byte(`{"assetID":"1234","privateProperties":"hash"}`)
+	key, err := CreateCompositeKey("A", []string{"1234"})
+	require.NoError(t, err)
+	// No _root_ mapping: field-level hiding; Verify only confirms the state is committed.
+	n := newCertifierNamespace(t, "asset_transfer", key, committed, nil)
+	require.NoError(t, (&QueryServiceCertifier{}).VerifyInputCertificationAt(n, 0, key))
+}
+
+func TestQueryServiceCertifier_MissingCommitted(t *testing.T) {
+	t.Parallel()
+	key, err := CreateCompositeKey("A", []string{"1234"})
+	require.NoError(t, err)
+	n := newCertifierNamespace(t, "asset_transfer", key, nil, nil)
+	err = (&QueryServiceCertifier{}).VerifyInputCertificationAt(n, 0, key)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no committed value")
 }
 
 func TestCertificationTypeFunctions(t *testing.T) {

--- a/platform/fabric/services/state/certification_test.go
+++ b/platform/fabric/services/state/certification_test.go
@@ -279,7 +279,7 @@ func TestNamespaceVerifyInputCertificationAtBranches(t *testing.T) {
 		driverTx.getRWSetErr = errors.New("rwset failed")
 		err := tx.VerifyInputCertificationAt(0, "k1")
 		require.Error(t, err)
-		require.ErrorContains(t, err, "filed getting rw set")
+		require.ErrorContains(t, err, "failed getting rw set")
 	})
 
 	t.Run("read key retrieval failure", func(t *testing.T) {

--- a/platform/fabric/services/state/certification_test.go
+++ b/platform/fabric/services/state/certification_test.go
@@ -97,44 +97,44 @@ func newCertifierNamespace(t *testing.T, ns, key string, committed []byte, mappi
 	return tx.Namespace
 }
 
-func TestQueryServiceCertifier_WholeState_OK(t *testing.T) {
+func TestTrustedReadCertifier_WholeState_OK(t *testing.T) {
 	t.Parallel()
 	root := []byte(`{"asset_id":"1234","price":10}`)
 	h := sha256.Sum256(root)
 	key, err := CreateCompositeKey("S", []string{"1234"})
 	require.NoError(t, err)
 	n := newCertifierNamespace(t, "asset_transfer", key, h[:], map[string][]byte{"_root_": root})
-	require.NoError(t, (&QueryServiceCertifier{}).VerifyInputCertificationAt(n, 0, key))
+	require.NoError(t, (&TrustedReadCertifier{}).VerifyInputCertificationAt(n, 0, key))
 }
 
-func TestQueryServiceCertifier_WholeState_Tampered(t *testing.T) {
+func TestTrustedReadCertifier_WholeState_Tampered(t *testing.T) {
 	t.Parallel()
 	root := []byte(`{"asset_id":"1234"}`)
 	wrong := sha256.Sum256([]byte("different"))
 	key, err := CreateCompositeKey("S", []string{"1234"})
 	require.NoError(t, err)
 	n := newCertifierNamespace(t, "asset_transfer", key, wrong[:], map[string][]byte{"_root_": root})
-	err = (&QueryServiceCertifier{}).VerifyInputCertificationAt(n, 0, key)
+	err = (&TrustedReadCertifier{}).VerifyInputCertificationAt(n, 0, key)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "hash mismatch")
 }
 
-func TestQueryServiceCertifier_FieldLevel_OK(t *testing.T) {
+func TestTrustedReadCertifier_FieldLevel_OK(t *testing.T) {
 	t.Parallel()
 	committed := []byte(`{"assetID":"1234","privateProperties":"hash"}`)
 	key, err := CreateCompositeKey("A", []string{"1234"})
 	require.NoError(t, err)
 	// No _root_ mapping: field-level hiding; Verify only confirms the state is committed.
 	n := newCertifierNamespace(t, "asset_transfer", key, committed, nil)
-	require.NoError(t, (&QueryServiceCertifier{}).VerifyInputCertificationAt(n, 0, key))
+	require.NoError(t, (&TrustedReadCertifier{}).VerifyInputCertificationAt(n, 0, key))
 }
 
-func TestQueryServiceCertifier_MissingCommitted(t *testing.T) {
+func TestTrustedReadCertifier_MissingCommitted(t *testing.T) {
 	t.Parallel()
 	key, err := CreateCompositeKey("A", []string{"1234"})
 	require.NoError(t, err)
 	n := newCertifierNamespace(t, "asset_transfer", key, nil, nil)
-	err = (&QueryServiceCertifier{}).VerifyInputCertificationAt(n, 0, key)
+	err = (&TrustedReadCertifier{}).VerifyInputCertificationAt(n, 0, key)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "no committed value")
 }

--- a/platform/fabric/services/state/flow_test.go
+++ b/platform/fabric/services/state/flow_test.go
@@ -1014,6 +1014,14 @@ func (m *mockDriverMetadataService) LoadTransient(context.Context, string) (fdri
 	return m.transientMap, nil
 }
 
+func (m *mockDriverMetadataService) PutFieldMapping(context.Context, string, string, []byte, fdriver.TransientMap) error {
+	return nil
+}
+
+func (m *mockDriverMetadataService) GetFieldMapping(context.Context, string, string, []byte) (fdriver.TransientMap, error) {
+	return nil, nil
+}
+
 type mockDriverChannel struct {
 	name     string
 	metadata fdriver.MetadataService

--- a/platform/fabric/services/state/tags.go
+++ b/platform/fabric/services/state/tags.go
@@ -113,16 +113,16 @@ func (n *Namespace) marshalTags(set *fabric.RWSet, source any) (any, map[string]
 		if ok {
 			switch tag {
 			case "hash":
-				// todo: supported types are string and byte slice
 				// todo: sample a nonce and add it to the transient
 				// replace the value with the hash
 				field := v.Field(i)
 				switch field.Kind() {
 				case reflect.String:
-					hash := sha256.New()
-					hash.Write([]byte(field.String()))
-					h := hash.Sum(nil)
-					field.SetString(base64.StdEncoding.EncodeToString(h))
+					// Hash-hiding for string fields is unimplemented: no preimage is
+					// retained here, so a reader can neither recover nor verify it (see
+					// unmarshalTags). Fail closed rather than emit an unrecoverable,
+					// unverifiable hash. Use a []byte field for hash-hiding.
+					return nil, nil, errors.Errorf("state:\"hash\" is not supported for string field [%s]; use []byte", t.Field(i).Name)
 				case reflect.Slice:
 					mapping[t.Field(i).Name] = field.Bytes()
 
@@ -147,12 +147,14 @@ func (n *Namespace) unmarshalTags(set *fabric.RWSet, source any, mapping map[str
 		if ok {
 			switch tag {
 			case "hash":
-				// todo: supported types are string and byte slice
 				// replace the value with the hash
 				field := v.Field(i)
 				switch field.Kind() {
 				case reflect.String:
-					// todo: load from transient the preimage, check that the image matches, set the preimage.
+					// Mirror marshalTags: string hash-hiding is unimplemented, so there is
+					// no preimage to verify. Fail closed so a hashed string can never pass
+					// unverified. Use a []byte field for hash-hiding.
+					return errors.Errorf("state:\"hash\" is not supported for string field [%s]; use []byte", t.Field(i).Name)
 				case reflect.Slice:
 					original, ok := mapping[t.Field(i).Name]
 					if !ok {

--- a/platform/fabric/services/state/tags_test.go
+++ b/platform/fabric/services/state/tags_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stringHashState has a string field tagged for hash-hiding, which is unsupported:
+// marshalTags cannot retain a recoverable/verifiable preimage for it, so both the
+// marshal and unmarshal paths must fail closed rather than emit or accept an
+// unverifiable hash.
+type stringHashState struct {
+	ID     string `json:"id"`
+	Secret string `state:"hash" json:"secret"`
+}
+
+func TestMarshalTagsRejectsStringHashField(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := (&Namespace{}).marshalTags(nil, &stringHashState{ID: "1", Secret: "top-secret"})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "Secret")
+	require.ErrorContains(t, err, "not supported")
+}
+
+func TestUnmarshalTagsRejectsStringHashField(t *testing.T) {
+	t.Parallel()
+
+	err := (&Namespace{}).unmarshalTags(nil, &stringHashState{ID: "1", Secret: "top-secret"}, nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "Secret")
+	require.ErrorContains(t, err, "not supported")
+}

--- a/platform/fabricx/core/transaction/mock/metadata_service.go
+++ b/platform/fabricx/core/transaction/mock/metadata_service.go
@@ -21,6 +21,22 @@ type MetadataService struct {
 	existsReturnsOnCall map[int]struct {
 		result1 bool
 	}
+	GetFieldMappingStub        func(context.Context, string, string, []byte) (driver.TransientMap, error)
+	getFieldMappingMutex       sync.RWMutex
+	getFieldMappingArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 []byte
+	}
+	getFieldMappingReturns struct {
+		result1 driver.TransientMap
+		result2 error
+	}
+	getFieldMappingReturnsOnCall map[int]struct {
+		result1 driver.TransientMap
+		result2 error
+	}
 	LoadTransientStub        func(context.Context, string) (driver.TransientMap, error)
 	loadTransientMutex       sync.RWMutex
 	loadTransientArgsForCall []struct {
@@ -34,6 +50,21 @@ type MetadataService struct {
 	loadTransientReturnsOnCall map[int]struct {
 		result1 driver.TransientMap
 		result2 error
+	}
+	PutFieldMappingStub        func(context.Context, string, string, []byte, driver.TransientMap) error
+	putFieldMappingMutex       sync.RWMutex
+	putFieldMappingArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 []byte
+		arg5 driver.TransientMap
+	}
+	putFieldMappingReturns struct {
+		result1 error
+	}
+	putFieldMappingReturnsOnCall map[int]struct {
+		result1 error
 	}
 	StoreTransientStub        func(context.Context, string, driver.TransientMap) error
 	storeTransientMutex       sync.RWMutex
@@ -114,6 +145,78 @@ func (fake *MetadataService) ExistsReturnsOnCall(i int, result1 bool) {
 	}{result1}
 }
 
+func (fake *MetadataService) GetFieldMapping(arg1 context.Context, arg2 string, arg3 string, arg4 []byte) (driver.TransientMap, error) {
+	var arg4Copy []byte
+	if arg4 != nil {
+		arg4Copy = make([]byte, len(arg4))
+		copy(arg4Copy, arg4)
+	}
+	fake.getFieldMappingMutex.Lock()
+	ret, specificReturn := fake.getFieldMappingReturnsOnCall[len(fake.getFieldMappingArgsForCall)]
+	fake.getFieldMappingArgsForCall = append(fake.getFieldMappingArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 []byte
+	}{arg1, arg2, arg3, arg4Copy})
+	stub := fake.GetFieldMappingStub
+	fakeReturns := fake.getFieldMappingReturns
+	fake.recordInvocation("GetFieldMapping", []interface{}{arg1, arg2, arg3, arg4Copy})
+	fake.getFieldMappingMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *MetadataService) GetFieldMappingCallCount() int {
+	fake.getFieldMappingMutex.RLock()
+	defer fake.getFieldMappingMutex.RUnlock()
+	return len(fake.getFieldMappingArgsForCall)
+}
+
+func (fake *MetadataService) GetFieldMappingCalls(stub func(context.Context, string, string, []byte) (driver.TransientMap, error)) {
+	fake.getFieldMappingMutex.Lock()
+	defer fake.getFieldMappingMutex.Unlock()
+	fake.GetFieldMappingStub = stub
+}
+
+func (fake *MetadataService) GetFieldMappingArgsForCall(i int) (context.Context, string, string, []byte) {
+	fake.getFieldMappingMutex.RLock()
+	defer fake.getFieldMappingMutex.RUnlock()
+	argsForCall := fake.getFieldMappingArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *MetadataService) GetFieldMappingReturns(result1 driver.TransientMap, result2 error) {
+	fake.getFieldMappingMutex.Lock()
+	defer fake.getFieldMappingMutex.Unlock()
+	fake.GetFieldMappingStub = nil
+	fake.getFieldMappingReturns = struct {
+		result1 driver.TransientMap
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *MetadataService) GetFieldMappingReturnsOnCall(i int, result1 driver.TransientMap, result2 error) {
+	fake.getFieldMappingMutex.Lock()
+	defer fake.getFieldMappingMutex.Unlock()
+	fake.GetFieldMappingStub = nil
+	if fake.getFieldMappingReturnsOnCall == nil {
+		fake.getFieldMappingReturnsOnCall = make(map[int]struct {
+			result1 driver.TransientMap
+			result2 error
+		})
+	}
+	fake.getFieldMappingReturnsOnCall[i] = struct {
+		result1 driver.TransientMap
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *MetadataService) LoadTransient(arg1 context.Context, arg2 string) (driver.TransientMap, error) {
 	fake.loadTransientMutex.Lock()
 	ret, specificReturn := fake.loadTransientReturnsOnCall[len(fake.loadTransientArgsForCall)]
@@ -177,6 +280,76 @@ func (fake *MetadataService) LoadTransientReturnsOnCall(i int, result1 driver.Tr
 		result1 driver.TransientMap
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *MetadataService) PutFieldMapping(arg1 context.Context, arg2 string, arg3 string, arg4 []byte, arg5 driver.TransientMap) error {
+	var arg4Copy []byte
+	if arg4 != nil {
+		arg4Copy = make([]byte, len(arg4))
+		copy(arg4Copy, arg4)
+	}
+	fake.putFieldMappingMutex.Lock()
+	ret, specificReturn := fake.putFieldMappingReturnsOnCall[len(fake.putFieldMappingArgsForCall)]
+	fake.putFieldMappingArgsForCall = append(fake.putFieldMappingArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 []byte
+		arg5 driver.TransientMap
+	}{arg1, arg2, arg3, arg4Copy, arg5})
+	stub := fake.PutFieldMappingStub
+	fakeReturns := fake.putFieldMappingReturns
+	fake.recordInvocation("PutFieldMapping", []interface{}{arg1, arg2, arg3, arg4Copy, arg5})
+	fake.putFieldMappingMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *MetadataService) PutFieldMappingCallCount() int {
+	fake.putFieldMappingMutex.RLock()
+	defer fake.putFieldMappingMutex.RUnlock()
+	return len(fake.putFieldMappingArgsForCall)
+}
+
+func (fake *MetadataService) PutFieldMappingCalls(stub func(context.Context, string, string, []byte, driver.TransientMap) error) {
+	fake.putFieldMappingMutex.Lock()
+	defer fake.putFieldMappingMutex.Unlock()
+	fake.PutFieldMappingStub = stub
+}
+
+func (fake *MetadataService) PutFieldMappingArgsForCall(i int) (context.Context, string, string, []byte, driver.TransientMap) {
+	fake.putFieldMappingMutex.RLock()
+	defer fake.putFieldMappingMutex.RUnlock()
+	argsForCall := fake.putFieldMappingArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+}
+
+func (fake *MetadataService) PutFieldMappingReturns(result1 error) {
+	fake.putFieldMappingMutex.Lock()
+	defer fake.putFieldMappingMutex.Unlock()
+	fake.PutFieldMappingStub = nil
+	fake.putFieldMappingReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *MetadataService) PutFieldMappingReturnsOnCall(i int, result1 error) {
+	fake.putFieldMappingMutex.Lock()
+	defer fake.putFieldMappingMutex.Unlock()
+	fake.PutFieldMappingStub = nil
+	if fake.putFieldMappingReturnsOnCall == nil {
+		fake.putFieldMappingReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.putFieldMappingReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *MetadataService) StoreTransient(arg1 context.Context, arg2 string, arg3 driver.TransientMap) error {

--- a/platform/fabricx/core/transaction/transaction.go
+++ b/platform/fabricx/core/transaction/transaction.go
@@ -25,9 +25,11 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	cdriver "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/transaction"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/rwset"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
@@ -491,7 +493,45 @@ func (t *Transaction) ProposalHasBeenEndorsedBy(party view.Identity) error {
 
 func (t *Transaction) StoreTransient() error {
 	logger.Debugf("Storing transient for [%s]", t.ID())
-	return t.channel.MetadataService().StoreTransient(t.ctx, t.ID(), t.TTransient)
+	if err := t.channel.MetadataService().StoreTransient(t.ctx, t.ID(), t.TTransient); err != nil {
+		return err
+	}
+	return t.persistFieldMappings()
+}
+
+// persistFieldMappings scans the transient for hash-hiding field-mapping entries and stores
+// each preimage under (ns, key, sha256(committed write value)) so a later reader can resolve
+// it from the committed value alone. This runs synchronously on the endorsement path (via
+// StoreTransient), before the node awaits finality, on both the assembling party and every
+// endorser. Best-effort per key: a key with no local write is skipped (its mapping is simply
+// not persisted); a preimage stored for a tx that later aborts is harmless because the read
+// path re-queries the committed value and re-hashes, and digest-keying makes it unreachable.
+func (t *Transaction) persistFieldMappings() error {
+	if t.rwset == nil {
+		return nil
+	}
+	for tkey, blob := range t.TTransient {
+		objectType, attrs, err := rwset.SplitCompositeKey(tkey)
+		if err != nil || objectType != "field_mapping" || len(attrs) < 2 {
+			continue
+		}
+		ns := attrs[0]
+		key, err := rwset.CreateCompositeKey(attrs[1], attrs[2:])
+		if err != nil {
+			continue
+		}
+		writeVal, err := t.rwset.GetState(cdriver.Namespace(ns), cdriver.PKey(key), cdriver.FromIntermediate)
+		if err != nil || len(writeVal) == 0 {
+			logger.Warnf("no write value for field-mapping [%s:%s]; skipping persist", ns, key)
+			continue
+		}
+		digest := sha256.Sum256(writeVal)
+		if err := t.channel.MetadataService().PutFieldMapping(
+			t.ctx, ns, key, digest[:], driver.TransientMap{tkey: blob}); err != nil {
+			return errors.Wrapf(err, "failed persisting field mapping for [%s:%s]", ns, key)
+		}
+	}
+	return nil
 }
 
 func (t *Transaction) ProposalResponses() ([]driver.ProposalResponse, error) {

--- a/platform/fabricx/core/transaction/transaction_test.go
+++ b/platform/fabricx/core/transaction/transaction_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	commondriver "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/rwset"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/transaction/mock"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
@@ -352,6 +353,77 @@ func TestAppendProposalResponseDriverWrapper(t *testing.T) {
 			tc.assert(t, tx)
 		})
 	}
+}
+
+func TestStoreTransientPersistsFieldMappings(t *testing.T) {
+	t.Parallel()
+
+	origKey, err := rwset.CreateCompositeKey("S", []string{"1234"})
+	require.NoError(t, err)
+	fmKey, err := rwset.CreateCompositeKey("field_mapping", []string{"asset_transfer", "S", "1234"})
+	require.NoError(t, err)
+	blob := []byte(`{"_root_":"cHJlaW1hZ2U="}`)
+	writeVal := []byte("on-ledger-hash-bytes")
+
+	fakeMDS := &mock.MetadataService{}
+	fakeRWSet := &mock.RWSet{}
+	fakeRWSet.GetStateReturns(writeVal, nil)
+	ch := &mock.Channel{}
+	ch.MetadataServiceReturns(fakeMDS)
+
+	tx := &Transaction{
+		ctx:     t.Context(),
+		TTxID:   "tx1",
+		channel: ch,
+		rwset:   fakeRWSet,
+		TTransient: driver.TransientMap{
+			fmKey:               blob,
+			"CertificationType": []byte("ChaincodesCertification"), // must be ignored
+		},
+	}
+
+	require.NoError(t, tx.StoreTransient())
+
+	// The transient blob itself is still persisted by txid.
+	require.Equal(t, 1, fakeMDS.StoreTransientCallCount())
+
+	// The field mapping is persisted under (ns, origKey, sha256(writeVal)).
+	require.Equal(t, 1, fakeMDS.PutFieldMappingCallCount())
+	_, ns, key, digest, mapping := fakeMDS.PutFieldMappingArgsForCall(0)
+	wantDigest := sha256.Sum256(writeVal)
+	require.Equal(t, "asset_transfer", ns)
+	require.Equal(t, origKey, key)
+	require.Equal(t, wantDigest[:], digest)
+	require.Equal(t, driver.TransientMap{fmKey: blob}, mapping)
+
+	// The write value came from the tx's own write set (FromIntermediate), for (ns, origKey).
+	require.Equal(t, 1, fakeRWSet.GetStateCallCount())
+	gotNs, gotKey, gotOpts := fakeRWSet.GetStateArgsForCall(0)
+	require.Equal(t, commondriver.Namespace("asset_transfer"), gotNs)
+	require.Equal(t, commondriver.PKey(origKey), gotKey)
+	require.Equal(t, []commondriver.GetStateOpt{commondriver.FromIntermediate}, gotOpts)
+}
+
+func TestStoreTransientNoFieldMappingsIsNoop(t *testing.T) {
+	t.Parallel()
+
+	fakeMDS := &mock.MetadataService{}
+	fakeRWSet := &mock.RWSet{}
+	ch := &mock.Channel{}
+	ch.MetadataServiceReturns(fakeMDS)
+
+	tx := &Transaction{
+		ctx:        t.Context(),
+		TTxID:      "tx1",
+		channel:    ch,
+		rwset:      fakeRWSet,
+		TTransient: driver.TransientMap{"CertificationType": []byte("x")},
+	}
+
+	require.NoError(t, tx.StoreTransient())
+	require.Equal(t, 1, fakeMDS.StoreTransientCallCount())
+	require.Equal(t, 0, fakeMDS.PutFieldMappingCallCount())
+	require.Equal(t, 0, fakeRWSet.GetStateCallCount())
 }
 
 // mustSerializedIdentityWithRealCert generates a self-signed ECDSA certificate and

--- a/platform/fabricx/core/vault/service.go
+++ b/platform/fabricx/core/vault/service.go
@@ -9,6 +9,7 @@ package vault
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/transaction"
 	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
 )
@@ -29,10 +30,13 @@ var logger = logging.MustGetLogger()
 // Returns:
 //   - *Vault: A new vault instance configured with the query service
 //   - error: An error if the query service cannot be obtained
-func New(configService fdriver.ConfigService, channel string, queryServiceProvider queryservice.Provider) (*Vault, error) {
+func New(configService fdriver.ConfigService, channel string, queryServiceProvider queryservice.Provider, metadataKVS fdriver.MetadataStore) (*Vault, error) {
 	queryService, err := queryServiceProvider.Get(configService.NetworkName(), channel)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed getting query service")
 	}
-	return NewVault(queryService), nil
+	// The vault reads field mappings from the same (network, channel)-keyed metadata store
+	// that Transaction.StoreTransient writes them to, so digests written on endorsement resolve here.
+	mds := transaction.NewMetadataService(metadataKVS, configService.NetworkName(), channel)
+	return NewVault(queryService, mds), nil
 }

--- a/platform/fabricx/core/vault/vault.go
+++ b/platform/fabricx/core/vault/vault.go
@@ -8,6 +8,7 @@ package vault
 
 import (
 	"context"
+	"crypto/sha256"
 
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 
@@ -24,20 +25,24 @@ import (
 // reached (which would indicate the vault was wired into a generic committer by mistake).
 type Vault struct {
 	queryService queryservice.QueryService // Remote query service for state and status queries
+	mds          fdriver.MetadataService   // Field-mapping (hash-hiding) metadata store
 	marshaller   *Marshaller               // Marshaller for RWSet serialization
 }
 
-// NewVault creates a new Vault instance with the given QueryService.
-// The vault will use the query service for all remote state queries and transaction status lookups.
+// NewVault creates a new Vault instance with the given QueryService and MetadataService.
+// The vault uses the query service for all remote state queries and transaction status
+// lookups, and the metadata service to resolve hash-hiding field mappings on a metadata miss.
 //
 // Parameters:
 //   - qs: QueryService instance for remote queries
+//   - mds: MetadataService backing the (ns,key,digest) field-mapping store (may be nil in tests)
 //
 // Returns:
 //   - *Vault: A new vault instance ready for use
-func NewVault(qs queryservice.QueryService) *Vault {
+func NewVault(qs queryservice.QueryService, mds fdriver.MetadataService) *Vault {
 	return &Vault{
 		queryService: qs,
+		mds:          mds,
 		marshaller:   NewMarshaller(),
 	}
 }
@@ -216,11 +221,32 @@ func (r *rwSetWrapper) DeleteState(namespace cdriver.Namespace, key cdriver.PKey
 // GetStateMetadata retrieves metadata for a given namespace and key.
 // It checks the local metadata writes first, returning nil if not found.
 func (r *rwSetWrapper) GetStateMetadata(namespace cdriver.Namespace, key cdriver.PKey, opts ...cdriver.GetStateOpt) (cdriver.Metadata, error) {
-	// Check meta writes first
+	// Check in-flight meta writes first.
 	if meta, exists := r.rws.MetaWrites[namespace][key]; exists {
 		return meta, nil
 	}
-	return nil, nil
+
+	opt := cdriver.FromBoth
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+	if opt == cdriver.FromIntermediate || r.v.mds == nil {
+		return nil, nil
+	}
+
+	// Fall back to the hash-hiding field-mapping store: resolve the committed on-ledger
+	// value, key by its sha256 digest, and return the stored {fieldMappingKey: mapping}
+	// so getFieldMapping finds meta[fieldMappingKey] exactly as on Fabric.
+	committed, err := r.v.queryService.GetState(namespace, key)
+	if err != nil || committed == nil || len(committed.Raw) == 0 {
+		return nil, nil
+	}
+	digest := sha256.Sum256(committed.Raw)
+	fm, err := r.v.mds.GetFieldMapping(context.Background(), string(namespace), string(key), digest[:])
+	if err != nil || len(fm) == 0 {
+		return nil, nil
+	}
+	return cdriver.Metadata(fm), nil
 }
 
 // SetStateMetadata sets metadata for a given namespace and key in the metadata write set.

--- a/platform/fabricx/core/vault/vault_test.go
+++ b/platform/fabricx/core/vault/vault_test.go
@@ -8,6 +8,7 @@ package vault_test
 
 import (
 	"context"
+	"crypto/sha256"
 	"testing"
 
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
@@ -18,9 +19,57 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/rwset"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/vault"
 )
+
+// mockMDS implements fdriver.MetadataService for exercising the field-mapping read fallback.
+type mockMDS struct {
+	fieldMappings map[string]fdriver.TransientMap // keyed by string(valueDigest)
+}
+
+func (m *mockMDS) Exists(context.Context, string) bool                                { return false }
+func (m *mockMDS) StoreTransient(context.Context, string, fdriver.TransientMap) error { return nil }
+func (m *mockMDS) LoadTransient(context.Context, string) (fdriver.TransientMap, error) {
+	return nil, nil
+}
+
+func (m *mockMDS) PutFieldMapping(_ context.Context, _, _ string, valueDigest []byte, mapping fdriver.TransientMap) error {
+	if m.fieldMappings == nil {
+		m.fieldMappings = map[string]fdriver.TransientMap{}
+	}
+	m.fieldMappings[string(valueDigest)] = mapping
+	return nil
+}
+
+func (m *mockMDS) GetFieldMapping(_ context.Context, _, _ string, valueDigest []byte) (fdriver.TransientMap, error) {
+	return m.fieldMappings[string(valueDigest)], nil
+}
+
+func TestVaultX_GetStateMetadataServesStoreOnMiss(t *testing.T) {
+	t.Parallel()
+
+	committed := []byte("committed-on-ledger-value")
+	digest := sha256.Sum256(committed)
+	origKey, err := rwset.CreateCompositeKey("S", []string{"1234"})
+	require.NoError(t, err)
+	fmKey, err := rwset.CreateCompositeKey("field_mapping", []string{"asset_transfer", "S", "1234"})
+	require.NoError(t, err)
+	stored := fdriver.TransientMap{fmKey: []byte(`{"_root_":"cHJlaW1hZ2U="}`)}
+
+	qs := newMockQueryService()
+	qs.setState("asset_transfer", driver.PKey(origKey), committed, 1)
+	mds := &mockMDS{fieldMappings: map[string]fdriver.TransientMap{string(digest[:]): stored}}
+
+	v := vault.NewVault(qs, mds)
+	rws, err := v.NewRWSet(context.Background(), "tx1")
+	require.NoError(t, err)
+
+	meta, err := rws.GetStateMetadata("asset_transfer", driver.PKey(origKey), driver.FromBoth)
+	require.NoError(t, err)
+	require.Equal(t, stored[fmKey], meta[fmKey])
+}
 
 // mockQueryService implements queryservice.QueryService for testing
 type mockQueryService struct {
@@ -101,7 +150,7 @@ func TestVaultX_NewQueryExecutor(t *testing.T) {
 	qs := newMockQueryService()
 	qs.setState("ns1", "key1", []byte("value1"), 1)
 
-	v := vault.NewVault(qs)
+	v := vault.NewVault(qs, nil)
 
 	ctx := context.Background()
 	qe, err := v.NewQueryExecutor(ctx)
@@ -130,7 +179,7 @@ func TestVaultX_NewRWSet(t *testing.T) {
 	qs := newMockQueryService()
 	qs.setState("ns1", "key1", []byte("value1"), 1)
 
-	v := vault.NewVault(qs)
+	v := vault.NewVault(qs, nil)
 	ctx := context.Background()
 
 	rws, err := v.NewRWSet(ctx, "tx1")
@@ -161,7 +210,7 @@ func TestVaultX_NewRWSet(t *testing.T) {
 func TestVaultX_NewRWSetFromBytes(t *testing.T) {
 	t.Parallel()
 	qs := newMockQueryService()
-	v := vault.NewVault(qs)
+	v := vault.NewVault(qs, nil)
 	ctx := context.Background()
 
 	// Create an RWSet and marshal it
@@ -188,7 +237,7 @@ func TestVaultX_Status(t *testing.T) {
 	qs := newMockQueryService()
 	qs.setTxStatus("tx1", 1) // COMMITTED
 
-	v := vault.NewVault(qs)
+	v := vault.NewVault(qs, nil)
 	ctx := context.Background()
 
 	code, msg, err := v.Status(ctx, "tx1")
@@ -205,7 +254,7 @@ func TestVaultX_Status_Unknown(t *testing.T) {
 	qs := newMockQueryService()
 	// tx1 intentionally left unset => committer does not know it yet.
 
-	v := vault.NewVault(qs)
+	v := vault.NewVault(qs, nil)
 	ctx := context.Background()
 
 	code, msg, err := v.Status(ctx, "tx1")
@@ -222,7 +271,7 @@ func TestVaultX_Statuses(t *testing.T) {
 	// tx3 is intentionally left unset: the batched query omits transactions the committer does not
 	// know, and Statuses must report those as Unknown ("not final yet") in the right position.
 
-	v := vault.NewVault(qs)
+	v := vault.NewVault(qs, nil)
 	ctx := context.Background()
 
 	statuses, err := v.Statuses(ctx, "tx1", "tx3", "tx2")
@@ -247,7 +296,7 @@ func TestVaultX_Statuses(t *testing.T) {
 func TestVaultX_SetDiscarded(t *testing.T) {
 	t.Parallel()
 	qs := newMockQueryService()
-	v := vault.NewVault(qs)
+	v := vault.NewVault(qs, nil)
 	ctx := context.Background()
 
 	require.PanicsWithValue(t,
@@ -258,7 +307,7 @@ func TestVaultX_SetDiscarded(t *testing.T) {
 func TestVaultX_DiscardTx(t *testing.T) {
 	t.Parallel()
 	qs := newMockQueryService()
-	v := vault.NewVault(qs)
+	v := vault.NewVault(qs, nil)
 	ctx := context.Background()
 
 	require.PanicsWithValue(t,
@@ -269,7 +318,7 @@ func TestVaultX_DiscardTx(t *testing.T) {
 func TestVaultX_CommitTX(t *testing.T) {
 	t.Parallel()
 	qs := newMockQueryService()
-	v := vault.NewVault(qs)
+	v := vault.NewVault(qs, nil)
 	ctx := context.Background()
 
 	require.PanicsWithValue(t,
@@ -280,7 +329,7 @@ func TestVaultX_CommitTX(t *testing.T) {
 func TestVaultX_InspectRWSet(t *testing.T) {
 	t.Parallel()
 	qs := newMockQueryService()
-	v := vault.NewVault(qs)
+	v := vault.NewVault(qs, nil)
 	ctx := context.Background()
 
 	// Create an RWSet and marshal it
@@ -309,7 +358,7 @@ func TestVaultX_InspectRWSet(t *testing.T) {
 func TestVaultX_RWSExists(t *testing.T) {
 	t.Parallel()
 	qs := newMockQueryService()
-	v := vault.NewVault(qs)
+	v := vault.NewVault(qs, nil)
 	ctx := context.Background()
 
 	// RWSExists has no error channel, so returning a value would be a misleading answer; it panics.
@@ -321,7 +370,7 @@ func TestVaultX_RWSExists(t *testing.T) {
 func TestVaultX_Match(t *testing.T) {
 	t.Parallel()
 	qs := newMockQueryService()
-	v := vault.NewVault(qs)
+	v := vault.NewVault(qs, nil)
 	ctx := context.Background()
 
 	// The vault retains no RWSet to match against, and Match is unreachable in the fabricx wiring,
@@ -343,7 +392,7 @@ func TestVaultX_Match(t *testing.T) {
 func TestVaultX_Close(t *testing.T) {
 	t.Parallel()
 	qs := newMockQueryService()
-	v := vault.NewVault(qs)
+	v := vault.NewVault(qs, nil)
 	ctx := context.Background()
 
 	// The vault holds no per-transaction state, so Close is a no-op that always succeeds.
@@ -359,7 +408,7 @@ func TestRWSet_Operations(t *testing.T) {
 	qs := newMockQueryService()
 	qs.setState("ns1", "existing", []byte("existing_value"), 1)
 
-	v := vault.NewVault(qs)
+	v := vault.NewVault(qs, nil)
 	ctx := context.Background()
 
 	rws, err := v.NewRWSet(ctx, "tx1")
@@ -412,7 +461,7 @@ func TestRWSet_GetReadAt(t *testing.T) {
 	qs.setState("ns1", "key1", []byte("value1"), 1)
 	qs.setState("ns1", "key2", []byte("value2"), 2)
 
-	v := vault.NewVault(qs)
+	v := vault.NewVault(qs, nil)
 	ctx := context.Background()
 
 	rws, err := v.NewRWSet(ctx, "tx1")
@@ -438,7 +487,7 @@ func TestRWSet_GetReadAt(t *testing.T) {
 func TestRWSet_GetWriteAt(t *testing.T) {
 	t.Parallel()
 	qs := newMockQueryService()
-	v := vault.NewVault(qs)
+	v := vault.NewVault(qs, nil)
 	ctx := context.Background()
 
 	rws, err := v.NewRWSet(ctx, "tx1")
@@ -469,7 +518,7 @@ func TestRWSet_ConcurrentBytes(t *testing.T) {
 	qs.setState("_meta", "ns1", nil, 7)
 	qs.setState("_meta", "ns2", nil, 9)
 
-	v := vault.NewVault(qs)
+	v := vault.NewVault(qs, nil)
 	ctx := context.Background()
 
 	const goroutines = 16

--- a/platform/fabricx/sdk/dig/providers.go
+++ b/platform/fabricx/sdk/dig/providers.go
@@ -97,7 +97,7 @@ func NewChannelProvider(in struct {
 		in.EndorseTxStore,
 		in.Drivers,
 		func(channelName string, configService fdriver.ConfigService, _ driver.VaultStore) (fdriver.Vault, error) {
-			return vault.New(configService, channelName, in.QueryServiceProvider)
+			return vault.New(configService, channelName, in.QueryServiceProvider, in.MetadataStore)
 		},
 		channelConfigProvider,
 		func(channelName string, nw fdriver.FabricNetworkService, chaincodeManager fdriver.ChaincodeManager) (fdriver.Ledger, error) {

--- a/platform/fabricx/sdk/dig/sdk.go
+++ b/platform/fabricx/sdk/dig/sdk.go
@@ -15,6 +15,7 @@ import (
 	common "github.com/hyperledger-labs/fabric-smart-client/platform/common/sdk/dig"
 	digutils "github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/dig"
 	fabric "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk/dig"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/state"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/config"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/grpc"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
@@ -62,6 +63,9 @@ func (p *SDK) Install() error {
 		p.Container().Provide(finality.NewListenerManagerProvider),
 		p.Container().Provide(digutils.Identity[*finality.Provider](), dig.As(new(finality.ListenerManagerProvider))),
 		p.Container().Provide(queryservice.NewProvider, dig.As(new(queryservice.Provider))),
+		// FabricX certifies state inputs against the trusted committer QueryService
+		// instead of chaincode endorsement; the state package resolves this per network.
+		p.Container().Provide(func() state.Certifier { return &state.QueryServiceCertifier{} }),
 	)
 	if err != nil {
 		return err
@@ -76,6 +80,7 @@ func (p *SDK) Install() error {
 		digutils.Register[finality.ListenerManagerProvider](p.Container()),
 		digutils.Register[queryservice.Provider](p.Container()),
 		digutils.Register[*ledger.Provider](p.Container()),
+		digutils.Register[state.Certifier](p.Container()),
 	)
 }
 

--- a/platform/fabricx/sdk/dig/sdk.go
+++ b/platform/fabricx/sdk/dig/sdk.go
@@ -63,9 +63,11 @@ func (p *SDK) Install() error {
 		p.Container().Provide(finality.NewListenerManagerProvider),
 		p.Container().Provide(digutils.Identity[*finality.Provider](), dig.As(new(finality.ListenerManagerProvider))),
 		p.Container().Provide(queryservice.NewProvider, dig.As(new(queryservice.Provider))),
-		// FabricX certifies state inputs against the trusted committer QueryService
-		// instead of chaincode endorsement; the state package resolves this per network.
-		p.Container().Provide(func() state.Certifier { return &state.QueryServiceCertifier{} }),
+		// On FabricX the committer QueryService serves authoritative reads, so state
+		// inputs are certified by trusting the vault's committed read rather than by
+		// chaincode endorsement. Register the trusted-read certifier as the state
+		// Certifier; the state package resolves it per network.
+		p.Container().Provide(func() state.Certifier { return &state.TrustedReadCertifier{} }),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
Make the FabricX ATSA transfer pass end-to-end with idemix, reusing the fabric/atsa views unmodified. Below the view layer:

- state: add a Certifier seam resolved per network; move chaincode logic verbatim into ChaincodeCertifier (Fabric unchanged); add TrustedReadCertifier (no-op CertifyInput; whole-state vs field-level verification branch).
- metadata: add (ns,key,sha256(committed value))-keyed field-mapping surface to MetadataService so overwrites/deletes resolve to the exact preimage.
- fabricx tx: persist field mappings synchronously on StoreTransient (endorsement path), independent of finality notifications.
- fabricx vault: serve the field mapping on a metadata miss by re-querying the committed value and keying by its digest.
- fabricx SDK: register TrustedReadCertifier per network.
- integration: fabricx/atsa idemix suite + README (make integration-tests-fabricx-atsa).

Closes #1606