### PR TITLE
fix(integration): nwo framework improvements

### DIFF
--- a/integration/nwo/fabric/commands/idemixgen.go
+++ b/integration/nwo/fabric/commands/idemixgen.go
@@ -37,13 +37,18 @@ func (c SignerConfig) SessionName() string {
 }
 
 func (c SignerConfig) Args() []string {
-	return []string{
+	args := []string{
 		"signerconfig",
 		"--ca-input", c.CAInput,
 		"--output", c.Output,
-		"--admin",
+	}
+	if c.Admin {
+		args = append(args, "--admin")
+	}
+	args = append(args,
 		"-u", c.OrgUnit,
 		"-e", c.EnrollmentID,
 		"-r", c.RevocationHandle,
-	}
+	)
+	return args
 }

--- a/integration/nwo/fabric/platform.go
+++ b/integration/nwo/fabric/platform.go
@@ -319,11 +319,15 @@ func (p *Platform) PeersByID(id string) *Peer {
 	})
 
 	for _, identity := range peer.Identities {
+		mspID := org.MSPID
+		if len(identity.MSPID) != 0 {
+			mspID = identity.MSPID
+		}
 		result.Identities = append(result.Identities, &Identity{
 			ID:    identity.ID,
 			Type:  identity.MSPType,
 			Path:  p.Network.PeerLocalExtraIdentityDir(peer, identity.ID),
-			MSPID: org.MSPID,
+			MSPID: mspID,
 		})
 	}
 


### PR DESCRIPTION
Closes #1634 

This PR resolves two underlying bugs in the `nwo` testing framework and identity parsing logic that were identified while testing Idemix.

**Key Fixes:**
- **Idemix Role Fix**: Removes the hardcoded `--admin` flag in `idemixgen` so Idemix transactions are properly signed as `member`.
- **MSPID Assignment**: Ensures Idemix MSPIDs aren't accidentally overwritten during network setup.