### PR TITLE
fix(test): fix flaky platform/fabric/services/endorser

### DIFF
--- a/platform/fabric/services/endorser/endorsement_proposal.go
+++ b/platform/fabric/services/endorser/endorsement_proposal.go
@@ -38,13 +38,27 @@ type answer struct {
 	party view.Identity
 }
 
-// defaultParallelEndorsementTimeout bounds, in aggregate, how long the initiator waits for
-// all contacted parties to answer when no explicit timeout has been configured via
+// defaultParallelEndorsementTimeout is the timeout applied when none has been configured via
 // WithTimeout. It matters beyond just the final receive step: session establishment and
 // sending the proposal to each party (both done inside collectEndorsement, before its own
 // receive-timeout kicks in) are not otherwise bounded, so an unresponsive or malicious party
 // could park its goroutine indefinitely and, with it, this view's wait on answerChannel.
+// See parallelEndorsementDeadlineGrace for how the timeout maps onto the two deadlines.
 const defaultParallelEndorsementTimeout = 30 * time.Second
+
+// parallelEndorsementDeadlineGrace is how much longer the aggregate deadline runs than the
+// per-party receive timeout that collectEndorsement arms with the configured timeout. Without
+// it the two expire together and the select in Call picks between them at random, so a silent
+// party is reported as often by the generic aggregate error as by the per-party one that names
+// it. The grace lets the per-party timeout land first, leaving the aggregate deadline as what
+// it is meant to be: the backstop for the session setup and send steps, which nothing else
+// bounds.
+//
+// The practical consequence is that the configured timeout bounds each party individually,
+// and the initiator gives up after timeout+grace overall rather than at timeout exactly. The
+// grace is a fixed amount, not a fraction, so it is negligible next to the default timeout but
+// dominates a caller-configured one in the tens of milliseconds.
+const parallelEndorsementDeadlineGrace = 500 * time.Millisecond
 
 type parallelCollectEndorsementsOnProposalView struct {
 	tx      EndorsementsOnProposalTransaction
@@ -87,7 +101,7 @@ func (c *parallelCollectEndorsementsOnProposalView) Call(viewCtx view.Context) (
 	}
 	vProviders := []fabric.VerifierProvider{&verifierProviderWrapper{m: ch.MSPManager()}}
 
-	deadline := time.NewTimer(timeout)
+	deadline := time.NewTimer(timeout + parallelEndorsementDeadlineGrace)
 	defer deadline.Stop()
 
 	for i := 0; i < len(c.parties); i++ {
@@ -100,7 +114,7 @@ func (c *parallelCollectEndorsementsOnProposalView) Call(viewCtx view.Context) (
 		}
 		logger.DebugfContext(viewCtx.Context(), "Received endorsement")
 		if a.err != nil {
-			return nil, errors.Wrapf(a.err, "got failure [%s] from [%s]", a.party.String(), a.err)
+			return nil, errors.Wrapf(a.err, "got failure from [%s]", a.party.String())
 		}
 
 		logger.Debugf("answer from [%s] contains [%d] responses, adding them", a.party, len(a.prs))
@@ -131,13 +145,18 @@ func (c *parallelCollectEndorsementsOnProposalView) Call(viewCtx view.Context) (
 			logger.DebugfContext(viewCtx.Context(), "Appended proposal")
 			err = c.tx.AppendProposalResponse(proposalResponse)
 			if err != nil {
-				return nil, errors.Wrapf(a.err, "failed appending response from [%s]", a.party.String())
+				return nil, errors.Wrapf(err, "failed appending response from [%s]", a.party.String())
 			}
 		}
 	}
 	return c.tx, nil
 }
 
