### PR TITLE
fix(fabricx): pin namespace versions at first touch and deduplicate rwset payload

### DIFF
--- a/platform/fabricx/core/transaction/transaction.go
+++ b/platform/fabricx/core/transaction/transaction.go
@@ -57,7 +57,9 @@ type Transaction struct {
 	TFunction         string
 	TParameters       [][]byte
 
-	RWSet      []byte `json:"RWSet,omitempty"`
+	// RWSet is cleared by dedupRWSet when it duplicates the first proposal response's
+	// payload, so it is frequently nil on the wire.
+	RWSet      []byte
 	TTransient driver.TransientMap
 
 	TProposal          *pb.Proposal
@@ -342,8 +344,13 @@ func (t *Transaction) Close() {
 	}
 }
 
-// Raw serializes the transaction to JSON. If the transaction has an open RWSet, it is
-// marshaled and saved to the RWSet field first, mutating the receiver in the process.
+// Raw serializes the transaction to JSON.
+//
+// It mutates the receiver twice. If the transaction has an open RWSet, it is marshalled
+// into the RWSet field; then, if those bytes duplicate the first proposal response's
+// payload, the field is cleared again. A caller that inspects t.RWSet afterwards will
+// therefore find it nil whenever the transaction already carries a proposal response —
+// read the payload instead, which is what the receiving side reconstructs from.
 func (t *Transaction) Raw() ([]byte, error) {
 	if t.rwset != nil {
 		var err error

--- a/platform/fabricx/core/transaction/transaction.go
+++ b/platform/fabricx/core/transaction/transaction.go
@@ -57,7 +57,7 @@ type Transaction struct {
 	TFunction         string
 	TParameters       [][]byte
 
-	RWSet      []byte
+	RWSet      []byte `json:"RWSet,omitempty"`
 	TTransient driver.TransientMap
 
 	TProposal          *pb.Proposal
@@ -319,7 +319,19 @@ func (t *Transaction) Done() error {
 		}
 		logger.Debugf("terminated simulation with [%s][len:%d]", t.rwset.Namespaces(), len(t.RWSet))
 	}
+
+	t.dedupRWSet()
+
 	return nil
+}
+
+func (t *Transaction) dedupRWSet() {
+	// If the exact same serialized RWSet bytes are already included in the first
+	// proposal response (Payload), drop the redundant field. The receiving side will
+	// use the proposal response's Payload to reconstruct it if t.RWSet is missing.
+	if len(t.TProposalResponses) > 0 && bytes.Equal(t.TProposalResponses[0].Payload, t.RWSet) {
+		t.RWSet = nil
+	}
 }
 
 func (t *Transaction) Close() {
@@ -330,6 +342,8 @@ func (t *Transaction) Close() {
 	}
 }
 
+// Raw serializes the transaction to JSON. If the transaction has an open RWSet, it is
+// marshaled and saved to the RWSet field first, mutating the receiver in the process.
 func (t *Transaction) Raw() ([]byte, error) {
 	if t.rwset != nil {
 		var err error
@@ -338,6 +352,7 @@ func (t *Transaction) Raw() ([]byte, error) {
 			return nil, errors.Wrap(err, "marshalling rws")
 		}
 	}
+	t.dedupRWSet()
 	return json.Marshal(t)
 }
 

--- a/platform/fabricx/core/transaction/transaction_test.go
+++ b/platform/fabricx/core/transaction/transaction_test.go
@@ -1167,3 +1167,38 @@ func TestEndorseProposalWithIdentity(t *testing.T) {
 		})
 	}
 }
+
+func TestTransaction_DeduplicateRWSet(t *testing.T) {
+	t.Parallel()
+	tx := &Transaction{
+		RWSet: []byte("duplicate payload"),
+		TProposalResponses: []*peer.ProposalResponse{
+			{
+				Payload: []byte("duplicate payload"),
+			},
+		},
+	}
+
+	err := tx.Done()
+	require.NoError(t, err)
+
+	// Since TProposalResponses contains the exact same bytes, RWSet should be cleared
+	require.Nil(t, tx.RWSet)
+
+	// Test non-matching payload
+	tx2 := &Transaction{
+		RWSet: []byte("some payload"),
+		TProposalResponses: []*peer.ProposalResponse{
+			{
+				Payload: []byte("different payload"),
+			},
+		},
+	}
+
+	err = tx2.Done()
+	require.NoError(t, err)
+
+	// Should not be cleared
+	require.NotNil(t, tx2.RWSet)
+	require.Equal(t, []byte("some payload"), tx2.RWSet)
+}

--- a/platform/fabricx/core/transaction/transaction_test.go
+++ b/platform/fabricx/core/transaction/transaction_test.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -1168,14 +1169,31 @@ func TestEndorseProposalWithIdentity(t *testing.T) {
 	}
 }
 
