### PR TITLE
fix finality listener leak

### DIFF
--- a/integration/fabricx/simple/views/create.go
+++ b/integration/fabricx/simple/views/create.go
@@ -96,6 +96,17 @@ func (i *CreateView) Call(viewCtx view.Context) (any, error) {
 		return nil, err
 	}
 
+	// An empty txID must be rejected: no committer notification could ever match
+	// it, so the registration would never be removed. The generic driver enforces
+	// this too (see integration/fabric/iou/views/approver.go), so this asserts the
+	// two drivers agree against a live committer. A throwaway WaitGroup is used so
+	// that an unexpected success cannot corrupt the real listener's count above.
+	var unusedWG sync.WaitGroup
+	unusedWG.Add(1)
+	if err := lm.AddFinalityListener("", utils.NewFinalityListener(tx.ID(), fdriver.Valid, &unusedWG)); err == nil {
+		return nil, errors.New("AddFinalityListener with an empty txID must fail")
+	}
+
 	// now we have a committer listener registered, we send the approved transaction to the orderer
 	logger.Infof("Submit tx (txID=%v) to ordering service", tx.ID())
 	if _, err = viewCtx.RunView(state.NewOrderingAndFinalityWithTimeoutView(tx, FinalityTimeout)); err != nil {

--- a/integration/fabricx/simple/views/create.go
+++ b/integration/fabricx/simple/views/create.go
@@ -96,17 +96,6 @@ func (i *CreateView) Call(viewCtx view.Context) (any, error) {
 		return nil, err
 	}
 
-	// An empty txID must be rejected: no committer notification could ever match
-	// it, so the registration would never be removed. The generic driver enforces
-	// this too (see integration/fabric/iou/views/approver.go), so this asserts the
-	// two drivers agree against a live committer. A throwaway WaitGroup is used so
-	// that an unexpected success cannot corrupt the real listener's count above.
-	var unusedWG sync.WaitGroup
-	unusedWG.Add(1)
-	if err := lm.AddFinalityListener("", utils.NewFinalityListener(tx.ID(), fdriver.Valid, &unusedWG)); err == nil {
-		return nil, errors.New("AddFinalityListener with an empty txID must fail")
-	}
-
 	// now we have a committer listener registered, we send the approved transaction to the orderer
 	logger.Infof("Submit tx (txID=%v) to ordering service", tx.ID())
 	if _, err = viewCtx.RunView(state.NewOrderingAndFinalityWithTimeoutView(tx, FinalityTimeout)); err != nil {

--- a/platform/fabricx/core/finality/nlm.go
+++ b/platform/fabricx/core/finality/nlm.go
@@ -212,6 +212,13 @@ func (n *notificationListenerManager) AddFinalityListener(txID driver.TxID, list
 	if listener == nil {
 		return errors.New("listener nil")
 	}
+	// An empty txID can never appear in a committer notification, so the entry it
+	// would create is unremovable. The generic driver already rejects this (see
+	// platform/common/core/generic/committer/listenermgr.go); keep the message
+	// identical so both drivers behave the same for the same API call.
+	if len(txID) == 0 {
+		return errors.New("tx id must be not empty")
+	}
 
 	n.handlersMu.Lock()
 	defer n.handlersMu.Unlock()

--- a/platform/fabricx/core/finality/nlm.go
+++ b/platform/fabricx/core/finality/nlm.go
@@ -157,13 +157,50 @@ func (n *notificationListenerManager) listen(ctx context.Context) error {
 	err = g.Wait()
 	logger.Debugf("Notification listener stream stopped.")
 
-	// Cleanup handlers map when listen() exits
-	n.handlersMu.Lock()
-	clear(n.handlers)
-	n.handlersMu.Unlock()
-	logger.Debugf("Cleared handlers map on listen() exit")
+	// The stream is gone, so nothing will ever notify these listeners. Settle them
+	// with Unknown instead of dropping them silently, so anyone blocked in IsFinal
+	// is released now rather than waiting out their own context.
+	//
+	// ctx, not gCtx: the errgroup context is already cancelled by the time g.Wait()
+	// returns, and invokeHandler derives its handler timeout from what we pass, so
+	// gCtx would hand every listener a dead context and deliver nothing. Strip
+	// cancellation from the parent too -- listen() is often returning *because*
+	// ctx was cancelled, and these callbacks still need to run.
+	n.settleAllAndClear(context.WithoutCancel(ctx), fdriver.Unknown)
 
 	return err
+}
+
+// settleAllAndClear empties the handlers map, invoking every listener still in it
+// with the given status. Used on stream teardown, where no notification can
+// arrive any more.
+func (n *notificationListenerManager) settleAllAndClear(ctx context.Context, status int) {
+	type pending struct {
+		txID      string
+		listeners []fabric.FinalityListener
+	}
+
+	var batch []pending
+
+	n.handlersMu.Lock()
+	for txID, entry := range n.handlers {
+		batch = append(batch, pending{txID: txID, listeners: entry.listeners})
+	}
+	clear(n.handlers)
+	n.handlersMu.Unlock()
+
+	if len(batch) == 0 {
+		logger.Debugf("Cleared handlers map on listen() exit")
+		return
+	}
+
+	logger.Debugf("Settling %d pending finality listener(s) with status %d on stream teardown", len(batch), status)
+
+	for _, p := range batch {
+		for _, h := range p.listeners {
+			n.invokeHandler(ctx, h, p.txID, status)
+		}
+	}
 }
 
 func parseResponse(resp *committerpb.NotificationResponse) map[string]int {

--- a/platform/fabricx/core/finality/nlm.go
+++ b/platform/fabricx/core/finality/nlm.go
@@ -32,13 +32,41 @@ var logger = logging.MustGetLogger()
 // will leak goroutines, but this is preferable to blocking the dispatcher.
 const DefaultHandlerTimeout = 5 * time.Second
 
+// DefaultListenerTTL bounds how long a listener may wait for a notification that
+// may never arrive. It is deliberately much longer than the timeout we ask the
+// committer for in AddFinalityListener: that timeout is documented non-strict
+// ("it is possible to receive notifications after the timeout has passed", see
+// notify.proto), so the remote must be given ample room to answer before we give
+// up locally. Expiry is a backstop against silence, not a competitor to the
+// remote deadline.
+const DefaultListenerTTL = 2 * time.Minute
+
+// DefaultSweepInterval is how often expired entries are collected. An entry's
+// worst-case lifetime is DefaultListenerTTL + DefaultSweepInterval.
+const DefaultSweepInterval = 30 * time.Second
+
+// handlerEntry holds the listeners waiting on one transaction, together with the
+// deadline after which they are settled locally. A zero expiresAt means the entry
+// never expires, which is what a manager built with listenerTTL == 0 produces.
+type handlerEntry struct {
+	listeners []fabric.FinalityListener
+	expiresAt time.Time
+}
+
 type notificationListenerManager struct {
 	notifyClient   committerpb.NotifierClient
 	requestQueue   chan *committerpb.NotificationRequest
 	responseQueue  chan *committerpb.NotificationResponse
 	handlerTimeout time.Duration
 
-	handlers   map[driver.TxID][]fabric.FinalityListener
+	// listenerTTL is how long an entry may stay unresolved before the sweeper
+	// settles it with Unknown. Zero disables local expiry entirely.
+	listenerTTL time.Duration
+	// sweepInterval is the sweep tick period. Ignored when listenerTTL is zero;
+	// falls back to DefaultSweepInterval if unset.
+	sweepInterval time.Duration
+
+	handlers   map[driver.TxID]*handlerEntry
 	handlersMu sync.RWMutex
 
 	// streamCtx holds the errgroup context of the currently active listen()
@@ -110,12 +138,27 @@ func (n *notificationListenerManager) listen(ctx context.Context) error {
 			status  int
 		}
 
+		// Sweep from this goroutine rather than a dedicated one: it is already the
+		// only goroutine that deletes entries on the notification path, so a sweep
+		// can never interleave with a dispatch and no listener can be settled twice.
+		sweepEvery := n.sweepInterval
+		if sweepEvery <= 0 {
+			sweepEvery = DefaultSweepInterval
+		}
+		ticker := time.NewTicker(sweepEvery)
+		defer ticker.Stop()
+
 		var resp *committerpb.NotificationResponse
 		for {
 			select {
 			case <-gCtx.Done():
 				return gCtx.Err()
 			case resp = <-n.responseQueue:
+			case <-ticker.C:
+				n.sweepExpired(gCtx)
+				// A tick carries no response; resp still holds the previous one, so
+				// falling through here would dispatch it a second time.
+				continue
 			}
 
 			res := parseResponse(resp)
@@ -126,39 +169,20 @@ func (n *notificationListenerManager) listen(ctx context.Context) error {
 			var calls []handlerCall
 
 			n.handlersMu.Lock()
-			for txID, v := range res {
-				handlers, ok := n.handlers[txID]
+			for txID, status := range res {
+				entry, ok := n.handlers[txID]
 				if !ok {
 					continue
 				}
 				delete(n.handlers, txID)
-				for _, h := range handlers {
-					calls = append(calls, handlerCall{handler: h, txID: txID, status: v})
+				for _, h := range entry.listeners {
+					calls = append(calls, handlerCall{handler: h, txID: txID, status: status})
 				}
 			}
 			n.handlersMu.Unlock()
 
-			// Invoke each handler in its own goroutine with a timeout.
-			// If a handler ignores the context and never returns, the goroutine
-			// will leak — but the dispatcher remains unblocked.
 			for _, c := range calls {
-				go func() {
-					timeoutCtx, cancel := context.WithTimeout(gCtx, n.handlerTimeout)
-					defer cancel()
-
-					done := make(chan struct{})
-					go func() {
-						c.handler.OnStatus(timeoutCtx, c.txID, c.status, "")
-						close(done)
-					}()
-
-					select {
-					case <-done:
-						// Handler completed within timeout
-					case <-timeoutCtx.Done():
-						logger.Warnf("OnStatus handler timed out for txID=%s (timeout=%s)", c.txID, n.handlerTimeout)
-					}
-				}()
+				n.invokeHandler(gCtx, c.handler, c.txID, c.status)
 			}
 		}
 	})
@@ -223,17 +247,22 @@ func (n *notificationListenerManager) AddFinalityListener(txID driver.TxID, list
 	n.handlersMu.Lock()
 	defer n.handlersMu.Unlock()
 
-	handlers := n.handlers[txID]
-	if slices.Contains(handlers, listener) {
-		logger.Warnf("The exact same listener is already registered for txID=%v. Skipping.", txID)
-		// Do not register the same instance twice
-		return nil
-	}
-	n.handlers[txID] = append(handlers, listener)
-
-	if len(handlers) > 0 {
+	if entry, existed := n.handlers[txID]; existed {
+		if slices.Contains(entry.listeners, listener) {
+			logger.Warnf("The exact same listener is already registered for txID=%v. Skipping.", txID)
+			// Do not register the same instance twice
+			return nil
+		}
+		// A joining listener inherits the existing deadline rather than extending
+		// it, so a busy txID cannot keep its entry alive indefinitely.
+		entry.listeners = append(entry.listeners, listener)
 		logger.Debugf("Additional listener registered for txID=%v. Request already sent.", txID)
 		return nil
+	}
+
+	n.handlers[txID] = &handlerEntry{
+		listeners: []fabric.FinalityListener{listener},
+		expiresAt: n.expiryFor(time.Now()),
 	}
 
 	// this is our first listener registered for the given txID
@@ -277,16 +306,16 @@ func (n *notificationListenerManager) RemoveFinalityListener(txID string, listen
 	n.handlersMu.Lock()
 	defer n.handlersMu.Unlock()
 
-	handlers, ok := n.handlers[txID]
-	if !ok || len(handlers) == 0 {
+	entry, ok := n.handlers[txID]
+	if !ok || len(entry.listeners) == 0 {
 		// no handlers registered for this txID, nothing to remove
 		logger.Debugf("RemoveFinalityListener called for unknown txID: %s", txID)
 		return nil
 	}
 
-	initialLength := len(handlers)
+	initialLength := len(entry.listeners)
 
-	newHandlers := slices.DeleteFunc(handlers, func(h fabric.FinalityListener) bool {
+	newHandlers := slices.DeleteFunc(entry.listeners, func(h fabric.FinalityListener) bool {
 		return h == listener
 	})
 
@@ -302,9 +331,103 @@ func (n *notificationListenerManager) RemoveFinalityListener(txID string, listen
 		logger.Debugf("Last finality listener removed for txID=%s.", txID)
 		delete(n.handlers, txID)
 	} else {
-		n.handlers[txID] = newHandlers
+		// Mutating the entry in place keeps the existing deadline: removing one
+		// listener must not extend the lifetime of the ones still waiting.
+		entry.listeners = newHandlers
 		logger.Debugf("Removed listener for txID=%s. %d listeners remaining.", txID, len(newHandlers))
 	}
 
 	return nil
+}
+
+// invokeHandler calls one listener in its own goroutine, bounded by
+// handlerTimeout. If a handler ignores context cancellation and never returns,
+// its goroutine leaks -- which is preferable to blocking the dispatcher. Shared
+// by the notification path and the expiry sweeper so both get the same isolation.
+func (n *notificationListenerManager) invokeHandler(ctx context.Context, h fabric.FinalityListener, txID string, status int) {
+	go func() {
+		timeoutCtx, cancel := context.WithTimeout(ctx, n.handlerTimeout)
+		defer cancel()
+
+		done := make(chan struct{})
+		go func() {
+			h.OnStatus(timeoutCtx, txID, status, "")
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// Handler completed within timeout
+		case <-timeoutCtx.Done():
+			logger.Warnf("OnStatus handler timed out for txID=%s (timeout=%s)", txID, n.handlerTimeout)
+		}
+	}()
+}
+
+// expiryFor returns the local deadline for an entry created at now, or the zero
+// time when local expiry is disabled.
+func (n *notificationListenerManager) expiryFor(now time.Time) time.Time {
+	if n.listenerTTL <= 0 {
+		return time.Time{}
+	}
+	return now.Add(n.listenerTTL)
+}
+
+// sweepExpired settles listeners whose local deadline has passed.
+//
+// Without this, the only steady-state path that removes a handlers entry is an
+// inbound notification, so a committer that never reports on a transaction --
+// because it dropped the subscription, is overloaded, or has a bug -- leaves the
+// entry, and the listener closure it pins, in the map forever. The timeout we set
+// on the outbound request does not help: it asks the *committer* to give up and
+// reply, so it too depends on the stream we are no longer hearing from.
+//
+// Listeners are settled with Unknown, which is the same outcome the committer's
+// own TimeoutTxIds path produces, so callers see nothing new. Note this can
+// report Unknown for a transaction that did in fact commit, because the remote
+// timeout is documented non-strict and a notification may arrive after we have
+// given up; DefaultListenerTTL is set well above the request timeout to make that
+// unlikely. Callers needing certainty can query the transaction status directly.
+//
+// Runs on the dispatcher goroutine (see the ticker in listen): the dispatcher is
+// the only other goroutine that deletes entries on the notification path, so a
+// sweep and a dispatch can never interleave and one listener can never be settled
+// twice. Keep it that way -- moving this off the dispatcher would make
+// double-invoke merely preventable rather than impossible.
+func (n *notificationListenerManager) sweepExpired(ctx context.Context) {
+	if n.listenerTTL <= 0 {
+		return
+	}
+
+	now := time.Now()
+
+	type expired struct {
+		txID      string
+		listeners []fabric.FinalityListener
+	}
+	var batch []expired
+
+	// Collect and delete under the lock; notify outside it, mirroring how the
+	// dispatcher handles its own callbacks.
+	n.handlersMu.Lock()
+	for txID, entry := range n.handlers {
+		if entry.expiresAt.IsZero() || entry.expiresAt.After(now) {
+			continue
+		}
+		batch = append(batch, expired{txID: txID, listeners: entry.listeners})
+		delete(n.handlers, txID)
+	}
+	n.handlersMu.Unlock()
+
+	if len(batch) == 0 {
+		return
+	}
+
+	logger.Debugf("Settling %d expired finality listener(s) with Unknown", len(batch))
+
+	for _, e := range batch {
+		for _, h := range e.listeners {
+			n.invokeHandler(ctx, h, e.txID, fdriver.Unknown)
+		}
+	}
 }

--- a/platform/fabricx/core/finality/nlm.go
+++ b/platform/fabricx/core/finality/nlm.go
@@ -132,12 +132,6 @@ func (n *notificationListenerManager) listen(ctx context.Context) error {
 
 	// spawn notification dispatcher
 	g.Go(func() error {
-		type handlerCall struct {
-			handler fabric.FinalityListener
-			txID    string
-			status  int
-		}
-
 		// Sweep from this goroutine rather than a dedicated one: it is already the
 		// only goroutine that deletes entries on the notification path, so a sweep
 		// can never interleave with a dispatch and no listener can be settled twice.
@@ -148,41 +142,14 @@ func (n *notificationListenerManager) listen(ctx context.Context) error {
 		ticker := time.NewTicker(sweepEvery)
 		defer ticker.Stop()
 
-		var resp *committerpb.NotificationResponse
 		for {
 			select {
 			case <-gCtx.Done():
 				return gCtx.Err()
-			case resp = <-n.responseQueue:
 			case <-ticker.C:
 				n.sweepExpired(gCtx)
-				// A tick carries no response; resp still holds the previous one, so
-				// falling through here would dispatch it a second time.
-				continue
-			}
-
-			res := parseResponse(resp)
-
-			// Collect handlers under lock, then release before spawning goroutines.
-			// This minimizes lock hold time — only map lookups and deletes happen
-			// under the lock. Goroutine scheduling happens entirely outside.
-			var calls []handlerCall
-
-			n.handlersMu.Lock()
-			for txID, status := range res {
-				entry, ok := n.handlers[txID]
-				if !ok {
-					continue
-				}
-				delete(n.handlers, txID)
-				for _, h := range entry.listeners {
-					calls = append(calls, handlerCall{handler: h, txID: txID, status: status})
-				}
-			}
-			n.handlersMu.Unlock()
-
-			for _, c := range calls {
-				n.invokeHandler(gCtx, c.handler, c.txID, c.status)
+			case resp := <-n.responseQueue:
+				n.dispatch(gCtx, resp)
 			}
 		}
 	})
@@ -371,6 +338,39 @@ func (n *notificationListenerManager) expiryFor(now time.Time) time.Time {
 		return time.Time{}
 	}
 	return now.Add(n.listenerTTL)
+}
+
+// dispatch settles the listeners named by one notification response.
+//
+// Collects under the lock and notifies outside it, so only map lookups and
+// deletes happen while handlersMu is held. Runs on the dispatcher goroutine,
+// which is what lets sweepExpired share the same map without either path being
+// able to settle a listener the other already settled.
+func (n *notificationListenerManager) dispatch(ctx context.Context, resp *committerpb.NotificationResponse) {
+	type handlerCall struct {
+		handler fabric.FinalityListener
+		txID    string
+		status  int
+	}
+
+	var calls []handlerCall
+
+	n.handlersMu.Lock()
+	for txID, status := range parseResponse(resp) {
+		entry, ok := n.handlers[txID]
+		if !ok {
+			continue
+		}
+		delete(n.handlers, txID)
+		for _, h := range entry.listeners {
+			calls = append(calls, handlerCall{handler: h, txID: txID, status: status})
+		}
+	}
+	n.handlersMu.Unlock()
+
+	for _, c := range calls {
+		n.invokeHandler(ctx, c.handler, c.txID, c.status)
+	}
 }
 
 // sweepExpired settles listeners whose local deadline has passed.

--- a/platform/fabricx/core/finality/nlm_test.go
+++ b/platform/fabricx/core/finality/nlm_test.go
@@ -420,6 +420,35 @@ func TestNotificationListenerManager(t *testing.T) {
 		require.False(t, exists, "Handler should not be added to the map for a nil listener")
 	})
 
+	t.Run("AddFinalityListener_Empty_TxID_Fails", func(t *testing.T) {
+		t.Parallel()
+		nlm, fakeStream := setupTest(t)
+		ctx := t.Context()
+		fakeStream.RecvStub = func() (*committerpb.NotificationResponse, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+
+		runManager(t, nlm)
+
+		// an empty txID must be rejected: no notification could ever match it, so
+		// the entry would never be removed
+		err := nlm.AddFinalityListener("", &mockListener{})
+
+		require.Error(t, err)
+		require.EqualError(t, err, "tx id must be not empty",
+			"message must match the generic driver's, so both drivers agree")
+
+		nlm.handlersMu.RLock()
+		_, exists := nlm.handlers[""]
+		nlm.handlersMu.RUnlock()
+		require.False(t, exists, "No handler entry should be created for an empty txID")
+
+		// and no subscription should have been sent for it
+		time.Sleep(shortWait)
+		require.Equal(t, 0, fakeStream.SendCallCount(), "Empty txID must not trigger a Send")
+	})
+
 	t.Run("Shutdown_Graceful_Exit", func(t *testing.T) {
 		t.Parallel()
 		nlm, fakeStream := setupTest(t)

--- a/platform/fabricx/core/finality/nlm_test.go
+++ b/platform/fabricx/core/finality/nlm_test.go
@@ -159,6 +159,17 @@ func listenersFor(nlm *notificationListenerManager, txID string) ([]fabric.Final
 	return slices.Clone(entry.listeners), true
 }
 
+// expiryOf returns an entry's local deadline, plus whether the entry exists.
+func expiryOf(nlm *notificationListenerManager, txID string) (time.Time, bool) {
+	nlm.handlersMu.RLock()
+	defer nlm.handlersMu.RUnlock()
+	entry, ok := nlm.handlers[txID]
+	if !ok {
+		return time.Time{}, false
+	}
+	return entry.expiresAt, true
+}
+
 // setExpiry overrides an entry's local deadline so tests can control expiry.
 func setExpiry(nlm *notificationListenerManager, txID string, at time.Time) {
 	nlm.handlersMu.Lock()
@@ -445,6 +456,38 @@ func TestNotificationListenerManager(t *testing.T) {
 		require.True(t, found1 && found2, "Both unique listeners (ml1 and ml2) must be present in the handler list.")
 	})
 
+	t.Run("Joining_Listener_Inherits_The_Existing_Deadline", func(t *testing.T) {
+		t.Parallel()
+		const targetTxID = "tx_deadline_inherited"
+		nlm, fakeStream := setupTest(t)
+		nlm.listenerTTL = time.Hour // long, so nothing expires during the test
+		ctx := t.Context()
+		fakeStream.RecvStub = func() (*committerpb.NotificationResponse, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+
+		runManager(t, nlm)
+
+		require.NoError(t, nlm.AddFinalityListener(targetTxID, &mockListener{}))
+		first, ok := expiryOf(nlm, targetTxID)
+		require.True(t, ok, "entry should exist after the first registration")
+		require.False(t, first.IsZero(), "a deadline must be stamped when listenerTTL is set")
+
+		// Registering a second listener for the same txID must not push the deadline
+		// out. Otherwise a txID that keeps attracting listeners could stay in the map
+		// indefinitely -- the exact unbounded growth this change exists to prevent.
+		time.Sleep(2 * tick) // ensure a later Now() would produce a different deadline
+		require.NoError(t, nlm.AddFinalityListener(targetTxID, &mockListener{}))
+
+		second, ok := expiryOf(nlm, targetTxID)
+		require.True(t, ok, "entry should still exist")
+		require.Equal(t, first, second, "a joining listener must inherit the deadline, not extend it")
+
+		handlers, _ := listenersFor(nlm, targetTxID)
+		require.Len(t, handlers, 2, "both listeners should be registered")
+	})
+
 	t.Run("AddFinalityListener_Nil_Listener_Fails", func(t *testing.T) {
 		t.Parallel()
 		nlm, fakeStream := setupTest(t)
@@ -670,6 +713,40 @@ func TestNotificationListenerManager(t *testing.T) {
 		_, exists = nlm.handlers[targetTxID]
 		nlm.handlersMu.RUnlock()
 		require.False(t, exists, "Map entry should be deleted after ml2 is removed")
+	})
+
+	t.Run("Removing_A_Listener_Preserves_The_Deadline", func(t *testing.T) {
+		t.Parallel()
+		const targetTxID = "tx_deadline_preserved"
+		nlm, fakeStream := setupTest(t)
+		nlm.listenerTTL = time.Hour // long, so nothing expires during the test
+		ctx := t.Context()
+		fakeStream.RecvStub = func() (*committerpb.NotificationResponse, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+
+		runManager(t, nlm)
+
+		ml1, ml2 := &mockListener{}, &mockListener{}
+		require.NoError(t, nlm.AddFinalityListener(targetTxID, ml1))
+		require.NoError(t, nlm.AddFinalityListener(targetTxID, ml2))
+
+		before, ok := expiryOf(nlm, targetTxID)
+		require.True(t, ok)
+		require.False(t, before.IsZero(), "a deadline must be stamped when listenerTTL is set")
+
+		// Removing one listener must not reset or extend the deadline for the ones
+		// still waiting: their entry should expire when it always would have.
+		require.NoError(t, nlm.RemoveFinalityListener(targetTxID, ml1))
+
+		after, ok := expiryOf(nlm, targetTxID)
+		require.True(t, ok, "entry should survive while ml2 is still registered")
+		require.Equal(t, before, after, "removing a listener must not change the deadline")
+
+		handlers, _ := listenersFor(nlm, targetTxID)
+		require.Len(t, handlers, 1)
+		require.Equal(t, ml2, handlers[0])
 	})
 
 	t.Run("Remove_NonExistent_Listener", func(t *testing.T) {

--- a/platform/fabricx/core/finality/nlm_test.go
+++ b/platform/fabricx/core/finality/nlm_test.go
@@ -8,6 +8,7 @@ package finality
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -105,14 +106,47 @@ func setupTest(tb testing.TB) (*notificationListenerManager, *mock.Notifier_Open
 		return fakeStream, nil
 	}
 
+	// listenerTTL is deliberately left zero here, which disables local expiry, so
+	// the sweeper stays inert for every test that does not opt in.
 	nlm := &notificationListenerManager{
 		notifyClient:  fakeClient,
 		requestQueue:  make(chan *committerpb.NotificationRequest),
 		responseQueue: make(chan *committerpb.NotificationResponse),
-		handlers:      make(map[driver.TxID][]fabric.FinalityListener),
+		handlers:      make(map[driver.TxID]*handlerEntry),
 	}
 
 	return nlm, fakeStream
+}
+
+// seedHandlers registers listeners directly, bypassing AddFinalityListener, to
+// isolate dispatch and sweep logic. It keeps the map's internal shape in one
+// place. Note expiresAt is left zero, meaning "never expires": call setExpiry to
+// make an entry sweep-eligible.
+func seedHandlers(nlm *notificationListenerManager, txID string, listeners ...fabric.FinalityListener) {
+	nlm.handlersMu.Lock()
+	defer nlm.handlersMu.Unlock()
+	nlm.handlers[txID] = &handlerEntry{listeners: listeners}
+}
+
+// listenersFor returns a snapshot of the listeners registered for txID, plus
+// whether the entry exists.
+func listenersFor(nlm *notificationListenerManager, txID string) ([]fabric.FinalityListener, bool) {
+	nlm.handlersMu.RLock()
+	defer nlm.handlersMu.RUnlock()
+	entry, ok := nlm.handlers[txID]
+	if !ok {
+		return nil, false
+	}
+	return slices.Clone(entry.listeners), true
+}
+
+// setExpiry overrides an entry's local deadline so tests can control expiry.
+func setExpiry(nlm *notificationListenerManager, txID string, at time.Time) {
+	nlm.handlersMu.Lock()
+	defer nlm.handlersMu.Unlock()
+	if entry, ok := nlm.handlers[txID]; ok {
+		entry.expiresAt = at
+	}
 }
 
 // runManager starts the manager asynchronously and ensures cleanup on test completion.
@@ -197,7 +231,7 @@ func TestNotificationListenerManager(t *testing.T) {
 				ml.wg.Add(1)
 
 				// manually inject into the map to isolate the Receive/Dispatch logic
-				nlm.handlers[tc.txID] = []fabric.FinalityListener{ml}
+				seedHandlers(nlm, tc.txID, ml)
 
 				// prepare the incoming gRPC message
 				resp := &committerpb.NotificationResponse{
@@ -245,7 +279,7 @@ func TestNotificationListenerManager(t *testing.T) {
 		ctx := t.Context()
 		ml := &mockListener{}
 		ml.wg.Add(1)
-		nlm.handlers[targetTxID] = []fabric.FinalityListener{ml}
+		seedHandlers(nlm, targetTxID, ml)
 
 		// prepare response with a TimeoutTxId
 		resp := &committerpb.NotificationResponse{
@@ -335,9 +369,7 @@ func TestNotificationListenerManager(t *testing.T) {
 		require.Equal(t, 1, fakeStream.SendCallCount(), "Duplicate AddFinalityListener call should NOT trigger a second Send")
 
 		// verify only one handler was registered internally.
-		nlm.handlersMu.RLock()
-		handlers, exists := nlm.handlers[targetTxID]
-		nlm.handlersMu.RUnlock()
+		handlers, exists := listenersFor(nlm, targetTxID)
 		require.True(t, exists, "Handler list should exist after first registration")
 		require.Len(t, handlers, 1, "There should be exactly ONE registered handler (the duplicate was rejected)")
 		require.Equal(t, ml, handlers[0], "The registered handler must be the original instance (ml)")
@@ -376,9 +408,7 @@ func TestNotificationListenerManager(t *testing.T) {
 		require.Equal(t, 1, fakeStream.SendCallCount(), "Second unique listener should NOT trigger a second Send")
 
 		// verify BOTH unique listeners were registered internally.
-		nlm.handlersMu.RLock()
-		handlers, exists := nlm.handlers[targetTxID]
-		nlm.handlersMu.RUnlock()
+		handlers, exists := listenersFor(nlm, targetTxID)
 
 		require.True(t, exists, "Handler list should exist")
 		require.Len(t, handlers, 2, "There should be exactly TWO registered handlers")
@@ -551,17 +581,15 @@ func TestNotificationListenerManager(t *testing.T) {
 		require.NoError(t, nlm.AddFinalityListener(targetTxID, ml1), "Setup: failed to add ml1")
 		require.NoError(t, nlm.AddFinalityListener(targetTxID, ml2), "Setup: failed to add ml2")
 
-		nlm.handlersMu.RLock()
-		require.Len(t, nlm.handlers[targetTxID], 2, "Setup: Expected 2 listeners")
-		nlm.handlersMu.RUnlock()
+		setupListeners, setupExists := listenersFor(nlm, targetTxID)
+		require.True(t, setupExists, "Setup: entry should exist")
+		require.Len(t, setupListeners, 2, "Setup: Expected 2 listeners")
 
 		err := nlm.RemoveFinalityListener(targetTxID, ml1)
 		require.NoError(t, err, "RemoveFinalityListener for ml1 should succeed")
 
 		// map entry must still exist and contain only ml2
-		nlm.handlersMu.RLock()
-		handlers, exists := nlm.handlers[targetTxID]
-		nlm.handlersMu.RUnlock()
+		handlers, exists := listenersFor(nlm, targetTxID)
 
 		require.True(t, exists, "Map entry should still exist")
 		require.Len(t, handlers, 1, "Expected 1 listener remaining (ml2)")
@@ -598,18 +626,16 @@ func TestNotificationListenerManager(t *testing.T) {
 		require.NoError(t, nlm.AddFinalityListener(targetTxID, ml2), "Setup: failed to add ml2")
 
 		// assert initial state
-		nlm.handlersMu.RLock()
-		require.Len(t, nlm.handlers[targetTxID], 2, "Setup: Expected 2 listeners")
-		nlm.handlersMu.RUnlock()
+		setupListeners, setupExists := listenersFor(nlm, targetTxID)
+		require.True(t, setupExists, "Setup: entry should exist")
+		require.Len(t, setupListeners, 2, "Setup: Expected 2 listeners")
 
 		// attempt to remove ml3 which was never added
 		err := nlm.RemoveFinalityListener(targetTxID, ml3Nonexistent)
 		require.NoError(t, err, "Attempt to remove non-existent listener should return nil")
 
 		// map must be unchanged (still 2 listeners)
-		nlm.handlersMu.RLock()
-		handlers, exists := nlm.handlers[targetTxID]
-		nlm.handlersMu.RUnlock()
+		handlers, exists := listenersFor(nlm, targetTxID)
 
 		require.True(t, exists, "Map entry should still exist")
 		require.Len(t, handlers, 2, "The number of handlers should not change")
@@ -674,7 +700,7 @@ func TestNotificationListenerManager(t *testing.T) {
 			onCalled: slowCalled,
 		}
 
-		nlm.handlers[targetTxID] = []fabric.FinalityListener{slowListener}
+		seedHandlers(nlm, targetTxID, slowListener)
 
 		resp := &committerpb.NotificationResponse{
 			TxStatusEvents: []*committerpb.TxStatus{
@@ -738,7 +764,7 @@ func TestNotificationListenerManager(t *testing.T) {
 			onCalled: stuckCalled,
 		}
 
-		nlm.handlers[targetTxID] = []fabric.FinalityListener{fastML, slowML, stuckListener}
+		seedHandlers(nlm, targetTxID, fastML, slowML, stuckListener)
 
 		resp := &committerpb.NotificationResponse{
 			TxStatusEvents: []*committerpb.TxStatus{
@@ -814,8 +840,8 @@ func TestNotificationListenerManager(t *testing.T) {
 		normalML := &mockListener{}
 		normalML.wg.Add(1)
 
-		nlm.handlers[leakyTxID] = []fabric.FinalityListener{leakyListener}
-		nlm.handlers[normalTxID] = []fabric.FinalityListener{normalML}
+		seedHandlers(nlm, leakyTxID, leakyListener)
+		seedHandlers(nlm, normalTxID, normalML)
 
 		// First response triggers the leaky handler,
 		// second triggers the normal one.
@@ -868,5 +894,165 @@ func TestNotificationListenerManager(t *testing.T) {
 			assert.Equal(collect, fdriver.Valid, status)
 		}, timeout, tick,
 			"normal listener must be notified despite leaky handler")
+	})
+}
+
+const (
+	testTTL   = 50 * time.Millisecond
+	testSweep = 10 * time.Millisecond
+)
+
+// setupSweepTest builds a manager with local expiry enabled and a Recv that
+// blocks, so the sweeper is the only thing touching the handlers map.
+func setupSweepTest(tb testing.TB) (*notificationListenerManager, *mock.Notifier_OpenNotificationStreamClient) {
+	tb.Helper()
+	nlm, fakeStream := setupTest(tb)
+	nlm.listenerTTL = testTTL
+	nlm.sweepInterval = testSweep
+	// setupTest leaves handlerTimeout zero, which would hand every listener an
+	// already-expired context; set it so the sweeper's callbacks are realistic.
+	nlm.handlerTimeout = DefaultHandlerTimeout
+	return nlm, fakeStream
+}
+
+// blockingRecv makes Recv park until the context is done, so no notification ever
+// arrives and only expiry can settle a listener.
+func blockingRecv(ctx context.Context, fakeStream *mock.Notifier_OpenNotificationStreamClient) {
+	fakeStream.RecvStub = func() (*committerpb.NotificationResponse, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+}
+
+func TestSweepExpired(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Deadline_Stamped_By_AddFinalityListener", func(t *testing.T) {
+		t.Parallel()
+		const targetTxID = "tx_production_deadline"
+		nlm, fakeStream := setupSweepTest(t)
+		blockingRecv(t.Context(), fakeStream)
+
+		runManager(t, nlm)
+
+		ml := &mockListener{}
+		ml.wg.Add(1)
+		// Register through the real API and set NO deadline by hand: the entry must
+		// expire purely because AddFinalityListener stamped it. This is what proves
+		// the leak is actually fixed in production, not just in the sweeper.
+		require.NoError(t, nlm.AddFinalityListener(targetTxID, ml))
+
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			txID, status := ml.getStatus()
+			assert.Equal(collect, targetTxID, txID)
+			assert.Equal(collect, fdriver.Unknown, status)
+		}, timeout, tick, "listener registered via AddFinalityListener must be settled by expiry")
+
+		_, exists := listenersFor(nlm, targetTxID)
+		require.False(t, exists, "expired entry must be removed from the map")
+	})
+
+	t.Run("Expired_Entry_Is_Settled_With_Unknown", func(t *testing.T) {
+		t.Parallel()
+		const targetTxID = "tx_expired"
+		nlm, fakeStream := setupSweepTest(t)
+		blockingRecv(t.Context(), fakeStream)
+
+		ml := &mockListener{}
+		ml.wg.Add(1)
+		seedHandlers(nlm, targetTxID, ml)
+		setExpiry(nlm, targetTxID, time.Now().Add(-time.Second)) // already overdue
+
+		runManager(t, nlm)
+
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			txID, status := ml.getStatus()
+			assert.Equal(collect, targetTxID, txID)
+			assert.Equal(collect, fdriver.Unknown, status,
+				"expiry reports Unknown, matching the committer's own timeout path")
+		}, timeout, tick, "timeout waiting for the sweeper to settle the listener")
+
+		_, exists := listenersFor(nlm, targetTxID)
+		require.False(t, exists, "expired entry must be removed from the map")
+	})
+
+	t.Run("Unexpired_Entry_Survives", func(t *testing.T) {
+		t.Parallel()
+		const targetTxID = "tx_not_yet_due"
+		nlm, fakeStream := setupSweepTest(t)
+		blockingRecv(t.Context(), fakeStream)
+
+		ml := &mockListener{} // no wg.Add: OnStatus must NOT be called
+		seedHandlers(nlm, targetTxID, ml)
+		setExpiry(nlm, targetTxID, time.Now().Add(time.Hour))
+
+		runManager(t, nlm)
+		time.Sleep(shortWait) // many sweep intervals
+
+		_, exists := listenersFor(nlm, targetTxID)
+		require.True(t, exists, "an entry whose deadline has not passed must not be swept")
+	})
+
+	t.Run("Zero_TTL_Disables_Expiry", func(t *testing.T) {
+		t.Parallel()
+		const targetTxID = "tx_expiry_disabled"
+		nlm, fakeStream := setupTest(t) // listenerTTL stays zero
+		nlm.sweepInterval = testSweep   // but tick fast, so the guard is what stops us
+		blockingRecv(t.Context(), fakeStream)
+
+		ml := &mockListener{} // no wg.Add: OnStatus must NOT be called
+		seedHandlers(nlm, targetTxID, ml)
+		setExpiry(nlm, targetTxID, time.Now().Add(-time.Second)) // overdue on purpose
+
+		runManager(t, nlm)
+		time.Sleep(shortWait) // many sweep intervals
+
+		_, exists := listenersFor(nlm, targetTxID)
+		require.True(t, exists, "listenerTTL == 0 must disable expiry even for an overdue entry")
+	})
+
+	t.Run("Notification_Wins_Without_Double_Invoke", func(t *testing.T) {
+		t.Parallel()
+		const targetTxID = "tx_no_double_settle"
+		nlm, fakeStream := setupSweepTest(t)
+		ctx := t.Context()
+
+		resp := &committerpb.NotificationResponse{
+			TxStatusEvents: []*committerpb.TxStatus{{
+				Ref:    &committerpb.TxRef{TxId: targetTxID},
+				Status: committerpb.Status_COMMITTED,
+			}},
+		}
+		var sent atomic.Bool
+		fakeStream.RecvStub = func() (*committerpb.NotificationResponse, error) {
+			if !sent.Swap(true) {
+				return resp, nil
+			}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+
+		// wg.Add(1) is the trap: a second OnStatus panics with "negative WaitGroup
+		// counter", which is exactly the double-settle we must never allow.
+		ml := &mockListener{}
+		ml.wg.Add(1)
+		seedHandlers(nlm, targetTxID, ml)
+		// A real deadline matters here. seedHandlers leaves expiresAt zero, and the
+		// sweeper skips zero-expiry entries, so without this the sweeper would never
+		// be a contender and the trap would be armed against nothing.
+		setExpiry(nlm, targetTxID, time.Now().Add(testTTL))
+
+		runManager(t, nlm)
+
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			_, status := ml.getStatus()
+			assert.Equal(collect, fdriver.Valid, status, "the notification should win")
+		}, timeout, tick, "timeout waiting for the notification to settle the listener")
+
+		// let several sweep intervals pass beyond the deadline
+		time.Sleep(4 * testTTL)
+
+		_, exists := listenersFor(nlm, targetTxID)
+		require.False(t, exists, "entry was removed by the notification")
 	})
 }

--- a/platform/fabricx/core/finality/nlm_test.go
+++ b/platform/fabricx/core/finality/nlm_test.go
@@ -38,18 +38,37 @@ const (
 
 // mockListener is a helper to verify callbacks
 type mockListener struct {
-	txID   string
-	status int
-	wg     sync.WaitGroup
-	lock   sync.RWMutex
+	txID    string
+	status  int
+	calls   int
+	wgCount int // how many callbacks wg is waiting for; see OnStatus
+	wg      sync.WaitGroup
+	lock    sync.RWMutex
 }
 
 func (m *mockListener) OnStatus(ctx context.Context, txID string, status int, errMsg string) {
 	m.lock.Lock()
 	m.txID = txID
 	m.status = status
+	m.calls++
+	expected := m.calls <= m.wgCount
 	m.lock.Unlock()
-	m.wg.Done()
+
+	// Only count down for callbacks the test asked to wait for. A listener still
+	// registered when listen() exits is now also settled with Unknown on teardown,
+	// and tests that never expected a callback must not see a negative WaitGroup
+	// counter for it. Assertions on txID/status/calls are unaffected.
+	if expected {
+		m.wg.Done()
+	}
+}
+
+// expect declares how many callbacks the test will wait on via wg.
+func (m *mockListener) expect(n int) {
+	m.lock.Lock()
+	m.wgCount += n
+	m.lock.Unlock()
+	m.wg.Add(n)
 }
 
 // getStatus is a helper to safely read the state for use in EventuallyWithT
@@ -228,7 +247,7 @@ func TestNotificationListenerManager(t *testing.T) {
 				ctx := t.Context()
 				// setup a mock listener expectation
 				ml := &mockListener{}
-				ml.wg.Add(1)
+				ml.expect(1)
 
 				// manually inject into the map to isolate the Receive/Dispatch logic
 				seedHandlers(nlm, tc.txID, ml)
@@ -278,7 +297,7 @@ func TestNotificationListenerManager(t *testing.T) {
 		nlm, fakeStream := setupTest(t)
 		ctx := t.Context()
 		ml := &mockListener{}
-		ml.wg.Add(1)
+		ml.expect(1)
 		seedHandlers(nlm, targetTxID, ml)
 
 		// prepare response with a TimeoutTxId
@@ -509,6 +528,54 @@ func TestNotificationListenerManager(t *testing.T) {
 		case <-time.After(timeout):
 			t.Fatal("listen() did not return after context cancellation within timeout")
 		}
+	})
+
+	t.Run("Shutdown_Settles_Pending_Listeners_With_Unknown", func(t *testing.T) {
+		t.Parallel()
+		const targetTxID = "tx_pending_at_shutdown"
+		nlm, fakeStream := setupTest(t)
+		// handlerTimeout must be non-zero here: invokeHandler derives the handler
+		// context from it, and a zero timeout would expire before OnStatus runs.
+		nlm.handlerTimeout = DefaultHandlerTimeout
+
+		ctx, cancel := context.WithCancel(context.Background())
+		fakeStream.RecvStub = func() (*committerpb.NotificationResponse, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+
+		// A delayedListener respects context cancellation, which a real listener
+		// does too. That matters here: teardown runs after the errgroup context is
+		// already cancelled, so handing listeners that context would deliver
+		// nothing. A mockListener would not notice, because it ignores ctx.
+		ml := &delayedListener{delay: tick}
+		ml.expect(1)
+		seedHandlers(nlm, targetTxID, ml)
+
+		listenErr := make(chan error, 1)
+		go func() { listenErr <- nlm.listen(ctx) }()
+		time.Sleep(shortWait)
+
+		// The stream dies with a listener still pending. Nothing can ever notify it,
+		// so teardown must settle it rather than drop it silently.
+		cancel()
+
+		select {
+		case <-listenErr:
+		case <-time.After(timeout):
+			t.Fatal("listen() did not return after context cancellation")
+		}
+
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			txID, status := ml.getStatus()
+			assert.Equal(collect, targetTxID, txID,
+				"a listener pending at teardown must still be invoked")
+			assert.Equal(collect, fdriver.Unknown, status,
+				"teardown cannot know the outcome, so it reports Unknown")
+		}, timeout, tick, "timeout waiting for OnStatus on stream teardown")
+
+		_, exists := listenersFor(nlm, targetTxID)
+		require.False(t, exists, "handlers map must be empty after teardown")
 	})
 
 	t.Run("Stream_Error_Handling", func(t *testing.T) {
@@ -751,11 +818,11 @@ func TestNotificationListenerManager(t *testing.T) {
 
 		// fastListener completes immediately
 		fastML := &mockListener{}
-		fastML.wg.Add(1)
+		fastML.expect(1)
 
 		// slowListener completes, but takes a while (still within timeout)
 		slowML := &delayedListener{delay: 100 * time.Millisecond}
-		slowML.wg.Add(1)
+		slowML.expect(1)
 
 		// stuckListener never returns (exceeds timeout)
 		stuckCalled := make(chan struct{})
@@ -838,7 +905,7 @@ func TestNotificationListenerManager(t *testing.T) {
 
 		// normalListener completes promptly
 		normalML := &mockListener{}
-		normalML.wg.Add(1)
+		normalML.expect(1)
 
 		seedHandlers(nlm, leakyTxID, leakyListener)
 		seedHandlers(nlm, normalTxID, normalML)
@@ -936,7 +1003,7 @@ func TestSweepExpired(t *testing.T) {
 		runManager(t, nlm)
 
 		ml := &mockListener{}
-		ml.wg.Add(1)
+		ml.expect(1)
 		// Register through the real API and set NO deadline by hand: the entry must
 		// expire purely because AddFinalityListener stamped it. This is what proves
 		// the leak is actually fixed in production, not just in the sweeper.
@@ -959,7 +1026,7 @@ func TestSweepExpired(t *testing.T) {
 		blockingRecv(t.Context(), fakeStream)
 
 		ml := &mockListener{}
-		ml.wg.Add(1)
+		ml.expect(1)
 		seedHandlers(nlm, targetTxID, ml)
 		setExpiry(nlm, targetTxID, time.Now().Add(-time.Second)) // already overdue
 
@@ -1035,7 +1102,7 @@ func TestSweepExpired(t *testing.T) {
 		// wg.Add(1) is the trap: a second OnStatus panics with "negative WaitGroup
 		// counter", which is exactly the double-settle we must never allow.
 		ml := &mockListener{}
-		ml.wg.Add(1)
+		ml.expect(1)
 		seedHandlers(nlm, targetTxID, ml)
 		// A real deadline matters here. seedHandlers leaves expiresAt zero, and the
 		// sweeper skips zero-expiry entries, so without this the sweeper would never

--- a/platform/fabricx/core/finality/provider.go
+++ b/platform/fabricx/core/finality/provider.go
@@ -148,8 +148,10 @@ func newNotifiWithGRPC(network string, grpcClientProvider GRPCClientProvider) (*
 		notifyClient:   notifyClient,
 		requestQueue:   make(chan *committerpb.NotificationRequest),  // Queue for outgoing requests to the committer
 		responseQueue:  make(chan *committerpb.NotificationResponse), // Queue for incoming responses/notifications
-		handlers:       make(map[string][]fabric.FinalityListener),   // Map: txID -> list of listeners
+		handlers:       make(map[driver.TxID]*handlerEntry),          // Map: txID -> listeners + local expiry deadline
 		handlerTimeout: DefaultHandlerTimeout,
+		listenerTTL:    DefaultListenerTTL,
+		sweepInterval:  DefaultSweepInterval,
 	}
 
 	return nlm, nil

--- a/platform/fabricx/core/finality/provider.go
+++ b/platform/fabricx/core/finality/provider.go
@@ -144,6 +144,11 @@ func newNotifiWithGRPC(network string, grpcClientProvider GRPCClientProvider) (*
 	// Create the gRPC client stub for the Notifier service
 	notifyClient := committerpb.NewNotifierClient(cc)
 
+	// TODO: make handlerTimeout, listenerTTL and sweepInterval configurable via
+	// core.yaml rather than hardcoding the defaults here. Provider already carries
+	// a ServiceConfigProvider, and committer/config.Config would be the natural
+	// home for the fields; newNotifiWithGRPC would then take the resolved config.
+	// Tracked in #1641.
 	nlm := &notificationListenerManager{
 		notifyClient:   notifyClient,
 		requestQueue:   make(chan *committerpb.NotificationRequest),  // Queue for outgoing requests to the committer

--- a/platform/fabricx/core/finality/provider_test.go
+++ b/platform/fabricx/core/finality/provider_test.go
@@ -19,7 +19,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	mock2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/finality/mock"
 )
 
@@ -66,7 +66,7 @@ func setupMockNotificationManager(t *testing.T, streamBehavior func(context.Cont
 		notifyClient:  fakeClient,
 		requestQueue:  make(chan *committerpb.NotificationRequest),
 		responseQueue: make(chan *committerpb.NotificationResponse),
-		handlers:      make(map[string][]fabric.FinalityListener),
+		handlers:      make(map[driver.TxID]*handlerEntry),
 	}
 
 	return nlm


### PR DESCRIPTION
Fixes #1626.

`notificationListenerManager.handlers` only shrank when a notification arrived
from the committer. The contract says the framework removes a listener once it
fires, so callers correctly never unregister — if the notification never comes,
nothing cleans up and the entry keeps the caller's listener closure alive. The
10s `Timeout` on the outbound request isn't a safety net: it asks the
*committer* to give up and reply, over the same stream whose silence is the
problem.

- **Reject an empty txID.** It can never appear in a notification, so its entry
  was unremovable. The generic driver already rejects this; the message now
  matches.
- **Expire stale listeners locally.** Entries carry a deadline and are settled
  with `Unknown` once it passes — the same outcome the committer's own
  `TimeoutTxIds` path produces. Defaults: TTL 2m, sweep 30s.
- **Assert the empty-txID guard against a live committer** in the simple
  integration test.