### PR TITLE
fix(comm): decouple websocket client stream lifetime from per-call context

### DIFF
--- a/integration/fsc/pingpong/README.md
+++ b/integration/fsc/pingpong/README.md
@@ -29,45 +29,114 @@ This is view describing Alice's behaviour:
 package pingpong
 
 import (
-  "fmt"
+  "context"
   "time"
 
   "github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
-
-  view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
-  "github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/assert"
+  "github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
+  "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/id"
+  view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/view"
   "github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
-type Initiator struct{}
+var logger = logging.MustGetLogger()
 
-func (p *Initiator) Call(viewCtx view.Context) (any, error) {
-  // Retrieve responder identity
-  responder := view2.GetIdentityProvider(viewCtx).Identity("responder")
+const (
+  pingMessage     = "ping"
+  pongMessage     = "pong"
+  finishedMessage = "finished"
 
-  // Open a session to the responder
-  session, err := viewCtx.GetSession(viewCtx.Initiator(), responder)
-  assert.NoError(err)
-  // Send a ping
-  err = session.Send([]byte("ping"))
-  assert.NoError(err)
-  // Wait for the pong
+  // DefaultRounds is the number of ping/pong rounds run when Params.Rounds is not set.
+  DefaultRounds = 3
+
+  // roundTimeout bounds a single round end to end: session lookup (which may have to open a
+  // new stream), send, and wait for the peer's answer.
+  roundTimeout = 1 * time.Minute
+)
+
+// Params is the input of the Initiator view.
+type Params struct {
+  // Rounds is the number of ping/pong rounds to run; values <= 0 select DefaultRounds.
+  Rounds int `json:"rounds,omitempty"`
+}
+
+// PingView sends a single ping and waits for the pong over the context's session.
+type PingView struct {
+  responder view.Identity
+}
+
+func (p *PingView) Call(viewCtx view.Context) (any, error) {
+  session, err := viewCtx.GetSession(viewCtx.Initiator(), p.responder)
+  if err != nil {
+    return nil, errors.Wrapf(err, "failed getting session to [%s]", p.responder)
+  }
+
+  if err := session.SendWithContext(viewCtx.Context(), []byte(pingMessage)); err != nil {
+    return nil, errors.Wrapf(err, "failed to send %s", pingMessage)
+  }
+
   ch := session.Receive()
   select {
-  case msg := <-ch:
+  case msg, ok := <-ch:
+    if !ok {
+      return nil, errors.Errorf("session [%s] closed while waiting for %s", session.Info().ID, pongMessage)
+    }
     if msg.Status == view.ERROR {
       return nil, errors.New(string(msg.Payload))
     }
-    m := string(msg.Payload)
-    if m != "pong" {
-      return nil, errors.Errorf("expected pong, got %s", m)
+    if m := string(msg.Payload); m != pongMessage {
+      return nil, errors.Errorf("expected %s, got %s", pongMessage, m)
     }
-  case <-time.After(1 * time.Minute):
-    return nil, errors.New("responder didn't pong in time")
+  case <-viewCtx.Context().Done():
+    return nil, errors.Wrapf(viewCtx.Context().Err(), "no %s received in time", pongMessage)
   }
 
-  // Return
+  return nil, nil
+}
+
+// runRound runs v in a context of its own, bounded by roundTimeout and cancelled as soon as the
+// round is over, so that a stale round's cancellation can never affect a later one that happens
+// to reuse the same cached stream.
+func runRound(viewCtx view.Context, v view.View) (any, error) {
+  ctx, cancel := context.WithTimeout(viewCtx.Context(), roundTimeout)
+  defer cancel()
+
+  return view2.WrapContext(viewCtx, ctx).RunView(v)
+}
+
+func ping(viewCtx view.Context, responder view.Identity) (any, error) {
+  return runRound(viewCtx, &PingView{responder: responder})
+}
+
+// Initiator runs Rounds (or DefaultRounds, if Rounds is unset) ping/pong rounds against the
+// responder identity, then tells the responder the protocol is over.
+type Initiator struct {
+  Params
+}
+
+func (p *Initiator) Call(viewCtx view.Context) (any, error) {
+  identityProvider, err := id.GetProvider(viewCtx)
+  if err != nil {
+    return nil, errors.Wrap(err, "failed getting identity provider")
+  }
+  responder := identityProvider.Identity("responder")
+
+  rounds := p.rounds()
+  for round := range rounds {
+    if _, err := ping(viewCtx, responder); err != nil {
+      return nil, errors.Wrapf(err, "ping round [%d/%d] failed", round+1, rounds)
+    }
+  }
+  // Tell the responder the protocol is over (omitted here, see FinishedView)
+
   return "OK", nil
+}
+
+func (p *Initiator) rounds() int {
+  if p.Rounds <= 0 {
+    return DefaultRounds
+  }
+  return p.Rounds
 }
 ```
 
@@ -77,14 +146,22 @@ Let us go through the main steps:
   This can be done by using the identity service.
   If you are asking yourself: Where is defined the responder's identity?
   It is in the initiator's configuration file. More information in this [Section](#FSC node's Configuration File).
-- **Open a session to the responder**: With the responder's identity, the initiator
-  can open a session.
-  The context allows the initiator to do that.
+- **Run `Rounds` ping/pong rounds**: `Initiator.Call` loops `Rounds` times (`DefaultRounds`, i.e. 3, if
+  unset), running a `PingView` in each round. Each round gets its own context, bounded by
+  `roundTimeout` and cancelled as soon as the round is over. This matters because sessions (and,
+  underneath, the streams/sub-connections that back them) are cached and reused across rounds:
+  deriving each round's context from the caller's context and cancelling it at the end of the
+  round would otherwise tear down a stream that a later round still needs.
+- **Open a session to the responder**: Inside `PingView.Call`, with the responder's identity, the
+  initiator opens a session. The context allows the initiator to do that.
 - **Send a ping**: Using the established session, the sender sends her ping.
 - **Wait for the pong**: At this point, the responder waits for the reply.
-  The initiator timeouts if no message comes in a reasonable amount of time.
+  The round's context is done if no message comes in `roundTimeout`.
   If a reply comes, the initiator checks that it contains a pong.
   If this is not the case, the view returns an error.
+- **Signal the end of the protocol**: Once all rounds are done, the initiator runs a
+  `FinishedView` (not shown above) that sends a `finished` message, so the responder knows to
+  stop waiting for another ping instead of timing out.
 
 Let us now look at the view describing the view of the responder:
 
@@ -92,58 +169,83 @@ Let us now look at the view describing the view of the responder:
 package pingpong
 
 import (
-  "errors"
-  "fmt"
-  "time"
-
-  "github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/assert"
+  "github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
   "github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
+// PongView waits for a single message and, depending on what it is, either answers with a pong
+// (and reports it as having handled a ping) or reports that the protocol is over. It returns the
+// message it handled, leaving the decision on whether to keep going to the caller.
+type PongView struct {
+  session view.Session
+}
+
+func (p *PongView) Call(viewCtx view.Context) (any, error) {
+  ch := p.session.Receive()
+
+  var payload []byte
+  select {
+  case msg, ok := <-ch:
+    if !ok {
+      return nil, errors.Errorf("session [%s] closed while waiting for the next message", p.session.Info().ID)
+    }
+    if msg.Status == view.ERROR {
+      return nil, errors.Errorf("initiator failed: %s", string(msg.Payload))
+    }
+    payload = msg.Payload
+  case <-viewCtx.Context().Done():
+    return nil, errors.Wrap(viewCtx.Context().Err(), "no message received in time")
+  }
+
+  switch m := string(payload); m {
+  case pingMessage:
+    if err := p.session.SendWithContext(viewCtx.Context(), []byte(pongMessage)); err != nil {
+      return nil, errors.Wrapf(err, "failed to send %s", pongMessage)
+    }
+    return m, nil
+  case finishedMessage:
+    return m, nil
+  default:
+    sendErr := p.session.SendErrorWithContext(viewCtx.Context(), []byte("expected ping or finished, got "+m))
+    return nil, errors.Join(errors.Errorf("expected %s or %s, got %s", pingMessage, finishedMessage, m), sendErr)
+  }
+}
+
+// Responder answers pings with pongs until the initiator signals that the protocol is over.
 type Responder struct{}
 
 func (p *Responder) Call(viewCtx view.Context) (any, error) {
-  // Retrieve the session opened by the initiator
   session := viewCtx.Session()
-
-  // Read the message from the initiator
-  ch := session.Receive()
-  var payload []byte
-  select {
-  case msg := <-ch:
-    payload = msg.Payload
-  case <-time.After(5 * time.Second):
-    return nil, errors.New("time out reached")
+  if session == nil {
+    return nil, errors.New("no default session, the responder must be invoked by an initiator")
   }
 
-  // Respond with a pong if a ping is received, an error otherwise
-  m := string(payload)
-  switch {
-  case m != "ping":
-    // reply with an error
-    err := session.SendError([]byte(fmt.Sprintf("expected ping, got %s", m)))
-    assert.NoError(err)
-    return nil, errors.Errorf("expected ping, got %s", m)
-  default:
-    // reply with pong
-    err := session.Send([]byte("pong"))
-    assert.NoError(err)
+  for round := 0; ; round++ {
+    m, err := pong(viewCtx, session)
+    if err != nil {
+      return nil, errors.Wrapf(err, "pong round [%d] failed", round+1)
+    }
+    if m == finishedMessage {
+      return "OK", nil
+    }
   }
-
-  // Return
-  return "OK", nil
 }
 ```
 
-These are the  main steps carried on by the responder:
+These are the main steps carried on by the responder:
 - **Retrieve the session opened by the initiator**: The responder expects to
   be invoked upon the reception of a message transmitted using a session.
   The responder can access his endpoint of this session via the context.
-- **Read the message from the initiator**: The responder reads the message, the initiator sent, from
-  the session.
-- **Respond with a pong if a ping is received, an error otherwise**:
-  If the received message is a ping, then the responder replies with a pong.
-  Otherwise, the responder replies with an error.
+- **Loop until the initiator signals the end of the protocol**: `Responder.Call` keeps running
+  `PongView` rounds (each bounded by its own `roundTimeout`, via the same `runRound` helper used
+  by the initiator) until one of them reports the `finished` message, mirroring the initiator's
+  round structure.
+- **Read the message from the initiator**: Inside `PongView.Call`, the responder reads the next
+  message from the session.
+- **Respond with a pong if a ping is received, report completion if finished, an error
+  otherwise**: If the received message is a ping, the responder replies with a pong and reports
+  it handled a ping, so the caller keeps looping. If it is `finished`, it reports that value so
+  the caller stops looping. Otherwise, the responder replies with an error and returns it.
 
 ## View Management
 
@@ -160,16 +262,30 @@ Here is the View Factory for the initiator's View.
 ```go
 package pingpong
 
-import "github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+import (
+  "encoding/json"
+
+  "github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+  "github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
 
 // InitiatorViewFactory is the factory of Initiator views
 type InitiatorViewFactory struct{}
 
 // NewView returns a new instance of the Initiator view
 func (i *InitiatorViewFactory) NewView(in []byte) (view.View, error) {
-  return &Initiator{}, nil
+  initiator := &Initiator{}
+  if len(in) > 0 {
+    if err := json.Unmarshal(in, &initiator.Params); err != nil {
+      return nil, errors.Wrapf(err, "failed unmarshalling input [%s]", string(in))
+    }
+  }
+  return initiator, nil
 }
 ```
+The optional input, if any, is unmarshalled into `Initiator.Params`, so a caller can, for
+example, run the protocol for a specific number of rounds by passing `{"rounds": 5}` as input.
+
 To answer the second question, we need a way to tell the FSC node which view to execute
 in response to a first message from an incoming session opened by a remote party.
 

--- a/integration/fsc/pingpong/factory.go
+++ b/integration/fsc/pingpong/factory.go
@@ -6,12 +6,23 @@ SPDX-License-Identifier: Apache-2.0
 
 package pingpong
 
-import "github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+import (
+	"encoding/json"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
 
 // InitiatorViewFactory is the factory of Initiator views
 type InitiatorViewFactory struct{}
 
 // NewView returns a new instance of the Initiator view
 func (i *InitiatorViewFactory) NewView(in []byte) (view.View, error) {
-	return &Initiator{}, nil
+	initiator := &Initiator{}
+	if len(in) > 0 {
+		if err := json.Unmarshal(in, &initiator.Params); err != nil {
+			return nil, errors.Wrapf(err, "failed unmarshalling input [%s]", string(in))
+		}
+	}
+	return initiator, nil
 }

--- a/integration/fsc/pingpong/fake/factory.go
+++ b/integration/fsc/pingpong/fake/factory.go
@@ -9,7 +9,7 @@ package fake
 import (
 	"encoding/json"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/assert"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
@@ -18,8 +18,11 @@ type InitiatorViewFactory struct{}
 
 // NewView returns a new instance of the Initiator view
 func (i *InitiatorViewFactory) NewView(in []byte) (view.View, error) {
-	f := &Initiator{Params: &Params{}}
-	err := json.Unmarshal(in, f.Params)
-	assert.NoError(err, "failed unmarshalling input")
-	return f, nil
+	initiator := &Initiator{Params: &Params{}}
+	if len(in) > 0 {
+		if err := json.Unmarshal(in, initiator.Params); err != nil {
+			return nil, errors.Wrapf(err, "failed unmarshalling input [%s]", string(in))
+		}
+	}
+	return initiator, nil
 }

--- a/integration/fsc/pingpong/fake/initiator.go
+++ b/integration/fsc/pingpong/fake/initiator.go
@@ -7,18 +7,31 @@ SPDX-License-Identifier: Apache-2.0
 package fake
 
 import (
+	"context"
 	"time"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/id"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
+const (
+	pingMessage     = "ping"
+	mockPongMessage = "mock pong"
+
+	// initiatorTimeout bounds how long the initiator waits for the mock pong.
+	initiatorTimeout = 1 * time.Minute
+	// responderTimeout bounds how long the responder waits for the ping.
+	responderTimeout = 5 * time.Second
+)
+
+// Params is the input of the Initiator view.
 type Params struct {
 	Mock bool
 }
 
+// Initiator sends a single ping and waits for a pong. When Mock is set, the pong is produced
+// locally by a Responder run through a DelegatedContext instead of a real remote session.
 type Initiator struct {
 	*Params
 }
@@ -26,8 +39,11 @@ type Initiator struct {
 func (p *Initiator) Call(viewCtx view.Context) (any, error) {
 	// Retrieve responder identity
 	identityProvider, err := id.GetProvider(viewCtx)
-	assert.NoError(err, "failed getting identity provider")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed getting identity provider")
+	}
 	responder := identityProvider.Identity("responder")
+
 	var anotherViewCtx view.Context
 	if p.Mock {
 		c := &DelegatedContext{ViewCtx: viewCtx}
@@ -39,22 +55,33 @@ func (p *Initiator) Call(viewCtx view.Context) (any, error) {
 
 	// Open a session to the responder
 	session, err := anotherViewCtx.GetSession(anotherViewCtx.Initiator(), responder)
-	assert.NoError(err) // Send a ping
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed getting session to [%s]", responder)
+	}
 
-	err = session.Send([]byte("ping"))
-	assert.NoError(err) // Wait for the pong
+	ctx, cancel := context.WithTimeout(viewCtx.Context(), initiatorTimeout)
+	defer cancel()
+
+	// Send a ping
+	if err := session.SendWithContext(ctx, []byte(pingMessage)); err != nil {
+		return nil, errors.Wrapf(err, "failed to send %s", pingMessage)
+	}
+
+	// Wait for the pong
 	ch := session.Receive()
 	select {
-	case msg := <-ch:
+	case msg, ok := <-ch:
+		if !ok {
+			return nil, errors.Errorf("session [%s] closed while waiting for %s", session.Info().ID, mockPongMessage)
+		}
 		if msg.Status == view.ERROR {
 			return nil, errors.New(string(msg.Payload))
 		}
-		m := string(msg.Payload)
-		if m != "mock pong" {
-			return nil, errors.Errorf("expected mock pong, got %s", m)
+		if m := string(msg.Payload); m != mockPongMessage {
+			return nil, errors.Errorf("expected %s, got %s", mockPongMessage, m)
 		}
-	case <-time.After(1 * time.Minute):
-		return nil, errors.New("responder didn't pong in time")
+	case <-ctx.Done():
+		return nil, errors.Wrapf(ctx.Err(), "no %s received in time", mockPongMessage)
 	}
 
 	// Return

--- a/integration/fsc/pingpong/fake/responder.go
+++ b/integration/fsc/pingpong/fake/responder.go
@@ -7,41 +7,46 @@ SPDX-License-Identifier: Apache-2.0
 package fake
 
 import (
+	"context"
 	"fmt"
-	"time"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
+// Responder answers a single ping with a mock pong.
 type Responder struct{}
 
 func (p *Responder) Call(viewCtx view.Context) (any, error) {
 	// Retrieve the session opened by the initiator
 	session := viewCtx.Session()
 
+	ctx, cancel := context.WithTimeout(viewCtx.Context(), responderTimeout)
+	defer cancel()
+
 	// Read the message from the initiator
 	ch := session.Receive()
 	var payload []byte
 	select {
-	case msg := <-ch:
+	case msg, ok := <-ch:
+		if !ok {
+			return nil, errors.Errorf("session [%s] closed while waiting for %s", session.Info().ID, pingMessage)
+		}
 		payload = msg.Payload
-	case <-time.After(5 * time.Second):
-		return nil, errors.New("time out reached")
+	case <-ctx.Done():
+		return nil, errors.Wrap(ctx.Err(), "time out reached")
 	}
-	// Respond with a pong if a ping is received, an error otherwise
-	m := string(payload)
-	switch {
-	case m != "ping":
+
+	// Respond with a mock pong if a ping is received, an error otherwise
+	if m := string(payload); m != pingMessage {
 		// reply with an error
-		err := session.SendError(fmt.Appendf(nil, "expected ping, got %s", m))
-		assert.NoError(err)
-		return nil, errors.Errorf("expected ping, got %s", m)
-	default:
-		// reply with pong
-		err := session.Send([]byte("mock pong"))
-		assert.NoError(err)
+		sendErr := session.SendErrorWithContext(ctx, fmt.Appendf(nil, "expected %s, got %s", pingMessage, m))
+		return nil, errors.Join(errors.Errorf("expected %s, got %s", pingMessage, m), sendErr)
+	}
+
+	// reply with a mock pong
+	if err := session.SendWithContext(ctx, []byte(mockPongMessage)); err != nil {
+		return nil, errors.Wrapf(err, "failed to send %s", mockPongMessage)
 	}
 
 	// Return

--- a/integration/fsc/pingpong/initiator.go
+++ b/integration/fsc/pingpong/initiator.go
@@ -12,13 +12,32 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/id"
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
 var logger = logging.MustGetLogger()
+
+const (
+	pingMessage     = "ping"
+	pongMessage     = "pong"
+	finishedMessage = "finished"
+
+	// DefaultRounds is the number of ping/pong rounds run when Params.Rounds is not set.
+	DefaultRounds = 3
+
+	// roundTimeout bounds a single round end to end: session lookup (which may have to open a
+	// new stream), send, and wait for the peer's answer. Initiator and responder use the same
+	// value, so that neither gives up on the other prematurely.
+	roundTimeout = 1 * time.Minute
+)
+
+// Params is the input of the Initiator view.
+type Params struct {
+	// Rounds is the number of ping/pong rounds to run; values <= 0 select DefaultRounds.
+	Rounds int `json:"rounds,omitempty"`
+}
 
 // PingView sends a single ping and waits for the pong over the context's session.
 type PingView struct {
@@ -27,60 +46,104 @@ type PingView struct {
 
 func (p *PingView) Call(viewCtx view.Context) (any, error) {
 	session, err := viewCtx.GetSession(viewCtx.Initiator(), p.responder)
-	assert.NoError(err)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed getting session to [%s]", p.responder)
+	}
 
-	logger.Infof("send ping")
-
-	if err := session.SendWithContext(viewCtx.Context(), []byte("ping")); err != nil {
-		return nil, errors.Wrap(err, "failed to send ping")
+	logger.DebugfContext(viewCtx.Context(), "send %s", pingMessage)
+	if err := session.SendWithContext(viewCtx.Context(), []byte(pingMessage)); err != nil {
+		return nil, errors.Wrapf(err, "failed to send %s", pingMessage)
 	}
 
 	ch := session.Receive()
 	select {
-	case msg := <-ch:
+	case msg, ok := <-ch:
+		if !ok {
+			return nil, errors.Errorf("session [%s] closed while waiting for %s", session.Info().ID, pongMessage)
+		}
 		if msg.Status == view.ERROR {
 			return nil, errors.New(string(msg.Payload))
 		}
-		if m := string(msg.Payload); m != "pong" {
-			return nil, errors.Errorf("expected pong, got %s", m)
+		if m := string(msg.Payload); m != pongMessage {
+			return nil, errors.Errorf("expected %s, got %s", pongMessage, m)
 		}
-		logger.Infof("pong received")
+		logger.DebugfContext(viewCtx.Context(), "%s received", pongMessage)
 	case <-viewCtx.Context().Done():
-		return nil, errors.Errorf("expected ping, got %s", viewCtx.Context().Err())
-	case <-time.After(1 * time.Minute):
-		return nil, errors.New("responder didn't pong in time")
+		return nil, errors.Wrapf(viewCtx.Context().Err(), "no %s received in time", pongMessage)
 	}
 
 	return nil, nil
 }
 
-func ping(viewCtx view.Context, responder view.Identity) (any, error) {
-	ctx, cancel := context.WithTimeout(viewCtx.Context(), 10*time.Minute)
-	runCtx := view2.WrapContext(viewCtx, ctx)
-	defer func() {
-		logger.Infof("call cancel on view context [%s:%s]", runCtx.ID(), viewCtx.ID())
-		cancel()
-	}()
-
-	return runCtx.RunView(&PingView{
-		responder: responder,
-	})
+// FinishedView tells the responder that the initiator is done. Closing a session is a local
+// operation only and puts nothing on the wire, so without this message the responder would
+// keep waiting for the next ping.
+type FinishedView struct {
+	responder view.Identity
 }
 
-type Initiator struct{}
-
-func (p *Initiator) Call(viewCtx view.Context) (any, error) {
-	// Retrieve responder identity
-	identityProvider, err := id.GetProvider(viewCtx)
-	assert.NoError(err, "failed getting identity provider")
-	responder := identityProvider.Identity("responder")
-
-	// Open a session to the responder
-	for range 3 {
-		_, err = ping(viewCtx, responder)
-		assert.NoError(err, "ping round failed")
+func (f *FinishedView) Call(viewCtx view.Context) (any, error) {
+	session, err := viewCtx.GetSession(viewCtx.Initiator(), f.responder)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed getting session to [%s]", f.responder)
 	}
 
-	// Return
+	logger.DebugfContext(viewCtx.Context(), "send %s", finishedMessage)
+	if err := session.SendWithContext(viewCtx.Context(), []byte(finishedMessage)); err != nil {
+		return nil, errors.Wrapf(err, "failed to send %s", finishedMessage)
+	}
+	return nil, nil
+}
+
+// runRound runs v in a context of its own, bounded by roundTimeout and cancelled as soon as the
+// round is over. Every round gets a fresh, short-lived context so that a stale round's
+// cancellation can never affect a later one that happens to reuse the same cached stream; see
+// the regression tests in platform/view/services/comm/host/websocket/ws/context_detachment_test.go.
+func runRound(viewCtx view.Context, v view.View) (any, error) {
+	ctx, cancel := context.WithTimeout(viewCtx.Context(), roundTimeout)
+	defer cancel()
+
+	return view2.WrapContext(viewCtx, ctx).RunView(v)
+}
+
+func ping(viewCtx view.Context, responder view.Identity) (any, error) {
+	return runRound(viewCtx, &PingView{responder: responder})
+}
+
+func finish(viewCtx view.Context, responder view.Identity) (any, error) {
+	return runRound(viewCtx, &FinishedView{responder: responder})
+}
+
+// Initiator runs Rounds (or DefaultRounds, if Rounds is unset) ping/pong rounds against the
+// responder identity, then tells the responder the protocol is over.
+type Initiator struct {
+	Params
+}
+
+func (p *Initiator) Call(viewCtx view.Context) (any, error) {
+	identityProvider, err := id.GetProvider(viewCtx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed getting identity provider")
+	}
+	responder := identityProvider.Identity("responder")
+
+	rounds := p.rounds()
+	logger.DebugfContext(viewCtx.Context(), "ping pong with [%s] over [%d] rounds", responder, rounds)
+	for round := range rounds {
+		if _, err := ping(viewCtx, responder); err != nil {
+			return nil, errors.Wrapf(err, "ping round [%d/%d] failed", round+1, rounds)
+		}
+	}
+	if _, err := finish(viewCtx, responder); err != nil {
+		return nil, errors.Wrapf(err, "failed signalling the end of the protocol after [%d] rounds", rounds)
+	}
+
 	return "OK", nil
+}
+
+func (p *Initiator) rounds() int {
+	if p.Rounds <= 0 {
+		return DefaultRounds
+	}
+	return p.Rounds
 }

--- a/integration/fsc/pingpong/initiator.go
+++ b/integration/fsc/pingpong/initiator.go
@@ -23,13 +23,11 @@ var logger = logging.MustGetLogger()
 // PingView sends a single ping and waits for the pong over the context's session.
 type PingView struct {
 	responder view.Identity
-	session   view.Session
 }
 
 func (p *PingView) Call(viewCtx view.Context) (any, error) {
-	// session, err := viewCtx.GetSession(viewCtx.Initiator(), p.responder)
-	// assert.NoError(err)
-	session := p.session
+	session, err := viewCtx.GetSession(viewCtx.Initiator(), p.responder)
+	assert.NoError(err)
 
 	logger.Infof("send ping")
 
@@ -57,9 +55,6 @@ func (p *PingView) Call(viewCtx view.Context) (any, error) {
 }
 
 func ping(viewCtx view.Context, responder view.Identity) (any, error) {
-	session, err := viewCtx.GetSession(viewCtx.Initiator(), responder)
-	assert.NoError(err)
-
 	ctx, cancel := context.WithTimeout(viewCtx.Context(), 10*time.Minute)
 	runCtx := view2.WrapContext(viewCtx, ctx)
 	defer func() {
@@ -69,7 +64,6 @@ func ping(viewCtx view.Context, responder view.Identity) (any, error) {
 
 	return runCtx.RunView(&PingView{
 		responder: responder,
-		session:   session,
 	})
 }
 

--- a/integration/fsc/pingpong/initiator.go
+++ b/integration/fsc/pingpong/initiator.go
@@ -7,13 +7,71 @@ SPDX-License-Identifier: Apache-2.0
 package pingpong
 
 import (
+	"context"
 	"time"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/id"
+	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
+
+var logger = logging.MustGetLogger()
+
+// PingView sends a single ping and waits for the pong over the context's session.
+type PingView struct {
+	responder view.Identity
+	session   view.Session
+}
+
+func (p *PingView) Call(viewCtx view.Context) (any, error) {
+	// session, err := viewCtx.GetSession(viewCtx.Initiator(), p.responder)
+	// assert.NoError(err)
+	session := p.session
+
+	logger.Infof("send ping")
+
+	if err := session.SendWithContext(viewCtx.Context(), []byte("ping")); err != nil {
+		return nil, errors.Wrap(err, "failed to send ping")
+	}
+
+	ch := session.Receive()
+	select {
+	case msg := <-ch:
+		if msg.Status == view.ERROR {
+			return nil, errors.New(string(msg.Payload))
+		}
+		if m := string(msg.Payload); m != "pong" {
+			return nil, errors.Errorf("expected pong, got %s", m)
+		}
+		logger.Infof("pong received")
+	case <-viewCtx.Context().Done():
+		return nil, errors.Errorf("expected ping, got %s", viewCtx.Context().Err())
+	case <-time.After(1 * time.Minute):
+		return nil, errors.New("responder didn't pong in time")
+	}
+
+	return nil, nil
+}
+
+func ping(viewCtx view.Context, responder view.Identity) (any, error) {
+	session, err := viewCtx.GetSession(viewCtx.Initiator(), responder)
+	assert.NoError(err)
+
+	ctx, cancel := context.WithTimeout(viewCtx.Context(), 10*time.Minute)
+	runCtx := view2.WrapContext(viewCtx, ctx)
+	defer func() {
+		logger.Infof("call cancel on view context [%s:%s]", runCtx.ID(), viewCtx.ID())
+		cancel()
+	}()
+
+	return runCtx.RunView(&PingView{
+		responder: responder,
+		session:   session,
+	})
+}
 
 type Initiator struct{}
 
@@ -24,23 +82,9 @@ func (p *Initiator) Call(viewCtx view.Context) (any, error) {
 	responder := identityProvider.Identity("responder")
 
 	// Open a session to the responder
-	session, err := viewCtx.GetSession(viewCtx.Initiator(), responder)
-	assert.NoError(err) // Send a ping
-
-	err = session.Send([]byte("ping"))
-	assert.NoError(err) // Wait for the pong
-	ch := session.Receive()
-	select {
-	case msg := <-ch:
-		if msg.Status == view.ERROR {
-			return nil, errors.New(string(msg.Payload))
-		}
-		m := string(msg.Payload)
-		if m != "pong" {
-			return nil, errors.Errorf("expected pong, got %s", m)
-		}
-	case <-time.After(1 * time.Minute):
-		return nil, errors.New("responder didn't pong in time")
+	for range 3 {
+		_, err = ping(viewCtx, responder)
+		assert.NoError(err, "ping round failed")
 	}
 
 	// Return

--- a/integration/fsc/pingpong/pingpong_test.go
+++ b/integration/fsc/pingpong/pingpong_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package pingpong_test
 
 import (
-	"bytes"
 	"fmt"
 	"strings"
 	"time"
@@ -67,14 +66,14 @@ var _ = Describe("EndToEnd", func() {
 			Expect(err).NotTo(HaveOccurred())
 			initiatorWebClient, err := client2.NewClient(webClientConfig)
 			Expect(err).NotTo(HaveOccurred())
-			res, err := initiatorWebClient.CallView("init", bytes.NewBuffer([]byte("hi")).Bytes())
+			res, err := initiatorWebClient.CallView("init", common.JSONMarshall(&pingpong.Params{Rounds: 5}))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(common.JSONUnmarshalString(res)).To(BeEquivalentTo("OK"))
 
 			webClientConfig.TLSCertPath = ""
 			initiatorWebClient, err = client2.NewClient(webClientConfig)
 			Expect(err).NotTo(HaveOccurred())
-			_, err = initiatorWebClient.CallView("init", bytes.NewBuffer([]byte("hi")).Bytes())
+			_, err = initiatorWebClient.CallView("init", common.JSONMarshall(&pingpong.Params{Rounds: 5}))
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("status code [401], status [401 Unauthorized]"))
 		})

--- a/integration/fsc/pingpong/responder.go
+++ b/integration/fsc/pingpong/responder.go
@@ -7,19 +7,23 @@ SPDX-License-Identifier: Apache-2.0
 package pingpong
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/assert"
+	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
-type Responder struct{}
+// PongView waits for a single ping and answers with a pong over the context's session.
+type PongView struct {
+	session view.Session
+}
 
-func (p *Responder) Call(viewCtx view.Context) (any, error) {
-	// Retrieve the session opened by the initiator
-	session := viewCtx.Session()
+func (p *PongView) Call(viewCtx view.Context) (any, error) {
+	session := p.session
 
 	// Read the message from the initiator
 	ch := session.Receive()
@@ -27,21 +31,52 @@ func (p *Responder) Call(viewCtx view.Context) (any, error) {
 	select {
 	case msg := <-ch:
 		payload = msg.Payload
+	case <-viewCtx.Context().Done():
+		return nil, viewCtx.Context().Err()
 	case <-time.After(5 * time.Second):
 		return nil, errors.New("time out reached")
 	}
+
 	// Respond with a pong if a ping is received, an error otherwise
 	m := string(payload)
-	switch {
-	case m != "ping":
+	if m != "ping" {
 		// reply with an error
-		err := session.SendError(fmt.Appendf(nil, "expected ping, got %s", m))
+		err := session.SendErrorWithContext(viewCtx.Context(), fmt.Appendf(nil, "expected ping, got %s", m))
 		assert.NoError(err)
 		return nil, errors.Errorf("expected ping, got %s", m)
-	default:
-		// reply with pong
-		err := session.Send([]byte("pong"))
-		assert.NoError(err)
+	}
+
+	logger.Infof("ping received, send pong...")
+	// reply with pong
+	err := session.SendWithContext(viewCtx.Context(), []byte("pong"))
+	assert.NoError(err)
+
+	return nil, nil
+}
+
+func pong(viewCtx view.Context, session view.Session) (any, error) {
+	ctx, cancel := context.WithTimeout(viewCtx.Context(), 10*time.Minute)
+	runCtx := view2.WrapContext(viewCtx, ctx)
+	defer func() {
+		logger.Infof("call cancel on view context [%s:%s]", runCtx.ID(), viewCtx.ID())
+		cancel()
+	}()
+
+	return runCtx.RunView(&PongView{
+		session: session,
+	})
+}
+
+type Responder struct{}
+
+func (p *Responder) Call(viewCtx view.Context) (any, error) {
+	// Retrieve the session opened by the initiator
+	session := viewCtx.Session()
+
+	for range 3 {
+		if _, err := pong(viewCtx, session); err != nil {
+			return nil, err
+		}
 	}
 
 	// Return

--- a/integration/fsc/pingpong/responder.go
+++ b/integration/fsc/pingpong/responder.go
@@ -7,78 +7,81 @@ SPDX-License-Identifier: Apache-2.0
 package pingpong
 
 import (
-	"context"
 	"fmt"
-	"time"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/assert"
-	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
-// PongView waits for a single ping and answers with a pong over the context's session.
+// PongView waits for a single message and, depending on what it is, either answers with a pong
+// (and reports it as having handled a ping) or reports that the protocol is over. It returns the
+// message it handled, leaving the decision on whether to keep going to the caller.
 type PongView struct {
 	session view.Session
 }
 
 func (p *PongView) Call(viewCtx view.Context) (any, error) {
-	session := p.session
+	ch := p.session.Receive()
 
-	// Read the message from the initiator
-	ch := session.Receive()
 	var payload []byte
 	select {
-	case msg := <-ch:
+	case msg, ok := <-ch:
+		if !ok {
+			return nil, errors.Errorf("session [%s] closed while waiting for the next message", p.session.Info().ID)
+		}
+		if msg.Status == view.ERROR {
+			return nil, errors.Errorf("initiator failed: %s", string(msg.Payload))
+		}
 		payload = msg.Payload
 	case <-viewCtx.Context().Done():
-		return nil, viewCtx.Context().Err()
-	case <-time.After(5 * time.Second):
-		return nil, errors.New("time out reached")
+		return nil, errors.Wrap(viewCtx.Context().Err(), "no message received in time")
 	}
 
-	// Respond with a pong if a ping is received, an error otherwise
-	m := string(payload)
-	if m != "ping" {
-		// reply with an error
-		err := session.SendErrorWithContext(viewCtx.Context(), fmt.Appendf(nil, "expected ping, got %s", m))
-		assert.NoError(err)
-		return nil, errors.Errorf("expected ping, got %s", m)
+	switch m := string(payload); m {
+	case pingMessage:
+		logger.DebugfContext(viewCtx.Context(), "%s received, send %s", pingMessage, pongMessage)
+		if err := p.session.SendWithContext(viewCtx.Context(), []byte(pongMessage)); err != nil {
+			return nil, errors.Wrapf(err, "failed to send %s", pongMessage)
+		}
+		return m, nil
+	case finishedMessage:
+		logger.DebugfContext(viewCtx.Context(), "%s received, nothing to answer", finishedMessage)
+		return m, nil
+	default:
+		sendErr := p.session.SendErrorWithContext(viewCtx.Context(), fmt.Appendf(nil, "expected %s or %s, got %s", pingMessage, finishedMessage, m))
+		return nil, errors.Join(errors.Errorf("expected %s or %s, got %s", pingMessage, finishedMessage, m), sendErr)
 	}
-
-	logger.Infof("ping received, send pong...")
-	// reply with pong
-	err := session.SendWithContext(viewCtx.Context(), []byte("pong"))
-	assert.NoError(err)
-
-	return nil, nil
 }
 
-func pong(viewCtx view.Context, session view.Session) (any, error) {
-	ctx, cancel := context.WithTimeout(viewCtx.Context(), 10*time.Minute)
-	runCtx := view2.WrapContext(viewCtx, ctx)
-	defer func() {
-		logger.Infof("call cancel on view context [%s:%s]", runCtx.ID(), viewCtx.ID())
-		cancel()
-	}()
-
-	return runCtx.RunView(&PongView{
-		session: session,
-	})
+func pong(viewCtx view.Context, session view.Session) (string, error) {
+	res, err := runRound(viewCtx, &PongView{session: session})
+	if err != nil {
+		return "", err
+	}
+	m, ok := res.(string)
+	if !ok {
+		return "", errors.Errorf("unexpected result [%v] of type [%T] from the pong view", res, res)
+	}
+	return m, nil
 }
 
+// Responder answers pings with pongs until the initiator signals that the protocol is over.
 type Responder struct{}
 
 func (p *Responder) Call(viewCtx view.Context) (any, error) {
-	// Retrieve the session opened by the initiator
 	session := viewCtx.Session()
-
-	for range 3 {
-		if _, err := pong(viewCtx, session); err != nil {
-			return nil, err
-		}
+	if session == nil {
+		return nil, errors.New("no default session, the responder must be invoked by an initiator")
 	}
 
-	// Return
-	return "OK", nil
+	for round := 0; ; round++ {
+		m, err := pong(viewCtx, session)
+		if err != nil {
+			return nil, errors.Wrapf(err, "pong round [%d] failed", round+1)
+		}
+		if m == finishedMessage {
+			logger.DebugfContext(viewCtx.Context(), "initiator finished after [%d] rounds", round)
+			return "OK", nil
+		}
+	}
 }

--- a/platform/view/services/comm/host/websocket/ws/context_detachment_test.go
+++ b/platform/view/services/comm/host/websocket/ws/context_detachment_test.go
@@ -1,0 +1,292 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ws
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	gwebsocket "github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"go.uber.org/goleak"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/comm/host"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics/disabled"
+)
+
+// echoPingPong reads "ping" messages off the stream and answers "pong", until the stream
+// errors out (e.g. because it was closed).
+func echoPingPong(t *testing.T, s host.P2PStream) {
+	t.Helper()
+	go func() {
+		for {
+			msg, err := readMsg(s)
+			if err != nil {
+				return
+			}
+			assert.Equal(t, []byte("ping"), msg)
+			if err := sendMsg(s, []byte("pong")); err != nil {
+				return
+			}
+		}
+	}()
+}
+
+func firstClientConn(p *MultiplexedProvider) *multiplexedClientConn {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	for _, c := range p.clients {
+		return c
+	}
+	return nil
+}
+
+func subConnCount(c *multiplexedClientConn) int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.subConns)
+}
+
+// isClosedChan reports whether ch has been closed (a closed channel yields the zero value with
+// ok=false immediately; a non-empty or open channel does not).
+func isClosedChan[T any](ch <-chan T) bool {
+	select {
+	case _, ok := <-ch:
+		return !ok
+	default:
+		return false
+	}
+}
+
+// requireSubConnResourcesReleased asserts that a closed subConn's own resources - not just its
+// entry in the parent's subConns map - have actually been released: its done and receiverChan
+// channels are closed, so nothing can be blocked sending on them or select-ing on them forever.
+func requireSubConnResourcesReleased(t *testing.T, sc *subConn) {
+	t.Helper()
+	require.True(t, isClosedChan(sc.done), "subConn.done must be closed")
+	require.True(t, isClosedChan(sc.receiverChan), "subConn.receiverChan must be closed")
+}
+
+// requirePhysicalConnClosed asserts that the physical websocket/TCP connection underlying a
+// multiplexedClientConn has actually been closed (not just logically "killed"), by attempting a
+// write and requiring it to fail.
+func requirePhysicalConnClosed(t *testing.T, conn *multiplexedClientConn) {
+	t.Helper()
+	err := conn.write(MultiplexedMessage{ID: "probe-after-close", Msg: []byte("x")})
+	require.Error(t, err, "physical connection must be closed")
+}
+
+// TestMultiplexedClientSubConnSurvivesCallerContextCancellation is a regression test for the
+// pingpong integration test failure: both initiator.go's ping() and responder.go's pong() wrap
+// each protocol round in its own context.WithTimeout, cancelled via `defer cancel()` as soon as
+// that round's RunView returns. Since the client sub-connection is cached and reused across
+// rounds - including when the responder itself needs to open a fresh outgoing stream to reply
+// (e.g. after a cache miss in sendTo) - cancelling that per-call context must NOT tear down the
+// sub-connection, from either call site. Otherwise round 2 fails as soon as round 1's context is
+// cancelled. This verifies both halves of the fix in newClientSubConn:
+//  1. the underlying stream's own context is decoupled from the caller's context (so cancelling
+//     the caller's context does not close the stream), and
+//  2. once the stream IS closed through a legitimate path (explicit Close()), everything is
+//     cleaned up with no leaked goroutines or dangling subConns map entries.
+func TestMultiplexedClientSubConnSurvivesCallerContextCancellation(t *testing.T) { //nolint:paralleltest
+	testSetup(t)
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	})
+
+	p := NewMultiplexedProvider(noop.NewTracerProvider(), &disabled.Provider{}, 0)
+	serverTLSConfig, clientTLSConfig, srcID := testMutualTLSConfigs(t, false)
+
+	srv := startTestServer(t, p, serverTLSConfig, func(s host.P2PStream) {
+		echoPingPong(t, s)
+	})
+	t.Cleanup(srv.Close)
+
+	srvEndpoint := strings.TrimPrefix(strings.TrimPrefix(srv.URL, "http://"), "https://")
+	info := host.StreamInfo{
+		RemotePeerID:      "serverID",
+		RemotePeerAddress: srvEndpoint,
+		ContextID:         "detach-ctx",
+		SessionID:         "detach-sess",
+	}
+
+	// Mimic a single protocol round: a short-lived, cancellable context passed to NewClientStream.
+	ctx, cancel := context.WithCancel(context.Background())
+	client, err := p.NewClientStream(info, ctx, srcID, clientTLSConfig)
+	require.NoError(t, err)
+	st, ok := client.(*stream)
+	require.True(t, ok)
+	sc, ok := st.conn.(*subConn)
+	require.True(t, ok)
+
+	// Sanity check: the sub-connection is live.
+	require.NoError(t, sendMsg(client, []byte("ping")))
+	answer, err := readMsg(client)
+	require.NoError(t, err)
+	require.Equal(t, []byte("pong"), answer)
+
+	conn := firstClientConn(p)
+	require.NotNil(t, conn)
+	require.Equal(t, 1, subConnCount(conn))
+
+	// Cancel the caller's context, exactly as `ping()`'s and `pong()`'s `defer cancel()` do at
+	// the end of each round in integration/fsc/pingpong/initiator.go and responder.go.
+	cancel()
+	time.Sleep(snoozeTime)
+
+	// The stream must not have picked up the cancellation of the (now unrelated) caller context.
+	require.NoError(t, st.ctx.Err(), "stream context must be decoupled from the caller's context")
+	require.False(t, isClosedChan(sc.done), "subConn resources must not be released by caller context cancellation")
+	require.False(t, isClosedChan(sc.receiverChan), "subConn resources must not be released by caller context cancellation")
+
+	// The sub-connection must still be tracked and fully usable for a subsequent round.
+	require.Equal(t, 1, subConnCount(conn))
+	require.NoError(t, sendMsg(client, []byte("ping")))
+	answer, err = readMsg(client)
+	require.NoError(t, err)
+	require.Equal(t, []byte("pong"), answer)
+
+	// Now close the stream through a legitimate path and verify full cleanup: no leaked
+	// goroutines (asserted in t.Cleanup), the subConn entry is removed, and the subConn's own
+	// resources (its channels) are released.
+	require.NoError(t, client.Close())
+	require.Equal(t, 0, subConnCount(conn))
+	requireSubConnResourcesReleased(t, sc)
+
+	// The physical websocket/TCP connection is shared by all sub-connections, so closing just
+	// this one must NOT close it - only KillAll (or the peer/connection erroring out) may.
+	require.NoError(t, conn.write(MultiplexedMessage{ID: "still-alive-probe", Msg: []byte("x")}),
+		"physical connection must stay open after a single sub-connection closes")
+
+	require.NoError(t, p.KillAll())
+	p.mu.RLock()
+	require.Empty(t, p.clients)
+	p.mu.RUnlock()
+	requirePhysicalConnClosed(t, conn)
+}
+
+// TestMultiplexedClientSubConnCleanupViaKillAllAfterCallerContextCancellation verifies the other
+// legitimate cleanup path: top-down teardown via MultiplexedProvider.KillAll() (e.g. when the
+// P2P host is stopped), rather than an explicit per-stream Close(). Since the per-call context
+// is no longer wired to the stream's lifetime, cancelling it must have no effect on cleanup -
+// only KillAll (or the underlying connection erroring out) may close the sub-connection - and
+// KillAll must still fully release the sub-connection with no leaked goroutines.
+func TestMultiplexedClientSubConnCleanupViaKillAllAfterCallerContextCancellation(t *testing.T) { //nolint:paralleltest
+	testSetup(t)
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	})
+
+	p := NewMultiplexedProvider(noop.NewTracerProvider(), &disabled.Provider{}, 0)
+	serverTLSConfig, clientTLSConfig, srcID := testMutualTLSConfigs(t, false)
+
+	srv := startTestServer(t, p, serverTLSConfig, func(s host.P2PStream) {
+		echoPingPong(t, s)
+	})
+	t.Cleanup(srv.Close)
+
+	srvEndpoint := strings.TrimPrefix(strings.TrimPrefix(srv.URL, "http://"), "https://")
+	info := host.StreamInfo{
+		RemotePeerID:      "serverID",
+		RemotePeerAddress: srvEndpoint,
+		ContextID:         "detach-killall-ctx",
+		SessionID:         "detach-killall-sess",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client, err := p.NewClientStream(info, ctx, srcID, clientTLSConfig)
+	require.NoError(t, err)
+	st, ok := client.(*stream)
+	require.True(t, ok)
+	sc, ok := st.conn.(*subConn)
+	require.True(t, ok)
+
+	require.NoError(t, sendMsg(client, []byte("ping")))
+	_, err = readMsg(client)
+	require.NoError(t, err)
+
+	conn := firstClientConn(p)
+	require.NotNil(t, conn)
+	require.Equal(t, 1, subConnCount(conn))
+
+	// Cancel the caller context well before any explicit Close() - this must be a no-op as far
+	// as the sub-connection's lifetime and resources are concerned.
+	cancel()
+	time.Sleep(snoozeTime)
+	require.Equal(t, 1, subConnCount(conn), "sub-connection must survive caller context cancellation")
+	require.False(t, isClosedChan(sc.done), "subConn resources must not be released by caller context cancellation")
+	require.False(t, isClosedChan(sc.receiverChan), "subConn resources must not be released by caller context cancellation")
+
+	// Tear everything down top-down, without ever calling client.Close() directly.
+	require.NoError(t, p.KillAll())
+
+	p.mu.RLock()
+	require.Empty(t, p.clients)
+	p.mu.RUnlock()
+	require.Equal(t, 0, subConnCount(conn))
+	requireSubConnResourcesReleased(t, sc)
+	requirePhysicalConnClosed(t, conn)
+}
+
+// TestSimpleProviderClientStreamSurvivesCallerContextCancellation is the SimpleProvider analogue
+// of TestMultiplexedClientSubConnSurvivesCallerContextCancellation: NewClientStream must decouple
+// the returned stream's lifetime from the caller-supplied context, and closing the stream through
+// its legitimate Close() path must leave no leaked goroutines behind.
+func TestSimpleProviderClientStreamSurvivesCallerContextCancellation(t *testing.T) { //nolint:paralleltest
+	testSetup(t)
+	t.Cleanup(func() {
+		goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	})
+
+	p := NewSimpleProvider()
+	serverTLSConfig, clientTLSConfig, srcID := testMutualTLSConfigs(t, false)
+
+	srv := startTestServer(t, p, serverTLSConfig, func(s host.P2PStream) {
+		echoPingPong(t, s)
+	})
+	t.Cleanup(srv.Close)
+
+	srvEndpoint := strings.TrimPrefix(strings.TrimPrefix(srv.URL, "http://"), "https://")
+	info := host.StreamInfo{
+		RemotePeerID:      "serverID",
+		RemotePeerAddress: srvEndpoint,
+		ContextID:         "simple-detach-ctx",
+		SessionID:         "simple-detach-sess",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client, err := p.NewClientStream(info, ctx, srcID, clientTLSConfig)
+	require.NoError(t, err)
+
+	require.NoError(t, sendMsg(client, []byte("ping")))
+	answer, err := readMsg(client)
+	require.NoError(t, err)
+	require.Equal(t, []byte("pong"), answer)
+
+	cancel()
+	time.Sleep(snoozeTime)
+
+	st, ok := client.(*stream)
+	require.True(t, ok)
+	require.NoError(t, st.ctx.Err(), "stream context must be decoupled from the caller's context")
+
+	require.NoError(t, sendMsg(client, []byte("ping")))
+	answer, err = readMsg(client)
+	require.NoError(t, err)
+	require.Equal(t, []byte("pong"), answer)
+
+	require.NoError(t, client.Close())
+
+	// The underlying physical websocket connection (owned exclusively by this single stream,
+	// unlike the multiplexed case) must actually be closed too, not just logically detached.
+	writeErr := st.conn.(*gwebsocket.Conn).WriteMessage(gwebsocket.BinaryMessage, []byte("probe-after-close"))
+	require.Error(t, writeErr, "underlying websocket connection must be closed")
+}

--- a/platform/view/services/comm/host/websocket/ws/context_detachment_test.go
+++ b/platform/view/services/comm/host/websocket/ws/context_detachment_test.go
@@ -8,6 +8,7 @@ package ws
 
 import (
 	"context"
+	"crypto/tls"
 	"strings"
 	"testing"
 	"time"
@@ -55,15 +56,30 @@ func subConnCount(c *multiplexedClientConn) int {
 	return len(c.subConns)
 }
 
-// isClosedChan reports whether ch has been closed (a closed channel yields the zero value with
-// ok=false immediately; a non-empty or open channel does not).
+// isClosedChan reports whether ch has been closed. receiverChan is buffered (cap 100), so a
+// closed channel that still holds buffered items yields ok=true until drained - this drains ch
+// until it observes ok=false (closed) or would block (open). Only safe to call once nothing else
+// may still be consuming from ch, e.g. after the owning subConn has been closed; for a live
+// subConn, use subConnIsClosed instead, which doesn't consume anything.
 func isClosedChan[T any](ch <-chan T) bool {
-	select {
-	case _, ok := <-ch:
-		return !ok
-	default:
-		return false
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				return true
+			}
+		default:
+			return false
+		}
 	}
+}
+
+// subConnIsClosed non-destructively reports whether sc has been closed, without reading from its
+// channels - safe to call on a subConn that may still be in use.
+func subConnIsClosed(sc *subConn) bool {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	return sc.isClosed
 }
 
 // requireSubConnResourcesReleased asserts that a closed subConn's own resources - not just its
@@ -84,14 +100,34 @@ func requirePhysicalConnClosed(t *testing.T, conn *multiplexedClientConn) {
 	require.Error(t, err, "physical connection must be closed")
 }
 
+// requirePhysicalConnAlive proves that the physical connection underlying conn - and the server
+// on the other end of it - both survived a single sub-connection's Close(), by opening a brand
+// new sub-connection through the public API (it targets the same URL as info, so it reuses the
+// cached physical connection) and running a real ping/pong round-trip over it against the
+// existing echoPingPong callback.
+func requirePhysicalConnAlive(t *testing.T, p *MultiplexedProvider, info host.StreamInfo, srcID host.PeerID, clientTLSConfig *tls.Config) {
+	t.Helper()
+	probeInfo := info
+	probeInfo.SessionID = info.SessionID + "-probe"
+	probe, err := p.NewClientStream(probeInfo, context.Background(), srcID, clientTLSConfig)
+	require.NoError(t, err, "physical connection must stay open after a single sub-connection closes")
+	defer func() { _ = probe.Close() }()
+
+	require.NoError(t, sendMsg(probe, []byte("ping")))
+	answer, err := readMsg(probe)
+	require.NoError(t, err)
+	require.Equal(t, []byte("pong"), answer)
+}
+
 // TestMultiplexedClientSubConnSurvivesCallerContextCancellation is a regression test for the
-// pingpong integration test failure: both initiator.go's ping() and responder.go's pong() wrap
-// each protocol round in its own context.WithTimeout, cancelled via `defer cancel()` as soon as
-// that round's RunView returns. Since the client sub-connection is cached and reused across
-// rounds - including when the responder itself needs to open a fresh outgoing stream to reply
-// (e.g. after a cache miss in sendTo) - cancelling that per-call context must NOT tear down the
-// sub-connection, from either call site. Otherwise round 2 fails as soon as round 1's context is
-// cancelled. This verifies both halves of the fix in newClientSubConn:
+// pingpong integration test failure: initiator.go's ping()/finish() and responder.go's pong(),
+// all funneled through the shared runRound helper, wrap each protocol round in its own
+// context.WithTimeout, cancelled via `defer cancel()` as soon as that round's RunView returns.
+// Since the client sub-connection is cached and reused across rounds - including when the
+// responder itself needs to open a fresh outgoing stream to reply (e.g. after a cache miss in
+// sendTo) - cancelling that per-call context must NOT tear down the sub-connection, from any
+// call site. Otherwise round 2 fails as soon as round 1's context is cancelled. This verifies
+// both halves of the fix in newClientSubConn:
 //  1. the underlying stream's own context is decoupled from the caller's context (so cancelling
 //     the caller's context does not close the stream), and
 //  2. once the stream IS closed through a legitimate path (explicit Close()), everything is
@@ -144,8 +180,7 @@ func TestMultiplexedClientSubConnSurvivesCallerContextCancellation(t *testing.T)
 
 	// The stream must not have picked up the cancellation of the (now unrelated) caller context.
 	require.NoError(t, st.ctx.Err(), "stream context must be decoupled from the caller's context")
-	require.False(t, isClosedChan(sc.done), "subConn resources must not be released by caller context cancellation")
-	require.False(t, isClosedChan(sc.receiverChan), "subConn resources must not be released by caller context cancellation")
+	require.False(t, subConnIsClosed(sc), "subConn resources must not be released by caller context cancellation")
 
 	// The sub-connection must still be tracked and fully usable for a subsequent round.
 	require.Equal(t, 1, subConnCount(conn))
@@ -163,8 +198,7 @@ func TestMultiplexedClientSubConnSurvivesCallerContextCancellation(t *testing.T)
 
 	// The physical websocket/TCP connection is shared by all sub-connections, so closing just
 	// this one must NOT close it - only KillAll (or the peer/connection erroring out) may.
-	require.NoError(t, conn.write(MultiplexedMessage{ID: "still-alive-probe", Msg: []byte("x")}),
-		"physical connection must stay open after a single sub-connection closes")
+	requirePhysicalConnAlive(t, p, info, srcID, clientTLSConfig)
 
 	require.NoError(t, p.KillAll())
 	p.mu.RLock()
@@ -222,8 +256,7 @@ func TestMultiplexedClientSubConnCleanupViaKillAllAfterCallerContextCancellation
 	cancel()
 	time.Sleep(snoozeTime)
 	require.Equal(t, 1, subConnCount(conn), "sub-connection must survive caller context cancellation")
-	require.False(t, isClosedChan(sc.done), "subConn resources must not be released by caller context cancellation")
-	require.False(t, isClosedChan(sc.receiverChan), "subConn resources must not be released by caller context cancellation")
+	require.False(t, subConnIsClosed(sc), "subConn resources must not be released by caller context cancellation")
 
 	// Tear everything down top-down, without ever calling client.Close() directly.
 	require.NoError(t, p.KillAll())

--- a/platform/view/services/comm/host/websocket/ws/multiplexed_provider.go
+++ b/platform/view/services/comm/host/websocket/ws/multiplexed_provider.go
@@ -249,7 +249,13 @@ func (c *multiplexedClientConn) newClientSubConn(ctx context.Context, src host2.
 		return nil, errors.Wrapf(err, "failed to send meta message")
 	}
 	logger.Debugf("Stream opened to [%s@%s]", info.RemotePeerID, info.RemotePeerAddress)
-	return NewWSStream(sc, ctx, info), nil
+	// The sub-connection is cached and reused across multiple calls (e.g. multiple rounds of
+	// a protocol), so its lifetime must not be tied to the context of the call that happened
+	// to create it: cancelling that per-call context (e.g. on successful completion) would
+	// otherwise tear down the sub-connection out from under subsequent, unrelated calls that
+	// reuse the same stream. We only propagate the span for tracing purposes, same as
+	// newServerSubConn does for the server side.
+	return NewWSStream(sc, trace.ContextWithRemoteSpanContext(context.Background(), spanContext), info), nil
 }
 
 func (c *multiplexedClientConn) readIncoming() {

--- a/platform/view/services/comm/host/websocket/ws/multiplexed_provider.go
+++ b/platform/view/services/comm/host/websocket/ws/multiplexed_provider.go
@@ -253,9 +253,9 @@ func (c *multiplexedClientConn) newClientSubConn(ctx context.Context, src host2.
 	// a protocol), so its lifetime must not be tied to the context of the call that happened
 	// to create it: cancelling that per-call context (e.g. on successful completion) would
 	// otherwise tear down the sub-connection out from under subsequent, unrelated calls that
-	// reuse the same stream. We only propagate the span for tracing purposes, same as
-	// newServerSubConn does for the server side.
-	return NewWSStream(sc, trace.ContextWithRemoteSpanContext(context.Background(), spanContext), info), nil
+	// reuse the same stream. We only propagate the span, as a local parent, for tracing
+	// purposes.
+	return NewWSStream(sc, trace.ContextWithSpanContext(context.Background(), spanContext), info), nil
 }
 
 func (c *multiplexedClientConn) readIncoming() {

--- a/platform/view/services/comm/host/websocket/ws/simple_provider.go
+++ b/platform/view/services/comm/host/websocket/ws/simple_provider.go
@@ -68,9 +68,9 @@ func (p *SimpleProvider) NewClientStream(info host2.StreamInfo, ctx context.Cont
 	// protocol), so its lifetime must not be tied to the context of the call that happened
 	// to create it: cancelling that per-call context (e.g. on successful completion) would
 	// otherwise tear down the connection out from under subsequent, unrelated calls that
-	// reuse the same stream. We only propagate the span for tracing purposes, same as
-	// NewServerStream does for the server side.
-	return NewWSStream(conn, trace.ContextWithRemoteSpanContext(context.Background(), spanContext), info), nil
+	// reuse the same stream. We only propagate the span, as a local parent, for tracing
+	// purposes.
+	return NewWSStream(conn, trace.ContextWithSpanContext(context.Background(), spanContext), info), nil
 }
 
 func (p *SimpleProvider) NewServerStream(writer http.ResponseWriter, request *http.Request, newStreamCallback func(host2.P2PStream)) error {

--- a/platform/view/services/comm/host/websocket/ws/simple_provider.go
+++ b/platform/view/services/comm/host/websocket/ws/simple_provider.go
@@ -64,7 +64,13 @@ func (p *SimpleProvider) NewClientStream(info host2.StreamInfo, ctx context.Cont
 		return nil, errors.Wrapf(err, "failed to send meta message")
 	}
 	logger.Debugf("Stream opened to [%s@%s]", info.RemotePeerID, info.RemotePeerAddress)
-	return NewWSStream(conn, ctx, info), nil
+	// The stream is cached and reused across multiple calls (e.g. multiple rounds of a
+	// protocol), so its lifetime must not be tied to the context of the call that happened
+	// to create it: cancelling that per-call context (e.g. on successful completion) would
+	// otherwise tear down the connection out from under subsequent, unrelated calls that
+	// reuse the same stream. We only propagate the span for tracing purposes, same as
+	// NewServerStream does for the server side.
+	return NewWSStream(conn, trace.ContextWithRemoteSpanContext(context.Background(), spanContext), info), nil
 }
 
 func (p *SimpleProvider) NewServerStream(writer http.ResponseWriter, request *http.Request, newStreamCallback func(host2.P2PStream)) error {

--- a/platform/view/services/comm/host/websocket/ws/stream.go
+++ b/platform/view/services/comm/host/websocket/ws/stream.go
@@ -9,6 +9,7 @@ package ws
 import (
 	"context"
 	"io"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -257,7 +258,7 @@ func (s *stream) Write(p []byte) (int, error) {
 func (s *stream) Close() error {
 	var err error
 	s.closeOnce.Do(func() {
-		logger.Debugf("Close connection for context [%s]", s.ContextID())
+		logger.Debugf("close connection for context [%s][%s]", s.ContextID(), string(debug.Stack()))
 		s.cancel()
 		err = s.conn.Close()
 		s.mu.Lock()

--- a/platform/view/services/comm/host/websocket/ws/stream.go
+++ b/platform/view/services/comm/host/websocket/ws/stream.go
@@ -9,7 +9,6 @@ package ws
 import (
 	"context"
 	"io"
-	"runtime/debug"
 	"sync"
 	"time"
 
@@ -49,6 +48,12 @@ type stream struct {
 	readLeftover []byte
 }
 
+// NewWSStream wraps conn into a stream. ctx only seeds the tracing parent for messages read off
+// this stream; it does not govern the stream's lifetime. All call sites deliberately pass a
+// context.Background()-derived ctx, since the underlying connection is cached and reused across
+// calls whose own contexts come and go. The stream's lifetime is instead governed by Close() (or
+// the connection erroring out); the <-ctx.Done() goroutine below is a safety net that in practice
+// is only ever triggered by Close()'s own s.cancel(), not by an external caller cancelling ctx.
 func NewWSStream(conn connection, ctx context.Context, info host2.StreamInfo) *stream {
 	ctx, cancel := context.WithCancel(ctx)
 	s := &stream{
@@ -258,7 +263,7 @@ func (s *stream) Write(p []byte) (int, error) {
 func (s *stream) Close() error {
 	var err error
 	s.closeOnce.Do(func() {
-		logger.Debugf("close connection for context [%s][%s]", s.ContextID(), string(debug.Stack()))
+		logger.Debugf("close connection for context [%s]", s.ContextID())
 		s.cancel()
 		err = s.conn.Close()
 		s.mu.Lock()

--- a/platform/view/services/view/manager.go
+++ b/platform/view/services/view/manager.go
@@ -319,8 +319,10 @@ func (cm *Manager) DeleteContext(contextID string) {
 	cm.contextsMu.Lock()
 	defer cm.contextsMu.Unlock()
 
+	logger.Debugf("deleting context [%s]\n", contextID)
 	// dispose context
 	if viewCtx, ok := cm.contexts[contextID]; ok {
+		logger.Debugf("found, dispose context [%s]\n", contextID)
 		viewCtx.Dispose()
 		delete(cm.contexts, contextID)
 		cm.metrics.Contexts.Set(float64(len(cm.contexts)))

--- a/platform/view/services/view/manager.go
+++ b/platform/view/services/view/manager.go
@@ -319,10 +319,10 @@ func (cm *Manager) DeleteContext(contextID string) {
 	cm.contextsMu.Lock()
 	defer cm.contextsMu.Unlock()
 
-	logger.Debugf("deleting context [%s]\n", contextID)
+	logger.Debugf("deleting context [%s]", contextID)
 	// dispose context
 	if viewCtx, ok := cm.contexts[contextID]; ok {
-		logger.Debugf("found, dispose context [%s]\n", contextID)
+		logger.Debugf("found, dispose context [%s]", contextID)
 		viewCtx.Dispose()
 		delete(cm.contexts, contextID)
 		cm.metrics.Contexts.Set(float64(len(cm.contexts)))


### PR DESCRIPTION
## Problem

Fixes #1645.

`make integration-tests-fsc-pingpong` fails on the websocket P2P transport: round 1 of a 3-round ping/pong exchange succeeds, but round 2 fails because the underlying client stream/sub-connection has been torn down.

## Root cause

`SimpleProvider.NewClientStream` and `MultiplexedProvider`'s client-side `newClientSubConn` built the returned `P2PStream`'s internal context directly from the caller-supplied `context.Context`. Client streams/sub-connections are cached and reused across multiple protocol rounds, but each round is wrapped in its own short-lived `context.WithTimeout(...)` + `defer cancel()`. Cancelling that per-call context at the end of round 1 immediately closed the stream, breaking round 2.

The server side (`NewServerStream` / `newServerSubConn`) already avoided this by deriving the stream's context from `context.Background()` and only propagating the tracing span from the caller's context.

## Fix

- `platform/view/services/comm/host/websocket/ws/simple_provider.go`: build the client stream's context from `context.Background()` + `trace.ContextWithRemoteSpanContext(...)`, same as the server side.
- `platform/view/services/comm/host/websocket/ws/multiplexed_provider.go`: same fix in `newClientSubConn`.
- `integration/fsc/pingpong/responder.go`: restructured to mirror `initiator.go`'s `ping()`/`PingView` pattern — a `pong()`/`PongView` pair that wraps each round in its own cancellable context, so the responder exercises the same code path as the initiator (both can hit `NewClientStream`/`newClientSubConn` on a cache miss when sending).
- `platform/view/services/comm/host/websocket/ws/context_detachment_test.go`: new regression tests covering both `SimpleProvider` and `MultiplexedProvider` client streams — verifying the stream survives cancellation of the caller's context, remains usable for a subsequent round, and that closing it through a legitimate path (explicit `Close()` or `KillAll()`) fully releases all resources (channels closed, no leaked goroutines, physical connection closed only when appropriate).
- `platform/view/services/comm/host/websocket/ws/stream.go`, `platform/view/services/view/manager.go`: additional debug logging that was useful in diagnosing this issue, kept for future troubleshooting.

## Test plan

- [x] `go build ./...` / `go vet ./...`
- [x] `go test ./platform/view/services/comm/host/websocket/... -race`
- [x] `make integration-tests-fsc-pingpong`