+// serializedRWSet builds a valid FabricX-encoded read-write set, so tests exercise the
+// dedup path with the kind of payload it actually sees rather than an opaque blob.
+func serializedRWSet(t *testing.T) []byte {
+	t.Helper()
+	raw, err := proto.Marshal(&applicationpb.Tx{
+		Namespaces: []*applicationpb.TxNamespace{{
+			NsId:      "ns1",
+			NsVersion: 7,
+			BlindWrites: []*applicationpb.Write{
+				{Key: []byte("key1"), Value: []byte("val1")},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	return raw
+}
+
 func TestTransaction_DeduplicateRWSet(t *testing.T) {
 	t.Parallel()
+	rwsetBytes := serializedRWSet(t)
+
 	tx := &Transaction{
-		RWSet: []byte("duplicate payload"),
+		RWSet: rwsetBytes,
 		TProposalResponses: []*peer.ProposalResponse{
-			{
-				Payload: []byte("duplicate payload"),
-			},
+			{Payload: rwsetBytes},
 		},
 	}
 
@@ -1187,11 +1205,9 @@ func TestTransaction_DeduplicateRWSet(t *testing.T) {
 
 	// Test non-matching payload
 	tx2 := &Transaction{
-		RWSet: []byte("some payload"),
+		RWSet: rwsetBytes,
 		TProposalResponses: []*peer.ProposalResponse{
-			{
-				Payload: []byte("different payload"),
-			},
+			{Payload: []byte("different payload")},
 		},
 	}
 
@@ -1200,5 +1216,132 @@ func TestTransaction_DeduplicateRWSet(t *testing.T) {
 
 	// Should not be cleared
 	require.NotNil(t, tx2.RWSet)
-	require.Equal(t, []byte("some payload"), tx2.RWSet)
+	require.Equal(t, rwsetBytes, tx2.RWSet)
+}
+
+// Dropping the RWSet field is only safe if the receiving side can rebuild an identical
+// read-write set from the proposal response payload. This walks the full path the dedup
+// relies on: serialize with the field dropped, ship the JSON, and reconstruct.
+func TestTransaction_DeduplicatedRWSetRoundTrips(t *testing.T) {
+	t.Parallel()
+	rwsetBytes := serializedRWSet(t)
+
+	sender := &Transaction{
+		ctx:   t.Context(),
+		TTxID: "tx1",
+		RWSet: rwsetBytes,
+		TProposalResponses: []*peer.ProposalResponse{
+			{Payload: rwsetBytes},
+		},
+	}
+
+	shipped, err := sender.Bytes()
+	require.NoError(t, err)
+
+	// The redundant payload must be gone from the wire form, while the key itself stays
+	// present as an explicit null so the JSON shape is unchanged for every consumer.
+	var onTheWire map[string]any
+	require.NoError(t, json.Unmarshal(shipped, &onTheWire))
+	require.Contains(t, onTheWire, "RWSet", "the key must still be emitted")
+	require.Nil(t, onTheWire["RWSet"], "the duplicated rwset must not be carried twice")
+
+	// The receiver reconstructs from the JSON alone.
+	fakeVault := &mock.Vault{}
+	fakeVault.NewRWSetFromBytesReturns(&mock.RWSet{}, nil)
+	ch := &mock.Channel{}
+	ch.VaultReturns(fakeVault)
+
+	// Decoded directly rather than through SetFromBytes, which additionally resolves the
+	// channel through the network service; the invariant under test is only that the
+	// dropped field is recoverable from the payload.
+	receiver := &Transaction{ctx: t.Context(), channel: ch}
+	require.NoError(t, json.Unmarshal(shipped, receiver))
+	require.Nil(t, receiver.RWSet, "the field arrives absent")
+
+	require.NoError(t, receiver.SetRWSet())
+	require.Equal(t, 1, fakeVault.NewRWSetFromBytesCallCount())
+	_, _, gotBytes := fakeVault.NewRWSetFromBytesArgsForCall(0)
+	require.Equal(t, rwsetBytes, gotBytes,
+		"the reconstructed rwset must be built from the exact bytes the sender dropped")
+}
+
+// rwSetWithWrites builds a serialized RWSet carrying n blind writes of valueSize bytes
+// each, so a benchmark can vary the payload independently of the rest of the transaction.
+func rwSetWithWrites(tb testing.TB, n, valueSize int) []byte {
+	tb.Helper()
+	writes := make([]*applicationpb.Write, 0, n)
+	for i := range n {
+		value := make([]byte, valueSize)
+		for j := range value {
+			value[j] = byte(i + j)
+		}
+		writes = append(writes, &applicationpb.Write{Key: fmt.Appendf(nil, "key%08d", i), Value: value})
+	}
+	raw, err := proto.Marshal(&applicationpb.Tx{
+		Namespaces: []*applicationpb.TxNamespace{{NsId: "ns1", NsVersion: 7, BlindWrites: writes}},
+	})
+	require.NoError(tb, err)
+	return raw
+}
+
+// BenchmarkTransactionBytes measures the JSON encoding of an endorsed transaction, which
+// is what every send pays. "Duplicated" is the pre-deduplication behaviour: the rwset
+// reaches the wire twice, once as RWSet and once as the proposal response payload, each
+// base64-expanded by a third. "Deduplicated" is Transaction.Bytes() as it stands now.
+//
+// bytes/op reports the size of the encoded transaction, so the saving is readable
+// alongside the allocation cost of producing it.
+func BenchmarkTransactionBytes(b *testing.B) {
+	cases := []struct {
+		name      string
+		writes    int
+		valueSize int
+	}{
+		// The shape the PR description quotes a saving for.
+		{name: "10Writes", writes: 10, valueSize: 32},
+		// The payload size the reproducer in #1599 drives, which is what #1628 is about.
+		{name: "256KiB", writes: 2048, valueSize: 128},
+	}
+
+	for _, tc := range cases {
+		raw := rwSetWithWrites(b, tc.writes, tc.valueSize)
+		newTx := func() *Transaction {
+			return &Transaction{
+				TTxID:              "tx1",
+				TProposalResponses: []*peer.ProposalResponse{{Payload: raw}},
+			}
+		}
+
+		b.Run(tc.name, func(b *testing.B) {
+			b.Run("Duplicated", func(b *testing.B) {
+				tx := newTx()
+				b.ReportAllocs()
+				var out []byte
+				for b.Loop() {
+					tx.RWSet = raw
+					var err error
+					out, err = json.Marshal(tx)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+				b.ReportMetric(float64(len(out)), "bytes/op")
+			})
+
+			b.Run("Deduplicated", func(b *testing.B) {
+				tx := newTx()
+				b.ReportAllocs()
+				var out []byte
+				for b.Loop() {
+					tx.RWSet = raw
+					var err error
+					out, err = tx.Bytes()
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+				b.ReportMetric(float64(len(out)), "bytes/op")
+			})
+		})
+	}
 }

--- a/platform/fabricx/core/vault/marshal.go
+++ b/platform/fabricx/core/vault/marshal.go
@@ -183,22 +183,32 @@ func sortedKeys[V any](m map[string]V) []string {
 
 // RWSetFromBytes deserializes a ReadWriteSet from FabricX protobuf format.
 // If namespaces are specified, only those namespaces will be included in the result.
+// It also returns the namespace versions carried by the serialized transaction, so a
+// reconstructed RWSet re-serializes to the versions it arrived with.
 // Returns an error if deserialization fails.
-func (m *Marshaller) RWSetFromBytes(raw []byte, namespaces ...string) (*vault.ReadWriteSet, error) {
+func (m *Marshaller) RWSetFromBytes(raw []byte, namespaces ...string) (*vault.ReadWriteSet, map[driver.Namespace]driver.RawVersion, error) {
 	rws := vault.EmptyRWSet()
-	if err := m.Append(&rws, raw, namespaces...); err != nil {
-		return nil, err
+	nsVersions, err := m.Append(&rws, raw, namespaces...)
+	if err != nil {
+		return nil, nil, err
 	}
-	return &rws, nil
+	return &rws, nsVersions, nil
 }
 
 // Append deserializes FabricX protobuf data and appends it to an existing ReadWriteSet.
-// If namespaces are specified, only those namespaces will be processed.
+// If namespaces are specified, only those namespaces are processed and every other
+// namespace in the payload is skipped; with none specified the whole payload is appended.
+//
+// It returns the NsVersion each processed namespace was serialized with. That version is
+// part of what the endorsement signature covers, so a party that reconstructs a
+// transaction and re-serializes it must reuse the incoming version rather than resolve a
+// current one.
+//
 // Returns an error if deserialization fails or if adding reads/writes fails.
-func (m *Marshaller) Append(destination *vault.ReadWriteSet, raw []byte, namespaces ...string) error {
+func (m *Marshaller) Append(destination *vault.ReadWriteSet, raw []byte, namespaces ...string) (map[driver.Namespace]driver.RawVersion, error) {
 	var txIn applicationpb.Tx
 	if err := proto.Unmarshal(raw, &txIn); err != nil {
-		return errors.Wrapf(err, "unmarshal tx from [len=%d][%s]", len(raw), logging.SHA256Base64(raw))
+		return nil, errors.Wrapf(err, "unmarshal tx from [len=%d][%s]", len(raw), logging.SHA256Base64(raw))
 	}
 
 	if logger.IsEnabledFor(zap.DebugLevel) {
@@ -206,38 +216,67 @@ func (m *Marshaller) Append(destination *vault.ReadWriteSet, raw []byte, namespa
 		logger.Debugf("Unmarshalled fabricx tx: %s", string(str))
 	}
 
+	// An empty filter means "every namespace"; otherwise only the listed ones are kept.
+	var wanted map[driver.Namespace]struct{}
+	if len(namespaces) > 0 {
+		wanted = make(map[driver.Namespace]struct{}, len(namespaces))
+		for _, ns := range namespaces {
+			wanted[ns] = struct{}{}
+		}
+	}
+
+	nsVersions := make(map[driver.Namespace]driver.RawVersion, len(txIn.GetNamespaces()))
 	for _, txNs := range txIn.GetNamespaces() {
+		if wanted != nil {
+			if _, ok := wanted[txNs.GetNsId()]; !ok {
+				continue
+			}
+		}
+		nsVersions[txNs.GetNsId()] = MarshalVersion(txNs.GetNsVersion())
+
 		for _, read := range txNs.GetReadsOnly() {
-			destination.ReadSet.Add(txNs.GetNsId(), string(read.GetKey()), MarshalVersion(read.GetVersion()))
+			destination.ReadSet.Add(txNs.GetNsId(), string(read.GetKey()), optionalVersion(read.Version))
 		}
 
 		for _, write := range txNs.GetBlindWrites() {
 			if err := destination.WriteSet.Add(txNs.GetNsId(), string(write.GetKey()), write.GetValue()); err != nil {
 				// TODO: ... should we really just stop here or revert all changes ... ?
-				return errors.Wrapf(err, "adding blindwrite [%s]", write.GetKey())
+				return nil, errors.Wrapf(err, "adding blindwrite [%s]", write.GetKey())
 			}
 		}
 
 		for _, readWrite := range txNs.GetReadWrites() {
-			// only add to the readset if it has a version, this is usually the case when a value is created for the first time
-			if readWrite.Version != nil {
-				destination.ReadSet.Add(txNs.GetNsId(), string(readWrite.GetKey()), MarshalVersion(readWrite.GetVersion()))
-			}
+			// A nil version means the key is expected not to exist yet — usually the case when
+			// a value is created for the first time. That is still a read dependency and has to
+			// enter the read set: a ReadWrite whose read half is dropped re-serializes as a
+			// BlindWrite, which is an unconditional write with a different meaning to the
+			// committer, and different bytes for the endorsement digest.
+			destination.ReadSet.Add(txNs.GetNsId(), string(readWrite.GetKey()), optionalVersion(readWrite.Version))
 
 			if err := destination.WriteSet.Add(txNs.GetNsId(), string(readWrite.GetKey()), readWrite.GetValue()); err != nil {
 				// TODO: ... should we really just stop here or revert all changes ... ?
-				return errors.Wrapf(err, "adding readwrite [%s]", readWrite.GetKey())
+				return nil, errors.Wrapf(err, "adding readwrite [%s]", readWrite.GetKey())
 			}
 		}
 	}
 
-	return nil
+	return nsVersions, nil
 }
 
 // MarshalVersion encodes a uint64 version number into a protobuf varint byte slice.
 // This is used for encoding version information in the FabricX format.
 func MarshalVersion(v uint64) []byte {
 	return protowire.AppendVarint(nil, v)
+}
+
+// optionalVersion encodes an optional protobuf version field. An absent version stays
+// absent rather than collapsing to version 0: Marshal emits no version for a nil
+// RawVersion and version 0 for an encoded zero, and those are different bytes on the wire.
+func optionalVersion(v *uint64) driver.RawVersion {
+	if v == nil {
+		return nil
+	}
+	return MarshalVersion(*v)
 }
 
 // UnmarshalVersion decodes a protobuf varint byte slice into a uint64 version number.

--- a/platform/fabricx/core/vault/nsversion_test.go
+++ b/platform/fabricx/core/vault/nsversion_test.go
@@ -1,0 +1,600 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vault_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/vault"
+)
+
+// nsVersionOf decodes serialized RWSet bytes and returns the NsVersion carried for ns.
+func nsVersionOf(t *testing.T, raw []byte, ns driver.Namespace) uint64 {
+	t.Helper()
+	var tx applicationpb.Tx
+	require.NoError(t, proto.Unmarshal(raw, &tx))
+	for _, txNs := range tx.GetNamespaces() {
+		if txNs.GetNsId() == string(ns) {
+			return txNs.GetNsVersion()
+		}
+	}
+	t.Fatalf("namespace %s not present in serialized rwset", ns)
+	return 0
+}
+
+// Bytes() is a pure function of RWSet state: the namespace versions are resolved when a
+// namespace is first touched, so serialization itself must never reach the query service.
+func TestRWSet_Bytes_IssuesNoQueries(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	qs.setState("_meta", "ns1", nil, 7)
+	v := vault.NewVault(qs, nil)
+
+	rws, err := v.NewRWSet(context.Background(), "tx1")
+	require.NoError(t, err)
+	require.NoError(t, rws.SetState("ns1", "key1", []byte("val1")))
+
+	statesBefore := qs.getStatesCount.Load()
+
+	first, err := rws.Bytes()
+	require.NoError(t, err)
+	require.NotEmpty(t, first)
+
+	for range 4 {
+		again, err := rws.Bytes()
+		require.NoError(t, err)
+		require.Equal(t, first, again, "Bytes() must be deterministic across calls")
+	}
+
+	require.Equal(t, statesBefore, qs.getStatesCount.Load(), "Bytes() must not query state")
+}
+
+// The namespace version belongs to the simulation snapshot, alongside the key read
+// versions captured by GetState. A _meta bump after the namespace was touched must not
+// change what this RWSet serializes to.
+func TestRWSet_NamespaceVersionPinnedAtFirstTouch(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	qs.setState("_meta", "ns1", nil, 7)
+	v := vault.NewVault(qs, nil)
+
+	rws, err := v.NewRWSet(context.Background(), "tx1")
+	require.NoError(t, err)
+	require.NoError(t, rws.SetState("ns1", "key1", []byte("val1")))
+
+	// The namespace policy is updated after the namespace entered the RWSet.
+	qs.setState("_meta", "ns1", nil, 9)
+
+	raw, err := rws.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), nsVersionOf(t, raw, "ns1"))
+}
+
+// A namespace with no _meta entry serializes with version 0, matching the "unknown
+// namespace" fallback.
+func TestRWSet_UnknownNamespaceSerializesVersionZero(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	v := vault.NewVault(qs, nil)
+
+	rws, err := v.NewRWSet(context.Background(), "tx1")
+	require.NoError(t, err)
+	require.NoError(t, rws.SetState("ns1", "key1", []byte("val1")))
+
+	raw, err := rws.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), nsVersionOf(t, raw, "ns1"))
+}
+
+// Namespace versions are resolved per RWSet, exactly like the key read versions GetState
+// captures: nothing is cached across transactions, so each RWSet sees the version current
+// when it touched the namespace, and a later transaction picks up an updated one.
+func TestVault_NamespaceVersionResolvedPerRWSet(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	qs.setState("_meta", "ns1", nil, 7)
+	v := vault.NewVault(qs, nil)
+	ctx := context.Background()
+
+	first, err := v.NewRWSet(ctx, "tx1")
+	require.NoError(t, err)
+	require.NoError(t, first.SetState("ns1", "key1", []byte("val1")))
+
+	// A namespace policy update lands between the two transactions.
+	qs.setState("_meta", "ns1", nil, 9)
+
+	second, err := v.NewRWSet(ctx, "tx2")
+	require.NoError(t, err)
+	require.NoError(t, second.SetState("ns1", "key1", []byte("val1")))
+
+	firstRaw, err := first.Bytes()
+	require.NoError(t, err)
+	secondRaw, err := second.Bytes()
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(7), nsVersionOf(t, firstRaw, "ns1"),
+		"the in-flight RWSet keeps the version it simulated against")
+	require.Equal(t, uint64(9), nsVersionOf(t, secondRaw, "ns1"),
+		"a new RWSet must pick up the updated version without a restart")
+}
+
+// Touching the same namespace repeatedly resolves its version once; only the first touch
+// reaches the query service.
+func TestRWSet_NamespaceVersionResolvedOncePerNamespace(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	qs.setState("_meta", "ns1", nil, 7)
+	v := vault.NewVault(qs, nil)
+
+	rws, err := v.NewRWSet(context.Background(), "tx1")
+	require.NoError(t, err)
+
+	before := qs.getStatesCount.Load()
+	for i := range 5 {
+		require.NoError(t, rws.SetState("ns1", driver.PKey(string(rune('a'+i))), []byte("val")))
+	}
+	require.Equal(t, before+1, qs.getStatesCount.Load(),
+		"only the first touch of a namespace resolves its version")
+}
+
+// An endorser reconstructs the RWSet from the proposer's bytes and re-serializes it to
+// sign. The signature covers NsVersion, so re-serialization must reproduce the version
+// the proposer used, not whatever _meta says at endorsement time.
+func TestRWSet_FromBytesPreservesNamespaceVersion(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	qs.setState("_meta", "ns1", nil, 7)
+	v := vault.NewVault(qs, nil)
+	ctx := context.Background()
+
+	proposer, err := v.NewRWSet(ctx, "tx1")
+	require.NoError(t, err)
+	require.NoError(t, proposer.SetState("ns1", "key1", []byte("val1")))
+	proposed, err := proposer.Bytes()
+	require.NoError(t, err)
+
+	// The namespace policy moves on before the endorser reconstructs the transaction.
+	qs.setState("_meta", "ns1", nil, 9)
+
+	endorser, err := v.NewRWSetFromBytes(ctx, "tx1", proposed)
+	require.NoError(t, err)
+	reserialized, err := endorser.Bytes()
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(7), nsVersionOf(t, reserialized, "ns1"))
+	require.Equal(t, proposed, reserialized,
+		"an endorser must sign over the same bytes the proposer produced")
+}
+
+// AppendRWSet carries namespace versions in the appended payload the same way
+// NewRWSetFromBytes does.
+func TestRWSet_AppendPreservesNamespaceVersion(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	qs.setState("_meta", "ns1", nil, 7)
+	v := vault.NewVault(qs, nil)
+	ctx := context.Background()
+
+	source, err := v.NewRWSet(ctx, "tx1")
+	require.NoError(t, err)
+	require.NoError(t, source.SetState("ns1", "key1", []byte("val1")))
+	raw, err := source.Bytes()
+	require.NoError(t, err)
+
+	qs.setState("_meta", "ns1", nil, 9)
+
+	target, err := v.NewRWSet(ctx, "tx1")
+	require.NoError(t, err)
+	require.NoError(t, target.AppendRWSet(raw))
+
+	appended, err := target.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), nsVersionOf(t, appended, "ns1"))
+}
+
+// First pin wins: a namespace already touched locally keeps the version it resolved, and
+// an appended payload does not overwrite it. Documented so the ordering hazard is explicit
+// — appending into an RWSet that already touched the namespace does not reproduce the
+// proposer's bytes.
+func TestRWSet_AppendDoesNotOverwriteAnEarlierPin(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	qs.setState("_meta", "ns1", nil, 7)
+	v := vault.NewVault(qs, nil)
+	ctx := context.Background()
+
+	source, err := v.NewRWSet(ctx, "tx1")
+	require.NoError(t, err)
+	require.NoError(t, source.SetState("ns1", "key1", []byte("val1")))
+	raw, err := source.Bytes()
+	require.NoError(t, err)
+
+	qs.setState("_meta", "ns1", nil, 9)
+
+	target, err := v.NewRWSet(ctx, "tx2")
+	require.NoError(t, err)
+	// The namespace is pinned at 9 here, before the payload carrying version 7 arrives.
+	require.NoError(t, target.SetState("ns1", "key2", []byte("val2")))
+	require.NoError(t, target.AppendRWSet(raw))
+
+	appended, err := target.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, uint64(9), nsVersionOf(t, appended, "ns1"))
+}
+
+// Resolving the namespace version happens on first touch, so that is where a query
+// service failure must surface — not later, from serialization.
+func TestRWSet_FirstTouchReportsVersionLookupError(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	qs.getStatesErr = errors.New("simulated lookup failure")
+	v := vault.NewVault(qs, nil)
+
+	rws, err := v.NewRWSet(context.Background(), "tx1")
+	require.NoError(t, err)
+
+	err = rws.SetState("ns1", "key1", []byte("val1"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "simulated lookup failure")
+}
+
+// GetState is a namespace touch too: reading pins the version alongside the key read
+// version it adds to the read set.
+func TestRWSet_GetStatePinsNamespaceVersion(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	qs.setState("_meta", "ns1", nil, 7)
+	qs.setState("ns1", "key1", []byte("val1"), 3)
+	v := vault.NewVault(qs, nil)
+
+	rws, err := v.NewRWSet(context.Background(), "tx1")
+	require.NoError(t, err)
+
+	val, err := rws.GetState("ns1", "key1")
+	require.NoError(t, err)
+	require.Equal(t, []byte("val1"), val)
+
+	qs.setState("_meta", "ns1", nil, 9)
+
+	raw, err := rws.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), nsVersionOf(t, raw, "ns1"))
+}
+
+// Concurrent first touches of the same namespace must agree on one pinned version;
+// otherwise two Bytes() calls on the same RWSet could disagree.
+func TestRWSet_ConcurrentFirstTouchPinsSingleVersion(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	qs.setState("_meta", "ns1", nil, 7)
+	v := vault.NewVault(qs, nil)
+
+	rws, err := v.NewRWSet(context.Background(), "tx1")
+	require.NoError(t, err)
+
+	var eg errgroup.Group
+	for g := range 16 {
+		eg.Go(func() error {
+			return rws.SetState("ns1", driver.PKey(string(rune('a'+g))), []byte("value"))
+		})
+	}
+	require.NoError(t, eg.Wait())
+
+	raw, err := rws.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), nsVersionOf(t, raw, "ns1"))
+}
+
+// Bytes() passes the pinned versions straight to Marshal, which rejects a namespace it has
+// no version for. Every mutating entry point must therefore pin, or serialization fails at
+// runtime. This walks each of them.
+func TestRWSet_EveryMutatorPinsNamespace(t *testing.T) {
+	t.Parallel()
+
+	mutators := map[string]func(t *testing.T, rws driver.RWSet){
+		"SetState": func(t *testing.T, rws driver.RWSet) {
+			t.Helper()
+			require.NoError(t, rws.SetState("ns1", "key1", []byte("val1")))
+		},
+		"DeleteState": func(t *testing.T, rws driver.RWSet) {
+			t.Helper()
+			require.NoError(t, rws.DeleteState("ns1", "key1"))
+		},
+		"AddReadAt": func(t *testing.T, rws driver.RWSet) {
+			t.Helper()
+			require.NoError(t, rws.AddReadAt("ns1", "key1", vault.MarshalVersion(3)))
+		},
+		"GetState": func(t *testing.T, rws driver.RWSet) {
+			t.Helper()
+			_, err := rws.GetState("ns1", "key1")
+			require.NoError(t, err)
+		},
+		"SetStateMetadata": func(t *testing.T, rws driver.RWSet) {
+			t.Helper()
+			require.NoError(t, rws.SetStateMetadata("ns1", "key1", driver.Metadata{"m": []byte("v")}))
+		},
+	}
+
+	for name, mutate := range mutators {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			qs := newMockQueryService()
+			qs.setState("_meta", "ns1", nil, 7)
+			qs.setState("ns1", "key1", []byte("val1"), 3)
+			v := vault.NewVault(qs, nil)
+
+			rws, err := v.NewRWSet(context.Background(), "tx1")
+			require.NoError(t, err)
+			mutate(t, rws)
+
+			// Serialization must succeed; an unpinned namespace makes Marshal fail with
+			// "nsInfo does not contain entry for ns".
+			raw, err := rws.Bytes()
+			require.NoError(t, err)
+
+			// SetStateMetadata alone produces no namespace in the FabricX encoding, which
+			// only carries reads and writes; the rest must carry the pinned version.
+			if name != "SetStateMetadata" {
+				require.Equal(t, uint64(7), nsVersionOf(t, raw, "ns1"))
+			}
+		})
+	}
+}
+
+// A namespace re-touched after Clear is re-pinned rather than serialized without a version.
+func TestRWSet_ClearedNamespaceIsRepinned(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	qs.setState("_meta", "ns1", nil, 7)
+	v := vault.NewVault(qs, nil)
+
+	rws, err := v.NewRWSet(context.Background(), "tx1")
+	require.NoError(t, err)
+	require.NoError(t, rws.SetState("ns1", "key1", []byte("val1")))
+	require.NoError(t, rws.Clear("ns1"))
+
+	qs.setState("_meta", "ns1", nil, 9)
+	require.NoError(t, rws.SetState("ns1", "key1", []byte("val1")))
+
+	raw, err := rws.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, uint64(9), nsVersionOf(t, raw, "ns1"),
+		"Clear drops the pin, so the next touch resolves a fresh version")
+}
+
+// IsValid checks the whole simulation snapshot, and the pinned namespace version is part
+// of it: the committer validates NsVersion as a read of _meta[ns], so a namespace policy
+// update invalidates the transaction just like a conflicting key read does.
+func TestRWSet_IsValid_DetectsNamespaceVersionChange(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	qs.setState("_meta", "ns1", nil, 7)
+	v := vault.NewVault(qs, nil)
+
+	rws, err := v.NewRWSet(context.Background(), "tx1")
+	require.NoError(t, err)
+	require.NoError(t, rws.SetState("ns1", "key1", []byte("val1")))
+	require.NoError(t, rws.IsValid())
+
+	qs.setState("_meta", "ns1", nil, 9)
+
+	err = rws.IsValid()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ns1")
+}
+
+// A namespace that gets registered after it was touched as unknown (version 0) also
+// invalidates the snapshot.
+func TestRWSet_IsValid_DetectsNamespaceRegisteredAfterTouch(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	v := vault.NewVault(qs, nil)
+
+	rws, err := v.NewRWSet(context.Background(), "tx1")
+	require.NoError(t, err)
+	require.NoError(t, rws.SetState("ns1", "key1", []byte("val1")))
+	require.NoError(t, rws.IsValid())
+
+	qs.setState("_meta", "ns1", nil, 1)
+
+	require.Error(t, rws.IsValid())
+}
+
+// Validating reads and namespace versions is a single batched round-trip, not one call
+// per key.
+func TestRWSet_IsValid_BatchesLookups(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	qs.setState("_meta", "ns1", nil, 7)
+	for _, k := range []driver.PKey{"key1", "key2", "key3"} {
+		qs.setState("ns1", k, []byte("val"), 1)
+	}
+	v := vault.NewVault(qs, nil)
+
+	rws, err := v.NewRWSet(context.Background(), "tx1")
+	require.NoError(t, err)
+	for _, k := range []driver.PKey{"key1", "key2", "key3"} {
+		_, err := rws.GetState("ns1", k)
+		require.NoError(t, err)
+	}
+
+	before := qs.getStatesCount.Load()
+	require.NoError(t, rws.IsValid())
+	require.Equal(t, before+1, qs.getStatesCount.Load(),
+		"IsValid should issue one batched query, not one per read")
+}
+
+// The _meta key list is built from both the RWSet's own reads and the pinned namespaces.
+// Those two sources overlap when the RWSet reads inside _meta, and the batch must not
+// carry the same key twice.
+func TestRWSet_IsValid_DoesNotDuplicateMetaKeys(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	qs.setState("_meta", "ns1", nil, 7)
+	v := vault.NewVault(qs, nil)
+
+	rws, err := v.NewRWSet(context.Background(), "tx1")
+	require.NoError(t, err)
+	require.NoError(t, rws.SetState("ns1", "key1", []byte("val1")))
+	// Read a key that lives in _meta, so the read keys and the pinned namespaces overlap.
+	_, err = rws.GetState("_meta", "ns1")
+	require.NoError(t, err)
+
+	require.NoError(t, rws.IsValid())
+
+	metaKeys := qs.lastQuery()["_meta"]
+	seen := make(map[driver.PKey]int, len(metaKeys))
+	for _, k := range metaKeys {
+		seen[k]++
+	}
+	for k, n := range seen {
+		require.Equal(t, 1, n, "key %s appears %d times in the _meta batch", k, n)
+	}
+}
+
+// Append's namespace filter is documented to restrict what is deserialized; InspectRWSet
+// and AppendRWSet both forward a caller-supplied list to it.
+func TestRWSet_AppendHonoursNamespaceFilter(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	qs.setState("_meta", "ns1", nil, 7)
+	qs.setState("_meta", "ns2", nil, 8)
+	v := vault.NewVault(qs, nil)
+	ctx := context.Background()
+
+	source, err := v.NewRWSet(ctx, "tx1")
+	require.NoError(t, err)
+	require.NoError(t, source.SetState("ns1", "key1", []byte("val1")))
+	require.NoError(t, source.SetState("ns2", "key2", []byte("val2")))
+	raw, err := source.Bytes()
+	require.NoError(t, err)
+
+	t.Run("AppendRWSet", func(t *testing.T) {
+		t.Parallel()
+		target, err := v.NewRWSet(ctx, "tx2")
+		require.NoError(t, err)
+		require.NoError(t, target.AppendRWSet(raw, "ns1"))
+
+		require.Equal(t, 1, target.NumWrites("ns1"))
+		require.Equal(t, 0, target.NumWrites("ns2"), "ns2 must be filtered out")
+		require.Equal(t, []driver.Namespace{"ns1"}, target.Namespaces())
+	})
+
+	t.Run("InspectRWSet", func(t *testing.T) {
+		t.Parallel()
+		inspected, err := v.InspectRWSet(ctx, raw, "ns2")
+		require.NoError(t, err)
+
+		require.Equal(t, 1, inspected.NumWrites("ns2"))
+		require.Equal(t, 0, inspected.NumWrites("ns1"), "ns1 must be filtered out")
+		require.Equal(t, []driver.Namespace{"ns2"}, inspected.Namespaces())
+
+		// The filtered result must still serialize, which requires the pinned version for
+		// the namespace that survived the filter.
+		out, err := inspected.Bytes()
+		require.NoError(t, err)
+		require.Equal(t, uint64(8), nsVersionOf(t, out, "ns2"))
+	})
+
+	t.Run("NoFilterKeepsEverything", func(t *testing.T) {
+		t.Parallel()
+		target, err := v.NewRWSet(ctx, "tx3")
+		require.NoError(t, err)
+		require.NoError(t, target.AppendRWSet(raw))
+		require.Equal(t, 1, target.NumWrites("ns1"))
+		require.Equal(t, 1, target.NumWrites("ns2"))
+	})
+}
+
+// namespacesOf decodes serialized RWSet bytes and returns the namespace ids it carries.
+func namespacesOf(t *testing.T, raw []byte) []string {
+	t.Helper()
+	var tx applicationpb.Tx
+	require.NoError(t, proto.Unmarshal(raw, &tx))
+	nss := make([]string, 0, len(tx.GetNamespaces()))
+	for _, txNs := range tx.GetNamespaces() {
+		nss = append(nss, txNs.GetNsId())
+	}
+	return nss
+}
+
+// Clear drops the namespace's pinned version, so it must drop the namespace from the
+// RWSet as well: a namespace that survives in the read/write maps without a pin makes
+// Marshal reject the whole RWSet.
+func TestRWSet_ClearedNamespaceStillSerializes(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	qs.setState("_meta", "ns1", nil, 7)
+	qs.setState("_meta", "ns2", nil, 8)
+	v := vault.NewVault(qs, nil)
+
+	rws, err := v.NewRWSet(context.Background(), "tx1")
+	require.NoError(t, err)
+	require.NoError(t, rws.SetState("ns1", "key1", []byte("val1")))
+	require.NoError(t, rws.SetState("ns2", "key2", []byte("val2")))
+
+	require.NoError(t, rws.Clear("ns1"))
+
+	raw, err := rws.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, []string{"ns2"}, namespacesOf(t, raw),
+		"a cleared namespace must not survive into the serialized form")
+	require.NotContains(t, rws.Namespaces(), driver.Namespace("ns1"))
+}
+
+// A read of a key that does not exist is serialized with no version at all. Append must
+// preserve that, because an endorser re-serializes what it received and signs the result.
+func TestRWSet_VersionlessReadRoundTrips(t *testing.T) {
+	t.Parallel()
+	first, err := proto.Marshal(&applicationpb.Tx{Namespaces: []*applicationpb.TxNamespace{{
+		NsId:      "ns1",
+		NsVersion: 7,
+		ReadsOnly: []*applicationpb.Read{{Key: []byte("missing-key"), Version: nil}},
+	}}})
+	require.NoError(t, err)
+
+	m := vault.NewMarshaller()
+	rws, nsVersions, err := m.RWSetFromBytes(first)
+	require.NoError(t, err)
+	second, err := m.Marshal("tx1", rws, nsVersions)
+	require.NoError(t, err)
+
+	require.Equal(t, first, second, "a versionless read must re-serialize unchanged")
+}
+
+// A ReadWrite with no version means "this key is created for the first time". Dropping it
+// from the read set turns it into a BlindWrite on re-serialization, which changes both the
+// bytes and their meaning to the committer.
+func TestRWSet_VersionlessReadWriteRoundTrips(t *testing.T) {
+	t.Parallel()
+	first, err := proto.Marshal(&applicationpb.Tx{Namespaces: []*applicationpb.TxNamespace{{
+		NsId:       "ns1",
+		NsVersion:  7,
+		ReadWrites: []*applicationpb.ReadWrite{{Key: []byte("new-key"), Version: nil, Value: []byte("val")}},
+	}}})
+	require.NoError(t, err)
+
+	m := vault.NewMarshaller()
+	rws, nsVersions, err := m.RWSetFromBytes(first)
+	require.NoError(t, err)
+	second, err := m.Marshal("tx1", rws, nsVersions)
+	require.NoError(t, err)
+
+	var back applicationpb.Tx
+	require.NoError(t, proto.Unmarshal(second, &back))
+	require.Len(t, back.GetNamespaces()[0].GetReadWrites(), 1,
+		"a versionless ReadWrite must stay a ReadWrite, not degrade to a BlindWrite")
+	require.Equal(t, first, second)
+}

