### PR TITLE
fix(comm): require TLS 1.3 minimum for websocket p2p client connections

### DIFF
--- a/docs/platform/view/services/comm/websocket.md
+++ b/docs/platform/view/services/comm/websocket.md
@@ -11,6 +11,7 @@ This transport is designed for deployments where standard web ports are preferre
 - **WebSocket Upgrade**: Connections are upgraded to WebSockets for persistent, full-duplex messaging.
 - **Multiplexing**: Multiple logical FSC streams are multiplexed over a single physical WebSocket.
 - **Mutual TLS**: mTLS is mandatory and strictly enforced for both server and client authentication (`tls.RequireAndVerifyClientCert`).
+- **TLS 1.3 Only**: Both server and client TLS configurations pin `MinVersion`/`MaxVersion` to `tls.VersionTLS13`; handshakes offering TLS 1.2 or lower are rejected.
 - **Dynamic Port Assignment**: The transport supports starting on a dynamic port (by setting the port to `0` in `listenAddress`). The actual assigned port is automatically retrieved and used for service discovery and readiness checks.
 
 ## Internal Architecture
@@ -66,6 +67,7 @@ type MultiplexedMessage struct {
 ## Performance and Security
 
 -   **TLS Caching**: Trusted root CAs are cached in memory to avoid disk I/O during handshakes. Dynamic trust updates (from the `EndpointService`) are appended to a clone of this cached pool in memory, significantly improving connection throughput.
+-   **Minimum TLS Version**: Both `ClientTLSConfig` and `ServerTLSConfig` (in `config.go`) set `MinVersion: tls.VersionTLS13`, so older protocol versions cannot be negotiated even if a peer offers them.
 -   **Identity Binding (Issue #871)**: The `PeerID` asserted in the application layer (during the WebSocket upgrade) is strictly validated against the public key extracted from the verified TLS certificate. The transport layer rejects any attempt to spoof an identity.
 -   **Runtime Trust Updates**: The transport dynamically integrates with the `EndpointService`. Any peer public key added to the `EndpointService` at runtime is automatically added to the trusted CA pool for both inbound and outbound connections.
 -   **Read Limits**: Each WebSocket connection has a 10MB read limit (`SetReadLimit`) to prevent OOM attacks.

--- a/platform/view/services/comm/host/websocket/config.go
+++ b/platform/view/services/comm/host/websocket/config.go
@@ -196,7 +196,7 @@ func newClientTLSConfig(serverRootCAPool *x509.CertPool, keyFile, certFile strin
 	}
 
 	tlsConfig := &tls.Config{
-		MinVersion: tls.VersionTLS12,
+		MinVersion: tls.VersionTLS13,
 		MaxVersion: tls.VersionTLS13,
 		// Certificates:       []tls.Certificate{cert},
 		RootCAs:            caCertPool,

--- a/platform/view/services/comm/host/websocket/ws/multiplexed_provider_test.go
+++ b/platform/view/services/comm/host/websocket/ws/multiplexed_provider_test.go
@@ -316,6 +316,63 @@ func TestRejectsPeerIDMismatch(t *testing.T) { //nolint:paralleltest,tparallel
 	}
 }
 
+// TestRejectsTLS12ClientHandshake asserts that the server-side TLS config's
+// MinVersion: tls.VersionTLS13 (config.go) is actually enforced: a client
+// that only offers TLS 1.2 must fail the handshake rather than being
+// negotiated down.
+func TestRejectsTLS12ClientHandshake(t *testing.T) { //nolint:paralleltest
+	testSetup(t)
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	})
+
+	p := NewMultiplexedProvider(noop.NewTracerProvider(), &disabled.Provider{}, 0)
+	t.Cleanup(func() {
+		_ = p.KillAll()
+	})
+	serverTLSConfig, clientTLSConfig, srcID := testMutualTLSConfigs(t, false)
+
+	received := make(chan struct{}, 1)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := p.NewServerStream(w, r, func(_ host.P2PStream) {
+			received <- struct{}{}
+		})
+		assert.NoError(t, err)
+	}))
+	srv.TLS = serverTLSConfig
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+
+	srvEndpoint := strings.TrimPrefix(strings.TrimPrefix(srv.URL, "http://"), "https://")
+
+	// force the client down to TLS 1.2; the server must reject the handshake
+	tls12ClientConfig := clientTLSConfig.Clone()
+	tls12ClientConfig.MinVersion = tls.VersionTLS12
+	tls12ClientConfig.MaxVersion = tls.VersionTLS12
+
+	info := host.StreamInfo{
+		RemotePeerID:      "serverID",
+		RemotePeerAddress: srvEndpoint,
+		ContextID:         "ctx",
+		SessionID:         "sess",
+	}
+
+	client, err := p.NewClientStream(info, t.Context(), srcID, tls12ClientConfig)
+	require.Error(t, err)
+	require.Nil(t, client)
+	require.Contains(t, err.Error(), "protocol version not supported")
+
+	select {
+	case <-received:
+		t.Fatal("server accepted a stream over a TLS 1.2 handshake")
+	default:
+	}
+
+	p.mu.RLock()
+	require.Empty(t, p.clients)
+	p.mu.RUnlock()
+}
+
 func testSetup(_ *testing.T) {
 	logSpec := cmp.Or(
 		os.Getenv("FABRIC_LOGGING_SPEC"),

--- a/platform/view/services/comm/host/websocket/ws/multiplexed_provider_test.go
+++ b/platform/view/services/comm/host/websocket/ws/multiplexed_provider_test.go
@@ -437,14 +437,14 @@ func testMutualTLSConfigs(t *testing.T, insecureSkipVerify bool) (*tls.Config, *
 	caCertPool.AddCert(caCert)
 
 	serverTLSConfig := &tls.Config{
-		MinVersion:   tls.VersionTLS12,
+		MinVersion:   tls.VersionTLS13,
 		MaxVersion:   tls.VersionTLS13,
 		Certificates: []tls.Certificate{serverCert},
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		ClientCAs:    caCertPool,
 	}
 	clientTLSConfig := &tls.Config{
-		MinVersion:   tls.VersionTLS12,
+		MinVersion:   tls.VersionTLS13,
 		MaxVersion:   tls.VersionTLS13,
 		Certificates: []tls.Certificate{clientCert},
 		RootCAs:      caCertPool,


### PR DESCRIPTION
## Summary
- The websocket P2P server TLS config already pinned `MinVersion: tls.VersionTLS13`, but the client config still allowed negotiating down to `tls.VersionTLS12`. This aligns the client with the server so both sides of the mTLS handshake reject anything below TLS 1.3.
- Updates the `ws` package test fixtures (`multiplexed_provider_test.go`) that also allowed TLS 1.2 as a minimum, for consistency with the enforced policy.
- Documents the TLS 1.3-only guarantee in `docs/platform/view/services/comm/websocket.md`.

Fixes #1630

## Test plan
- [x] `go build ./platform/view/services/comm/host/websocket/...`
- [x] `go vet ./platform/view/services/comm/host/websocket/...`
- [x] `go test ./platform/view/services/comm/host/websocket/...` (both `websocket` and `websocket/ws` packages pass)