### PR TITLE
refactor(view): merge SendWithContext into Send, SendErrorWithContext into SendError

### DIFF
--- a/docs/platform/view/programming-model.md
+++ b/docs/platform/view/programming-model.md
@@ -183,7 +183,7 @@ func (p *Initiator) Call(viewCtx view.Context) (any, error) {
 		return nil, err
 	}
 
-	if err := session.Send(p.in); err != nil {
+	if err := session.Send(viewCtx.Context(), p.in); err != nil {
 		return nil, err
 	}
 
@@ -219,7 +219,7 @@ func (p *Responder) Call(viewCtx view.Context) (any, error) {
 	session := viewCtx.Session()
 	msg := <-session.Receive()
 
-	if err := session.Send(msg.Payload); err != nil {
+	if err := session.Send(viewCtx.Context(), msg.Payload); err != nil {
 		return nil, err
 	}
 	return "OK", nil

--- a/docs/platform/view/services/comm/readme.md
+++ b/docs/platform/view/services/comm/readme.md
@@ -17,7 +17,7 @@ The Comm layer abstracts the underlying network transport and provides a session
 1.  **P2PNode**: The central orchestrator that manages active streams, sessions, and message dispatching. It uses a **bounded worker pool** for concurrent message dispatching to prevent resource exhaustion.
 2.  **EndpointService**: The source of truth for peer identities and addresses. It manages resolvers that map PeerIDs to network endpoints and provides the public keys used for dynamic trust updates.
 3.  **P2PHost**: An interface for transport-specific implementations. FSC supports multiple transport types (e.g., Libp2p, WebSocket). The interface exposes `PeerID()`, which returns the local node's cryptographic peer identifier — the same value remote peers observe as `StreamInfo.RemotePeerID` and `SessionInfo.RemotePKID` when they connect to this node.
-4.  **NetworkStreamSession**: Implements the `view.Session` interface. It provides the high-level API (`Send`, `Receive`, `Close`) used by View developers. It includes **automatic cleanup** of dead stream references to prevent memory bloat.
+4.  **NetworkStreamSession**: Implements the `view.Session` interface. It provides the high-level API (`Send`, `SendError`, `Receive`, `Close`) used by View developers. It includes **automatic cleanup** of dead stream references to prevent memory bloat.
 
 ### Message Flow
 
@@ -110,7 +110,7 @@ if err != nil {
 }
 
 // Send a message
-err = session.Send([]byte("Hello Peer"))
+err = session.Send(context.Background(), []byte("Hello Peer"))
 
 // Receive a message
 msg := <-session.Receive()

--- a/docs/platform/view/services/view-service.md
+++ b/docs/platform/view/services/view-service.md
@@ -407,7 +407,7 @@ The View Service integrates with the P2P Service for handling incoming messages:
 4. **View Execution**: Runs the responder view in the context
 5. **Error Handling**: Sends error messages back to the initiator on failure
 
-The text sent is the raw error returned by the responder view (`err.Error()`), forwarded unmodified via `Session().SendError(...)`. The runtime does not inspect or filter it — deciding what information is safe to disclose to a remote, potentially untrusted caller is the responder view's responsibility, not the P2P service's. See the [View API](../view-api.md#send-and-receive) for guidance on what responder views should and shouldn't return as errors.
+The text sent is the raw error returned by the responder view (`err.Error()`), forwarded unmodified via `Session().SendError(context.WithoutCancel(viewCtx.Context()), ...)`. The runtime does not inspect or filter it — deciding what information is safe to disclose to a remote, potentially untrusted caller is the responder view's responsibility, not the P2P service's. See the [View API](../view-api.md#send-and-receive) for guidance on what responder views should and shouldn't return as errors.
 
 ### Message Flow
 
@@ -434,7 +434,7 @@ sequenceDiagram
     Context-->>P2P: Complete
     
     alt Error
-        P2P->>Context: Session().SendError(err)
+        P2P->>Context: Session().SendError(ctx, err)
     end
     
     alt New Context

--- a/docs/platform/view/view-api.md
+++ b/docs/platform/view/view-api.md
@@ -202,10 +202,8 @@ The View API models node-to-node communication through `view.Session`:
 ```go
 type Session interface {
     Info() SessionInfo
-    Send(payload []byte) error
-    SendWithContext(ctx context.Context, payload []byte) error
-    SendError(payload []byte) error
-    SendErrorWithContext(ctx context.Context, payload []byte) error
+    Send(ctx context.Context, payload []byte) error
+    SendError(ctx context.Context, payload []byte) error
     Receive() <-chan *Message
     Close()
 }
@@ -213,9 +211,9 @@ type Session interface {
 
 ### Send and Receive
 
-`Send` and `SendWithContext` transmit an application payload to the remote party.
+`Send` transmits an application payload to the remote party using the provided context.
 
-`SendError` and `SendErrorWithContext` transmit an error response. These methods set the message status to `view.ERROR`, allowing the recipient to distinguish protocol failures from normal payloads.
+`SendError` transmits an error response using the provided context. This method sets the message status to `view.ERROR`, allowing the recipient to distinguish protocol failures from normal payloads.
 
 The payload passed to `SendError` is transmitted as-is. When a responder view returns an error from `Call`, the P2P runtime forwards `err.Error()` verbatim to the remote caller via `SendError` — it does not inspect, wrap, or redact it. The runtime's job is only to decide *that* an error gets returned; deciding *what* information that error is allowed to contain is the application's responsibility. Since the remote party may be untrusted, responder views should return business-logic errors verbatim (callers legitimately need that detail to react, and tests rely on it), but should wrap or replace errors that could carry internal detail (stack-adjacent context, file paths, credentials) with a sanitized message before returning them.
 

--- a/docs/platform/view/view-api.md
+++ b/docs/platform/view/view-api.md
@@ -371,7 +371,7 @@ func (p *Initiator) Call(viewCtx view.Context) (any, error) {
         return nil, err
     }
 
-    if err := session.Send([]byte("ping")); err != nil {
+    if err := session.Send(viewCtx.Context(), []byte("ping")); err != nil {
         return nil, err
     }
 
@@ -401,12 +401,12 @@ func (p *Responder) Call(viewCtx view.Context) (any, error) {
     select {
     case msg := <-session.Receive():
         if string(msg.Payload) != "ping" {
-            if err := session.SendError([]byte("expected ping")); err != nil {
+            if err := session.SendError(viewCtx.Context(), []byte("expected ping")); err != nil {
                 return nil, err
             }
             return nil, errors.New("expected ping")
         }
-        if err := session.Send([]byte("pong")); err != nil {
+        if err := session.Send(viewCtx.Context(), []byte("pong")); err != nil {
             return nil, err
         }
         return "OK", nil

--- a/integration/fabric/stoprestart/initiator.go
+++ b/integration/fabric/stoprestart/initiator.go
@@ -31,7 +31,7 @@ func (p *Initiator) Call(viewCtx view.Context) (any, error) {
 	session, err := viewCtx.GetSession(viewCtx.Initiator(), responder)
 	assert.NoError(err)
 	// Send your input from the client
-	err = session.Send(p.in)
+	err = session.Send(viewCtx.Context(), p.in)
 	assert.NoError(err)
 	// Wait to receive it back
 	ch := session.Receive()

--- a/integration/fabric/stoprestart/responder.go
+++ b/integration/fabric/stoprestart/responder.go
@@ -31,7 +31,7 @@ func (p *Responder) Call(viewCtx view.Context) (any, error) {
 	}
 
 	// Echo back what you received from the initiator
-	err := session.Send(payload)
+	err := session.Send(viewCtx.Context(), payload)
 	assert.NoError(err)
 
 	// Return

--- a/integration/fabric/twonets/views/ping.go
+++ b/integration/fabric/twonets/views/ping.go
@@ -31,7 +31,7 @@ func (p *Ping) Call(viewCtx view.Context) (any, error) {
 	// Open a session to the responder
 	session, err := viewCtx.GetSession(viewCtx.Initiator(), responder)
 	assert.NoError(err) // Send a ping
-	err = session.Send([]byte("ping"))
+	err = session.Send(viewCtx.Context(), []byte("ping"))
 	assert.NoError(err) // Wait for the pong
 	ch := session.Receive()
 	select {

--- a/integration/fabric/twonets/views/pong.go
+++ b/integration/fabric/twonets/views/pong.go
@@ -38,7 +38,7 @@ func (p *Pong) Call(viewCtx view.Context) (any, error) {
 	switch {
 	case m != "ping":
 		// reply with an error
-		err := session.SendError(fmt.Appendf(nil, "exptectd ping, got %s", m))
+		err := session.SendError(viewCtx.Context(), fmt.Appendf(nil, "exptectd ping, got %s", m))
 		assert.NoError(err)
 		return nil, fmt.Errorf("exptectd ping, got %s", m)
 	default:
@@ -47,7 +47,7 @@ func (p *Pong) Call(viewCtx view.Context) (any, error) {
 		assert.NoError(err)
 		raw, err := json.Marshal(names)
 		assert.NoError(err)
-		assert.NoError(session.Send(raw))
+		assert.NoError(session.Send(viewCtx.Context(), raw))
 	}
 
 	// Return

--- a/integration/fsc/pingpong/README.md
+++ b/integration/fsc/pingpong/README.md
@@ -71,7 +71,7 @@ func (p *PingView) Call(viewCtx view.Context) (any, error) {
     return nil, errors.Wrapf(err, "failed getting session to [%s]", p.responder)
   }
 
-  if err := session.SendWithContext(viewCtx.Context(), []byte(pingMessage)); err != nil {
+  if err := session.Send(viewCtx.Context(), []byte(pingMessage)); err != nil {
     return nil, errors.Wrapf(err, "failed to send %s", pingMessage)
   }
 
@@ -199,14 +199,14 @@ func (p *PongView) Call(viewCtx view.Context) (any, error) {
 
   switch m := string(payload); m {
   case pingMessage:
-    if err := p.session.SendWithContext(viewCtx.Context(), []byte(pongMessage)); err != nil {
+    if err := p.session.Send(viewCtx.Context(), []byte(pongMessage)); err != nil {
       return nil, errors.Wrapf(err, "failed to send %s", pongMessage)
     }
     return m, nil
   case finishedMessage:
     return m, nil
   default:
-    sendErr := p.session.SendErrorWithContext(viewCtx.Context(), []byte("expected ping or finished, got "+m))
+    sendErr := p.session.SendError(viewCtx.Context(), []byte("expected ping or finished, got "+m))
     return nil, errors.Join(errors.Errorf("expected %s or %s, got %s", pingMessage, finishedMessage, m), sendErr)
   }
 }

--- a/integration/fsc/pingpong/fake/initiator.go
+++ b/integration/fsc/pingpong/fake/initiator.go
@@ -63,7 +63,7 @@ func (p *Initiator) Call(viewCtx view.Context) (any, error) {
 	defer cancel()
 
 	// Send a ping
-	if err := session.SendWithContext(ctx, []byte(pingMessage)); err != nil {
+	if err := session.Send(ctx, []byte(pingMessage)); err != nil {
 		return nil, errors.Wrapf(err, "failed to send %s", pingMessage)
 	}
 

--- a/integration/fsc/pingpong/fake/responder.go
+++ b/integration/fsc/pingpong/fake/responder.go
@@ -40,12 +40,12 @@ func (p *Responder) Call(viewCtx view.Context) (any, error) {
 	// Respond with a mock pong if a ping is received, an error otherwise
 	if m := string(payload); m != pingMessage {
 		// reply with an error
-		sendErr := session.SendErrorWithContext(ctx, fmt.Appendf(nil, "expected %s, got %s", pingMessage, m))
+		sendErr := session.SendError(ctx, fmt.Appendf(nil, "expected %s, got %s", pingMessage, m))
 		return nil, errors.Join(errors.Errorf("expected %s, got %s", pingMessage, m), sendErr)
 	}
 
 	// reply with a mock pong
-	if err := session.SendWithContext(ctx, []byte(mockPongMessage)); err != nil {
+	if err := session.Send(ctx, []byte(mockPongMessage)); err != nil {
 		return nil, errors.Wrapf(err, "failed to send %s", mockPongMessage)
 	}
 

--- a/integration/fsc/pingpong/initiator.go
+++ b/integration/fsc/pingpong/initiator.go
@@ -89,7 +89,7 @@ func (f *FinishedView) Call(viewCtx view.Context) (any, error) {
 	}
 
 	logger.DebugfContext(viewCtx.Context(), "send %s", finishedMessage)
-	if err := session.SendWithContext(viewCtx.Context(), []byte(finishedMessage)); err != nil {
+	if err := session.Send(viewCtx.Context(), []byte(finishedMessage)); err != nil {
 		return nil, errors.Wrapf(err, "failed to send %s", finishedMessage)
 	}
 	return nil, nil

--- a/integration/fsc/pingpong/initiator.go
+++ b/integration/fsc/pingpong/initiator.go
@@ -51,7 +51,7 @@ func (p *PingView) Call(viewCtx view.Context) (any, error) {
 	}
 
 	logger.DebugfContext(viewCtx.Context(), "send %s", pingMessage)
-	if err := session.SendWithContext(viewCtx.Context(), []byte(pingMessage)); err != nil {
+	if err := session.Send(viewCtx.Context(), []byte(pingMessage)); err != nil {
 		return nil, errors.Wrapf(err, "failed to send %s", pingMessage)
 	}
 

--- a/integration/fsc/pingpong/responder.go
+++ b/integration/fsc/pingpong/responder.go
@@ -40,7 +40,7 @@ func (p *PongView) Call(viewCtx view.Context) (any, error) {
 	switch m := string(payload); m {
 	case pingMessage:
 		logger.DebugfContext(viewCtx.Context(), "%s received, send %s", pingMessage, pongMessage)
-		if err := p.session.SendWithContext(viewCtx.Context(), []byte(pongMessage)); err != nil {
+		if err := p.session.Send(viewCtx.Context(), []byte(pongMessage)); err != nil {
 			return nil, errors.Wrapf(err, "failed to send %s", pongMessage)
 		}
 		return m, nil
@@ -48,7 +48,7 @@ func (p *PongView) Call(viewCtx view.Context) (any, error) {
 		logger.DebugfContext(viewCtx.Context(), "%s received, nothing to answer", finishedMessage)
 		return m, nil
 	default:
-		sendErr := p.session.SendErrorWithContext(viewCtx.Context(), fmt.Appendf(nil, "expected %s or %s, got %s", pingMessage, finishedMessage, m))
+		sendErr := p.session.SendError(viewCtx.Context(), fmt.Appendf(nil, "expected %s or %s, got %s", pingMessage, finishedMessage, m))
 		return nil, errors.Join(errors.Errorf("expected %s or %s, got %s", pingMessage, finishedMessage, m), sendErr)
 	}
 }

--- a/integration/fsc/signedpingpong/initiator.go
+++ b/integration/fsc/signedpingpong/initiator.go
@@ -63,7 +63,7 @@ func (a *AliceInitiator) Call(viewCtx view.Context) (any, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "alice: failed marshalling signed message")
 	}
-	if err := session.SendWithContext(viewCtx.Context(), raw); err != nil {
+	if err := session.Send(viewCtx.Context(), raw); err != nil {
 		return nil, errors.Wrap(err, "alice: failed sending")
 	}
 

--- a/integration/fsc/signedpingpong/responder.go
+++ b/integration/fsc/signedpingpong/responder.go
@@ -94,7 +94,7 @@ func (b *BobResponder) Call(viewCtx view.Context) (any, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "bob: failed marshalling reply")
 	}
-	if err := session.SendWithContext(viewCtx.Context(), raw); err != nil {
+	if err := session.Send(viewCtx.Context(), raw); err != nil {
 		return nil, errors.Wrap(err, "bob: failed sending reply")
 	}
 

--- a/integration/fsc/stoprestart/initiator.go
+++ b/integration/fsc/stoprestart/initiator.go
@@ -35,7 +35,7 @@ func (p *Initiator) Call(viewCtx view.Context) (any, error) {
 	session, err := viewCtx.GetSession(viewCtx.Initiator(), responder)
 	assert.NoError(err) // Send a ping
 	logger.DebugfContext(viewCtx.Context(), "send_ping")
-	err = session.SendWithContext(viewCtx.Context(), []byte("ping"))
+	err = session.Send(viewCtx.Context(), []byte("ping"))
 	assert.NoError(err) // Wait for the pong
 	logger.DebugfContext(viewCtx.Context(), "wait_pong")
 	ch := session.Receive()

--- a/integration/fsc/stoprestart/responder.go
+++ b/integration/fsc/stoprestart/responder.go
@@ -44,12 +44,12 @@ func (p *Responder) Call(viewCtx view.Context) (any, error) {
 	switch {
 	case m != "ping":
 		// reply with an error
-		err := session.SendErrorWithContext(rcvCtx, fmt.Appendf(nil, "exptectd ping, got %s", m))
+		err := session.SendError(rcvCtx, fmt.Appendf(nil, "exptectd ping, got %s", m))
 		assert.NoError(err)
 		return nil, errors.Errorf("exptectd ping, got %s", m)
 	default:
 		// reply with pong
-		err := session.SendWithContext(rcvCtx, []byte("pong"))
+		err := session.Send(rcvCtx, []byte("pong"))
 		assert.NoError(err)
 	}
 

--- a/platform/fabric/services/endorser/endorsement.go
+++ b/platform/fabric/services/endorser/endorsement.go
@@ -86,7 +86,7 @@ func (c *collectEndorsementsView) Call(viewCtx view.Context) (any, error) {
 
 		// Send transaction
 		logger.DebugfContext(viewCtx.Context(), "Send raw transaction to party")
-		err = session.SendWithContext(viewCtx.Context(), txRaw)
+		err = session.Send(viewCtx.Context(), txRaw)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed sending transaction content")
 		}
@@ -238,7 +238,7 @@ func (s *endorseView) Call(viewCtx view.Context) (any, error) {
 		return nil, err
 	}
 
-	err = viewCtx.Session().SendWithContext(viewCtx.Context(), raw)
+	err = viewCtx.Session().Send(viewCtx.Context(), raw)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/fabric/services/endorser/endorsement_proposal.go
+++ b/platform/fabric/services/endorser/endorsement_proposal.go
@@ -230,7 +230,7 @@ func (s *endorsementsOnProposalResponderView) Call(viewCtx view.Context) (any, e
 	}
 
 	// Send the proposal responses back
-	err = session.SendWithContext(viewCtx.Context(), &Response{ProposalResponses: prs})
+	err = session.Send(viewCtx.Context(), &Response{ProposalResponses: prs})
 	if err != nil {
 		return nil, err
 	}

--- a/platform/fabric/services/endorser/endorsement_test.go
+++ b/platform/fabric/services/endorser/endorsement_test.go
@@ -633,12 +633,12 @@ func TestParallelCollectEndorsementsOnProposalViewInternal(t *testing.T) {
 
 	// Case 3: Send error
 	f.ctx.GetSessionReturns(f.session, nil)
-	f.session.SendWithContextReturns(fmt.Errorf("err"))
+	f.session.SendReturns(fmt.Errorf("err"))
 	_, err = v.Call(f.ctx)
 	require.Error(t, err)
 
 	// Case 4: Receive error
-	f.session.SendWithContextReturns(nil)
+	f.session.SendReturns(nil)
 	msgCh := make(chan *view.Message, 1)
 	msgCh <- &view.Message{Status: view.ERROR, Payload: []byte("err")}
 	f.session.ReceiveReturns(msgCh)
@@ -734,7 +734,7 @@ func TestParallelCollectEndorsementsOnProposalView_TimesOutOnPartyThatNeverAccep
 	t.Cleanup(func() { close(release) })
 
 	f.session.ReceiveReturns(make(chan *view.Message))
-	f.session.SendWithContextCalls(func(context.Context, []byte) error {
+	f.session.SendCalls(func(context.Context, []byte) error {
 		<-release
 		return nil
 	})
@@ -829,12 +829,12 @@ func TestEndorsementOnProposalResponderViewInternal(t *testing.T) {
 	require.NoError(t, err)
 
 	// Case 2: Session send failure
-	fakeSession.SendWithContextReturns(fmt.Errorf("err"))
+	fakeSession.SendReturns(fmt.Errorf("err"))
 	_, err = ev.Call(fakeCtx)
 	require.Error(t, err)
 
 	// Case 3: EndorseProposalResponseWithIdentity failure
-	fakeSession.SendWithContextReturns(nil)
+	fakeSession.SendReturns(nil)
 	fakeTx.EndorseProposalResponseWithIdentityReturns(fmt.Errorf("err"))
 	_, err = ev.Call(fakeCtx)
 	require.Error(t, err)

--- a/platform/fabric/services/endorser/mock/session.go
+++ b/platform/fabric/services/endorser/mock/session.go
@@ -33,10 +33,11 @@ type Session struct {
 	receiveReturnsOnCall map[int]struct {
 		result1 <-chan *view.Message
 	}
-	SendStub        func([]byte) error
+	SendStub        func(context.Context, []byte) error
 	sendMutex       sync.RWMutex
 	sendArgsForCall []struct {
-		arg1 []byte
+		arg1 context.Context
+		arg2 []byte
 	}
 	sendReturns struct {
 		result1 error
@@ -44,39 +45,16 @@ type Session struct {
 	sendReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SendErrorStub        func([]byte) error
+	SendErrorStub        func(context.Context, []byte) error
 	sendErrorMutex       sync.RWMutex
 	sendErrorArgsForCall []struct {
-		arg1 []byte
+		arg1 context.Context
+		arg2 []byte
 	}
 	sendErrorReturns struct {
 		result1 error
 	}
 	sendErrorReturnsOnCall map[int]struct {
-		result1 error
-	}
-	SendErrorWithContextStub        func(context.Context, []byte) error
-	sendErrorWithContextMutex       sync.RWMutex
-	sendErrorWithContextArgsForCall []struct {
-		arg1 context.Context
-		arg2 []byte
-	}
-	sendErrorWithContextReturns struct {
-		result1 error
-	}
-	sendErrorWithContextReturnsOnCall map[int]struct {
-		result1 error
-	}
-	SendWithContextStub        func(context.Context, []byte) error
-	sendWithContextMutex       sync.RWMutex
-	sendWithContextArgsForCall []struct {
-		arg1 context.Context
-		arg2 []byte
-	}
-	sendWithContextReturns struct {
-		result1 error
-	}
-	sendWithContextReturnsOnCall map[int]struct {
 		result1 error
 	}
 	invocations      map[string][][]interface{}
@@ -213,23 +191,24 @@ func (fake *Session) ReceiveReturnsOnCall(i int, result1 <-chan *view.Message) {
 	}{result1}
 }
 
-func (fake *Session) Send(arg1 []byte) error {
-	var arg1Copy []byte
-	if arg1 != nil {
-		arg1Copy = make([]byte, len(arg1))
-		copy(arg1Copy, arg1)
+func (fake *Session) Send(arg1 context.Context, arg2 []byte) error {
+	var arg2Copy []byte
+	if arg2 != nil {
+		arg2Copy = make([]byte, len(arg2))
+		copy(arg2Copy, arg2)
 	}
 	fake.sendMutex.Lock()
 	ret, specificReturn := fake.sendReturnsOnCall[len(fake.sendArgsForCall)]
 	fake.sendArgsForCall = append(fake.sendArgsForCall, struct {
-		arg1 []byte
-	}{arg1Copy})
+		arg1 context.Context
+		arg2 []byte
+	}{arg1, arg2Copy})
 	stub := fake.SendStub
 	fakeReturns := fake.sendReturns
-	fake.recordInvocation("Send", []interface{}{arg1Copy})
+	fake.recordInvocation("Send", []interface{}{arg1, arg2Copy})
 	fake.sendMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -243,17 +222,17 @@ func (fake *Session) SendCallCount() int {
 	return len(fake.sendArgsForCall)
 }
 
-func (fake *Session) SendCalls(stub func([]byte) error) {
+func (fake *Session) SendCalls(stub func(context.Context, []byte) error) {
 	fake.sendMutex.Lock()
 	defer fake.sendMutex.Unlock()
 	fake.SendStub = stub
 }
 
-func (fake *Session) SendArgsForCall(i int) []byte {
+func (fake *Session) SendArgsForCall(i int) (context.Context, []byte) {
 	fake.sendMutex.RLock()
 	defer fake.sendMutex.RUnlock()
 	argsForCall := fake.sendArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *Session) SendReturns(result1 error) {
@@ -279,23 +258,24 @@ func (fake *Session) SendReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *Session) SendError(arg1 []byte) error {
-	var arg1Copy []byte
-	if arg1 != nil {
-		arg1Copy = make([]byte, len(arg1))
-		copy(arg1Copy, arg1)
+func (fake *Session) SendError(arg1 context.Context, arg2 []byte) error {
+	var arg2Copy []byte
+	if arg2 != nil {
+		arg2Copy = make([]byte, len(arg2))
+		copy(arg2Copy, arg2)
 	}
 	fake.sendErrorMutex.Lock()
 	ret, specificReturn := fake.sendErrorReturnsOnCall[len(fake.sendErrorArgsForCall)]
 	fake.sendErrorArgsForCall = append(fake.sendErrorArgsForCall, struct {
-		arg1 []byte
-	}{arg1Copy})
+		arg1 context.Context
+		arg2 []byte
+	}{arg1, arg2Copy})
 	stub := fake.SendErrorStub
 	fakeReturns := fake.sendErrorReturns
-	fake.recordInvocation("SendError", []interface{}{arg1Copy})
+	fake.recordInvocation("SendError", []interface{}{arg1, arg2Copy})
 	fake.sendErrorMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -309,17 +289,17 @@ func (fake *Session) SendErrorCallCount() int {
 	return len(fake.sendErrorArgsForCall)
 }
 
-func (fake *Session) SendErrorCalls(stub func([]byte) error) {
+func (fake *Session) SendErrorCalls(stub func(context.Context, []byte) error) {
 	fake.sendErrorMutex.Lock()
 	defer fake.sendErrorMutex.Unlock()
 	fake.SendErrorStub = stub
 }
 
-func (fake *Session) SendErrorArgsForCall(i int) []byte {
+func (fake *Session) SendErrorArgsForCall(i int) (context.Context, []byte) {
 	fake.sendErrorMutex.RLock()
 	defer fake.sendErrorMutex.RUnlock()
 	argsForCall := fake.sendErrorArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *Session) SendErrorReturns(result1 error) {
@@ -341,140 +321,6 @@ func (fake *Session) SendErrorReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.sendErrorReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *Session) SendErrorWithContext(arg1 context.Context, arg2 []byte) error {
-	var arg2Copy []byte
-	if arg2 != nil {
-		arg2Copy = make([]byte, len(arg2))
-		copy(arg2Copy, arg2)
-	}
-	fake.sendErrorWithContextMutex.Lock()
-	ret, specificReturn := fake.sendErrorWithContextReturnsOnCall[len(fake.sendErrorWithContextArgsForCall)]
-	fake.sendErrorWithContextArgsForCall = append(fake.sendErrorWithContextArgsForCall, struct {
-		arg1 context.Context
-		arg2 []byte
-	}{arg1, arg2Copy})
-	stub := fake.SendErrorWithContextStub
-	fakeReturns := fake.sendErrorWithContextReturns
-	fake.recordInvocation("SendErrorWithContext", []interface{}{arg1, arg2Copy})
-	fake.sendErrorWithContextMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *Session) SendErrorWithContextCallCount() int {
-	fake.sendErrorWithContextMutex.RLock()
-	defer fake.sendErrorWithContextMutex.RUnlock()
-	return len(fake.sendErrorWithContextArgsForCall)
-}
-
-func (fake *Session) SendErrorWithContextCalls(stub func(context.Context, []byte) error) {
-	fake.sendErrorWithContextMutex.Lock()
-	defer fake.sendErrorWithContextMutex.Unlock()
-	fake.SendErrorWithContextStub = stub
-}
-
-func (fake *Session) SendErrorWithContextArgsForCall(i int) (context.Context, []byte) {
-	fake.sendErrorWithContextMutex.RLock()
-	defer fake.sendErrorWithContextMutex.RUnlock()
-	argsForCall := fake.sendErrorWithContextArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *Session) SendErrorWithContextReturns(result1 error) {
-	fake.sendErrorWithContextMutex.Lock()
-	defer fake.sendErrorWithContextMutex.Unlock()
-	fake.SendErrorWithContextStub = nil
-	fake.sendErrorWithContextReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *Session) SendErrorWithContextReturnsOnCall(i int, result1 error) {
-	fake.sendErrorWithContextMutex.Lock()
-	defer fake.sendErrorWithContextMutex.Unlock()
-	fake.SendErrorWithContextStub = nil
-	if fake.sendErrorWithContextReturnsOnCall == nil {
-		fake.sendErrorWithContextReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.sendErrorWithContextReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *Session) SendWithContext(arg1 context.Context, arg2 []byte) error {
-	var arg2Copy []byte
-	if arg2 != nil {
-		arg2Copy = make([]byte, len(arg2))
-		copy(arg2Copy, arg2)
-	}
-	fake.sendWithContextMutex.Lock()
-	ret, specificReturn := fake.sendWithContextReturnsOnCall[len(fake.sendWithContextArgsForCall)]
-	fake.sendWithContextArgsForCall = append(fake.sendWithContextArgsForCall, struct {
-		arg1 context.Context
-		arg2 []byte
-	}{arg1, arg2Copy})
-	stub := fake.SendWithContextStub
-	fakeReturns := fake.sendWithContextReturns
-	fake.recordInvocation("SendWithContext", []interface{}{arg1, arg2Copy})
-	fake.sendWithContextMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *Session) SendWithContextCallCount() int {
-	fake.sendWithContextMutex.RLock()
-	defer fake.sendWithContextMutex.RUnlock()
-	return len(fake.sendWithContextArgsForCall)
-}
-
-func (fake *Session) SendWithContextCalls(stub func(context.Context, []byte) error) {
-	fake.sendWithContextMutex.Lock()
-	defer fake.sendWithContextMutex.Unlock()
-	fake.SendWithContextStub = stub
-}
-
-func (fake *Session) SendWithContextArgsForCall(i int) (context.Context, []byte) {
-	fake.sendWithContextMutex.RLock()
-	defer fake.sendWithContextMutex.RUnlock()
-	argsForCall := fake.sendWithContextArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *Session) SendWithContextReturns(result1 error) {
-	fake.sendWithContextMutex.Lock()
-	defer fake.sendWithContextMutex.Unlock()
-	fake.SendWithContextStub = nil
-	fake.sendWithContextReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *Session) SendWithContextReturnsOnCall(i int, result1 error) {
-	fake.sendWithContextMutex.Lock()
-	defer fake.sendWithContextMutex.Unlock()
-	fake.SendWithContextStub = nil
-	if fake.sendWithContextReturnsOnCall == nil {
-		fake.sendWithContextReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.sendWithContextReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }

--- a/platform/fabric/services/state/flow.go
+++ b/platform/fabric/services/state/flow.go
@@ -92,7 +92,7 @@ func (s *sendReceiveView) Call(viewCtx view.Context) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = session.Send(sendStateRaw)
+	err = session.Send(viewCtx.Context(), sendStateRaw)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +139,7 @@ func (s *replyView) Call(viewCtx view.Context) (any, error) {
 		return nil, err
 	}
 
-	err = session.Send(raw)
+	err = session.Send(viewCtx.Context(), raw)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/fabric/services/state/flow_test.go
+++ b/platform/fabric/services/state/flow_test.go
@@ -30,7 +30,7 @@ type mockSession struct {
 
 func (m *mockSession) Info() view.SessionInfo { return view.SessionInfo{} }
 
-func (m *mockSession) Send(payload []byte) error {
+func (m *mockSession) Send(_ context.Context, payload []byte) error {
 	if m.sendErr != nil {
 		return m.sendErr
 	}
@@ -38,16 +38,8 @@ func (m *mockSession) Send(payload []byte) error {
 	return nil
 }
 
-func (m *mockSession) SendWithContext(_ context.Context, payload []byte) error {
-	return m.Send(payload)
-}
-
-func (m *mockSession) SendError(payload []byte) error {
-	return m.Send(payload)
-}
-
-func (m *mockSession) SendErrorWithContext(_ context.Context, payload []byte) error {
-	return m.Send(payload)
+func (m *mockSession) SendError(_ context.Context, payload []byte) error {
+	return m.Send(context.Background(), payload)
 }
 
 func (m *mockSession) Receive() <-chan *view.Message { return m.recv }

--- a/platform/fabric/services/state/recipients.go
+++ b/platform/fabric/services/state/recipients.go
@@ -93,7 +93,7 @@ func (f RequestRecipientIdentityView) Call(viewCtx view.Context) (any, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed marshalling recipient request")
 	}
-	err = session.Send(rrRaw)
+	err = session.Send(viewCtx.Context(), rrRaw)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (s *RespondRequestRecipientIdentityView) Call(viewCtx view.Context) (any, e
 	}
 
 	// Step 3: send the public key back to the invoker
-	err = session.Send(recipientDataRaw)
+	err = session.Send(viewCtx.Context(), recipientDataRaw)
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +253,7 @@ func (f *ExchangeRecipientIdentitiesView) Call(viewCtx view.Context) (any, error
 	if err != nil {
 		return nil, err
 	}
-	if err := session.Send(requestRaw); err != nil {
+	if err := session.Send(viewCtx.Context(), requestRaw); err != nil {
 		return nil, err
 	}
 
@@ -347,7 +347,7 @@ func (s *RespondExchangeRecipientIdentitiesView) Call(viewCtx view.Context) (any
 		return nil, err
 	}
 
-	if err := session.Send(recipientDataRaw); err != nil {
+	if err := session.Send(viewCtx.Context(), recipientDataRaw); err != nil {
 		return nil, err
 	}
 

--- a/platform/fabric/services/state/transaction.go
+++ b/platform/fabric/services/state/transaction.go
@@ -186,7 +186,7 @@ func (f *sendTransactionView) Call(viewCtx view.Context) (any, error) {
 		}
 
 		// Send transaction
-		err = session.Send(txRaw)
+		err = session.Send(viewCtx.Context(), txRaw)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed sending transaction content")
 		}
@@ -211,7 +211,7 @@ func (f *sendTransactionBackView) Call(viewCtx view.Context) (any, error) {
 	session := viewCtx.Session()
 
 	// Send transaction
-	err = session.Send(txRaw)
+	err = session.Send(viewCtx.Context(), txRaw)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed sending transaction content")
 	}

--- a/platform/view/services/comm/host/websocket/p2p_test.go
+++ b/platform/view/services/comm/host/websocket/p2p_test.go
@@ -85,7 +85,7 @@ func TestMTLSCallerIdentityBinding(t *testing.T) { //nolint:paralleltest
 	require.NoError(t, err)
 	require.NotNil(t, session)
 
-	require.NoError(t, session.Send([]byte("ping")))
+	require.NoError(t, session.Send(ctx, []byte("ping")))
 
 	masterSession, err := node.MasterSession()
 	require.NoError(t, err)
@@ -103,7 +103,7 @@ func TestMTLSCallerIdentityBinding(t *testing.T) { //nolint:paralleltest
 	require.Error(t, err)
 	require.True(t, responder.Info().Caller.Equal(view.Identity(msg.FromPKID)))
 
-	require.NoError(t, responder.Send([]byte("pong")))
+	require.NoError(t, responder.Send(ctx, []byte("pong")))
 	reply := <-session.Receive()
 	require.NotNil(t, reply)
 	require.Equal(t, []byte("pong"), reply.Payload)
@@ -412,7 +412,7 @@ func TestSessionInfoSecurityGuarantees(t *testing.T) { //nolint:paralleltest
 	// Alice initiates a session to Bob
 	session, err := aliceNode.NewSession("alice-view", "ctx-1", bobNode.Address, []byte(bobNode.ID))
 	require.NoError(t, err)
-	require.NoError(t, session.Send([]byte("hello bob")))
+	require.NoError(t, session.Send(ctx, []byte("hello bob")))
 
 	masterSession, err := bobNode.MasterSession()
 	require.NoError(t, err)
@@ -453,7 +453,7 @@ func TestSessionInfoSecurityGuarantees(t *testing.T) { //nolint:paralleltest
 	charlieSession, err := charlieP2PNode.NewResponderSession(msg.SessionID, msg.ContextID, bobNode.Address, []byte(bobNode.ID), nil, nil)
 	require.NoError(t, err)
 	// Charlie's Send might fail because Bob rejects the connection at the transport level (Identity Binding)
-	_ = charlieSession.Send([]byte("i am alice"))
+	_ = charlieSession.Send(ctx, []byte("i am alice"))
 
 	// Bob should NOT receive Charlie's message in Alice's session
 	select {

--- a/platform/view/services/comm/io/conn.go
+++ b/platform/view/services/comm/io/conn.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package io
 
 import (
+	"context"
 	"io"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
@@ -20,8 +21,8 @@ type commSCCConn struct {
 }
 
 // NewConn creates a new connection conn backed by the comm scc
-func NewConn(index int, session view.Session) (Conn, error) {
-	msgConn, err := NewMsgConn(index, session)
+func NewConn(ctx context.Context, index int, session view.Session) (Conn, error) {
+	msgConn, err := NewMsgConn(ctx, index, session)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/view/services/comm/io/msgconn.go
+++ b/platform/view/services/comm/io/msgconn.go
@@ -33,6 +33,9 @@ type commSCCMsgConn struct {
 }
 
 func NewMsgConn(ctx context.Context, index int, session view.Session) (MsgConn, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	conn := &commSCCMsgConn{
 		ctx:          ctx,
 		session:      session,

--- a/platform/view/services/comm/io/msgconn.go
+++ b/platform/view/services/comm/io/msgconn.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package io
 
 import (
+	"context"
 	"time"
 
 	"go.uber.org/zap/zapcore"
@@ -21,6 +22,7 @@ const (
 )
 
 type commSCCMsgConn struct {
+	ctx     context.Context
 	index   int
 	session view.Session
 	ch      <-chan *view.Message
@@ -30,8 +32,9 @@ type commSCCMsgConn struct {
 	readCounter  uint64
 }
 
-func NewMsgConn(index int, session view.Session) (MsgConn, error) {
+func NewMsgConn(ctx context.Context, index int, session view.Session) (MsgConn, error) {
 	conn := &commSCCMsgConn{
+		ctx:          ctx,
 		session:      session,
 		index:        index,
 		ch:           session.Receive(),
@@ -49,7 +52,7 @@ func (c *commSCCMsgConn) Write(data []byte) (n int, err error) {
 	}
 
 	c.writeCounter++
-	err = c.session.Send(data)
+	err = c.session.Send(c.ctx, data)
 	if err != nil {
 		errMsg := errors.Errorf("failed sending message to [%s]: [%s]", c.session, err)
 		return 0, errMsg

--- a/platform/view/services/comm/io/msgconn_test.go
+++ b/platform/view/services/comm/io/msgconn_test.go
@@ -25,7 +25,7 @@ func TestNewMsgConn(t *testing.T) {
 			ch: make(chan *view.Message, 10),
 		}
 
-		conn, err := NewMsgConn(0, session)
+		conn, err := NewMsgConn(t.Context(), 0, session)
 		require.NoError(t, err)
 		require.NotNil(t, conn)
 	})
@@ -39,7 +39,7 @@ func TestMsgConn_Write(t *testing.T) {
 			ch: make(chan *view.Message, 10),
 		}
 
-		conn, err := NewMsgConn(0, session)
+		conn, err := NewMsgConn(t.Context(), 0, session)
 		require.NoError(t, err)
 
 		data := []byte("test message")
@@ -56,7 +56,7 @@ func TestMsgConn_Write(t *testing.T) {
 			ch: make(chan *view.Message, 10),
 		}
 
-		conn, err := NewMsgConn(0, session)
+		conn, err := NewMsgConn(t.Context(), 0, session)
 		require.NoError(t, err)
 
 		n, err := conn.Write([]byte{})
@@ -71,7 +71,7 @@ func TestMsgConn_Write(t *testing.T) {
 			sendError: assert.AnError,
 		}
 
-		conn, err := NewMsgConn(0, session)
+		conn, err := NewMsgConn(t.Context(), 0, session)
 		require.NoError(t, err)
 
 		n, err := conn.Write([]byte("test"))
@@ -86,7 +86,7 @@ func TestMsgConn_Write(t *testing.T) {
 			ch: make(chan *view.Message, 10),
 		}
 
-		conn, err := NewMsgConn(0, session)
+		conn, err := NewMsgConn(t.Context(), 0, session)
 		require.NoError(t, err)
 
 		messages := [][]byte{
@@ -115,7 +115,7 @@ func TestMsgConn_Read(t *testing.T) {
 		ch := make(chan *view.Message, 10)
 		session := &mockSession{ch: ch}
 
-		conn, err := NewMsgConn(0, session)
+		conn, err := NewMsgConn(t.Context(), 0, session)
 		require.NoError(t, err)
 
 		expectedData := []byte("test message")
@@ -134,7 +134,7 @@ func TestMsgConn_Read(t *testing.T) {
 		ch := make(chan *view.Message, 10)
 		session := &mockSession{ch: ch}
 
-		conn, err := NewMsgConn(0, session)
+		conn, err := NewMsgConn(t.Context(), 0, session)
 		require.NoError(t, err)
 
 		messages := [][]byte{
@@ -163,7 +163,7 @@ func TestMsgConn_Read(t *testing.T) {
 		ch := make(chan *view.Message, 10)
 		session := &mockSession{ch: ch}
 
-		conn, err := NewMsgConn(0, session)
+		conn, err := NewMsgConn(t.Context(), 0, session)
 		require.NoError(t, err)
 
 		close(ch)
@@ -179,7 +179,7 @@ func TestMsgConn_Read(t *testing.T) {
 		ch := make(chan *view.Message, 10)
 		session := &mockSession{ch: ch}
 
-		conn, err := NewMsgConn(0, session)
+		conn, err := NewMsgConn(t.Context(), 0, session)
 		require.NoError(t, err)
 
 		ch <- nil
@@ -195,7 +195,7 @@ func TestMsgConn_Read(t *testing.T) {
 		ch := make(chan *view.Message, 10)
 		session := &mockSession{ch: ch}
 
-		conn, err := NewMsgConn(0, session)
+		conn, err := NewMsgConn(t.Context(), 0, session)
 		require.NoError(t, err)
 
 		ch <- &view.Message{
@@ -214,7 +214,7 @@ func TestMsgConn_Read(t *testing.T) {
 		ch := make(chan *view.Message, 10)
 		session := &mockSession{ch: ch}
 
-		conn, err := NewMsgConn(0, session)
+		conn, err := NewMsgConn(t.Context(), 0, session)
 		require.NoError(t, err)
 
 		ch <- &view.Message{
@@ -237,7 +237,7 @@ func TestMsgConn_Flush(t *testing.T) {
 			ch: make(chan *view.Message, 10),
 		}
 
-		conn, err := NewMsgConn(0, session)
+		conn, err := NewMsgConn(t.Context(), 0, session)
 		require.NoError(t, err)
 
 		err = conn.Flush()
@@ -253,7 +253,7 @@ type mockSession struct {
 	sessionID    string
 }
 
-func (m *mockSession) Send(payload []byte) error {
+func (m *mockSession) Send(_ context.Context, payload []byte) error {
 	if m.sendError != nil {
 		return m.sendError
 	}
@@ -283,20 +283,12 @@ func (m *mockSession) Context() view.Context {
 	return nil
 }
 
-func (m *mockSession) SendWithContext(ctx context.Context, payload []byte) error {
-	return m.Send(payload)
-}
-
-func (m *mockSession) SendError(payload []byte) error {
+func (m *mockSession) SendError(_ context.Context, payload []byte) error {
 	if m.sendError != nil {
 		return m.sendError
 	}
 	m.sentMessages = append(m.sentMessages, payload)
 	return nil
-}
-
-func (m *mockSession) SendErrorWithContext(ctx context.Context, payload []byte) error {
-	return m.SendError(payload)
 }
 
 func (m *mockSession) ReceiveWithTimeout(timeout time.Duration) (*view.Message, error) {

--- a/platform/view/services/comm/io/test_utils.go
+++ b/platform/view/services/comm/io/test_utils.go
@@ -34,13 +34,13 @@ func SessionTwoParties(t *testing.T, network ...networkNode) {
 	session01, err := network[0].NewResponderSession(
 		"session_id", "context_id", "", []byte(network[1].ID()), nil, nil)
 	require.NoError(t, err)
-	conn01, err := NewConn(0, session01)
+	conn01, err := NewConn(ctx, 0, session01)
 	require.NoError(t, err)
 
 	session10, err := network[1].NewResponderSession(
 		"session_id", "context_id", "", []byte(network[0].ID()), nil, nil)
 	require.NoError(t, err)
-	conn10, err := NewConn(1, session10)
+	conn10, err := NewConn(ctx, 1, session10)
 	require.NoError(t, err)
 
 	num := 10000

--- a/platform/view/services/comm/p2p_remedy_test.go
+++ b/platform/view/services/comm/p2p_remedy_test.go
@@ -254,7 +254,7 @@ func TestStreamLeak(t *testing.T) { //nolint:paralleltest
 	session, err := p.getOrCreateSession("sess1", "addr", "ctx", "view", nil, []byte("peer1"), nil)
 	require.NoError(t, err)
 
-	err = session.Send([]byte("hello"))
+	err = session.Send(t.Context(), []byte("hello"))
 	require.NoError(t, err)
 
 	p.streamsMutex.RLock()

--- a/platform/view/services/comm/pingpong_test.go
+++ b/platform/view/services/comm/pingpong_test.go
@@ -66,7 +66,7 @@ func TestPingPongSessionLevel(t *testing.T) { //nolint:paralleltest
 			// For this test, we'll just use the same session and vary the message content
 			for i := range msgsPerSession {
 				msg := fmt.Sprintf("ping-%d-%d", sessionID, i)
-				err := sess.Send([]byte(msg))
+				err := sess.Send(t.Context(), []byte(msg))
 				assert.NoError(t, err, "Failed to send message")
 				atomic.AddInt64(&sentCount, 1)
 
@@ -97,7 +97,7 @@ func TestPingPongSessionLevel(t *testing.T) { //nolint:paralleltest
 
 				// Send a pong back
 				pongMsg := fmt.Sprintf("pong-%s", string(msg.Payload))
-				err := sess.Send([]byte(pongMsg))
+				err := sess.Send(t.Context(), []byte(pongMsg))
 				assert.NoError(t, err, "Failed to send pong message")
 				atomic.AddInt64(&receivedCount, 1)
 

--- a/platform/view/services/comm/session.go
+++ b/platform/view/services/comm/session.go
@@ -142,22 +142,13 @@ func (n *NetworkStreamSession) Info() view.SessionInfo {
 }
 
 // Send sends the payload to the endpoint.
-func (n *NetworkStreamSession) Send(payload []byte) error {
-	return n.SendWithContext(context.TODO(), payload)
-}
-
-// SendWithContext sends the payload to the endpoint with the passed context.Ctx.
-func (n *NetworkStreamSession) SendWithContext(ctx context.Context, payload []byte) error {
+// Send sends the payload to the endpoint with the passed context.Ctx.
+func (n *NetworkStreamSession) Send(ctx context.Context, payload []byte) error {
 	return n.sendWithStatus(ctx, payload, view.OK)
 }
 
-// SendError sends an error to the endpoint with the passed payload.
-func (n *NetworkStreamSession) SendError(payload []byte) error {
-	return n.SendErrorWithContext(context.TODO(), payload)
-}
-
-// SendErrorWithContext sends an error to the endpoint with the passed context.Ctx and payload.
-func (n *NetworkStreamSession) SendErrorWithContext(ctx context.Context, payload []byte) error {
+// SendError sends an error to the endpoint with the passed context.Ctx and payload.
+func (n *NetworkStreamSession) SendError(ctx context.Context, payload []byte) error {
 	return n.sendWithStatus(ctx, payload, view.ERROR)
 }
 

--- a/platform/view/services/comm/session.go
+++ b/platform/view/services/comm/session.go
@@ -141,13 +141,12 @@ func (n *NetworkStreamSession) Info() view.SessionInfo {
 	return ret
 }
 
-// Send sends the payload to the endpoint.
-// Send sends the payload to the endpoint with the passed context.Ctx.
+// Send sends the payload to the endpoint with the passed context.Context.
 func (n *NetworkStreamSession) Send(ctx context.Context, payload []byte) error {
 	return n.sendWithStatus(ctx, payload, view.OK)
 }
 
-// SendError sends an error to the endpoint with the passed context.Ctx and payload.
+// SendError sends an error to the endpoint with the passed context.Context and payload.
 func (n *NetworkStreamSession) SendError(ctx context.Context, payload []byte) error {
 	return n.sendWithStatus(ctx, payload, view.ERROR)
 }

--- a/platform/view/services/comm/session/bidi.go
+++ b/platform/view/services/comm/session/bidi.go
@@ -87,9 +87,7 @@ func (s *localSession) Info() view.SessionInfo {
 	return info
 }
 
-func (s *localSession) Send(payload []byte) error { return s.SendWithContext(context.TODO(), payload) }
-
-func (s *localSession) SendWithContext(ctx context.Context, payload []byte) error {
+func (s *localSession) Send(ctx context.Context, payload []byte) error {
 	if s.closed.Load() {
 		return errors.New("session is closed")
 	}
@@ -116,11 +114,7 @@ func (s *localSession) SendWithContext(ctx context.Context, payload []byte) erro
 	}
 }
 
-func (s *localSession) SendError(payload []byte) error {
-	return s.SendErrorWithContext(context.TODO(), payload)
-}
-
-func (s *localSession) SendErrorWithContext(ctx context.Context, payload []byte) error {
+func (s *localSession) SendError(ctx context.Context, payload []byte) error {
 	if s.closed.Load() {
 		return errors.New("session is closed")
 	}

--- a/platform/view/services/comm/session/bidi_test.go
+++ b/platform/view/services/comm/session/bidi_test.go
@@ -29,7 +29,7 @@ func TestLocalBidirectionalChannel_SendReceive(t *testing.T) {
 	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
 	require.NoError(t, err)
 	payload := []byte("hello")
-	require.NoError(t, ch.LeftSession().Send(payload))
+	require.NoError(t, ch.LeftSession().Send(t.Context(), payload))
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		select {
 		case msg := <-ch.RightSession().Receive():
@@ -48,7 +48,7 @@ func TestLocalBidirectionalChannel_BidirectionalCommunication(t *testing.T) {
 	require.NoError(t, err)
 	left := ch.LeftSession()
 	right := ch.RightSession()
-	require.NoError(t, left.Send([]byte("from left")))
+	require.NoError(t, left.Send(t.Context(), []byte("from left")))
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		select {
 		case msg := <-right.Receive():
@@ -57,7 +57,7 @@ func TestLocalBidirectionalChannel_BidirectionalCommunication(t *testing.T) {
 			assert.Fail(c, "no message received yet")
 		}
 	}, time.Second, 10*time.Millisecond)
-	require.NoError(t, right.Send([]byte("from right")))
+	require.NoError(t, right.Send(t.Context(), []byte("from right")))
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		select {
 		case msg := <-left.Receive():
@@ -73,7 +73,7 @@ func TestLocalBidirectionalChannel_SendError(t *testing.T) {
 	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
 	require.NoError(t, err)
 	errPayload := []byte("something went wrong")
-	require.NoError(t, ch.LeftSession().SendError(errPayload))
+	require.NoError(t, ch.LeftSession().SendError(t.Context(), errPayload))
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		select {
 		case msg := <-ch.RightSession().Receive():
@@ -100,7 +100,7 @@ func TestLocalBidirectionalChannel_SendAfterClose(t *testing.T) {
 	require.NoError(t, err)
 	left := ch.LeftSession()
 	left.Close()
-	err = left.Send([]byte("data"))
+	err = left.Send(t.Context(), []byte("data"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "session is closed")
 }
@@ -111,7 +111,7 @@ func TestLocalBidirectionalChannel_SendErrorAfterClose(t *testing.T) {
 	require.NoError(t, err)
 	left := ch.LeftSession()
 	left.Close()
-	err = left.SendError([]byte("data"))
+	err = left.SendError(t.Context(), []byte("data"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "session is closed")
 }
@@ -135,7 +135,7 @@ func TestLocalBidirectionalChannel_SendWithContext(t *testing.T) {
 	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
 	require.NoError(t, err)
 	payload := []byte("with context")
-	require.NoError(t, ch.LeftSession().SendWithContext(t.Context(), payload))
+	require.NoError(t, ch.LeftSession().Send(t.Context(), payload))
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		select {
 		case msg := <-ch.RightSession().Receive():
@@ -152,6 +152,6 @@ func TestLocalBidirectionalChannel_SendWithCancelledContext(t *testing.T) {
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
-	err = ch.LeftSession().SendWithContext(ctx, []byte("data"))
+	err = ch.LeftSession().Send(ctx, []byte("data"))
 	require.Error(t, err)
 }

--- a/platform/view/services/comm/session/json.go
+++ b/platform/view/services/comm/session/json.go
@@ -106,31 +106,23 @@ func (j *jsonSession) ReceiveRawWithTimeout(d time.Duration) ([]byte, error) {
 	return raw, nil
 }
 
-func (j *jsonSession) Send(state any) error {
-	return j.SendWithContext(j.ctx, state)
-}
-
-func (j *jsonSession) SendWithContext(ctx context.Context, state any) error {
+func (j *jsonSession) Send(ctx context.Context, state any) error {
 	v, err := json.Marshal(state)
 	if err != nil {
 		return err
 	}
 	logger.DebugfContext(ctx, "json session, send message [%s]", logging.SHA256Base64(v))
-	return j.s.SendWithContext(ctx, v)
+	return j.s.Send(ctx, v)
 }
 
 func (j *jsonSession) SendRaw(ctx context.Context, raw []byte) error {
 	logger.DebugfContext(ctx, "json session, send raw message [%s]", logging.SHA256Base64(raw))
-	return j.s.SendWithContext(ctx, raw)
+	return j.s.Send(ctx, raw)
 }
 
-func (j *jsonSession) SendError(err string) error {
-	return j.SendErrorWithContext(j.ctx, err)
-}
-
-func (j *jsonSession) SendErrorWithContext(ctx context.Context, err string) error {
+func (j *jsonSession) SendError(ctx context.Context, err string) error {
 	logger.ErrorfContext(ctx, "json session, send error: %w", err)
-	return j.s.SendErrorWithContext(ctx, []byte(err))
+	return j.s.SendError(ctx, []byte(err))
 }
 
 func (j *jsonSession) Session() Session {

--- a/platform/view/services/comm/session/json_test.go
+++ b/platform/view/services/comm/session/json_test.go
@@ -81,7 +81,7 @@ func TestJSONSession_Send(t *testing.T) {
 	require.NoError(t, err)
 	js := newJSONSession(ch.LeftSession(), t.Context())
 	type payload struct{ Name string }
-	require.NoError(t, js.Send(payload{Name: "hello"}))
+	require.NoError(t, js.Send(t.Context(), payload{Name: "hello"}))
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		select {
 		case msg := <-ch.RightSession().Receive():
@@ -97,7 +97,7 @@ func TestJSONSession_SendError(t *testing.T) {
 	ch, err := NewLocalBidirectionalChannel("caller", "ctx", "endpoint", nil)
 	require.NoError(t, err)
 	js := newJSONSession(ch.LeftSession(), t.Context())
-	require.NoError(t, js.SendError("something failed"))
+	require.NoError(t, js.SendError(t.Context(), "something failed"))
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		select {
 		case msg := <-ch.RightSession().Receive():

--- a/platform/view/services/comm/session/support_test.go
+++ b/platform/view/services/comm/session/support_test.go
@@ -23,13 +23,9 @@ type mockSession struct {
 
 func (m *mockSession) Info() view.SessionInfo { return view.SessionInfo{} }
 
-func (m *mockSession) Send([]byte) error { return nil }
+func (m *mockSession) Send(context.Context, []byte) error { return nil }
 
-func (m *mockSession) SendWithContext(context.Context, []byte) error { return nil }
-
-func (m *mockSession) SendError([]byte) error { return nil }
-
-func (m *mockSession) SendErrorWithContext(context.Context, []byte) error { return nil }
+func (m *mockSession) SendError(context.Context, []byte) error { return nil }
 
 func (m *mockSession) Receive() <-chan *view.Message { return m.ch }
 

--- a/platform/view/services/comm/session_deadlock_test.go
+++ b/platform/view/services/comm/session_deadlock_test.go
@@ -170,8 +170,8 @@ func TestSessionRecoverAfterClose(t *testing.T) { //nolint:paralleltest
 	require.True(t, sess.Info().Closed)
 
 	// After closing, we should not be able to send or receive.
-	require.ErrorIs(t, sess.Send([]byte("data")), ErrSessionClosed)
-	require.ErrorIs(t, sess.SendError([]byte("error")), ErrSessionClosed)
+	require.ErrorIs(t, sess.Send(t.Context(), []byte("data")), ErrSessionClosed)
+	require.ErrorIs(t, sess.SendError(t.Context(), []byte("error")), ErrSessionClosed)
 	require.False(t, s.enqueue(&view.Message{Payload: []byte("msg2")}))
 
 	// Now, create a new session with the same parameters (simulating a reconnect).

--- a/platform/view/services/comm/session_test.go
+++ b/platform/view/services/comm/session_test.go
@@ -78,8 +78,8 @@ func TestSessionLifecycle(t *testing.T) { //nolint:paralleltest
 
 	require.False(t, sess.Info().Closed)
 
-	require.NoError(t, sess.Send([]byte("some message")))
-	require.NoError(t, sess.SendError([]byte("some error")))
+	require.NoError(t, sess.Send(t.Context(), []byte("some message")))
+	require.NoError(t, sess.SendError(t.Context(), []byte("some error")))
 
 	msg := &view.Message{
 		Payload: []byte("some message"),
@@ -103,8 +103,8 @@ func TestSessionLifecycle(t *testing.T) { //nolint:paralleltest
 	require.True(t, sess.Info().Closed)
 
 	// sending on closed session should return an error
-	require.ErrorIs(t, sess.Send([]byte("some message")), ErrSessionClosed)
-	require.ErrorIs(t, sess.SendError([]byte("some error")), ErrSessionClosed)
+	require.ErrorIs(t, sess.Send(t.Context(), []byte("some message")), ErrSessionClosed)
+	require.ErrorIs(t, sess.SendError(t.Context(), []byte("some error")), ErrSessionClosed)
 
 	// enqueue on closed session should just drop the message
 	require.Empty(t, s.incoming)

--- a/platform/view/services/comm/sessions_test_utils.go
+++ b/platform/view/services/comm/sessions_test_utils.go
@@ -71,7 +71,7 @@ func runInitiator(t *testing.T, ctx context.Context, bootstrapNode, targetNode *
 		assert.NotNil(t, s)
 
 		messagesToSend := messages(s.Info().ID)
-		err = s.Send(messagesToSend[0])
+		err = s.Send(ctx, messagesToSend[0])
 		if err != nil {
 			t.Errorf("Sender [%s]: failed to send first message: %v", s.Info().ID, err)
 			return
@@ -89,7 +89,7 @@ func runInitiator(t *testing.T, ctx context.Context, bootstrapNode, targetNode *
 		}
 
 		for j := 1; j < len(messagesToSend); j++ {
-			if err := s.Send(messagesToSend[j]); err != nil {
+			if err := s.Send(ctx, messagesToSend[j]); err != nil {
 				t.Errorf("Sender [%s]: failed to send message %d: %v", s.Info().ID, j, err)
 				return
 			}
@@ -155,7 +155,7 @@ func runResponder(t *testing.T, ctx context.Context, node *HostNode, msg *view.M
 	}
 	defer s.Close()
 
-	if err := s.Send([]byte("READY")); err != nil {
+	if err := s.Send(ctx, []byte("READY")); err != nil {
 		t.Errorf("Responder [%s]: failed to send READY: %v", msg.SessionID, err)
 		return
 	}
@@ -174,7 +174,7 @@ func runResponder(t *testing.T, ctx context.Context, node *HostNode, msg *view.M
 	}
 
 	time.Sleep(100 * time.Millisecond)
-	if err := s.Send([]byte("FINAL_ACK")); err != nil {
+	if err := s.Send(ctx, []byte("FINAL_ACK")); err != nil {
 		t.Errorf("Responder [%s]: failed to send FINAL_ACK: %v", msg.SessionID, err)
 	}
 }

--- a/platform/view/services/comm/sig_exchange_test_utils.go
+++ b/platform/view/services/comm/sig_exchange_test_utils.go
@@ -128,7 +128,7 @@ func SignedSessionExchangeTestRound(t *testing.T, alice, bob *SignedExchangePart
 		if !assert.NoError(t, err, "alice failed to marshal signed message") {
 			return
 		}
-		if !assert.NoError(t, session.SendWithContext(ctx, raw)) {
+		if !assert.NoError(t, session.Send(ctx, raw)) {
 			return
 		}
 
@@ -193,7 +193,7 @@ func SignedSessionExchangeTestRound(t *testing.T, alice, bob *SignedExchangePart
 	require.NoError(t, err, "bob failed to sign")
 	bobRaw, err := utils.MarshalSignedMessage([]byte(bobMsg), bobSig)
 	require.NoError(t, err, "bob failed to marshal signed message")
-	require.NoError(t, responder.SendWithContext(ctx, bobRaw))
+	require.NoError(t, responder.Send(ctx, bobRaw))
 
 	wg.Wait()
 }

--- a/platform/view/services/comm/stress_test.go
+++ b/platform/view/services/comm/stress_test.go
@@ -55,7 +55,7 @@ func runLargeMessageTest(t *testing.T, p *P2PNode, size int) {
 	require.NoError(t, err)
 	session.SetEnqueueTimeout(200 * time.Millisecond)
 
-	err = session.Send(payload)
+	err = session.Send(t.Context(), payload)
 	assert.NoError(t, err)
 }
 
@@ -167,7 +167,7 @@ func TestConcurrentSendAndClose(t *testing.T) { //nolint:paralleltest
 		go func(id int) {
 			defer wg.Done()
 			for j := range msgsPerSender {
-				_ = session.Send(fmt.Appendf(nil, "msg-%d-%d", id, j))
+				_ = session.Send(t.Context(), fmt.Appendf(nil, "msg-%d-%d", id, j))
 			}
 		}(i)
 	}

--- a/platform/view/services/comm/test_utils.go
+++ b/platform/view/services/comm/test_utils.go
@@ -87,14 +87,14 @@ func SessionsTestRound(t *testing.T, bootstrapNode, node *HostNode) {
 		assert.NoError(t, err)
 		assert.NotNil(t, session)
 
-		err = session.Send([]byte("ciao"))
+		err = session.Send(ctx, []byte("ciao"))
 		assert.NoError(t, err)
 
 		sessionMsgs := session.Receive()
 		msg := <-sessionMsgs
 		assert.Equal(t, []byte("ciaoback"), msg.Payload)
 
-		err = session.Send([]byte("ciao on session"))
+		err = session.Send(ctx, []byte("ciao on session"))
 		assert.NoError(t, err)
 
 		session.Close()
@@ -112,7 +112,7 @@ func SessionsTestRound(t *testing.T, bootstrapNode, node *HostNode) {
 	require.NoError(t, err)
 	require.NotNil(t, session)
 
-	require.NoError(t, session.Send([]byte("ciaoback")))
+	require.NoError(t, session.Send(ctx, []byte("ciaoback")))
 
 	sessionMsgs := session.Receive()
 	msg = <-sessionMsgs
@@ -139,7 +139,7 @@ func SessionsForMPCTestRound(t *testing.T, bootstrapNode, node *HostNode) {
 		assert.NoError(t, err)
 		assert.NotNil(t, session)
 
-		err = session.Send([]byte("ciao"))
+		err = session.Send(ctx, []byte("ciao"))
 		assert.NoError(t, err)
 
 		sessionMsgs := session.Receive()
@@ -157,7 +157,7 @@ func SessionsForMPCTestRound(t *testing.T, bootstrapNode, node *HostNode) {
 	msg := <-sessionMsgs
 	require.Equal(t, []byte("ciao"), msg.Payload)
 
-	require.NoError(t, session.Send([]byte("ciaoback")))
+	require.NoError(t, session.Send(ctx, []byte("ciaoback")))
 
 	session.Close()
 
@@ -198,7 +198,7 @@ func SessionsMultipleMessagesTestRound(t *testing.T, bootstrapNode, node *HostNo
 
 			// Send first message to trigger master session on responder
 			messagesToSend := messages(s.Info().ID)
-			err = s.Send(messagesToSend[0])
+			err = s.Send(ctx, messagesToSend[0])
 			assert.NoError(t, err)
 
 			// Wait for READY signal from responder to ensure dedicated session is active
@@ -214,7 +214,7 @@ func SessionsMultipleMessagesTestRound(t *testing.T, bootstrapNode, node *HostNo
 			// Send the rest of the messages
 			for j := 1; j < len(messagesToSend); j++ {
 				// logger.Infof("send message [%s] on session [%s]", string(messagesToSend[j]), s.Info().ID)
-				err = s.Send(messagesToSend[j])
+				err = s.Send(ctx, messagesToSend[j])
 				assert.NoError(t, err)
 			}
 
@@ -267,7 +267,7 @@ func SessionsMultipleMessagesTestRound(t *testing.T, bootstrapNode, node *HostNo
 				assert.NotNil(t, s)
 
 				// Signal READY to sender
-				assert.NoError(t, s.Send([]byte("READY")))
+				assert.NoError(t, s.Send(ctx, []byte("READY")))
 
 				sessionMsgs := s.Receive()
 				for j := 1; j < len(messagesToReceive); j++ {
@@ -287,7 +287,7 @@ func SessionsMultipleMessagesTestRound(t *testing.T, bootstrapNode, node *HostNo
 
 				time.Sleep(time.Second)
 				// Send FINAL ACK
-				assert.NoError(t, s.Send([]byte("FINAL_ACK")))
+				assert.NoError(t, s.Send(ctx, []byte("FINAL_ACK")))
 
 				s.Close()
 			}(firstMsg)

--- a/platform/view/services/id/ecdsa/view.go
+++ b/platform/view/services/id/ecdsa/view.go
@@ -49,7 +49,7 @@ func (f twoPartyCollectEphemeralKeyView) Call(viewCtx view.Context) (any, error)
 	}
 
 	// send the public key
-	err = session.Send(id)
+	err = session.Send(viewCtx.Context(), id)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func (s *twoPartyEphemeralKeyResponderView) Call(viewCtx view.Context) (any, err
 	}
 
 	// Step 3: send the public key back to the invoker
-	err = session.Send(id)
+	err = session.Send(viewCtx.Context(), id)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/view/services/view/mock/session.go
+++ b/platform/view/services/view/mock/session.go
@@ -34,10 +34,11 @@ type Session struct {
 	receiveReturnsOnCall map[int]struct {
 		result1 <-chan *viewa.Message
 	}
-	SendStub        func([]byte) error
+	SendStub        func(context.Context, []byte) error
 	sendMutex       sync.RWMutex
 	sendArgsForCall []struct {
-		arg1 []byte
+		arg1 context.Context
+		arg2 []byte
 	}
 	sendReturns struct {
 		result1 error
@@ -45,39 +46,16 @@ type Session struct {
 	sendReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SendErrorStub        func([]byte) error
+	SendErrorStub        func(context.Context, []byte) error
 	sendErrorMutex       sync.RWMutex
 	sendErrorArgsForCall []struct {
-		arg1 []byte
+		arg1 context.Context
+		arg2 []byte
 	}
 	sendErrorReturns struct {
 		result1 error
 	}
 	sendErrorReturnsOnCall map[int]struct {
-		result1 error
-	}
-	SendErrorWithContextStub        func(context.Context, []byte) error
-	sendErrorWithContextMutex       sync.RWMutex
-	sendErrorWithContextArgsForCall []struct {
-		arg1 context.Context
-		arg2 []byte
-	}
-	sendErrorWithContextReturns struct {
-		result1 error
-	}
-	sendErrorWithContextReturnsOnCall map[int]struct {
-		result1 error
-	}
-	SendWithContextStub        func(context.Context, []byte) error
-	sendWithContextMutex       sync.RWMutex
-	sendWithContextArgsForCall []struct {
-		arg1 context.Context
-		arg2 []byte
-	}
-	sendWithContextReturns struct {
-		result1 error
-	}
-	sendWithContextReturnsOnCall map[int]struct {
 		result1 error
 	}
 	invocations      map[string][][]interface{}
@@ -214,23 +192,24 @@ func (fake *Session) ReceiveReturnsOnCall(i int, result1 <-chan *viewa.Message) 
 	}{result1}
 }
 
-func (fake *Session) Send(arg1 []byte) error {
-	var arg1Copy []byte
-	if arg1 != nil {
-		arg1Copy = make([]byte, len(arg1))
-		copy(arg1Copy, arg1)
+func (fake *Session) Send(arg1 context.Context, arg2 []byte) error {
+	var arg2Copy []byte
+	if arg2 != nil {
+		arg2Copy = make([]byte, len(arg2))
+		copy(arg2Copy, arg2)
 	}
 	fake.sendMutex.Lock()
 	ret, specificReturn := fake.sendReturnsOnCall[len(fake.sendArgsForCall)]
 	fake.sendArgsForCall = append(fake.sendArgsForCall, struct {
-		arg1 []byte
-	}{arg1Copy})
+		arg1 context.Context
+		arg2 []byte
+	}{arg1, arg2Copy})
 	stub := fake.SendStub
 	fakeReturns := fake.sendReturns
-	fake.recordInvocation("Send", []interface{}{arg1Copy})
+	fake.recordInvocation("Send", []interface{}{arg1, arg2Copy})
 	fake.sendMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -244,17 +223,17 @@ func (fake *Session) SendCallCount() int {
 	return len(fake.sendArgsForCall)
 }
 
-func (fake *Session) SendCalls(stub func([]byte) error) {
+func (fake *Session) SendCalls(stub func(context.Context, []byte) error) {
 	fake.sendMutex.Lock()
 	defer fake.sendMutex.Unlock()
 	fake.SendStub = stub
 }
 
-func (fake *Session) SendArgsForCall(i int) []byte {
+func (fake *Session) SendArgsForCall(i int) (context.Context, []byte) {
 	fake.sendMutex.RLock()
 	defer fake.sendMutex.RUnlock()
 	argsForCall := fake.sendArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *Session) SendReturns(result1 error) {
@@ -280,23 +259,24 @@ func (fake *Session) SendReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *Session) SendError(arg1 []byte) error {
-	var arg1Copy []byte
-	if arg1 != nil {
-		arg1Copy = make([]byte, len(arg1))
-		copy(arg1Copy, arg1)
+func (fake *Session) SendError(arg1 context.Context, arg2 []byte) error {
+	var arg2Copy []byte
+	if arg2 != nil {
+		arg2Copy = make([]byte, len(arg2))
+		copy(arg2Copy, arg2)
 	}
 	fake.sendErrorMutex.Lock()
 	ret, specificReturn := fake.sendErrorReturnsOnCall[len(fake.sendErrorArgsForCall)]
 	fake.sendErrorArgsForCall = append(fake.sendErrorArgsForCall, struct {
-		arg1 []byte
-	}{arg1Copy})
+		arg1 context.Context
+		arg2 []byte
+	}{arg1, arg2Copy})
 	stub := fake.SendErrorStub
 	fakeReturns := fake.sendErrorReturns
-	fake.recordInvocation("SendError", []interface{}{arg1Copy})
+	fake.recordInvocation("SendError", []interface{}{arg1, arg2Copy})
 	fake.sendErrorMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -310,17 +290,17 @@ func (fake *Session) SendErrorCallCount() int {
 	return len(fake.sendErrorArgsForCall)
 }
 
-func (fake *Session) SendErrorCalls(stub func([]byte) error) {
+func (fake *Session) SendErrorCalls(stub func(context.Context, []byte) error) {
 	fake.sendErrorMutex.Lock()
 	defer fake.sendErrorMutex.Unlock()
 	fake.SendErrorStub = stub
 }
 
-func (fake *Session) SendErrorArgsForCall(i int) []byte {
+func (fake *Session) SendErrorArgsForCall(i int) (context.Context, []byte) {
 	fake.sendErrorMutex.RLock()
 	defer fake.sendErrorMutex.RUnlock()
 	argsForCall := fake.sendErrorArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *Session) SendErrorReturns(result1 error) {
@@ -342,140 +322,6 @@ func (fake *Session) SendErrorReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.sendErrorReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *Session) SendErrorWithContext(arg1 context.Context, arg2 []byte) error {
-	var arg2Copy []byte
-	if arg2 != nil {
-		arg2Copy = make([]byte, len(arg2))
-		copy(arg2Copy, arg2)
-	}
-	fake.sendErrorWithContextMutex.Lock()
-	ret, specificReturn := fake.sendErrorWithContextReturnsOnCall[len(fake.sendErrorWithContextArgsForCall)]
-	fake.sendErrorWithContextArgsForCall = append(fake.sendErrorWithContextArgsForCall, struct {
-		arg1 context.Context
-		arg2 []byte
-	}{arg1, arg2Copy})
-	stub := fake.SendErrorWithContextStub
-	fakeReturns := fake.sendErrorWithContextReturns
-	fake.recordInvocation("SendErrorWithContext", []interface{}{arg1, arg2Copy})
-	fake.sendErrorWithContextMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *Session) SendErrorWithContextCallCount() int {
-	fake.sendErrorWithContextMutex.RLock()
-	defer fake.sendErrorWithContextMutex.RUnlock()
-	return len(fake.sendErrorWithContextArgsForCall)
-}
-
-func (fake *Session) SendErrorWithContextCalls(stub func(context.Context, []byte) error) {
-	fake.sendErrorWithContextMutex.Lock()
-	defer fake.sendErrorWithContextMutex.Unlock()
-	fake.SendErrorWithContextStub = stub
-}
-
-func (fake *Session) SendErrorWithContextArgsForCall(i int) (context.Context, []byte) {
-	fake.sendErrorWithContextMutex.RLock()
-	defer fake.sendErrorWithContextMutex.RUnlock()
-	argsForCall := fake.sendErrorWithContextArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *Session) SendErrorWithContextReturns(result1 error) {
-	fake.sendErrorWithContextMutex.Lock()
-	defer fake.sendErrorWithContextMutex.Unlock()
-	fake.SendErrorWithContextStub = nil
-	fake.sendErrorWithContextReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *Session) SendErrorWithContextReturnsOnCall(i int, result1 error) {
-	fake.sendErrorWithContextMutex.Lock()
-	defer fake.sendErrorWithContextMutex.Unlock()
-	fake.SendErrorWithContextStub = nil
-	if fake.sendErrorWithContextReturnsOnCall == nil {
-		fake.sendErrorWithContextReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.sendErrorWithContextReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *Session) SendWithContext(arg1 context.Context, arg2 []byte) error {
-	var arg2Copy []byte
-	if arg2 != nil {
-		arg2Copy = make([]byte, len(arg2))
-		copy(arg2Copy, arg2)
-	}
-	fake.sendWithContextMutex.Lock()
-	ret, specificReturn := fake.sendWithContextReturnsOnCall[len(fake.sendWithContextArgsForCall)]
-	fake.sendWithContextArgsForCall = append(fake.sendWithContextArgsForCall, struct {
-		arg1 context.Context
-		arg2 []byte
-	}{arg1, arg2Copy})
-	stub := fake.SendWithContextStub
-	fakeReturns := fake.sendWithContextReturns
-	fake.recordInvocation("SendWithContext", []interface{}{arg1, arg2Copy})
-	fake.sendWithContextMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *Session) SendWithContextCallCount() int {
-	fake.sendWithContextMutex.RLock()
-	defer fake.sendWithContextMutex.RUnlock()
-	return len(fake.sendWithContextArgsForCall)
-}
-
-func (fake *Session) SendWithContextCalls(stub func(context.Context, []byte) error) {
-	fake.sendWithContextMutex.Lock()
-	defer fake.sendWithContextMutex.Unlock()
-	fake.SendWithContextStub = stub
-}
-
-func (fake *Session) SendWithContextArgsForCall(i int) (context.Context, []byte) {
-	fake.sendWithContextMutex.RLock()
-	defer fake.sendWithContextMutex.RUnlock()
-	argsForCall := fake.sendWithContextArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *Session) SendWithContextReturns(result1 error) {
-	fake.sendWithContextMutex.Lock()
-	defer fake.sendWithContextMutex.Unlock()
-	fake.SendWithContextStub = nil
-	fake.sendWithContextReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *Session) SendWithContextReturnsOnCall(i int, result1 error) {
-	fake.sendWithContextMutex.Lock()
-	defer fake.sendWithContextMutex.Unlock()
-	fake.SendWithContextStub = nil
-	if fake.sendWithContextReturnsOnCall == nil {
-		fake.sendWithContextReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.sendWithContextReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }

--- a/platform/view/services/view/p2p/service.go
+++ b/platform/view/services/view/p2p/service.go
@@ -159,8 +159,8 @@ func (s *Service) respond(responder view.View, id view.Identity, msg *view.Messa
 	if err != nil {
 		logger.DebugfContext(viewCtx.Context(), "[%s] Respond Failure [from:%s], [sessionID:%s], [contextID:%s] [%s]\n", id, msg.FromEndpoint, msg.SessionID, msg.ContextID, err)
 
-		// send the error back to the caller
-		if serr := viewCtx.Session().SendError([]byte(err.Error())); serr != nil {
+		// Keep error reporting uncancellable while preserving values from the responder context.
+		if serr := viewCtx.Session().SendError(context.WithoutCancel(viewCtx.Context()), []byte(err.Error())); serr != nil {
 			logger.Error(serr.Error())
 		}
 	}

--- a/platform/view/services/view/p2p/service_test.go
+++ b/platform/view/services/view/p2p/service_test.go
@@ -149,6 +149,7 @@ func TestService_PanicIsReturnedToRemoteCaller(t *testing.T) {
 
 	respCtx := &mock.Context{}
 	respCtx.SessionReturns(respSession)
+	respCtx.ContextReturns(t.Context())
 	// The default Runner (p2p.NewDefaultRunner) just delegates to viewCtx.RunView(responder).
 	// The real implementation (viewpkg.RunViewNow) recovers any panic raised by the
 	// responder's Call and turns it into an error (wrapping ErrViewExecutionFailed with the
@@ -199,7 +200,9 @@ func TestService_PanicIsReturnedToRemoteCaller(t *testing.T) {
 		return respSession.SendErrorCallCount() > 0
 	}, 5*time.Second, 10*time.Millisecond, "SendError was never called with the panic's error text")
 
-	sentPayload := respSession.SendErrorArgsForCall(0)
+	sentCtx, sentPayload := respSession.SendErrorArgsForCall(0)
+	require.NotNil(t, sentCtx)
+	require.NoError(t, sentCtx.Err())
 	require.Contains(t, string(sentPayload), sensitivePanicText)
 }
 

--- a/platform/view/view/session.go
+++ b/platform/view/view/session.go
@@ -72,17 +72,11 @@ func (i *SessionInfo) String() string {
 type Session interface {
 	Info() SessionInfo
 
-	// Send sends the payload to the endpoint
-	Send(payload []byte) error
+	// Send sends the payload to the endpoint with the passed context.
+	Send(ctx context.Context, payload []byte) error
 
-	// SendWithContext sends the payload to the endpoint with the passed context
-	SendWithContext(ctx context.Context, payload []byte) error
-
-	// SendError sends an error to the endpoint with the passed payload
-	SendError(payload []byte) error
-
-	// SendErrorWithContext sends an error to the endpoint with the passed payload and context
-	SendErrorWithContext(ctx context.Context, payload []byte) error
+	// SendError sends an error to the endpoint with the passed payload and context.
+	SendError(ctx context.Context, payload []byte) error
 
 	// Receive returns a channel of messages received from the endpoint
 	Receive() <-chan *Message


### PR DESCRIPTION
Closes #1648

## Summary

`view.Session` carried a duplicated context/non-context method pair (`Send`/`SendWithContext`, `SendError`/`SendErrorWithContext`). In both real implementations the non-context variants were nothing but `context.TODO()` wrappers around the context-taking ones — a migration artifact that doubled the interface surface, forced every mock/fake to implement four methods where two suffice, and let call sites silently opt out of cancellation and trace propagation.

This collapses each pair into the single ctx-first name:

```go
Send(ctx context.Context, payload []byte) error
SendError(ctx context.Context, payload []byte) error
```

This is an intentional breaking API change — no deprecation shims, no compat wrappers. Downstream consumers (Panurus) will pick it up on the next tag.

- `jsonSession` gets the same treatment one layer up (its `SendRaw(ctx, raw)` was already ctx-first and is the convention this now matches).
- `commSCCMsgConn`/`commSCCConn` thread and store a ctx through their constructors, since they implement `io.Writer` and `Write([]byte)` has no ctx to forward.
- The one semantic-risk site, `platform/view/services/view/p2p/service.go` (reporting a responder-view failure back to the remote caller), uses `context.WithoutCancel(viewCtx.Context())` instead of the live `viewCtx.Context()` — that context can be cancelled or reused across rounds via `Manager.NewResponderContext`, so passing it live could make error reporting fail with `ctx.Err()` on an otherwise healthy connection, silently dropping the error the remote caller is waiting for. `WithoutCancel` preserves today's un-cancellable behavior while still propagating trace/log values.
- Mocks regenerated via counterfeiter (`platform/view/services/view/mock/session.go`, `platform/fabric/services/endorser/mock/session.go`); hand-written test mocks and call sites updated to match.
- Docs updated (`docs/platform/view/view-api.md`, `docs/platform/view/programming-model.md`, `docs/platform/view/services/comm/readme.md`, `docs/platform/view/services/view-service.md`).

## Test plan

- [x] `go build ./... && go vet ./...` (root module)
- [x] `go build ./... && go vet ./...` (`integration` module)
- [x] `go build ./... && go vet ./...` (`platform/view/services/comm/host/libp2p` module)
- [x] `go test -count=1 ./platform/view/services/comm/... ./platform/view/services/view/... ./platform/fabric/services/endorser/... ./platform/fabric/services/state/... ./platform/view/services/id/...`
- [x] `make checks` and `make lint` clean
- [x] `make tidy` is a no-op (only new stdlib `context` imports)
- [x] `./scripts/find-mocks.sh` → all `OK`
- [x] `grep -rn 'SendWithContext\|SendErrorWithContext' --include='*.go' .` → zero hits outside test function names