--- a/platform/fabricx/core/vault/vault.go
+++ b/platform/fabricx/core/vault/vault.go
@@ -7,8 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package vault
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
+	"maps"
+	"sync"
 
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 
@@ -17,6 +20,10 @@ import (
 	cdriver "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
+)
+
+const (
+	metaNamespace = "_meta"
 )
 
 // Vault implements the fdriver.Vault interface for FabricX. Several interface methods
@@ -111,18 +118,29 @@ func (v *Vault) NewQueryExecutor(ctx context.Context) (cdriver.QueryExecutor, er
 // rwSetWrapper wraps a ReadWriteSet to implement the cdriver.RWSet interface.
 // It provides read/write operations with QueryService integration for state queries.
 type rwSetWrapper struct {
-	txID cdriver.TxID          // Transaction ID
-	rws  *vault.ReadWriteSet   // Underlying read-write set
-	qe   cdriver.QueryExecutor // Query executor for state queries
-	v    *Vault                // Parent vault for accessing query service
+	txID        cdriver.TxID          // Transaction ID
+	rws         *vault.ReadWriteSet   // Underlying read-write set
+	qe          cdriver.QueryExecutor // Query executor for state queries
+	v           *Vault                // Parent vault for accessing query service
+	mu          sync.Mutex            // Protects cachedBytes
+	cachedBytes []byte                // Cached serialized bytes of the rwset
 }
 
 // IsValid validates that all reads in the RWSet are still valid by checking
 // that the versions in the ledger match the versions in the read set.
 // Returns an error if any read is invalid (version mismatch or key deleted).
 func (r *rwSetWrapper) IsValid() error {
-	// Validate that all reads are still valid
+	r.mu.Lock()
+	// create a copy of the reads to validate without holding the lock during network queries
+	readsCopy := make(map[cdriver.Namespace]map[string]cdriver.RawVersion)
 	for ns, reads := range r.rws.Reads {
+		readsCopy[ns] = make(map[string]cdriver.RawVersion)
+		maps.Copy(readsCopy[ns], reads)
+	}
+	r.mu.Unlock()
+
+	// Validate that all reads are still valid
+	for ns, reads := range readsCopy {
 		for key, expectedVersion := range reads {
 			vaultValue, err := r.v.queryService.GetState(ns, key)
 			if err != nil {
@@ -149,21 +167,31 @@ func (r *rwSetWrapper) IsClosed() bool {
 
 // Clear removes all reads, writes, and metadata writes for the specified namespace.
 func (r *rwSetWrapper) Clear(ns cdriver.Namespace) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.rws.ReadSet.Clear(ns)
 	r.rws.WriteSet.Clear(ns)
 	r.rws.MetaWriteSet.Clear(ns)
+	r.cachedBytes = nil
 	return nil
 }
 
 // AddReadAt adds a read dependency for the given namespace, key, and version to the read set.
 func (r *rwSetWrapper) AddReadAt(ns cdriver.Namespace, key string, version cdriver.RawVersion) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.rws.ReadSet.Add(ns, key, version)
+	r.cachedBytes = nil
 	return nil
 }
 
 // SetState sets the value for the given namespace and key in the write set.
 func (r *rwSetWrapper) SetState(namespace cdriver.Namespace, key cdriver.PKey, value cdriver.RawValue) error {
-	return r.rws.WriteSet.Add(namespace, key, value)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	err := r.rws.WriteSet.Add(namespace, key, value)
+	r.cachedBytes = nil
+	return err
 }
 
 // GetState retrieves the state for a given namespace and key.
@@ -171,7 +199,10 @@ func (r *rwSetWrapper) SetState(namespace cdriver.Namespace, key cdriver.PKey, v
 // The behavior can be controlled with GetStateOpt options.
 func (r *rwSetWrapper) GetState(namespace cdriver.Namespace, key cdriver.PKey, opts ...cdriver.GetStateOpt) (cdriver.RawValue, error) {
 	// Check writes first
-	if val, exists := r.rws.Writes[namespace][key]; exists {
+	r.mu.Lock()
+	val, exists := r.rws.Writes[namespace][key]
+	r.mu.Unlock()
+	if exists {
 		return val, nil
 	}
 
@@ -195,7 +226,10 @@ func (r *rwSetWrapper) GetState(namespace cdriver.Namespace, key cdriver.PKey, o
 	}
 
 	// Add to read set
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.rws.ReadSet.Add(namespace, key, vaultValue.Version)
+	r.cachedBytes = nil
 
 	return vaultValue.Raw, nil
 }
@@ -215,14 +249,21 @@ func (r *rwSetWrapper) GetDirectState(namespace cdriver.Namespace, key cdriver.P
 
 // DeleteState marks a key for deletion by adding a nil value to the write set.
 func (r *rwSetWrapper) DeleteState(namespace cdriver.Namespace, key cdriver.PKey) error {
-	return r.rws.WriteSet.Add(namespace, key, nil)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	err := r.rws.WriteSet.Add(namespace, key, nil)
+	r.cachedBytes = nil
+	return err
 }
 
 // GetStateMetadata retrieves metadata for a given namespace and key.
 // It checks the local metadata writes first, returning nil if not found.
 func (r *rwSetWrapper) GetStateMetadata(namespace cdriver.Namespace, key cdriver.PKey, opts ...cdriver.GetStateOpt) (cdriver.Metadata, error) {
 	// Check in-flight meta writes first.
-	if meta, exists := r.rws.MetaWrites[namespace][key]; exists {
+	r.mu.Lock()
+	meta, exists := r.rws.MetaWrites[namespace][key]
+	r.mu.Unlock()
+	if exists {
 		return meta, nil
 	}
 
@@ -251,12 +292,18 @@ func (r *rwSetWrapper) GetStateMetadata(namespace cdriver.Namespace, key cdriver
 
 // SetStateMetadata sets metadata for a given namespace and key in the metadata write set.
 func (r *rwSetWrapper) SetStateMetadata(namespace cdriver.Namespace, key cdriver.PKey, metadata cdriver.Metadata) error {
-	return r.rws.MetaWriteSet.Add(namespace, key, metadata)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	err := r.rws.MetaWriteSet.Add(namespace, key, metadata)
+	r.cachedBytes = nil
+	return err
 }
 
 // GetReadKeyAt returns the key of the i-th read in the specified namespace.
 // Returns an error if the index is out of bounds.
 func (r *rwSetWrapper) GetReadKeyAt(ns cdriver.Namespace, i int) (cdriver.PKey, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	key, ok := r.rws.ReadSet.GetAt(ns, i)
 	if !ok {
 		return "", errors.Errorf("index %d out of bounds for namespace %s", i, ns)
@@ -288,6 +335,8 @@ func (r *rwSetWrapper) GetReadAt(ns cdriver.Namespace, i int) (cdriver.PKey, cdr
 // GetWriteAt returns the i-th write (key, value) in the specified namespace.
 // Returns an error if the index is out of bounds.
 func (r *rwSetWrapper) GetWriteAt(ns cdriver.Namespace, i int) (cdriver.PKey, cdriver.RawValue, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	key, ok := r.rws.WriteSet.GetAt(ns, i)
 	if !ok {
 		return "", nil, errors.Errorf("index %d out of bounds for namespace %s", i, ns)
@@ -298,16 +347,26 @@ func (r *rwSetWrapper) GetWriteAt(ns cdriver.Namespace, i int) (cdriver.PKey, cd
 
 // NumReads returns the number of reads in the specified namespace.
 func (r *rwSetWrapper) NumReads(ns cdriver.Namespace) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return len(r.rws.Reads[ns])
 }
 
 // NumWrites returns the number of writes in the specified namespace.
 func (r *rwSetWrapper) NumWrites(ns cdriver.Namespace) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return len(r.rws.Writes[ns])
 }
 
 // Namespaces returns all namespace labels present in this RWSet (reads, writes, or metadata).
 func (r *rwSetWrapper) Namespaces() []cdriver.Namespace {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.namespacesLocked()
+}
+
+func (r *rwSetWrapper) namespacesLocked() []cdriver.Namespace {
 	nsMap := make(map[cdriver.Namespace]bool)
 	for ns := range r.rws.Reads {
 		nsMap[ns] = true
@@ -329,34 +388,58 @@ func (r *rwSetWrapper) Namespaces() []cdriver.Namespace {
 // AppendRWSet deserializes and appends RWSet data from bytes to this RWSet.
 // If namespaces are specified, only those namespaces will be appended.
 func (r *rwSetWrapper) AppendRWSet(raw []byte, nss ...cdriver.Namespace) error {
-	return r.v.marshaller.Append(r.rws, raw, nss...)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	err := r.v.marshaller.Append(r.rws, raw, nss...)
+	r.cachedBytes = nil
+	return err
 }
 
 // Bytes serializes this RWSet to bytes in FabricX protobuf format.
 // It automatically fetches namespace versions from the _meta namespace via QueryService.
+// Note: It holds the RWSet lock across the remote GetStates network query.
+// If a cached version exists, it returns a defensive copy and skips the version lookup.
+// It assumes _meta versions are stable for the RWSet's lifetime.
 func (r *rwSetWrapper) Bytes() ([]byte, error) {
-	// Get namespace versions from the query service
-	namespaces := r.Namespaces()
-	nsInfo := make(map[cdriver.Namespace]cdriver.RawVersion)
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
-	for _, ns := range namespaces {
-		// Try to get namespace version from _meta namespace
-		vaultValue, err := r.v.queryService.GetState("_meta", ns)
-		if err != nil {
-			// If error, use version 0
-			nsInfo[ns] = MarshalVersion(0)
-		} else if vaultValue == nil {
-			// If not found, use version 0
-			nsInfo[ns] = MarshalVersion(0)
+	if r.cachedBytes == nil {
+		namespaces := r.namespacesLocked()
+		nsInfo := make(map[cdriver.Namespace]cdriver.RawVersion, len(namespaces))
+		if len(namespaces) == 0 {
+			raw, err := r.v.marshaller.Marshal(string(r.txID), r.rws, nsInfo)
+			if err != nil {
+				return nil, err
+			}
+			r.cachedBytes = raw
 		} else {
-			// Use the version from _meta
-			nsInfo[ns] = vaultValue.Version
+			states, err := r.v.queryService.GetStates(map[cdriver.Namespace][]cdriver.PKey{metaNamespace: namespaces})
+			if err != nil {
+				// Failed to query versions, fail the marshal instead of silently using version 0.
+				return nil, errors.Wrapf(err, "failed to query %s versions for tx %s", metaNamespace, string(r.txID))
+			}
+			metaStates := states[metaNamespace] // nil-safe
+
+			for _, ns := range namespaces {
+				if v, ok := metaStates[ns]; ok {
+					nsInfo[ns] = v.Version
+				} else {
+					nsInfo[ns] = MarshalVersion(0) // unknown namespace
+				}
+			}
+
+			// Pass nsInfo per call rather than through shared marshaller state, so concurrent
+			// Bytes() calls on different RWSets from the same vault do not race.
+			raw, err := r.v.marshaller.Marshal(string(r.txID), r.rws, nsInfo)
+			if err != nil {
+				return nil, err
+			}
+			r.cachedBytes = raw
 		}
 	}
 
-	// Pass nsInfo per call rather than through shared marshaller state, so concurrent
-	// Bytes() calls on different RWSets from the same vault do not race.
-	return r.v.marshaller.Marshal(string(r.txID), r.rws, nsInfo)
+	return bytes.Clone(r.cachedBytes), nil
 }
 
 // Done is a no-op. The vault does not retain the ReadWriteSet.
@@ -370,6 +453,13 @@ func (r *rwSetWrapper) Equals(rws any, nss ...cdriver.Namespace) error {
 	other, ok := rws.(*rwSetWrapper)
 	if !ok {
 		return errors.Errorf("expected *rwSetWrapper, got %T", rws)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r != other {
+		other.mu.Lock()
+		defer other.mu.Unlock()
 	}
 
 	if err := r.rws.Reads.Equals(other.rws.Reads, nss...); err != nil {

--- a/platform/fabricx/core/vault/vault.go
+++ b/platform/fabricx/core/vault/vault.go
@@ -12,6 +12,7 @@ import (
 	"crypto/sha256"
 	"maps"
 	"sync"
+	"unsafe"
 
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 
@@ -455,11 +456,19 @@ func (r *rwSetWrapper) Equals(rws any, nss ...cdriver.Namespace) error {
 		return errors.Errorf("expected *rwSetWrapper, got %T", rws)
 	}
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r != other {
+	if r == other {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+	} else if uintptr(unsafe.Pointer(r)) < uintptr(unsafe.Pointer(other)) {
+		r.mu.Lock()
+		defer r.mu.Unlock()
 		other.mu.Lock()
 		defer other.mu.Unlock()
+	} else {
+		other.mu.Lock()
+		defer other.mu.Unlock()
+		r.mu.Lock()
+		defer r.mu.Unlock()
 	}
 
 	if err := r.rws.Reads.Equals(other.rws.Reads, nss...); err != nil {

--- a/platform/fabricx/core/vault/vault.go
+++ b/platform/fabricx/core/vault/vault.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"maps"
+	"slices"
 	"sync"
 	"unsafe"
 
@@ -118,46 +119,166 @@ func (v *Vault) NewQueryExecutor(ctx context.Context) (cdriver.QueryExecutor, er
 
 // rwSetWrapper wraps a ReadWriteSet to implement the cdriver.RWSet interface.
 // It provides read/write operations with QueryService integration for state queries.
+//
+// Concurrency: every method is race-free — the mutex guards all shared state, so
+// concurrent calls cannot corrupt the RWSet or trip the race detector. That is weaker
+// than atomicity: methods that consult the RWSet, query the network, and then mutate
+// (notably GetState) release the lock in between, so a concurrent SetState on the same
+// key can interleave. See GetState for what that produces. Callers that need a coherent
+// simulation must not mutate one RWSet from multiple goroutines.
 type rwSetWrapper struct {
-	txID        cdriver.TxID          // Transaction ID
-	rws         *vault.ReadWriteSet   // Underlying read-write set
-	qe          cdriver.QueryExecutor // Query executor for state queries
-	v           *Vault                // Parent vault for accessing query service
-	mu          sync.Mutex            // Protects cachedBytes
-	cachedBytes []byte                // Cached serialized bytes of the rwset
+	txID cdriver.TxID          // Transaction ID
+	rws  *vault.ReadWriteSet   // Underlying read-write set
+	qe   cdriver.QueryExecutor // Query executor for state queries
+	v    *Vault                // Parent vault for accessing query service
+
+	mu sync.Mutex // Protects rws, nsVersions and cachedBytes
+	// nsVersions holds the _meta version pinned for each namespace at the moment it first
+	// entered the RWSet, alongside the key read versions captured by GetState. Together
+	// they form one simulation snapshot.
+	nsVersions  map[cdriver.Namespace]cdriver.RawVersion
+	cachedBytes []byte // Memoized serialization; Bytes() is pure, so this is only an optimization
 }
 
-// IsValid validates that all reads in the RWSet are still valid by checking
-// that the versions in the ledger match the versions in the read set.
-// Returns an error if any read is invalid (version mismatch or key deleted).
+// pinNamespace resolves and records the version of ns unless it is already pinned.
+// The first pin wins: a namespace's version is fixed at first touch and never revised,
+// so repeated serializations of the same RWSet agree.
+//
+// The version is read from _meta at the moment the namespace enters the RWSet, exactly
+// as GetState reads a key's version when it enters the read set. Nothing is cached
+// between RWSets, so a namespace policy update is picked up by the next transaction.
+//
+// The lookup runs without holding r.mu, so a slow query service cannot stall unrelated
+// operations on this RWSet.
+func (r *rwSetWrapper) pinNamespace(ns cdriver.Namespace) error {
+	r.mu.Lock()
+	_, pinned := r.nsVersions[ns]
+	r.mu.Unlock()
+	if pinned {
+		return nil
+	}
+
+	version, err := r.v.namespaceVersion(ns)
+	if err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pinNamespaceVersionLocked(ns, version)
+	return nil
+}
+
+// pinNamespaceVersionLocked records version for ns unless a version is already pinned.
+func (r *rwSetWrapper) pinNamespaceVersionLocked(ns cdriver.Namespace, version cdriver.RawVersion) {
+	if _, pinned := r.nsVersions[ns]; !pinned {
+		r.nsVersions[ns] = version
+	}
+}
+
+// IsValid validates that the whole simulation snapshot is still current: every key read
+// version, and every namespace version pinned when a namespace was first touched.
+//
+// The namespace versions belong here because the committer validates a transaction's
+// NsVersion as a read-only dependency on _meta[ns] (see the preparer in fabric-x-committer),
+// so a namespace policy update invalidates a transaction exactly like a conflicting key
+// read does.
+//
+// Reads and namespace versions are checked in one batched query rather than one call per key.
 func (r *rwSetWrapper) IsValid() error {
 	r.mu.Lock()
-	// create a copy of the reads to validate without holding the lock during network queries
-	readsCopy := make(map[cdriver.Namespace]map[string]cdriver.RawVersion)
+	// Copy the snapshot so the network query runs without holding the lock.
+	readsCopy := make(map[cdriver.Namespace]map[string]cdriver.RawVersion, len(r.rws.Reads))
 	for ns, reads := range r.rws.Reads {
-		readsCopy[ns] = make(map[string]cdriver.RawVersion)
+		readsCopy[ns] = make(map[string]cdriver.RawVersion, len(reads))
 		maps.Copy(readsCopy[ns], reads)
 	}
+	nsVersionsCopy := make(map[cdriver.Namespace]cdriver.RawVersion, len(r.nsVersions))
+	maps.Copy(nsVersionsCopy, r.nsVersions)
 	r.mu.Unlock()
 
-	// Validate that all reads are still valid
+	// Build the batch as key sets. The RWSet's own reads and the pinned namespaces both
+	// contribute keys to _meta whenever the RWSet reads inside that namespace, so the two
+	// sources have to be merged rather than concatenated.
+	querySets := make(map[cdriver.Namespace]map[cdriver.PKey]struct{}, len(readsCopy)+1)
+	addKey := func(ns cdriver.Namespace, key cdriver.PKey) {
+		keys, ok := querySets[ns]
+		if !ok {
+			keys = make(map[cdriver.PKey]struct{})
+			querySets[ns] = keys
+		}
+		keys[key] = struct{}{}
+	}
+	for ns, reads := range readsCopy {
+		for key := range reads {
+			addKey(ns, key)
+		}
+	}
+	for ns := range nsVersionsCopy {
+		addKey(metaNamespace, cdriver.PKey(ns))
+	}
+
+	// A namespace with no keys makes the query service reject the whole batch.
+	query := make(map[cdriver.Namespace][]cdriver.PKey, len(querySets))
+	for ns, keys := range querySets {
+		if len(keys) == 0 {
+			continue
+		}
+		query[ns] = slices.Collect(maps.Keys(keys))
+	}
+	if len(query) == 0 {
+		return nil
+	}
+
+	states, err := r.v.queryService.GetStates(query)
+	if err != nil {
+		return errors.Wrapf(err, "failed to validate rwset for tx %s", string(r.txID))
+	}
+
 	for ns, reads := range readsCopy {
 		for key, expectedVersion := range reads {
-			vaultValue, err := r.v.queryService.GetState(ns, key)
-			if err != nil {
-				return errors.Wrapf(err, "failed to validate read for namespace=%s, key=%s", ns, key)
-			}
+			current, found := states[ns][key]
 
 			// Check version match
-			if vaultValue == nil && expectedVersion != nil {
+			if !found && expectedVersion != nil {
 				return errors.Errorf("read validation failed: key %s in namespace %s was deleted", key, ns)
 			}
-			if vaultValue != nil && !r.v.versionEqual(expectedVersion, vaultValue.Version) {
+			if found && !r.v.versionEqual(expectedVersion, current.Version) {
 				return errors.Errorf("read validation failed: version mismatch for key %s in namespace %s", key, ns)
 			}
 		}
 	}
+
+	for ns, pinnedVersion := range nsVersionsCopy {
+		current, found := states[metaNamespace][cdriver.PKey(ns)]
+		// An unregistered namespace was pinned at version 0; it stays valid only while it
+		// remains unregistered.
+		currentVersion := MarshalVersion(0)
+		if found {
+			currentVersion = current.Version
+		}
+		if !r.v.versionEqual(pinnedVersion, currentVersion) {
+			return errors.Errorf("read validation failed: namespace %s version changed since simulation", ns)
+		}
+	}
+
 	return nil
+}
+
+// namespaceVersion reads the version of ns from the _meta namespace. A namespace with no
+// _meta entry is reported as version 0, matching how an unregistered namespace has always
+// been serialized.
+func (v *Vault) namespaceVersion(ns cdriver.Namespace) (cdriver.RawVersion, error) {
+	states, err := v.queryService.GetStates(map[cdriver.Namespace][]cdriver.PKey{
+		metaNamespace: {cdriver.PKey(ns)},
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to query %s version for namespace %s", metaNamespace, ns)
+	}
+	if state, ok := states[metaNamespace][cdriver.PKey(ns)]; ok {
+		return state.Version, nil
+	}
+	return MarshalVersion(0), nil
 }
 
 // IsClosed returns whether this RWSet has been closed. Always returns false
@@ -167,18 +288,33 @@ func (r *rwSetWrapper) IsClosed() bool {
 }
 
 // Clear removes all reads, writes, and metadata writes for the specified namespace.
+// The namespace's pinned version is dropped too, so touching it again re-pins it.
+//
+// The ReadSet/WriteSet/MetaWriteSet Clear methods only empty the namespace's inner map,
+// leaving the namespace key behind. That leftover has to go as well: Marshal ranges over
+// the write and read maps and demands a pinned version for every namespace it finds, so a
+// key that outlives its pin makes the next Bytes() fail.
 func (r *rwSetWrapper) Clear(ns cdriver.Namespace) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.rws.ReadSet.Clear(ns)
 	r.rws.WriteSet.Clear(ns)
 	r.rws.MetaWriteSet.Clear(ns)
+	delete(r.rws.Reads, ns)
+	delete(r.rws.OrderedReads, ns)
+	delete(r.rws.Writes, ns)
+	delete(r.rws.OrderedWrites, ns)
+	delete(r.rws.MetaWrites, ns)
+	delete(r.nsVersions, ns)
 	r.cachedBytes = nil
 	return nil
 }
 
 // AddReadAt adds a read dependency for the given namespace, key, and version to the read set.
 func (r *rwSetWrapper) AddReadAt(ns cdriver.Namespace, key string, version cdriver.RawVersion) error {
+	if err := r.pinNamespace(ns); err != nil {
+		return err
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.rws.ReadSet.Add(ns, key, version)
@@ -188,6 +324,9 @@ func (r *rwSetWrapper) AddReadAt(ns cdriver.Namespace, key string, version cdriv
 
 // SetState sets the value for the given namespace and key in the write set.
 func (r *rwSetWrapper) SetState(namespace cdriver.Namespace, key cdriver.PKey, value cdriver.RawValue) error {
+	if err := r.pinNamespace(namespace); err != nil {
+		return err
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	err := r.rws.WriteSet.Add(namespace, key, value)
@@ -198,6 +337,13 @@ func (r *rwSetWrapper) SetState(namespace cdriver.Namespace, key cdriver.PKey, v
 // GetState retrieves the state for a given namespace and key.
 // It first checks the local write set, then queries the remote storage if needed.
 // The behavior can be controlled with GetStateOpt options.
+//
+// The write-set check, the remote query and the read-set update are three separate
+// critical sections, not one atomic operation. A SetState for the same key that lands in
+// between makes this method record a read even though the key is now locally written, and
+// Marshal turns a key that is both read and written into a ReadWrite — a version-
+// conditional write the caller never asked for, which the committer invalidates on any
+// concurrent ledger update. Do not simulate one RWSet from multiple goroutines.
 func (r *rwSetWrapper) GetState(namespace cdriver.Namespace, key cdriver.PKey, opts ...cdriver.GetStateOpt) (cdriver.RawValue, error) {
 	// Check writes first
 	r.mu.Lock()
@@ -226,7 +372,10 @@ func (r *rwSetWrapper) GetState(namespace cdriver.Namespace, key cdriver.PKey, o
 		return nil, nil
 	}
 
-	// Add to read set
+	// Add to read set, pinning the namespace version alongside the key's read version.
+	if err := r.pinNamespace(namespace); err != nil {
+		return nil, err
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.rws.ReadSet.Add(namespace, key, vaultValue.Version)
@@ -250,6 +399,9 @@ func (r *rwSetWrapper) GetDirectState(namespace cdriver.Namespace, key cdriver.P
 
 // DeleteState marks a key for deletion by adding a nil value to the write set.
 func (r *rwSetWrapper) DeleteState(namespace cdriver.Namespace, key cdriver.PKey) error {
+	if err := r.pinNamespace(namespace); err != nil {
+		return err
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	err := r.rws.WriteSet.Add(namespace, key, nil)
@@ -293,6 +445,9 @@ func (r *rwSetWrapper) GetStateMetadata(namespace cdriver.Namespace, key cdriver
 
 // SetStateMetadata sets metadata for a given namespace and key in the metadata write set.
 func (r *rwSetWrapper) SetStateMetadata(namespace cdriver.Namespace, key cdriver.PKey, metadata cdriver.Metadata) error {
+	if err := r.pinNamespace(namespace); err != nil {
+		return err
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	err := r.rws.MetaWriteSet.Add(namespace, key, metadata)
@@ -364,10 +519,7 @@ func (r *rwSetWrapper) NumWrites(ns cdriver.Namespace) int {
 func (r *rwSetWrapper) Namespaces() []cdriver.Namespace {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.namespacesLocked()
-}
 
-func (r *rwSetWrapper) namespacesLocked() []cdriver.Namespace {
 	nsMap := make(map[cdriver.Namespace]bool)
 	for ns := range r.rws.Reads {
 		nsMap[ns] = true
@@ -388,56 +540,43 @@ func (r *rwSetWrapper) namespacesLocked() []cdriver.Namespace {
 
 // AppendRWSet deserializes and appends RWSet data from bytes to this RWSet.
 // If namespaces are specified, only those namespaces will be appended.
+// Namespace versions come from the appended payload rather than from the vault's
+// snapshot, so the result re-serializes to the versions it arrived with.
 func (r *rwSetWrapper) AppendRWSet(raw []byte, nss ...cdriver.Namespace) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	err := r.v.marshaller.Append(r.rws, raw, nss...)
+	nsVersions, err := r.v.marshaller.Append(r.rws, raw, nss...)
 	r.cachedBytes = nil
-	return err
+	if err != nil {
+		return err
+	}
+	for ns, version := range nsVersions {
+		r.pinNamespaceVersionLocked(ns, version)
+	}
+	return nil
 }
 
 // Bytes serializes this RWSet to bytes in FabricX protobuf format.
-// It automatically fetches namespace versions from the _meta namespace via QueryService.
-// Note: It holds the RWSet lock across the remote GetStates network query.
-// If a cached version exists, it returns a defensive copy and skips the version lookup.
-// It assumes _meta versions are stable for the RWSet's lifetime.
+//
+// Serialization is a pure function of RWSet state: namespace versions were resolved when
+// each namespace was first touched, so Bytes() performs no network I/O and repeated calls
+// return identical bytes. That matters because the endorsement digest covers NsVersion,
+// and the endorsement flow serializes the same RWSet once per endorsing party.
+//
+// The result is memoized, but only as an optimization — the cache holds no correctness
+// weight now that the inputs cannot change underneath it.
 func (r *rwSetWrapper) Bytes() ([]byte, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if r.cachedBytes == nil {
-		namespaces := r.namespacesLocked()
-		nsInfo := make(map[cdriver.Namespace]cdriver.RawVersion, len(namespaces))
-		if len(namespaces) == 0 {
-			raw, err := r.v.marshaller.Marshal(string(r.txID), r.rws, nsInfo)
-			if err != nil {
-				return nil, err
-			}
-			r.cachedBytes = raw
-		} else {
-			states, err := r.v.queryService.GetStates(map[cdriver.Namespace][]cdriver.PKey{metaNamespace: namespaces})
-			if err != nil {
-				// Failed to query versions, fail the marshal instead of silently using version 0.
-				return nil, errors.Wrapf(err, "failed to query %s versions for tx %s", metaNamespace, string(r.txID))
-			}
-			metaStates := states[metaNamespace] // nil-safe
-
-			for _, ns := range namespaces {
-				if v, ok := metaStates[ns]; ok {
-					nsInfo[ns] = v.Version
-				} else {
-					nsInfo[ns] = MarshalVersion(0) // unknown namespace
-				}
-			}
-
-			// Pass nsInfo per call rather than through shared marshaller state, so concurrent
-			// Bytes() calls on different RWSets from the same vault do not race.
-			raw, err := r.v.marshaller.Marshal(string(r.txID), r.rws, nsInfo)
-			if err != nil {
-				return nil, err
-			}
-			r.cachedBytes = raw
+		// Marshal rejects a namespace missing from nsVersions, which would mean a code path
+		// mutated the RWSet without pinning a version for it.
+		raw, err := r.v.marshaller.Marshal(string(r.txID), r.rws, r.nsVersions)
+		if err != nil {
+			return nil, err
 		}
+		r.cachedBytes = raw
 	}
 
 	return bytes.Clone(r.cachedBytes), nil
@@ -494,17 +633,21 @@ func (v *Vault) NewRWSet(ctx context.Context, txID cdriver.TxID) (cdriver.RWSet,
 	}
 
 	return &rwSetWrapper{
-		txID: txID,
-		rws:  &rws,
-		qe:   qe,
-		v:    v,
+		txID:       txID,
+		rws:        &rws,
+		qe:         qe,
+		v:          v,
+		nsVersions: make(map[cdriver.Namespace]cdriver.RawVersion),
 	}, nil
 }
 
 // NewRWSetFromBytes creates a new RWSet by deserializing it from bytes.
 // The returned wrapper owns the ReadWriteSet; the vault does not retain a reference to it.
+// Namespace versions are taken from the serialized transaction, so re-serializing the
+// result reproduces the bytes it was built from — which is what lets an endorser sign
+// over the same digest the proposer produced.
 func (v *Vault) NewRWSetFromBytes(ctx context.Context, txID cdriver.TxID, rwset []byte) (cdriver.RWSet, error) {
-	rws, err := v.marshaller.RWSetFromBytes(rwset)
+	rws, nsVersions, err := v.marshaller.RWSetFromBytes(rwset)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal rwset")
 	}
@@ -515,10 +658,11 @@ func (v *Vault) NewRWSetFromBytes(ctx context.Context, txID cdriver.TxID, rwset 
 	}
 
 	return &rwSetWrapper{
-		txID: txID,
-		rws:  rws,
-		qe:   qe,
-		v:    v,
+		txID:       txID,
+		rws:        rws,
+		qe:         qe,
+		v:          v,
+		nsVersions: nsVersions,
 	}, nil
 }
 
@@ -588,7 +732,7 @@ func (v *Vault) CommitTX(context.Context, cdriver.TxID, cdriver.BlockNum, cdrive
 // If namespaces are specified, only those namespaces will be included.
 // The RWSet is not stored locally (ephemeral).
 func (v *Vault) InspectRWSet(ctx context.Context, rwset []byte, namespaces ...cdriver.Namespace) (cdriver.RWSet, error) {
-	rws, err := v.marshaller.RWSetFromBytes(rwset, namespaces...)
+	rws, nsVersions, err := v.marshaller.RWSetFromBytes(rwset, namespaces...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal rwset for inspection")
 	}
@@ -600,10 +744,11 @@ func (v *Vault) InspectRWSet(ctx context.Context, rwset []byte, namespaces ...cd
 
 	// Return ephemeral RWSet (not stored in local map)
 	return &rwSetWrapper{
-		txID: "", // Empty txID for ephemeral rwset
-		rws:  rws,
-		qe:   qe,
-		v:    v,
+		txID:       "", // Empty txID for ephemeral rwset
+		rws:        rws,
+		qe:         qe,
+		v:          v,
+		nsVersions: nsVersions,
 	}, nil
 }
 

--- a/platform/fabricx/core/vault/vault_test.go
+++ b/platform/fabricx/core/vault/vault_test.go
@@ -9,6 +9,7 @@ package vault_test
 import (
 	"context"
 	"crypto/sha256"
+	"sync/atomic"
 	"testing"
 
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
@@ -73,8 +74,10 @@ func TestVaultX_GetStateMetadataServesStoreOnMiss(t *testing.T) {
 
 // mockQueryService implements queryservice.QueryService for testing
 type mockQueryService struct {
-	states     map[driver.Namespace]map[driver.PKey]driver.VaultValue
-	txStatuses map[string]int32
+	states         map[driver.Namespace]map[driver.PKey]driver.VaultValue
+	txStatuses     map[string]int32
+	getStatesCount atomic.Int32
+	getStatesErr   error
 }
 
 func newMockQueryService() *mockQueryService {
@@ -94,6 +97,10 @@ func (m *mockQueryService) GetState(ns driver.Namespace, key driver.PKey) (*driv
 }
 
 func (m *mockQueryService) GetStates(keys map[driver.Namespace][]driver.PKey) (map[driver.Namespace]map[driver.PKey]driver.VaultValue, error) {
+	m.getStatesCount.Add(1)
+	if m.getStatesErr != nil {
+		return nil, m.getStatesErr
+	}
 	result := make(map[driver.Namespace]map[driver.PKey]driver.VaultValue)
 	for ns, keyList := range keys {
 		result[ns] = make(map[driver.PKey]driver.VaultValue)
@@ -547,4 +554,148 @@ func TestRWSet_ConcurrentBytes(t *testing.T) {
 		})
 	}
 	require.NoError(t, eg.Wait())
+}
+
+func TestRWSet_ConcurrentMutation(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	v := vault.NewVault(qs, nil)
+	ctx := context.Background()
+
+	rws, err := v.NewRWSet(ctx, driver.TxID("tx"))
+	require.NoError(t, err)
+
+	var eg errgroup.Group
+	for g := range 16 {
+		eg.Go(func() error {
+			if g%2 == 0 {
+				_ = rws.SetState("ns1", "key", []byte("value"))
+			} else {
+				_, _ = rws.Bytes()
+			}
+			return nil
+		})
+	}
+	require.NoError(t, eg.Wait())
+}
+
+func TestRWSet_Bytes_GetStatesError(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	v := vault.NewVault(qs, nil)
+	rws, err := v.NewRWSet(context.Background(), "tx1")
+	require.NoError(t, err)
+
+	err = rws.SetState("ns1", "key1", []byte("val1"))
+	require.NoError(t, err)
+
+	qs.getStatesErr = errors.New("simulated error")
+
+	_, err = rws.Bytes()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "simulated error")
+}
+
+func TestRWSet_Bytes_EmptyNamespaces(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	v := vault.NewVault(qs, nil)
+	rws, err := v.NewRWSet(context.Background(), "tx1")
+	require.NoError(t, err)
+
+	_, err = rws.Bytes()
+	require.NoError(t, err)
+}
+
+func TestRWSet_CacheInvalidation(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	qs.setState("ns1", "key1", []byte("val1"), 1)
+	v := vault.NewVault(qs, nil)
+	rws, err := v.NewRWSet(context.Background(), "tx1")
+	require.NoError(t, err)
+
+	err = rws.SetState("ns1", "key1", []byte("val2"))
+	require.NoError(t, err)
+
+	// First Bytes() triggers GetStates and populates cache
+	initialCount := qs.getStatesCount.Load()
+	b1, err := rws.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, initialCount+1, qs.getStatesCount.Load())
+
+	// Second Bytes() should hit cache and NOT trigger GetStates
+	b2, err := rws.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, initialCount+1, qs.getStatesCount.Load())
+	require.Equal(t, b1, b2)
+
+	// GetState adds to read set, mutating RWSet and invalidating cache
+	qs.setState("ns2", "key2", []byte("val3"), 1)
+	_, err = rws.GetState("ns2", "key2")
+	require.NoError(t, err)
+
+	// Third Bytes() should miss cache and trigger GetStates
+	b3, err := rws.Bytes()
+	require.NoError(t, err)
+	require.Equal(t, initialCount+2, qs.getStatesCount.Load())
+	require.NotEqual(t, b1, b3)
+}
+
+func TestRWSet_DefensiveCopy(t *testing.T) {
+	t.Parallel()
+	qs := newMockQueryService()
+	v := vault.NewVault(qs, nil)
+	rws, err := v.NewRWSet(context.Background(), "tx1")
+	require.NoError(t, err)
+
+	err = rws.SetState("ns1", "key1", []byte("val1"))
+	require.NoError(t, err)
+
+	b1, err := rws.Bytes()
+	require.NoError(t, err)
+	require.NotEmpty(t, b1)
+
+	// Modify b1
+	b1[0] ^= 0xFF
+
+	b2, err := rws.Bytes()
+	require.NoError(t, err)
+
+	// They should not share the underlying slice memory
+	require.NotEqual(t, b1, b2)
+}
+
+func BenchmarkRWSet_Bytes(b *testing.B) {
+	qs := newMockQueryService()
+	qs.setState("ns1", "key1", []byte("val1"), 1)
+	v := vault.NewVault(qs, nil)
+	rws, err := v.NewRWSet(context.Background(), "tx1")
+	require.NoError(b, err)
+
+	err = rws.SetState("ns1", "key1", []byte("val1"))
+	require.NoError(b, err)
+
+	b.Run("Uncached", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			_ = rws.SetState("ns1", "key1", []byte("val1"))
+			b.StartTimer()
+			_, _ = rws.Bytes()
+		}
+	})
+
+	b.Run("Cached", func(b *testing.B) {
+		b.ReportAllocs()
+		// Populate cache once
+		_, err := rws.Bytes()
+		require.NoError(b, err)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			// Repeated calls should hit cache and just copy slice
+			_, _ = rws.Bytes()
+		}
+	})
 }

--- a/platform/fabricx/core/vault/vault_test.go
+++ b/platform/fabricx/core/vault/vault_test.go
@@ -9,6 +9,7 @@ package vault_test
 import (
 	"context"
 	"crypto/sha256"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -78,6 +79,11 @@ type mockQueryService struct {
 	txStatuses     map[string]int32
 	getStatesCount atomic.Int32
 	getStatesErr   error
+
+	// queryMu guards lastGetStates, which records the shape of the most recent batch so
+	// tests can assert on how a query was assembled.
+	queryMu       sync.Mutex
+	lastGetStates map[driver.Namespace][]driver.PKey
 }
 
 func newMockQueryService() *mockQueryService {
@@ -96,8 +102,18 @@ func (m *mockQueryService) GetState(ns driver.Namespace, key driver.PKey) (*driv
 	return nil, nil
 }
 
+// lastQuery returns the namespace/key map of the most recent GetStates call.
+func (m *mockQueryService) lastQuery() map[driver.Namespace][]driver.PKey {
+	m.queryMu.Lock()
+	defer m.queryMu.Unlock()
+	return m.lastGetStates
+}
+
 func (m *mockQueryService) GetStates(keys map[driver.Namespace][]driver.PKey) (map[driver.Namespace]map[driver.PKey]driver.VaultValue, error) {
 	m.getStatesCount.Add(1)
+	m.queryMu.Lock()
+	m.lastGetStates = keys
+	m.queryMu.Unlock()
 	if m.getStatesErr != nil {
 		return nil, m.getStatesErr
 	}
@@ -521,7 +537,7 @@ func TestRWSet_GetWriteAt(t *testing.T) {
 func TestRWSet_ConcurrentBytes(t *testing.T) {
 	t.Parallel()
 	qs := newMockQueryService()
-	// Give the namespaces a non-default _meta version so Bytes() builds a populated nsInfo map.
+	// Give the namespaces a non-default version so Bytes() builds a populated nsInfo map.
 	qs.setState("_meta", "ns1", nil, 7)
 	qs.setState("_meta", "ns2", nil, 9)
 
@@ -579,9 +595,12 @@ func TestRWSet_ConcurrentMutation(t *testing.T) {
 	require.NoError(t, eg.Wait())
 }
 
-func TestRWSet_Bytes_GetStatesError(t *testing.T) {
+// Once a namespace has been touched, serialization no longer depends on the query
+// service, so it keeps working while the query service is failing.
+func TestRWSet_Bytes_SucceedsWhenStateQueriesFail(t *testing.T) {
 	t.Parallel()
 	qs := newMockQueryService()
+	qs.setState("_meta", "ns1", nil, 7)
 	v := vault.NewVault(qs, nil)
 	rws, err := v.NewRWSet(context.Background(), "tx1")
 	require.NoError(t, err)
@@ -591,9 +610,9 @@ func TestRWSet_Bytes_GetStatesError(t *testing.T) {
 
 	qs.getStatesErr = errors.New("simulated error")
 
-	_, err = rws.Bytes()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "simulated error")
+	raw, err := rws.Bytes()
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
 }
 
 func TestRWSet_Bytes_EmptyNamespaces(t *testing.T) {
@@ -610,6 +629,8 @@ func TestRWSet_Bytes_EmptyNamespaces(t *testing.T) {
 func TestRWSet_CacheInvalidation(t *testing.T) {
 	t.Parallel()
 	qs := newMockQueryService()
+	qs.setState("_meta", "ns1", nil, 1)
+	qs.setState("_meta", "ns2", nil, 1)
 	qs.setState("ns1", "key1", []byte("val1"), 1)
 	v := vault.NewVault(qs, nil)
 	rws, err := v.NewRWSet(context.Background(), "tx1")
@@ -618,27 +639,21 @@ func TestRWSet_CacheInvalidation(t *testing.T) {
 	err = rws.SetState("ns1", "key1", []byte("val2"))
 	require.NoError(t, err)
 
-	// First Bytes() triggers GetStates and populates cache
-	initialCount := qs.getStatesCount.Load()
 	b1, err := rws.Bytes()
 	require.NoError(t, err)
-	require.Equal(t, initialCount+1, qs.getStatesCount.Load())
 
-	// Second Bytes() should hit cache and NOT trigger GetStates
+	// Serializing again returns the same bytes without re-marshalling.
 	b2, err := rws.Bytes()
 	require.NoError(t, err)
-	require.Equal(t, initialCount+1, qs.getStatesCount.Load())
 	require.Equal(t, b1, b2)
 
-	// GetState adds to read set, mutating RWSet and invalidating cache
+	// GetState adds to the read set, mutating the RWSet and invalidating the memoized bytes.
 	qs.setState("ns2", "key2", []byte("val3"), 1)
 	_, err = rws.GetState("ns2", "key2")
 	require.NoError(t, err)
 
-	// Third Bytes() should miss cache and trigger GetStates
 	b3, err := rws.Bytes()
 	require.NoError(t, err)
-	require.Equal(t, initialCount+2, qs.getStatesCount.Load())
 	require.NotEqual(t, b1, b3)
 }
 


### PR DESCRIPTION
Closes #1628

## Description

`NsVersion` was read from `_meta` inside `Bytes()` — at *serialization* time — while every key read version is captured at *simulation* time by `GetState`. The committer validates `NsVersion` as a read-only dependency on `_meta[ns]` and the endorsement digest covers it, so that split made serialization non-deterministic, let an endorser sign a different digest than the proposer (`Marshaller.Append` discarded the incoming version), and put a network round-trip on the serialization path.

Making serialization deterministic is what unlocks the payload deduplication below: the two copies of the rwset a `Transaction` carries were only ever *accidentally* equal.

**Changes:**

1. **Namespace versions are pinned at first touch** (`vault.go`, `marshal.go`). Resolved from `_meta` when a namespace first enters the RWSet, alongside the key read versions. `Append` / `RWSetFromBytes` now return the payload's `NsVersion` so a reconstructed transaction re-serializes to the bytes it arrived with. Nothing is cached between RWSets, so a policy update is picked up by the next transaction.
2. **`Bytes()` is pure** — no network I/O, deterministic across calls. The memoized result is now only an optimization. `Marshal` rejects an unpinned namespace, so a missed pin fails loudly instead of silently emitting version 0.
3. **Versionless reads survive deserialization** (`marshal.go`). `Append` collapsed an absent version to version 0 for `ReadsOnly`, and dropped the read half of a `ReadWrite` entirely — turning it into a `BlindWrite`, an unconditional write with a different meaning to the committer. Both broke the round-trip property (1) depends on, for the common case of a key being created for the first time. `optionalVersion` keeps absent absent.
4. **`IsValid()` validates the full snapshot** — pinned namespace versions as well as key reads, in one batched query rather than one call per key.
5. **`Append` honours its namespace filter**, which it documented but ignored (`InspectRWSet`'s argument was silently dropped).
6. **`Clear()` removes the namespace, not just its contents.** `ReadSet.Clear` and friends empty the inner map but leave the namespace key behind, while `Clear` drops the pinned version — and `Marshal` demands a version for every namespace it finds in the read/write maps. The wrapper now removes the leftover keys too.
7. **Payload deduplication** (`transaction.go`). `Transaction` carried the rwset twice — as `RWSet` and as `TProposalResponses[0].Payload` — base64-encoded both times. `dedupRWSet` drops the duplicate.

## Measurements

`BenchmarkTransactionBytes` (`platform/fabricx/core/transaction`) encodes an endorsed transaction the way every send does. *Duplicated* is the previous behaviour, *Deduplicated* is `Bytes()` as it now stands. `bytes/op` is the size of the encoded transaction; `B/op` is the allocation cost of producing it.

```
BenchmarkTransactionBytes/10Writes/Duplicated-10       1155 ns/op     1589 bytes/op    1793 B/op   1 allocs/op
BenchmarkTransactionBytes/10Writes/Deduplicated-10      849 ns/op      923 bytes/op    1072 B/op   3 allocs/op
BenchmarkTransactionBytes/256KiB/Duplicated-10       388784 ns/op   803101 bytes/op  812148 B/op   1 allocs/op
BenchmarkTransactionBytes/256KiB/Deduplicated-10     198982 ns/op   401679 bytes/op  413488 B/op   3 allocs/op
```

- 10 writes: **42% smaller** on the wire, 40% less allocation, 26% faster.
- 256 KiB (the payload size the #1599 reproducer drives, which is what #1628 is about):
  **50% smaller**, 49% less allocation, 49% faster.

`BenchmarkRWSet_Bytes` (`platform/fabricx/core/vault`) covers the memoization separately:
2932 ns/op, 984 B/op, 19 allocs → 23 ns/op, 24 B/op, 1 alloc on a repeat serialization.

## What this does *not* change

**`_meta` round trips per endorsement are unchanged.** The previous `Bytes()` already issued one `GetState("_meta", ns)` per namespace; pinning issues one `GetStates` per namespace at first touch. The count is the same — what changes is *when*: the lookups leave the serialization path, so serializing N times for N endorsing parties costs one set of lookups instead of N. #1628's suggestion of a TTL cache was deliberately not taken: a cached version could disagree with the key read versions captured in the same simulation, which is the bug this PR is fixing.

The batched form (`GetStates`) is used in `IsValid`, which previously issued one call per key.

## Round-trip scope

`Bytes()` after `NewRWSetFromBytes` reproduces the input exactly for payloads in canonical form — sorted namespaces, sorted keys, no empty namespaces — which is what `Marshal` always produces, so FSC-to-FSC endorsement is byte-stable. A payload from another producer in non-canonical order is canonicalized on the way back out. That is unchanged by this PR and is called out only so the guarantee is not read as broader than it is.

## Wire compatibility

JSON *shape* is unchanged: `RWSet` is deliberately not tagged `omitempty`, so a deduplicated transaction emits `"RWSet": null` rather than dropping the key. `SetRWSet()` already preferred `TProposalResponses` before this PR, so an old node reconstructs a new node's transaction without ever reading `RWSet` — rolling upgrades are safe. Only code reading `Transaction.RWSet` *directly*, rather than via `GetRWSet()`, is affected; nothing in this repository does.

Two behavioural changes downstream consumers should know about:

- `SetState` / `DeleteState` / `AddReadAt` / `SetStateMetadata` can now return a query-service error, because they resolve the namespace version. Previously a failed `_meta` lookup was swallowed and the namespace was silently serialized at version 0.
- `InspectRWSet(raw, namespaces...)` now actually filters. It documented this and did not do it.

## Concurrency

`rwSetWrapper` is **race-free** — a mutex guards all shared state — but **not atomic**: `GetState` releases the lock between the write-set check, the query and the read-set update, so a concurrent `SetState` on the same key can interleave and produce a `ReadWrite` the caller never asked for. One RWSet must not be simulated from multiple goroutines. Documented on the type and on `GetState`. `Equals` takes the two locks in a fixed address order to avoid AB/BA deadlock.

## Testing

`nsversion_test.go` covers version preservation through `NewRWSetFromBytes` / `AppendRWSet` (asserting an endorser reproduces the proposer's bytes exactly), first-touch pinning, `Bytes()` issuing no queries, a table proving every mutating entry point pins, `IsValid`'s namespace checks and batching, versionless `ReadsOnly` and `ReadWrite` round trips, and that a cleared namespace leaves the RWSet serializable.

`TestTransaction_DeduplicatedRWSetRoundTrips` walks the invariant the dedup rests on: serialize with the field dropped, ship, decode, `SetRWSet()`, and assert the vault receives the exact bytes that were dropped. `BenchmarkTransactionBytes` and `BenchmarkRWSet_Bytes` provide the numbers above.