### PR TITLE
testing(nwo/fabric-x): add multiple orderer endpoints for integration test

### DIFF
--- a/integration/nwo/fabric/network/checks.go
+++ b/integration/nwo/fabric/network/checks.go
@@ -35,7 +35,11 @@ func (n *Network) CheckTopology() {
 
 // CheckTopologyOrderers checks that the orderers' ports are allocated
 func (n *Network) CheckTopologyOrderers() {
-	for _, o := range n.Orderers {
+	for i, o := range n.Orderers {
+		// Set default Id if not already set (1-based indexing for BFT)
+		if o.Id == 0 {
+			o.Id = i + 1
+		}
 		ports := api.Ports{}
 		for _, portName := range OrdererPortNames() {
 			ports[portName] = n.Context.ReservePort()

--- a/integration/nwo/fabric/network/configtx_test.go
+++ b/integration/nwo/fabric/network/configtx_test.go
@@ -7,16 +7,20 @@ SPDX-License-Identifier: Apache-2.0
 package network
 
 import (
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
-	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api"
-	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common/context"
-	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/topology"
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
+
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api"
+	nwocontext "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common/context"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/topology"
 )
 
 type configtx struct {
@@ -26,77 +30,163 @@ type configtx struct {
 	} `yaml:"Organizations"`
 	Profiles map[string]struct {
 		Orderer struct {
-			ConsenterMapping []struct {
-				Port int `yaml:"Port"`
-			} `yaml:"ConsenterMapping"`
+			ConsenterMapping []consenter `yaml:"ConsenterMapping"`
 		} `yaml:"Orderer"`
 	} `yaml:"Profiles"`
 }
 
-func TestConfigTxArmaMultiOrdererSharedPort(t *testing.T) {
+type consenter struct {
+	ID       int    `yaml:"ID"`
+	Host     string `yaml:"Host"`
+	Port     int    `yaml:"Port"`
+	MSPID    string `yaml:"MSPID"`
+	Identity string `yaml:"Identity"`
+}
+
+const (
+	testOrdererCount = 4
+	// base values chosen so that every orderer ends up with a distinct host and
+	// distinct ports: a template that silently uses the wrong orderer therefore
+	// produces a different address instead of an accidentally matching one.
+	testListenPortBase  = 21100
+	testClusterPortBase = 21200
+)
+
+func testOrdererHost(i int) string { return fmt.Sprintf("10.0.0.%d", i+1) }
+
+func testListenPort(i int) uint16 { return uint16(testListenPortBase + i) }
+
+func testClusterPort(i int) uint16 { return uint16(testClusterPortBase + i) }
+
+// generateConfigTx renders configtx.yaml for a network of testOrdererCount
+// orderers, each with its own host and its own ports, and returns the parsed
+// result. profileOrderers controls the order in which the profile references
+// them, which need not match the network-wide order.
+func generateConfigTx(t *testing.T, consensusType string, profileOrderers []string) configtx {
+	t.Helper()
 	gomega.RegisterTestingT(t)
-	ctx := context.New(t.TempDir(), 20000, nil)
+
+	orderers := make([]*topology.Orderer, 0, testOrdererCount)
+	for i := range testOrdererCount {
+		orderers = append(orderers, &topology.Orderer{
+			Name:         fmt.Sprintf("orderer%d", i+1),
+			Organization: "OrdererOrg",
+			Id:           i + 1,
+		})
+	}
 
 	topo := &topology.Topology{
 		TopologyName: "default",
 		TopologyType: "fabric",
 		Driver:       "generic",
 		Default:      true,
-		Consensus:    &topology.Consensus{Type: "arma"},
-		Orderers: []*topology.Orderer{
-			{Name: "orderer1", Organization: "OrdererOrg"},
-			{Name: "orderer2", Organization: "OrdererOrg"},
-			{Name: "orderer3", Organization: "OrdererOrg"},
-			{Name: "orderer4", Organization: "OrdererOrg"},
-		},
-		Organizations: []*topology.Organization{
-			{ID: "OrdererOrg", Name: "OrdererOrg", MSPID: "OrdererMSP"},
-		},
-		Profiles: []*topology.Profile{
-			{Name: "OrgsChannel", Orderers: []string{"orderer1", "orderer2", "orderer3", "orderer4"}},
-		},
+		Consensus:    &topology.Consensus{Type: consensusType},
+		Orderers:     orderers,
+		Organizations: []*topology.Organization{{
+			ID:     "OrdererOrg",
+			Name:   "OrdererOrg",
+			MSPID:  "OrdererMSP",
+			Domain: "example.com",
+		}},
+		Profiles: []*topology.Profile{{
+			Name:     "OrgsChannel",
+			Orderers: profileOrderers,
+		}},
 	}
 
-	n := New(ctx, topo, nil, nil, "test-network")
+	n := New(nwocontext.New(t.TempDir(), 0, nil), topo, nil, nil, "test-network")
 	n.Templates = &topology.Templates{}
-	
-	// Pre-assign ports so we know what to expect
-	port := ctx.ReservePort()
-	for _, o := range topo.Orderers {
-		ctx.SetPortsByOrdererID(n.Prefix, o.ID(), api.Ports{
-			ListenPort: port,
+
+	for i, o := range orderers {
+		n.Context.SetPortsByOrdererID(n.Prefix, o.ID(), api.Ports{
+			ListenPort:  testListenPort(i),
+			ClusterPort: testClusterPort(i),
 		})
-		ctx.SetHostByOrdererID(n.Prefix, o.ID(), "127.0.0.1")
+		n.Context.SetHostByOrdererID(n.Prefix, o.ID(), testOrdererHost(i))
 	}
 
-	err := os.MkdirAll(filepath.Dir(n.ConfigTxConfigPath()), 0755)
-	require.NoError(t, err)
-
+	require.NoError(t, os.MkdirAll(filepath.Dir(n.ConfigTxConfigPath()), 0o755))
 	n.GenerateConfigTxConfig()
 
-	b, err := os.ReadFile(n.ConfigTxConfigPath())
+	raw, err := os.ReadFile(n.ConfigTxConfigPath())
 	require.NoError(t, err)
 
 	var conf configtx
-	err = yaml.Unmarshal(b, &conf)
-	require.NoError(t, err)
+	require.NoError(t, yaml.Unmarshal(raw, &conf), "generated configtx.yaml is not valid yaml:\n%s", raw)
 
-	// Verify all 4 OrdererEndpoints have the same port (orderer1's ListenPort)
-	expectedPort := n.OrdererPort(topo.Orderers[0], ListenPort)
-	require.Greater(t, expectedPort, uint16(0))
+	return conf
+}
+
+// allOrderers returns the network-wide orderer names in order.
+func allOrderers() []string {
+	names := make([]string, 0, testOrdererCount)
+	for i := range testOrdererCount {
+		names = append(names, fmt.Sprintf("orderer%d", i+1))
+	}
+	return names
+}
+
+// requireSharedEndpoint asserts that every logical orderer resolves to the
+// endpoint of orderer1 -- the only orderer the fabric-x committer container
+// actually binds -- while keeping four distinct consenter identities.
+func requireSharedEndpoint(t *testing.T, conf configtx) {
+	t.Helper()
+
+	wantHost := testOrdererHost(0)
+	wantPort := testListenPort(0)
+	wantEndpoint := net.JoinHostPort(wantHost, strconv.Itoa(int(wantPort)))
 
 	require.Len(t, conf.Organizations, 1)
-	require.Len(t, conf.Organizations[0].OrdererEndpoints, 4)
-	for _, ep := range conf.Organizations[0].OrdererEndpoints {
-		require.Contains(t, ep, string("127.0.0.1"))
-		// Endpoint format is "host:port", check if port matches expectedPort
+	require.Len(t, conf.Organizations[0].OrdererEndpoints, testOrdererCount)
+	for _, endpoint := range conf.Organizations[0].OrdererEndpoints {
+		require.Equal(t, wantEndpoint, endpoint, "every orderer endpoint must point at orderer1")
 	}
 
-	// Verify ConsenterMapping
 	profile, ok := conf.Profiles["OrgsChannel"]
 	require.True(t, ok)
-	require.Len(t, profile.Orderer.ConsenterMapping, 4)
-	for _, mapping := range profile.Orderer.ConsenterMapping {
-		require.Equal(t, int(expectedPort), mapping.Port)
+	require.Len(t, profile.Orderer.ConsenterMapping, testOrdererCount)
+
+	identities := make(map[string]struct{}, testOrdererCount)
+	ids := make(map[int]struct{}, testOrdererCount)
+	for _, c := range profile.Orderer.ConsenterMapping {
+		require.Equal(t, wantHost, c.Host, "every consenter must point at orderer1's host")
+		require.Equal(t, int(wantPort), c.Port, "every consenter must point at orderer1's port")
+		require.Equal(t, "OrdererMSP", c.MSPID)
+		identities[c.Identity] = struct{}{}
+		ids[c.ID] = struct{}{}
+	}
+	require.Len(t, identities, testOrdererCount, "each consenter must keep its own signing identity")
+	require.Len(t, ids, testOrdererCount, "each consenter must keep its own id")
+}
+
+// TestConfigTxArmaMultiOrdererSharedPort checks that an arma network maps all
+// logical orderers onto the single endpoint exposed by the committer container.
+func TestConfigTxArmaMultiOrdererSharedPort(t *testing.T) { //nolint:paralleltest // gomega.RegisterTestingT is process-wide
+	requireSharedEndpoint(t, generateConfigTx(t, "arma", allOrderers()))
+}
+
+// TestConfigTxArmaProfileOrdererOrderIndependent checks that the shared
+// endpoint is the network's first orderer even when the profile lists the
+// orderers in a different order: the container binds the network's first
+// orderer regardless of what any profile says.
+func TestConfigTxArmaProfileOrdererOrderIndependent(t *testing.T) { //nolint:paralleltest // gomega.RegisterTestingT is process-wide
+	requireSharedEndpoint(t, generateConfigTx(t, "arma", []string{"orderer2", "orderer3", "orderer4", "orderer1"}))
+}
+
+// TestConfigTxBFTConsenterMapping checks that a plain BFT network keeps one
+// consenter per orderer, each with its own host and cluster port.
+func TestConfigTxBFTConsenterMapping(t *testing.T) { //nolint:paralleltest // gomega.RegisterTestingT is process-wide
+	conf := generateConfigTx(t, "BFT", allOrderers())
+
+	profile, ok := conf.Profiles["OrgsChannel"]
+	require.True(t, ok)
+	require.Len(t, profile.Orderer.ConsenterMapping, testOrdererCount)
+
+	for i, c := range profile.Orderer.ConsenterMapping {
+		require.Equal(t, i+1, c.ID)
+		require.Equal(t, testOrdererHost(i), c.Host, "consenter must carry its own host")
+		require.Equal(t, int(testClusterPort(i)), c.Port, "consenter must carry its own cluster port")
+		require.Equal(t, "OrdererMSP", c.MSPID)
+		require.Contains(t, c.Identity, fmt.Sprintf("orderer%d.example.com-cert.pem", i+1))
 	}
 }

--- a/integration/nwo/fabric/network/configtx_test.go
+++ b/integration/nwo/fabric/network/configtx_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package network
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common/context"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/topology"
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+)
+
+type configtx struct {
+	Organizations []struct {
+		Name             string   `yaml:"Name"`
+		OrdererEndpoints []string `yaml:"OrdererEndpoints"`
+	} `yaml:"Organizations"`
+	Profiles map[string]struct {
+		Orderer struct {
+			ConsenterMapping []struct {
+				Port int `yaml:"Port"`
+			} `yaml:"ConsenterMapping"`
+		} `yaml:"Orderer"`
+	} `yaml:"Profiles"`
+}
+
+func TestConfigTxArmaMultiOrdererSharedPort(t *testing.T) {
+	gomega.RegisterTestingT(t)
+	ctx := context.New(t.TempDir(), 20000, nil)
+
+	topo := &topology.Topology{
+		TopologyName: "default",
+		TopologyType: "fabric",
+		Driver:       "generic",
+		Default:      true,
+		Consensus:    &topology.Consensus{Type: "arma"},
+		Orderers: []*topology.Orderer{
+			{Name: "orderer1", Organization: "OrdererOrg"},
+			{Name: "orderer2", Organization: "OrdererOrg"},
+			{Name: "orderer3", Organization: "OrdererOrg"},
+			{Name: "orderer4", Organization: "OrdererOrg"},
+		},
+		Organizations: []*topology.Organization{
+			{ID: "OrdererOrg", Name: "OrdererOrg", MSPID: "OrdererMSP"},
+		},
+		Profiles: []*topology.Profile{
+			{Name: "OrgsChannel", Orderers: []string{"orderer1", "orderer2", "orderer3", "orderer4"}},
+		},
+	}
+
+	n := New(ctx, topo, nil, nil, "test-network")
+	n.Templates = &topology.Templates{}
+	
+	// Pre-assign ports so we know what to expect
+	port := ctx.ReservePort()
+	for _, o := range topo.Orderers {
+		ctx.SetPortsByOrdererID(n.Prefix, o.ID(), api.Ports{
+			ListenPort: port,
+		})
+		ctx.SetHostByOrdererID(n.Prefix, o.ID(), "127.0.0.1")
+	}
+
+	err := os.MkdirAll(filepath.Dir(n.ConfigTxConfigPath()), 0755)
+	require.NoError(t, err)
+
+	n.GenerateConfigTxConfig()
+
+	b, err := os.ReadFile(n.ConfigTxConfigPath())
+	require.NoError(t, err)
+
+	var conf configtx
+	err = yaml.Unmarshal(b, &conf)
+	require.NoError(t, err)
+
+	// Verify all 4 OrdererEndpoints have the same port (orderer1's ListenPort)
+	expectedPort := n.OrdererPort(topo.Orderers[0], ListenPort)
+	require.Greater(t, expectedPort, uint16(0))
+
+	require.Len(t, conf.Organizations, 1)
+	require.Len(t, conf.Organizations[0].OrdererEndpoints, 4)
+	for _, ep := range conf.Organizations[0].OrdererEndpoints {
+		require.Contains(t, ep, string("127.0.0.1"))
+		// Endpoint format is "host:port", check if port matches expectedPort
+	}
+
+	// Verify ConsenterMapping
+	profile, ok := conf.Profiles["OrgsChannel"]
+	require.True(t, ok)
+	require.Len(t, profile.Orderer.ConsenterMapping, 4)
+	for _, mapping := range profile.Orderer.ConsenterMapping {
+		require.Equal(t, int(expectedPort), mapping.Port)
+	}
+}

--- a/integration/nwo/fabric/network/network_support.go
+++ b/integration/nwo/fabric/network/network_support.go
@@ -571,6 +571,18 @@ func (n *Network) OrdererLocalTLSDir(o *topology.Orderer) string {
 	return n.OrdererLocalCryptoDir(o, "tls")
 }
 
+// OrdererSignCert returns the path to the orderer's certificate.
+func (n *Network) OrdererSignCert(o *topology.Orderer) string {
+	org := n.Organization(o.Organization)
+	gomega.Expect(org).NotTo(gomega.BeNil())
+
+	return filepath.Join(
+		n.OrdererLocalMSPDir(o),
+		"signcerts",
+		fmt.Sprintf("%s.%s-cert.pem", o.Name, org.Domain),
+	)
+}
+
 // ProfileForChannel gets the configtxgen profile name associated with the
 // specified channel.
 func (n *Network) ProfileForChannel(channelName string) string {

--- a/integration/nwo/fabric/topology/configtx_template.go
+++ b/integration/nwo/fabric/topology/configtx_template.go
@@ -112,7 +112,12 @@ Organizations:{{ range .PeerOrgs }}
       Rule: OR('{{.MSPID}}.admin')
   {{- end }}
   OrdererEndpoints:{{ range $w.OrderersInOrg .Name }}
+  {{- if eq $w.Consensus.Type "arma" }}
+  {{- $firstOrderer := index $.Orderers 0 }}
+  - {{ $w.OrdererHost . }}:{{ $w.OrdererPort $firstOrderer "Listen" }}
+  {{- else }}
   - {{ $w.OrdererAddress . "Listen" }}
+  {{- end }}
   {{- end }}
 {{ end }}
 
@@ -198,6 +203,19 @@ Profiles:{{ range .Profiles }}
           Port: {{ $w.OrdererPort . "Cluster" }}
           ClientTLSCert: {{ $w.OrdererLocalCryptoDir . "tls" }}/server.crt
           ServerTLSCert: {{ $w.OrdererLocalCryptoDir . "tls" }}/server.crt
+        {{- end }}{{- end }}
+      {{- end }}
+      {{- if eq $w.Consensus.Type "arma" }}
+      {{- $firstOrdererName := index .Orderers 0 }}
+      {{- $firstOrderer := $w.Orderer $firstOrdererName }}
+      ConsenterMapping:{{ range $index, $orderer := .Orderers }}{{ with $w.Orderer . }}
+      - ID: {{ .Id }}
+        Host: 127.0.0.1
+        Port: {{ $w.OrdererPort $firstOrderer "Listen" }}
+        MSPID: {{ ($w.Organization .Organization).MSPID}}
+        ClientTLSCert: {{ $w.OrdererLocalCryptoDir $firstOrderer "tls" }}/server.crt
+        ServerTLSCert: {{ $w.OrdererLocalCryptoDir $firstOrderer "tls" }}/server.crt
+        Identity: {{ $w.OrdererSignCert .}}
         {{- end }}{{- end }}
       {{- end }}
       Organizations:{{ range $w.OrgsForOrderers .Orderers }}

--- a/integration/nwo/fabric/topology/configtx_template.go
+++ b/integration/nwo/fabric/topology/configtx_template.go
@@ -113,8 +113,7 @@ Organizations:{{ range .PeerOrgs }}
   {{- end }}
   OrdererEndpoints:{{ range $w.OrderersInOrg .Name }}
   {{- if eq $w.Consensus.Type "arma" }}
-  {{- $firstOrderer := index $.Orderers 0 }}
-  - {{ $w.OrdererHost . }}:{{ $w.OrdererPort $firstOrderer "Listen" }}
+  - {{ $w.OrdererAddress (index $.Orderers 0) "Listen" }}
   {{- else }}
   - {{ $w.OrdererAddress . "Listen" }}
   {{- end }}
@@ -183,15 +182,6 @@ Profiles:{{ range .Profiles }}
         SyncOnStart:               false
         SpeedUpViewChange:         false
       {{- end }}
-      ConsenterMapping:{{ range $index, $orderer := .Orderers }}{{ with $w.Orderer . }}
-      - ID: {{ .Id }}
-        {{ $w.OrdererHost . }}
-        Port: {{ $w.OrdererPort . "Cluster" }}
-        MSPID: {{ ($w.Organization .Organization).MSPID}}
-        ClientTLSCert: {{ $w.OrdererLocalCryptoDir . "tls" }}/server.crt
-        ServerTLSCert: {{ $w.OrdererLocalCryptoDir . "tls" }}/server.crt
-        Identity: {{ $w.OrdererSignCert .}}
-        {{- end }}{{- end }}
       {{- end }}
       {{- if eq $w.Consensus.Type "etcdraft" }}
       EtcdRaft:
@@ -205,17 +195,22 @@ Profiles:{{ range .Profiles }}
           ServerTLSCert: {{ $w.OrdererLocalCryptoDir . "tls" }}/server.crt
         {{- end }}{{- end }}
       {{- end }}
-      {{- if eq $w.Consensus.Type "arma" }}
-      {{- $firstOrdererName := index .Orderers 0 }}
-      {{- $firstOrderer := $w.Orderer $firstOrdererName }}
-      ConsenterMapping:{{ range $index, $orderer := .Orderers }}{{ with $w.Orderer . }}
+      {{- if or (eq $w.Consensus.Type "BFT") (eq $w.Consensus.Type "arma") }}
+      ConsenterMapping:{{ range .Orderers }}{{ with $w.Orderer . }}
+      {{- $arma := eq $w.Consensus.Type "arma" }}
+      {{- $endpoint := . }}
+      {{- /* arma runs against the fabric-x committer container, which binds a single
+             ordering endpoint. Every logical consenter therefore shares the address
+             and TLS material of the network's first orderer -- the one the container
+             binds -- while keeping its own id and signing identity. */}}
+      {{- if $arma }}{{ $endpoint = index $.Orderers 0 }}{{ end }}
       - ID: {{ .Id }}
-        Host: 127.0.0.1
-        Port: {{ $w.OrdererPort $firstOrderer "Listen" }}
-        MSPID: {{ ($w.Organization .Organization).MSPID}}
-        ClientTLSCert: {{ $w.OrdererLocalCryptoDir $firstOrderer "tls" }}/server.crt
-        ServerTLSCert: {{ $w.OrdererLocalCryptoDir $firstOrderer "tls" }}/server.crt
-        Identity: {{ $w.OrdererSignCert .}}
+        Host: {{ $w.OrdererHost $endpoint }}
+        Port: {{ if $arma }}{{ $w.OrdererPort $endpoint "Listen" }}{{ else }}{{ $w.OrdererPort $endpoint "Cluster" }}{{ end }}
+        MSPID: {{ ($w.Organization .Organization).MSPID }}
+        ClientTLSCert: {{ $w.OrdererLocalCryptoDir $endpoint "tls" }}/server.crt
+        ServerTLSCert: {{ $w.OrdererLocalCryptoDir $endpoint "tls" }}/server.crt
+        Identity: {{ $w.OrdererSignCert . }}
         {{- end }}{{- end }}
       {{- end }}
       Organizations:{{ range $w.OrgsForOrderers .Orderers }}

--- a/integration/nwo/fabricx/extensions/scv2/container.go
+++ b/integration/nwo/fabricx/extensions/scv2/container.go
@@ -60,7 +60,7 @@ func (e *Extension) launchContainer() {
 	// orderer config file and load it into the container.
 	// This can be removed and replaced with proper configuration via env vars once the issue #567 is fixed.
 	mockOrdererConfigPath := filepath.Clean(filepath.Join(e.network.Context.RootDir(), e.network.Prefix, "mock-orderer.yaml"))
-	utils.Must(generateMockOrdererConfigFile(mockOrdererConfigPath, e.network.Orderers))
+	utils.Must(generateMockOrdererConfigFile(mockOrdererConfigPath, ordererConsenters(e.network)))
 
 	d := utils.MustGet(docker.GetInstance())
 	localIP := utils.MustGet(d.LocalIP(networkID))

--- a/integration/nwo/fabricx/extensions/scv2/container.go
+++ b/integration/nwo/fabricx/extensions/scv2/container.go
@@ -60,7 +60,7 @@ func (e *Extension) launchContainer() {
 	// orderer config file and load it into the container.
 	// This can be removed and replaced with proper configuration via env vars once the issue #567 is fixed.
 	mockOrdererConfigPath := filepath.Clean(filepath.Join(e.network.Context.RootDir(), e.network.Prefix, "mock-orderer.yaml"))
-	utils.Must(generateMockOrdererConfigFile(mockOrdererConfigPath))
+	utils.Must(generateMockOrdererConfigFile(mockOrdererConfigPath, e.network.Orderers))
 
 	d := utils.MustGet(docker.GetInstance())
 	localIP := utils.MustGet(d.LocalIP(networkID))

--- a/integration/nwo/fabricx/extensions/scv2/orderer.go
+++ b/integration/nwo/fabricx/extensions/scv2/orderer.go
@@ -7,10 +7,13 @@ SPDX-License-Identifier: Apache-2.0
 package scv2
 
 import (
+	"fmt"
 	"os"
+	
+	fabric_topology "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/topology"
 )
 
-func generateMockOrdererConfigFile(configPath string) error {
+func generateMockOrdererConfigFile(configPath string, orderers []*fabric_topology.Orderer) error {
 	configContent := `
 logging:
   logSpec: info:grpc=error
@@ -36,8 +39,16 @@ artifacts-path:
 # as they must be set via the config yaml in order to override via env vars
 genesis-block-path: /root/artifacts/config-block.pb.bin
 consenter-msp-identities:
-  - msp-id: OrdererMSP
-    msp-dir: /root/artifacts/crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp
 `
+	for _, o := range orderers {
+		mspID := o.Organization
+		if mspID == "OrdererOrg" {
+			mspID = "Orderer"
+		}
+		configContent += fmt.Sprintf(`  - msp-id: %sMSP
+    msp-dir: /root/artifacts/crypto/ordererOrganizations/example.com/orderers/%s.example.com/msp
+`, mspID, o.Name)
+	}
+
 	return os.WriteFile(configPath, []byte(configContent), 0o600)
 }

--- a/integration/nwo/fabricx/extensions/scv2/orderer.go
+++ b/integration/nwo/fabricx/extensions/scv2/orderer.go
@@ -9,11 +9,35 @@ package scv2
 import (
 	"fmt"
 	"os"
-	
-	fabric_topology "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/topology"
+
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabricx/network"
 )
 
-func generateMockOrdererConfigFile(configPath string, orderers []*fabric_topology.Orderer) error {
+// consenter is one identity the mock ordering service signs blocks as. The
+// fabric-x committer container binds a single ordering endpoint, so the BFT
+// client's 3f+1 consenters are distinguished by their MSP identity alone.
+type consenter struct {
+	MSPID  string
+	MSPDir string
+}
+
+// ordererConsenters resolves one consenter identity per orderer in the topology.
+func ordererConsenters(n *network.Network) []consenter {
+	consenters := make([]consenter, 0, len(n.Orderers))
+	for _, o := range n.Orderers {
+		consenters = append(consenters, consenter{
+			MSPID:  n.Organization(o.Organization).MSPID,
+			MSPDir: containerOrdererMSPDir(n, o),
+		})
+	}
+
+	return consenters
+}
+
+// generateMockOrdererConfigFile creates a mock orderer configuration.
+// NOTE: This is a simplified mock configuration. The consenter-msp-identities
+// are hardcoded and must match the actual network topology.
+func generateMockOrdererConfigFile(configPath string, consenters []consenter) error {
 	configContent := `
 logging:
   logSpec: info:grpc=error
@@ -40,14 +64,8 @@ artifacts-path:
 genesis-block-path: /root/artifacts/config-block.pb.bin
 consenter-msp-identities:
 `
-	for _, o := range orderers {
-		mspID := o.Organization
-		if mspID == "OrdererOrg" {
-			mspID = "Orderer"
-		}
-		configContent += fmt.Sprintf(`  - msp-id: %sMSP
-    msp-dir: /root/artifacts/crypto/ordererOrganizations/example.com/orderers/%s.example.com/msp
-`, mspID, o.Name)
+	for _, c := range consenters {
+		configContent += fmt.Sprintf("  - msp-id: %s\n    msp-dir: %s\n", c.MSPID, c.MSPDir)
 	}
 
 	return os.WriteFile(configPath, []byte(configContent), 0o600)

--- a/integration/nwo/fabricx/extensions/scv2/orderer_test.go
+++ b/integration/nwo/fabricx/extensions/scv2/orderer_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package scv2
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+
+	nwocontext "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common/context"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/topology"
+	fabricx_network "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabricx/network"
+)
+
+type mockOrdererConfig struct {
+	ConsenterMSPIdentities []struct {
+		MSPID  string `yaml:"msp-id"`
+		MSPDir string `yaml:"msp-dir"`
+	} `yaml:"consenter-msp-identities"`
+}
+
+// newOrdererNetwork builds a network whose orderer organization deliberately
+// uses a non-default MSP id and domain, so that any hardcoded "OrdererMSP" or
+// "example.com" shows up as a wrong path rather than an accidental match.
+func newOrdererNetwork(t *testing.T) *fabricx_network.Network {
+	t.Helper()
+
+	topo := &topology.Topology{
+		TopologyName: "default",
+		TopologyType: "fabricx",
+		Driver:       "fabricx",
+		Organizations: []*topology.Organization{{
+			ID:     "OrdererOrg",
+			Name:   "OrdererOrg",
+			MSPID:  "CustomOrdererMSP",
+			Domain: "orderers.example.org",
+		}},
+		Orderers: []*topology.Orderer{
+			{Name: "orderer1", Organization: "OrdererOrg", Id: 1},
+			{Name: "orderer2", Organization: "OrdererOrg", Id: 2},
+		},
+	}
+
+	return fabricx_network.New(
+		nwocontext.New(t.TempDir(), 0, nil), topo, nil, nil, "test-network", "Org1", "SC",
+	)
+}
+
+func TestGenerateMockOrdererConfigFile(t *testing.T) {
+	t.Parallel()
+
+	n := newOrdererNetwork(t)
+
+	configPath := filepath.Join(t.TempDir(), "mock-orderer.yaml")
+	require.NoError(t, generateMockOrdererConfigFile(configPath, ordererConsenters(n)))
+
+	raw, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	var conf mockOrdererConfig
+	require.NoError(t, yaml.Unmarshal(raw, &conf), "generated mock-orderer.yaml is not valid yaml:\n%s", raw)
+
+	require.Equal(t, []struct {
+		MSPID  string `yaml:"msp-id"`
+		MSPDir string `yaml:"msp-dir"`
+	}{
+		{
+			MSPID:  "CustomOrdererMSP",
+			MSPDir: "/root/artifacts/crypto/ordererOrganizations/orderers.example.org/orderers/orderer1.orderers.example.org/msp",
+		},
+		{
+			MSPID:  "CustomOrdererMSP",
+			MSPDir: "/root/artifacts/crypto/ordererOrganizations/orderers.example.org/orderers/orderer2.orderers.example.org/msp",
+		},
+	}, conf.ConsenterMSPIdentities)
+}

--- a/integration/nwo/fabricx/extensions/scv2/utils.go
+++ b/integration/nwo/fabricx/extensions/scv2/utils.go
@@ -47,6 +47,22 @@ func containerSidecarTLSDir(n *network.Network, p *topology.Peer) string {
 	)
 }
 
+func containerOrdererMSPDir(n *network.Network, o *topology.Orderer) string {
+	org := n.Organization(o.Organization)
+
+	return path.Join(
+		"/",
+		"root",
+		"artifacts",
+		"crypto",
+		"ordererOrganizations",
+		org.Domain,
+		"orderers",
+		fmt.Sprintf("%s.%s", o.Name, org.Domain),
+		"msp",
+	)
+}
+
 func containerOrdererTLSDir(n *network.Network, o *topology.Orderer) string {
 	org := n.Organization(o.Organization)
 

--- a/integration/nwo/fabricx/network/network.go
+++ b/integration/nwo/fabricx/network/network.go
@@ -120,7 +120,6 @@ func (n *Network) CheckTopology() {
 
 	// cleanup chaincode
 	// TODO cleanup the chaincode
-	n.CheckTopologyOrderers()
 }
 
 func (n *Network) removePeers() {

--- a/integration/nwo/fabricx/network/network.go
+++ b/integration/nwo/fabricx/network/network.go
@@ -29,7 +29,7 @@ import (
 var logger = logging.MustGetLogger()
 
 const (
-	DefaultConsensusType     = "etcdraft"
+	DefaultConsensusType     = "arma"
 	defaultEventuallyTimeout = 60 * time.Second
 
 	// namespacePropagationTimeout is the maximum time to wait for deployed

--- a/integration/nwo/fabricx/topology.go
+++ b/integration/nwo/fabricx/topology.go
@@ -114,6 +114,16 @@ func NewTopologyWithName(name string) *Topology {
 	topo.TopologyType = PlatformName
 	topo.Driver = PlatformName
 
+	topo.Orderers = []*fabric_topology.Orderer{
+		{Name: "orderer1", Organization: "OrdererOrg", Id: 1},
+		{Name: "orderer2", Organization: "OrdererOrg", Id: 2},
+		{Name: "orderer3", Organization: "OrdererOrg", Id: 3},
+		{Name: "orderer4", Organization: "OrdererOrg", Id: 4},
+	}
+	for _, p := range topo.Profiles {
+		p.Orderers = []string{"orderer1", "orderer2", "orderer3", "orderer4"}
+	}
+
 	return &Topology{
 		Topology: topo,
 		Committer: CommitterConfig{


### PR DESCRIPTION
Closes #1578

### Description

Updates `fabric-x` integration tests to use a 3f+1 BFT orderer cluster instead of a single endpoint:

- **Consensus & Topology**: Sets default consensus to `"arma"` and declares 4 orderers (`orderer1`-`orderer4`) so `cryptogen` generates 3f+1 identities.
- **Mock Orderer Config**: Dynamically generates `consenter-msp-identities` to map all 4 orderer MSPs in the test backend.
- **ConfigTx Generator Fix**: Updates the template to map all 4 logical `ConsenterMapping` entries and endpoints to a **single shared physical port** and TLS cert. This bypasses the mock container's single-port limit while preserving the 4 distinct logical identities BFT needs.
- **Tests**: Adds `TestConfigTxArmaMultiOrdererSharedPort` to validate this multi-orderer shared-port config generation.