+// WithTimeout sets how long each contacted party has to answer. Call gives up on the
+// collection as a whole after timeout+parallelEndorsementDeadlineGrace, so that a party that
+// answers nothing is reported by name rather than by the generic aggregate error; see
+// parallelEndorsementDeadlineGrace. A timeout of zero or less selects
+// defaultParallelEndorsementTimeout.
 func (c *parallelCollectEndorsementsOnProposalView) WithTimeout(timeout time.Duration) *parallelCollectEndorsementsOnProposalView {
 	c.timeout = timeout
 	return c

--- a/platform/fabric/services/endorser/endorsement_test.go
+++ b/platform/fabric/services/endorser/endorsement_test.go
@@ -524,99 +524,23 @@ func TestReceiveTransactionView(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestParallelCollectEndorsementsOnProposalViewInternal(t *testing.T) {
-	t.Parallel()
-	fakeCtx := &mock.Context{}
-	fakeCtx.ContextReturns(context.Background())
-	fakeSP := &mock.Provider{}
-	fakeCtx.GetServiceCalls(func(v any) (any, error) {
-		return fakeSP.GetService(v)
-	})
-
-	fakeFNSP := &mock.FabricNetworkServiceProvider{}
-	fakeFNS := &mock.FabricNetworkService{}
-	fakeFNS.NameReturns("net1")
-	fakeFNSP.FabricNetworkServiceReturns(fakeFNS, nil)
-	fakeNSP := fabric.NewNetworkServiceProvider(fakeFNSP, nil)
-	networkServiceProviderType := reflect.TypeFor[*fabric.NetworkServiceProvider]()
-	fakeSP.GetServiceCalls(func(v any) (any, error) {
-		if v == networkServiceProviderType {
-			return fakeNSP, nil
-		}
-		return nil, nil
-	})
-
-	fakeTM := &mock.TransactionManager{}
-	fakeFNS.TransactionManagerReturns(fakeTM)
-
-	fakeCH := &mock.Channel{}
-	fakeCH.NameReturns("ch1")
-	fakeFNS.ChannelReturns(fakeCH, nil)
-	fakeCM := &mock.ChannelMembership{}
-	fakeCH.ChannelMembershipReturns(fakeCM)
-
-	fakeTx := &mock.Transaction{}
-	fakeTx.NetworkReturns("net1")
-	fakeTx.ChannelReturns("ch1")
-	fakeTx.BytesReturns([]byte("raw"), nil)
-	fakeTx.IDReturns("tx1")
-
-	ft := &Transaction{
-		Transaction: fabric.NewTransaction(fabric.NewNetworkService(nil, fakeFNS, "net1"), fakeTx),
-	}
-
-	v := NewParallelCollectEndorsementsOnProposalView(ft, []byte("bob"))
-	v.WithTimeout(1 * time.Second)
-
-	fakeSession := &mock.Session{}
-	fakeCtx.GetSessionReturns(fakeSession, nil)
-	fakeCtx.InitiatorReturns(&fakeView{})
-
-	// Case 1: Success
-	respPayload, _ := json.Marshal(&Response{
-		ProposalResponses: [][]byte{[]byte("resp1")},
-	})
-	msgCh := make(chan *view.Message, 1)
-	msgCh <- &view.Message{Payload: respPayload}
-	fakeSession.ReceiveReturns(msgCh)
-
-	fakeResp := &mock.ProposalResponse{}
-	fakeResp.EndorserReturns([]byte("bob"))
-	fakeResp.VerifyEndorsementReturns(nil)
-	fakeTM.NewProposalResponseFromBytesReturns(fakeResp, nil)
-
-	_, err := v.Call(fakeCtx)
-	require.NoError(t, err)
-	require.Equal(t, 1, fakeTx.AppendProposalResponseCallCount())
-
-	// Case 2: Session error
-	fakeCtx.GetSessionReturns(nil, fmt.Errorf("err"))
-	_, err = v.Call(fakeCtx)
-	require.Error(t, err)
-
-	// Case 3: Send error
-	fakeCtx.GetSessionReturns(fakeSession, nil)
-	fakeSession.SendWithContextReturns(fmt.Errorf("err"))
-	_, err = v.Call(fakeCtx)
-	require.Error(t, err)
-
-	// Case 4: Receive error
-	fakeSession.SendWithContextReturns(nil)
-	msgCh = make(chan *view.Message, 1)
-	msgCh <- &view.Message{Status: view.ERROR, Payload: []byte("err")}
-	fakeSession.ReceiveReturns(msgCh)
-	_, err = v.Call(fakeCtx)
-	require.Error(t, err)
+// parallelEndorsementFixture bundles the fakes that every
+// TestParallelCollectEndorsementsOnProposalView_* case needs, so each test only spells out
+// the behaviour it is actually about.
+type parallelEndorsementFixture struct {
+	ctx     *mock.Context
+	session *mock.Session
+	tx      *mock.Transaction
+	tm      *mock.TransactionManager
+	ft      *Transaction
 }
 
-// TestParallelCollectEndorsementsOnProposalView_RejectsUnverifiedResponse demonstrates
-// that parallelCollectEndorsementsOnProposalView.Call (endorsement_proposal.go) now
-// calls ProposalResponse.VerifyEndorsement, and checks that the endorser is bound to
-// the contacted party, before appending a remote-supplied proposal response to the
-// transaction - mirroring the sequential collectEndorsementsView.Call, which verifies
-// signatures against a set of VerifierProviders.
-func TestParallelCollectEndorsementsOnProposalView_RejectsUnverifiedResponse(t *testing.T) {
-	t.Parallel()
+// newParallelEndorsementFixture wires a view context whose service provider resolves the
+// network service for "net1"/"ch1", together with the transaction the view collects
+// endorsements for and the session it reaches the parties over. Pass an endpoint.Service to
+// have it resolved through the same provider - only the binding check in Call needs one, and
+// the cases that do not reach that check never look it up.
+func newParallelEndorsementFixture(endpointService *endpoint.Service) *parallelEndorsementFixture {
 	fakeCtx := &mock.Context{}
 	fakeCtx.ContextReturns(context.Background())
 	fakeSP := &mock.Provider{}
@@ -631,16 +555,11 @@ func TestParallelCollectEndorsementsOnProposalView_RejectsUnverifiedResponse(t *
 	fakeNSP := fabric.NewNetworkServiceProvider(fakeFNSP, nil)
 	networkServiceProviderType := reflect.TypeFor[*fabric.NetworkServiceProvider]()
 	endpointServiceType := reflect.TypeFor[*endpoint.Service]()
-
-	fakeBindingStore := &mock.BindingStore{}
-	fakeBindingStore.HaveSameBindingReturns(false, nil)
-	endpointService, _ := endpoint.NewService(fakeBindingStore)
-
 	fakeSP.GetServiceCalls(func(v any) (any, error) {
 		if v == networkServiceProviderType {
 			return fakeNSP, nil
 		}
-		if v == endpointServiceType {
+		if v == endpointServiceType && endpointService != nil {
 			return endpointService, nil
 		}
 		return nil, nil
@@ -652,8 +571,7 @@ func TestParallelCollectEndorsementsOnProposalView_RejectsUnverifiedResponse(t *
 	fakeCH := &mock.Channel{}
 	fakeCH.NameReturns("ch1")
 	fakeFNS.ChannelReturns(fakeCH, nil)
-	fakeCM := &mock.ChannelMembership{}
-	fakeCH.ChannelMembershipReturns(fakeCM)
+	fakeCH.ChannelMembershipReturns(&mock.ChannelMembership{})
 
 	fakeTx := &mock.Transaction{}
 	fakeTx.NetworkReturns("net1")
@@ -661,37 +579,102 @@ func TestParallelCollectEndorsementsOnProposalView_RejectsUnverifiedResponse(t *
 	fakeTx.BytesReturns([]byte("raw"), nil)
 	fakeTx.IDReturns("tx1")
 
-	ft := &Transaction{
-		Transaction: fabric.NewTransaction(fabric.NewNetworkService(nil, fakeFNS, "net1"), fakeTx),
-	}
-
-	// Party contacted is "bob", but the returned response claims to be endorsed by
-	// "mallory" - an identity with no relationship to "bob" whatsoever.
-	v := NewParallelCollectEndorsementsOnProposalView(ft, []byte("bob"))
-	v.WithTimeout(1 * time.Second)
-
 	fakeSession := &mock.Session{}
 	fakeCtx.GetSessionReturns(fakeSession, nil)
 	fakeCtx.InitiatorReturns(&fakeView{})
 
-	respPayload, _ := json.Marshal(&Response{
-		ProposalResponses: [][]byte{[]byte("resp-from-mallory")},
-	})
+	return &parallelEndorsementFixture{
+		ctx:     fakeCtx,
+		session: fakeSession,
+		tx:      fakeTx,
+		tm:      fakeTM,
+		ft: &Transaction{
+			Transaction: fabric.NewTransaction(fabric.NewNetworkService(nil, fakeFNS, "net1"), fakeTx),
+		},
+	}
+}
+
+// answerWith makes the fixture's session deliver a single Response carrying prs, endorsed by
+// endorser, and has the transaction manager unmarshal it into a proposal response that
+// verifies. Returns that proposal response so a test can override what it reports.
+func (f *parallelEndorsementFixture) answerWith(t *testing.T, endorser view.Identity, prs ...[]byte) *mock.ProposalResponse {
+	t.Helper()
+	respPayload, err := json.Marshal(&Response{ProposalResponses: prs})
+	require.NoError(t, err)
 	msgCh := make(chan *view.Message, 1)
 	msgCh <- &view.Message{Payload: respPayload}
-	fakeSession.ReceiveReturns(msgCh)
+	f.session.ReceiveReturns(msgCh)
+
+	fakeResp := &mock.ProposalResponse{}
+	fakeResp.EndorserReturns(endorser)
+	fakeResp.VerifyEndorsementReturns(nil)
+	f.tm.NewProposalResponseFromBytesReturns(fakeResp, nil)
+	return fakeResp
+}
+
+func TestParallelCollectEndorsementsOnProposalViewInternal(t *testing.T) {
+	t.Parallel()
+	f := newParallelEndorsementFixture(nil)
+
+	v := NewParallelCollectEndorsementsOnProposalView(f.ft, []byte("bob"))
+	v.WithTimeout(1 * time.Second)
+
+	// Case 1: Success
+	f.answerWith(t, []byte("bob"), []byte("resp1"))
+
+	_, err := v.Call(f.ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, f.tx.AppendProposalResponseCallCount())
+
+	// Case 2: Session error
+	f.ctx.GetSessionReturns(nil, fmt.Errorf("err"))
+	_, err = v.Call(f.ctx)
+	require.Error(t, err)
+
+	// Case 3: Send error
+	f.ctx.GetSessionReturns(f.session, nil)
+	f.session.SendWithContextReturns(fmt.Errorf("err"))
+	_, err = v.Call(f.ctx)
+	require.Error(t, err)
+
+	// Case 4: Receive error
+	f.session.SendWithContextReturns(nil)
+	msgCh := make(chan *view.Message, 1)
+	msgCh <- &view.Message{Status: view.ERROR, Payload: []byte("err")}
+	f.session.ReceiveReturns(msgCh)
+	_, err = v.Call(f.ctx)
+	require.Error(t, err)
+}
+
+// TestParallelCollectEndorsementsOnProposalView_RejectsUnverifiedResponse demonstrates
+// that parallelCollectEndorsementsOnProposalView.Call (endorsement_proposal.go) now
+// calls ProposalResponse.VerifyEndorsement, and checks that the endorser is bound to
+// the contacted party, before appending a remote-supplied proposal response to the
+// transaction - mirroring the sequential collectEndorsementsView.Call, which verifies
+// signatures against a set of VerifierProviders.
+func TestParallelCollectEndorsementsOnProposalView_RejectsUnverifiedResponse(t *testing.T) {
+	t.Parallel()
+	fakeBindingStore := &mock.BindingStore{}
+	fakeBindingStore.HaveSameBindingReturns(false, nil)
+	endpointService, err := endpoint.NewService(fakeBindingStore)
+	require.NoError(t, err)
+
+	f := newParallelEndorsementFixture(endpointService)
+
+	// Party contacted is "bob", but the returned response claims to be endorsed by
+	// "mallory" - an identity with no relationship to "bob" whatsoever.
+	v := NewParallelCollectEndorsementsOnProposalView(f.ft, []byte("bob"))
+	v.WithTimeout(1 * time.Second)
 
 	// This response is neither signed by "bob" nor bound to "bob", so it must be
 	// rejected regardless of what VerifyEndorsement would say.
-	fakeResp := &mock.ProposalResponse{}
-	fakeResp.EndorserReturns([]byte("mallory"))
+	fakeResp := f.answerWith(t, []byte("mallory"), []byte("resp-from-mallory"))
 	fakeResp.VerifyEndorsementReturns(errors.New("signature verification failed"))
-	fakeTM.NewProposalResponseFromBytesReturns(fakeResp, nil)
 
-	_, err := v.Call(fakeCtx)
+	_, err = v.Call(f.ctx)
 
 	require.Error(t, err, "unverified proposal response from an unrelated identity must be rejected")
-	require.Equal(t, 0, fakeTx.AppendProposalResponseCallCount())
+	require.Equal(t, 0, f.tx.AppendProposalResponseCallCount())
 }
 
 // TestParallelCollectEndorsementsOnProposalView_TimesOutOnSilentParty demonstrates that
@@ -704,60 +687,19 @@ func TestParallelCollectEndorsementsOnProposalView_RejectsUnverifiedResponse(t *
 // returns a timeout error instead of hanging indefinitely.
 func TestParallelCollectEndorsementsOnProposalView_TimesOutOnSilentParty(t *testing.T) {
 	t.Parallel()
-	fakeCtx := &mock.Context{}
-	fakeCtx.ContextReturns(context.Background())
-	fakeSP := &mock.Provider{}
-	fakeCtx.GetServiceCalls(func(v any) (any, error) {
-		return fakeSP.GetService(v)
-	})
-
-	fakeFNSP := &mock.FabricNetworkServiceProvider{}
-	fakeFNS := &mock.FabricNetworkService{}
-	fakeFNS.NameReturns("net1")
-	fakeFNSP.FabricNetworkServiceReturns(fakeFNS, nil)
-	fakeNSP := fabric.NewNetworkServiceProvider(fakeFNSP, nil)
-	networkServiceProviderType := reflect.TypeFor[*fabric.NetworkServiceProvider]()
-	fakeSP.GetServiceCalls(func(v any) (any, error) {
-		if v == networkServiceProviderType {
-			return fakeNSP, nil
-		}
-		return nil, nil
-	})
-
-	fakeTM := &mock.TransactionManager{}
-	fakeFNS.TransactionManagerReturns(fakeTM)
-
-	fakeCH := &mock.Channel{}
-	fakeCH.NameReturns("ch1")
-	fakeFNS.ChannelReturns(fakeCH, nil)
-	fakeCM := &mock.ChannelMembership{}
-	fakeCH.ChannelMembershipReturns(fakeCM)
-
-	fakeTx := &mock.Transaction{}
-	fakeTx.NetworkReturns("net1")
-	fakeTx.ChannelReturns("ch1")
-	fakeTx.BytesReturns([]byte("raw"), nil)
-	fakeTx.IDReturns("tx1")
-
-	ft := &Transaction{
-		Transaction: fabric.NewTransaction(fabric.NewNetworkService(nil, fakeFNS, "net1"), fakeTx),
-	}
+	f := newParallelEndorsementFixture(nil)
 
 	// A short timeout so the test doesn't wait out defaultParallelEndorsementTimeout; the
 	// party's session never delivers a response (empty, never-fed channel), simulating a
 	// silent/unresponsive remote peer.
-	v := NewParallelCollectEndorsementsOnProposalView(ft, []byte("bob"))
+	v := NewParallelCollectEndorsementsOnProposalView(f.ft, []byte("bob"))
 	v.WithTimeout(50 * time.Millisecond)
-
-	fakeSession := &mock.Session{}
-	fakeCtx.GetSessionReturns(fakeSession, nil)
-	fakeCtx.InitiatorReturns(&fakeView{})
-	fakeSession.ReceiveReturns(make(chan *view.Message))
+	f.session.ReceiveReturns(make(chan *view.Message))
 
 	done := make(chan struct{})
 	var err error
 	go func() {
-		_, err = v.Call(fakeCtx)
+		_, err = v.Call(f.ctx)
 		close(done)
 	}()
 
@@ -768,7 +710,70 @@ func TestParallelCollectEndorsementsOnProposalView_TimesOutOnSilentParty(t *test
 	}
 
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "timeout")
+	// The per-party ReceiveWithTimeout expires a full parallelEndorsementDeadlineGrace before
+	// the aggregate deadline, so barring a pathological scheduling stall the error reported is
+	// the per-party one, which names the party that went silent.
+	require.Contains(t, err.Error(), "time out reached on session")
+	require.Contains(t, err.Error(), "got failure from ["+view.Identity("bob").String()+"]")
+}
+
+// TestParallelCollectEndorsementsOnProposalView_TimesOutOnPartyThatNeverAcceptsTheSend covers
+// the aggregate deadline itself: collectEndorsement's own ReceiveWithTimeout bounds only the
+// receive step, so a party that parks the goroutine in session setup or SendRaw is caught by
+// nothing else. Here the send blocks forever, so the per-party timeout never arms and the
+// aggregate deadline in Call is the only thing that can return.
+func TestParallelCollectEndorsementsOnProposalView_TimesOutOnPartyThatNeverAcceptsTheSend(t *testing.T) {
+	t.Parallel()
+	f := newParallelEndorsementFixture(nil)
+
+	v := NewParallelCollectEndorsementsOnProposalView(f.ft, []byte("bob"))
+	v.WithTimeout(50 * time.Millisecond)
+
+	// Release the parked goroutine when the test ends so it does not outlive the test.
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	f.session.ReceiveReturns(make(chan *view.Message))
+	f.session.SendWithContextCalls(func(context.Context, []byte) error {
+		<-release
+		return nil
+	})
+
+	done := make(chan struct{})
+	var err error
+	go func() {
+		_, err = v.Call(f.ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Call did not return - it appears to be blocking forever on a party stuck in send")
+	}
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timeout waiting for endorsement from [1] parties")
+}
+
+// TestParallelCollectEndorsementsOnProposalView_ReportsAppendFailure guards against
+// AppendProposalResponse failures being swallowed: the error must reach the caller rather than
+// Call returning a nil transaction and a nil error.
+func TestParallelCollectEndorsementsOnProposalView_ReportsAppendFailure(t *testing.T) {
+	t.Parallel()
+	f := newParallelEndorsementFixture(nil)
+	f.tx.AppendProposalResponseReturns(errors.New("cannot append"))
+
+	v := NewParallelCollectEndorsementsOnProposalView(f.ft, []byte("bob"))
+	v.WithTimeout(1 * time.Second)
+
+	f.answerWith(t, []byte("bob"), []byte("resp1"))
+
+	tx, err := v.Call(f.ctx)
+	require.Error(t, err)
+	require.Nil(t, tx)
+	require.Contains(t, err.Error(), "failed appending response from ["+view.Identity("bob").String()+"]")
+	require.Contains(t, err.Error(), "cannot append")
 }
 
 func TestEndorsementOnProposalResponderViewInternal(t *testing.T) {


### PR DESCRIPTION
`TestParallelCollectEndorsementsOnProposalView_TimesOutOnSilentParty` was flaky because `parallelCollectEndorsementsOnProposalView.Call` armed its aggregate deadline with the same duration that `collectEndorsement` passes to `ReceiveWithTimeout`, so both fired at once and `select` picked between them at random — one path reports `"time out reached on session"`, the other `"timeout waiting for endorsement"`, and only the first matched the assertion. 

The aggregate deadline now runs a fixed grace period longer than the per-party timeout, so a silent party is consistently reported by the error that names it, leaving the aggregate deadline as the backstop for the session-setup and send steps that nothing else bounds. 

Along the way this fixes a real bug in the same loop: the `AppendProposalResponse` error path wrapped `a.err`, which is always `nil` there, so `Wrapf` returned `nil` and `Call` handed the caller `(nil, nil)` instead of the append failure. Adds tests for the aggregate deadline and for the swallowed append error, and extracts the fake wiring the parallel-endorsement tests share into a fixture.