### PR TITLE
feat(fabricx): make finality listener timeouts configurable

### DIFF
--- a/docs/platform/fabric-x/configuration.md
+++ b/docs/platform/fabric-x/configuration.md
@@ -17,16 +17,21 @@ Both services support endpoint-based gRPC connectivity and optional TLS or mutua
 
 ### Notification service tuning
 
-The finality listener manager backing `notificationService` accepts various timeout configurations. They control the local expiry backstop that settles a finality listener with `Unknown` if the committer never notifies it (see `platform/fabricx/core/finality/nlm.go`):
+`notificationService` configures the client used to subscribe to transaction status updates from the committer's notification service. It is what backs, for example, the finality listeners a view application registers via `fabric.Channel().Committer().AddFinalityListener(txID, listener)`: It subscribes to the transaction on the notification stream and invokes the listener's `OnStatus` callback once the committer reports an outcome.
 
 | Key | Default | What it controls |
 |-----|---------|------------------|
-| `requestTimeout` | `30s` | Sent to the committer as the outbound notification request's timeout, so it gives up and replies once it passes rather than the client aborting locally and marking transactions the committer may already know the outcome of as `Unknown`. |
-| `handlerTimeout` | `5s` | How long a single `OnStatus` callback may run before it is abandoned. |
-| `listenerTTL` | `2m` | How long a listener may wait for a notification before being settled locally with `Unknown`. Set it comfortably above `requestTimeout` — that timeout is documented non-strict, so a late notification can still arrive after it passes. Setting `listenerTTL: 0` explicitly disables local expiry. |
-| `sweepInterval` | `30s` | How often expired entries are collected. Worst-case entry lifetime is `listenerTTL + sweepInterval`. |
+| `endpoints[].address` | — | `host:port` of a notification service endpoint. At least one is required. |
+| `endpoints[].connectionTimeout` | `30s` | Minimum timeout for establishing the gRPC connection to that endpoint. |
+| `endpoints[].tls` | disabled | TLS settings for that endpoint: `enabled`, `rootCerts` (server TLS), plus `clientKey` / `clientCert` (mutual TLS) and `serverNameOverride`. |
+| `requestTimeout` | `30s` | How long the committer waits for a subscribed transaction before answering. It is sent to the committer as the subscription's timeout, so the committer reports the outcomes it does have and flags only the still-pending transactions as timed out — rather than the client giving up locally and treating the whole batch as `Unknown`. In practice this is how long a finality listener waits before it is settled. |
+| `handlerTimeout` | `5s` | How long a single `OnStatus` callback may run before it is abandoned so it cannot block the dispatcher. Callbacks that ignore context cancellation leak a goroutine. |
+| `listenerTTL` | `2m` | Local backstop: how long a listener may wait without hearing anything at all — a dead or silent stream — before FSC settles it locally with `Unknown`. Keep it comfortably above `requestTimeout`; the committer's timeout is documented non-strict, so a late notification can still arrive after it passes. `listenerTTL: 0` disables the local backstop entirely. |
+| `sweepInterval` | `30s` | How often expired listeners are collected. A listener's worst-case lifetime is `listenerTTL + sweepInterval`. Ignored when `listenerTTL` is `0`. |
 
-Example:
+Note that `Unknown` does not mean the transaction failed — only that there is no outcome yet for it within the configured bounds. A caller that needs certainty should query the transaction status directly.
+
+Complete example:
 
 ```yaml
 fabric:
@@ -34,13 +39,28 @@ fabric:
     notificationService:
       endpoints:
         - address: 127.0.0.1:5516
+          connectionTimeout: 30s
+          tls:
+            enabled: true
+            rootCerts:
+              - /path/to/ca.crt
+            # for mutual TLS, also set:
+            # clientKey: /path/to/client.key
+            # clientCert: /path/to/client.crt
       requestTimeout: 30s
       handlerTimeout: 5s
       listenerTTL: 2m
       sweepInterval: 30s
 ```
 
-Omitting any of these keys keeps the default shown above. Only `listenerTTL: 0` is treated specially — it disables local expiry rather than falling back to the default.
+Invalid timeouts are omitted, in which case the default above applies. Two zero values are meaningful rather than "unset":
+
+- `listenerTTL: 0` disables the local expiry backstop, leaving the committer's
+  reply as the only thing that ever settles a listener.
+- `requestTimeout: 0` delegates the subscription timeout to the committer's own
+  configuration rather than to the `30s` above.
+
+`handlerTimeout: 0` and `sweepInterval: 0` have no such meaning and fall back to their defaults.
 
 ## Related Documentation
 

--- a/docs/platform/fabric-x/configuration.md
+++ b/docs/platform/fabric-x/configuration.md
@@ -13,7 +13,33 @@ The Fabric-x platform currently documents configuration for these services:
 - `fabric.<network>.notificationService`
 - `fabric.<network>.queryService`
 
-Both services support endpoint-based gRPC connectivity and optional TLS or mutual TLS settings.
+Both services support endpoint-based gRPC connectivity and optional TLS or mutual TLS settings, plus a `requestTimeout` for outbound gRPC calls (default `30s`).
+
+### Finality listener tuning (`notificationService` only)
+
+The finality listener manager backing `notificationService` accepts three additional durations. They control the local expiry backstop that settles a finality listener with `Unknown` if the committer never notifies it (see `platform/fabricx/core/finality/nlm.go`):
+
+| Key | Default | What it controls |
+|-----|---------|------------------|
+| `handlerTimeout` | `5s` | How long a single `OnStatus` callback may run before it is abandoned. |
+| `listenerTTL` | `2m` | How long a listener may wait for a notification before being settled locally with `Unknown`. Set it comfortably above the committer's own notification timeout — that timeout is documented non-strict, so a late notification can still arrive after it passes. Setting `listenerTTL: 0` explicitly disables local expiry. |
+| `sweepInterval` | `30s` | How often expired entries are collected. Worst-case entry lifetime is `listenerTTL + sweepInterval`. |
+
+Example:
+
+```yaml
+fabric:
+  <network>:
+    notificationService:
+      endpoints:
+        - address: 127.0.0.1:5516
+      requestTimeout: 30s
+      handlerTimeout: 5s
+      listenerTTL: 2m
+      sweepInterval: 30s
+```
+
+Omitting any of these keys keeps the default shown above. Only `listenerTTL: 0` is treated specially — it disables local expiry rather than falling back to the default.
 
 ## Related Documentation
 

--- a/docs/platform/fabric-x/configuration.md
+++ b/docs/platform/fabric-x/configuration.md
@@ -15,14 +15,15 @@ The Fabric-x platform currently documents configuration for these services:
 
 Both services support endpoint-based gRPC connectivity and optional TLS or mutual TLS settings, plus a `requestTimeout` for outbound gRPC calls (default `30s`).
 
-### Finality listener tuning (`notificationService` only)
+### Notification service tuning
 
-The finality listener manager backing `notificationService` accepts three additional durations. They control the local expiry backstop that settles a finality listener with `Unknown` if the committer never notifies it (see `platform/fabricx/core/finality/nlm.go`):
+The finality listener manager backing `notificationService` accepts various timeout configurations. They control the local expiry backstop that settles a finality listener with `Unknown` if the committer never notifies it (see `platform/fabricx/core/finality/nlm.go`):
 
 | Key | Default | What it controls |
 |-----|---------|------------------|
+| `requestTimeout` | `30s` | Sent to the committer as the outbound notification request's timeout, so it gives up and replies once it passes rather than the client aborting locally and marking transactions the committer may already know the outcome of as `Unknown`. |
 | `handlerTimeout` | `5s` | How long a single `OnStatus` callback may run before it is abandoned. |
-| `listenerTTL` | `2m` | How long a listener may wait for a notification before being settled locally with `Unknown`. Set it comfortably above the committer's own notification timeout — that timeout is documented non-strict, so a late notification can still arrive after it passes. Setting `listenerTTL: 0` explicitly disables local expiry. |
+| `listenerTTL` | `2m` | How long a listener may wait for a notification before being settled locally with `Unknown`. Set it comfortably above `requestTimeout` — that timeout is documented non-strict, so a late notification can still arrive after it passes. Setting `listenerTTL: 0` explicitly disables local expiry. |
 | `sweepInterval` | `30s` | How often expired entries are collected. Worst-case entry lifetime is `listenerTTL + sweepInterval`. |
 
 Example:

--- a/platform/fabricx/core/committer/config/config.go
+++ b/platform/fabricx/core/committer/config/config.go
@@ -15,18 +15,38 @@ import (
 // DefaultRequestTimeout is the default timeout for gRPC requests.
 const DefaultRequestTimeout = 30 * time.Second
 
-// DefaultHandlerTimeout is the maximum time allowed for a finality listener
-// handler to complete. See finality.DefaultHandlerTimeout for the rationale.
+// DefaultHandlerTimeout is the maximum time allowed for a single finality
+// listener OnStatus callback to run before it is abandoned. If a handler
+// exceeds this timeout, a warning is logged and the handler is abandoned.
+// Note: handlers that ignore context cancellation will leak goroutines, but
+// this is preferable to blocking the dispatcher.
 const DefaultHandlerTimeout = 5 * time.Second
 
-// DefaultListenerTTL bounds how long a finality listener may wait for a
-// notification that may never arrive. See finality.DefaultListenerTTL for the
-// rationale.
+// DefaultListenerTTL bounds how long a finality listener may wait locally for
+// a notification that may never arrive before being settled with Unknown. It
+// is deliberately much longer than RequestTimeout: that timeout is documented
+// non-strict ("it is possible to receive notifications after the timeout has
+// passed", see notify.proto), so the remote must be given ample room to
+// answer before the listener gives up locally. Local expiry is a backstop
+// against silence, not a competitor to the remote deadline.
 const DefaultListenerTTL = 2 * time.Minute
 
 // DefaultSweepInterval is how often expired finality listener entries are
-// collected. See finality.DefaultSweepInterval for the rationale.
+// collected. An entry's worst-case lifetime is ListenerTTL + SweepInterval.
 const DefaultSweepInterval = 30 * time.Second
+
+// DefaultConfig returns a Config with every field set to its documented
+// default. Use it where no ServiceBackend is available (e.g. a caller that
+// never resolves configuration for a real network) but a fully-defaulted
+// Config is still required.
+func DefaultConfig() Config {
+	return Config{
+		RequestTimeout: DefaultRequestTimeout,
+		HandlerTimeout: DefaultHandlerTimeout,
+		ListenerTTL:    DefaultListenerTTL,
+		SweepInterval:  DefaultSweepInterval,
+	}
+}
 
 // Config holds the configuration for the gRPC client.
 type Config struct {
@@ -94,9 +114,13 @@ type ServiceBackend interface {
 // NewNotificationServiceConfig creates a new Config instance by unmarshaling the "notificationService" key
 // from the provided ServiceBackend. It returns an error if the unmarshaling fails.
 //
-// HandlerTimeout, ListenerTTL and SweepInterval are pre-seeded with their
-// defaults before unmarshaling, so a deployment that omits them keeps today's
-// behavior.
+// The returned Config is fully resolved: HandlerTimeout, ListenerTTL and
+// SweepInterval are pre-seeded with their defaults before unmarshaling, so a
+// deployment that omits them keeps today's behavior, and HandlerTimeout /
+// SweepInterval fall back to their defaults if explicitly set to zero too --
+// unlike ListenerTTL, they have no "zero disables it" meaning, so a zero value
+// would otherwise hand every listener an already-expired context. Callers can
+// use every field as-is, with no further nil or zero-value handling.
 func NewNotificationServiceConfig(configService ServiceBackend) (*Config, error) {
 	config := &Config{
 		RequestTimeout: DefaultRequestTimeout,
@@ -108,6 +132,13 @@ func NewNotificationServiceConfig(configService ServiceBackend) (*Config, error)
 	err := configService.UnmarshalKey("notificationService", &config)
 	if err != nil {
 		return config, errors.Wrap(err, "unmarshal notificationService")
+	}
+
+	if config.HandlerTimeout <= 0 {
+		config.HandlerTimeout = DefaultHandlerTimeout
+	}
+	if config.SweepInterval <= 0 {
+		config.SweepInterval = DefaultSweepInterval
 	}
 
 	return config, nil

--- a/platform/fabricx/core/committer/config/config.go
+++ b/platform/fabricx/core/committer/config/config.go
@@ -15,12 +15,38 @@ import (
 // DefaultRequestTimeout is the default timeout for gRPC requests.
 const DefaultRequestTimeout = 30 * time.Second
 
+// DefaultHandlerTimeout is the maximum time allowed for a finality listener
+// handler to complete. See finality.DefaultHandlerTimeout for the rationale.
+const DefaultHandlerTimeout = 5 * time.Second
+
+// DefaultListenerTTL bounds how long a finality listener may wait for a
+// notification that may never arrive. See finality.DefaultListenerTTL for the
+// rationale.
+const DefaultListenerTTL = 2 * time.Minute
+
+// DefaultSweepInterval is how often expired finality listener entries are
+// collected. See finality.DefaultSweepInterval for the rationale.
+const DefaultSweepInterval = 30 * time.Second
+
 // Config holds the configuration for the gRPC client.
 type Config struct {
 	// Endpoints is a list of gRPC endpoints to connect to.
 	Endpoints []Endpoint `yaml:"endpoints,omitempty"`
 	// RequestTimeout is the timeout for gRPC requests.
 	RequestTimeout time.Duration `yaml:"requestTimeout,omitempty"`
+	// HandlerTimeout is the maximum time allowed for a single finality listener
+	// OnStatus callback to run before it is abandoned. Only meaningful for the
+	// notification service. A value of zero falls back to DefaultHandlerTimeout.
+	HandlerTimeout time.Duration `yaml:"handlerTimeout,omitempty"`
+	// ListenerTTL bounds how long a finality listener may wait locally for a
+	// notification before being settled with Unknown. Only meaningful for the
+	// notification service. Explicitly setting it to zero disables local expiry;
+	// leaving it unset falls back to DefaultListenerTTL.
+	ListenerTTL time.Duration `yaml:"listenerTTL,omitempty"`
+	// SweepInterval is how often expired finality listener entries are
+	// collected. Only meaningful for the notification service. A value of zero
+	// falls back to DefaultSweepInterval.
+	SweepInterval time.Duration `yaml:"sweepInterval,omitempty"`
 }
 
 // Endpoint describes a single gRPC endpoint.
@@ -67,9 +93,16 @@ type ServiceBackend interface {
 
 // NewNotificationServiceConfig creates a new Config instance by unmarshaling the "notificationService" key
 // from the provided ServiceBackend. It returns an error if the unmarshaling fails.
+//
+// HandlerTimeout, ListenerTTL and SweepInterval are pre-seeded with their
+// defaults before unmarshaling, so a deployment that omits them keeps today's
+// behavior.
 func NewNotificationServiceConfig(configService ServiceBackend) (*Config, error) {
 	config := &Config{
 		RequestTimeout: DefaultRequestTimeout,
+		HandlerTimeout: DefaultHandlerTimeout,
+		ListenerTTL:    DefaultListenerTTL,
+		SweepInterval:  DefaultSweepInterval,
 	}
 
 	err := configService.UnmarshalKey("notificationService", &config)

--- a/platform/fabricx/core/committer/config/config.go
+++ b/platform/fabricx/core/committer/config/config.go
@@ -122,12 +122,8 @@ type ServiceBackend interface {
 // would otherwise hand every listener an already-expired context. Callers can
 // use every field as-is, with no further nil or zero-value handling.
 func NewNotificationServiceConfig(configService ServiceBackend) (*Config, error) {
-	config := &Config{
-		RequestTimeout: DefaultRequestTimeout,
-		HandlerTimeout: DefaultHandlerTimeout,
-		ListenerTTL:    DefaultListenerTTL,
-		SweepInterval:  DefaultSweepInterval,
-	}
+	defaults := DefaultConfig()
+	config := &defaults
 
 	err := configService.UnmarshalKey("notificationService", &config)
 	if err != nil {

--- a/platform/fabricx/core/committer/config/config_test.go
+++ b/platform/fabricx/core/committer/config/config_test.go
@@ -51,6 +51,52 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 		require.Equal(t, config.DefaultRequestTimeout, cfg.RequestTimeout)
 	})
 
+	t.Run("finality defaults when unset", func(t *testing.T) {
+		t.Parallel()
+		fakeConfigService := &mock.ServiceBackend{}
+		fakeConfigService.UnmarshalKeyReturns(nil)
+
+		cfg, err := config.NewNotificationServiceConfig(fakeConfigService)
+		require.NoError(t, err)
+		require.Equal(t, config.DefaultHandlerTimeout, cfg.HandlerTimeout)
+		require.Equal(t, config.DefaultListenerTTL, cfg.ListenerTTL)
+		require.Equal(t, config.DefaultSweepInterval, cfg.SweepInterval)
+	})
+
+	t.Run("explicit zero listenerTTL overrides default to disable expiry", func(t *testing.T) {
+		t.Parallel()
+		fakeConfigService := &mock.ServiceBackend{}
+		fakeConfigService.UnmarshalKeyStub = func(key string, rawVal any) error {
+			if cfg, ok := rawVal.(**config.Config); ok {
+				(*cfg).ListenerTTL = 0
+			}
+			return nil
+		}
+
+		cfg, err := config.NewNotificationServiceConfig(fakeConfigService)
+		require.NoError(t, err)
+		require.Zero(t, cfg.ListenerTTL, "an explicit zero must override the default, not be treated as unset")
+	})
+
+	t.Run("configured finality durations are preserved", func(t *testing.T) {
+		t.Parallel()
+		fakeConfigService := &mock.ServiceBackend{}
+		fakeConfigService.UnmarshalKeyStub = func(key string, rawVal any) error {
+			if cfg, ok := rawVal.(**config.Config); ok {
+				(*cfg).HandlerTimeout = 7 * time.Second
+				(*cfg).ListenerTTL = 3 * time.Minute
+				(*cfg).SweepInterval = 45 * time.Second
+			}
+			return nil
+		}
+
+		cfg, err := config.NewNotificationServiceConfig(fakeConfigService)
+		require.NoError(t, err)
+		require.Equal(t, 7*time.Second, cfg.HandlerTimeout)
+		require.Equal(t, 3*time.Minute, cfg.ListenerTTL)
+		require.Equal(t, 45*time.Second, cfg.SweepInterval)
+	})
+
 	t.Run("error unmarshal", func(t *testing.T) {
 		t.Parallel()
 		fakeConfigService := &mock.ServiceBackend{}

--- a/platform/fabricx/core/committer/config/config_test.go
+++ b/platform/fabricx/core/committer/config/config_test.go
@@ -78,6 +78,23 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 		require.Zero(t, cfg.ListenerTTL, "an explicit zero must override the default, not be treated as unset")
 	})
 
+	t.Run("explicit zero handlerTimeout and sweepInterval fall back to defaults", func(t *testing.T) {
+		t.Parallel()
+		fakeConfigService := &mock.ServiceBackend{}
+		fakeConfigService.UnmarshalKeyStub = func(key string, rawVal any) error {
+			if cfg, ok := rawVal.(**config.Config); ok {
+				(*cfg).HandlerTimeout = 0
+				(*cfg).SweepInterval = 0
+			}
+			return nil
+		}
+
+		cfg, err := config.NewNotificationServiceConfig(fakeConfigService)
+		require.NoError(t, err)
+		require.Equal(t, config.DefaultHandlerTimeout, cfg.HandlerTimeout, "unlike ListenerTTL, zero has no special meaning here")
+		require.Equal(t, config.DefaultSweepInterval, cfg.SweepInterval, "unlike ListenerTTL, zero has no special meaning here")
+	})
+
 	t.Run("configured finality durations are preserved", func(t *testing.T) {
 		t.Parallel()
 		fakeConfigService := &mock.ServiceBackend{}
@@ -107,6 +124,15 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 		require.Contains(t, err.Error(), "unmarshal-error")
 		require.NotNil(t, cfg)
 	})
+}
+
+func TestDefaultConfig(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultConfig()
+	require.Equal(t, config.DefaultRequestTimeout, cfg.RequestTimeout)
+	require.Equal(t, config.DefaultHandlerTimeout, cfg.HandlerTimeout)
+	require.Equal(t, config.DefaultListenerTTL, cfg.ListenerTTL)
+	require.Equal(t, config.DefaultSweepInterval, cfg.SweepInterval)
 }
 
 func TestNewQueryServiceConfig(t *testing.T) {

--- a/platform/fabricx/core/finality/nlm.go
+++ b/platform/fabricx/core/finality/nlm.go
@@ -15,34 +15,22 @@ import (
 
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/config"
 )
 
 var logger = logging.MustGetLogger()
 
-// DefaultHandlerTimeout is the maximum time allowed for a finality listener
-// handler to complete. If a handler exceeds this timeout, a warning is logged
-// and the handler is abandoned. Note: Handlers that ignore context cancellation
-// will leak goroutines, but this is preferable to blocking the dispatcher.
-const DefaultHandlerTimeout = 5 * time.Second
-
-// DefaultListenerTTL bounds how long a listener may wait for a notification that
-// may never arrive. It is deliberately much longer than the timeout we ask the
-// committer for in AddFinalityListener: that timeout is documented non-strict
-// ("it is possible to receive notifications after the timeout has passed", see
-// notify.proto), so the remote must be given ample room to answer before we give
-// up locally. Expiry is a backstop against silence, not a competitor to the
-// remote deadline.
-const DefaultListenerTTL = 2 * time.Minute
-
-// DefaultSweepInterval is how often expired entries are collected. An entry's
-// worst-case lifetime is DefaultListenerTTL + DefaultSweepInterval.
-const DefaultSweepInterval = 30 * time.Second
+// DefaultHandlerTimeout, DefaultListenerTTL and DefaultSweepInterval live in
+// committer/config, the single source of truth for the notification service's
+// configurable defaults; this package consumes them via config.Config rather
+// than defining its own copies.
 
 // handlerEntry holds the listeners waiting on one transaction, together with the
 // deadline after which they are settled locally. A zero expiresAt means the entry
@@ -58,11 +46,17 @@ type notificationListenerManager struct {
 	responseQueue  chan *committerpb.NotificationResponse
 	handlerTimeout time.Duration
 
+	// requestTimeout is sent to the committer as the outbound NotificationRequest's
+	// Timeout, so it gives up and replies once it passes rather than us aborting the
+	// gRPC call locally and marking transactions the committer may already have an
+	// answer for as Unknown. See notify.proto's Timeout field doc.
+	requestTimeout time.Duration
+
 	// listenerTTL is how long an entry may stay unresolved before the sweeper
 	// settles it with Unknown. Zero disables local expiry entirely.
 	listenerTTL time.Duration
 	// sweepInterval is the sweep tick period. Ignored when listenerTTL is zero;
-	// falls back to DefaultSweepInterval if unset.
+	// falls back to config.DefaultSweepInterval if unset.
 	sweepInterval time.Duration
 
 	handlers   map[driver.TxID]*handlerEntry
@@ -136,7 +130,7 @@ func (n *notificationListenerManager) listen(ctx context.Context) error {
 		// can never interleave with a dispatch and no listener can be settled twice.
 		sweepEvery := n.sweepInterval
 		if sweepEvery <= 0 {
-			sweepEvery = DefaultSweepInterval
+			sweepEvery = config.DefaultSweepInterval
 		}
 		ticker := time.NewTicker(sweepEvery)
 		defer ticker.Stop()
@@ -274,10 +268,12 @@ func (n *notificationListenerManager) AddFinalityListener(txID driver.TxID, list
 		TxStatusRequest: &committerpb.TxIDsBatch{
 			TxIds: txIDs,
 		},
-		// Timeout deliberately left unset: notify.proto has the committer apply
-		// its own configured default when this field is absent.
-		// The committer operator is in a better position to know
-		// the right timeout for their network than FSC's client code is
+		// Timeout tells the committer to reply once it passes rather than leaving
+		// it to its own internal max-timeout. Without this, a client-side abort
+		// (e.g. our own listenerTTL firing) can mark transactions Unknown that the
+		// committer already knows the outcome of, because the committer never got
+		// a reason to answer early. See notify.proto's Timeout field doc.
+		Timeout: durationpb.New(n.requestTimeout),
 	}
 
 	// Guard the send against a dead stream: once listen()'s errgroup context
@@ -424,7 +420,7 @@ func (n *notificationListenerManager) dispatch(ctx context.Context, resp *commit
 // own TimeoutTxIds path produces, so callers see nothing new. Note this can
 // report Unknown for a transaction that did in fact commit, because the remote
 // timeout is documented non-strict and a notification may arrive after we have
-// given up; DefaultListenerTTL is set well above the request timeout to make that
+// given up; listenerTTL is configured well above requestTimeout to make that
 // unlikely. Callers needing certainty can query the transaction status directly.
 //
 // Runs on the dispatcher goroutine (see the ticker in listen): the dispatcher is

--- a/platform/fabricx/core/finality/nlm.go
+++ b/platform/fabricx/core/finality/nlm.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
@@ -275,8 +274,10 @@ func (n *notificationListenerManager) AddFinalityListener(txID driver.TxID, list
 		TxStatusRequest: &committerpb.TxIDsBatch{
 			TxIds: txIDs,
 		},
-		// TODO: set a proper timeout
-		Timeout: durationpb.New(10 * time.Second),
+		// Timeout deliberately left unset: notify.proto has the committer apply
+		// its own configured default when this field is absent.
+		// The committer operator is in a better position to know
+		// the right timeout for their network than FSC's client code is
 	}
 
 	// Guard the send against a dead stream: once listen()'s errgroup context

--- a/platform/fabricx/core/finality/nlm_test.go
+++ b/platform/fabricx/core/finality/nlm_test.go
@@ -18,11 +18,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/config"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/finality/mock"
 )
 
@@ -31,9 +33,10 @@ import (
 //go:generate counterfeiter -o mock/notifier_grpc_client.go --fake-name NotifierClient github.com/hyperledger/fabric-x-common/api/committerpb.NotifierClient
 
 const (
-	tick      = 10 * time.Millisecond
-	timeout   = 1 * time.Second
-	shortWait = 100 * time.Millisecond
+	tick               = 10 * time.Millisecond
+	timeout            = 1 * time.Second
+	shortWait          = 100 * time.Millisecond
+	testRequestTimeout = 30 * time.Second
 )
 
 // mockListener is a helper to verify callbacks
@@ -128,10 +131,11 @@ func setupTest(tb testing.TB) (*notificationListenerManager, *mock.Notifier_Open
 	// listenerTTL is deliberately left zero here, which disables local expiry, so
 	// the sweeper stays inert for every test that does not opt in.
 	nlm := &notificationListenerManager{
-		notifyClient:  fakeClient,
-		requestQueue:  make(chan *committerpb.NotificationRequest),
-		responseQueue: make(chan *committerpb.NotificationResponse),
-		handlers:      make(map[driver.TxID]*handlerEntry),
+		notifyClient:   fakeClient,
+		requestQueue:   make(chan *committerpb.NotificationRequest),
+		responseQueue:  make(chan *committerpb.NotificationResponse),
+		handlers:       make(map[driver.TxID]*handlerEntry),
+		requestTimeout: testRequestTimeout,
 	}
 
 	return nlm, fakeStream
@@ -365,6 +369,7 @@ func TestNotificationListenerManager(t *testing.T) {
 		req := fakeStream.SendArgsForCall(0)
 		require.NotNil(t, req.GetTxStatusRequest())
 		require.Contains(t, req.GetTxStatusRequest().GetTxIds(), "tx_send_check")
+		require.Equal(t, durationpb.New(testRequestTimeout), req.GetTimeout(), "outbound request must carry requestTimeout so the committer can reply early")
 	})
 
 	t.Run("AddFinalityListener_Duplicate_Is_Rejected", func(t *testing.T) {
@@ -579,7 +584,7 @@ func TestNotificationListenerManager(t *testing.T) {
 		nlm, fakeStream := setupTest(t)
 		// handlerTimeout must be non-zero here: invokeHandler derives the handler
 		// context from it, and a zero timeout would expire before OnStatus runs.
-		nlm.handlerTimeout = DefaultHandlerTimeout
+		nlm.handlerTimeout = config.DefaultHandlerTimeout
 
 		ctx, cancel := context.WithCancel(context.Background())
 		fakeStream.RecvStub = func() (*committerpb.NotificationResponse, error) {
@@ -1055,7 +1060,7 @@ func setupSweepTest(tb testing.TB) (*notificationListenerManager, *mock.Notifier
 	nlm.sweepInterval = testSweep
 	// setupTest leaves handlerTimeout zero, which would hand every listener an
 	// already-expired context; set it so the sweeper's callbacks are realistic.
-	nlm.handlerTimeout = DefaultHandlerTimeout
+	nlm.handlerTimeout = config.DefaultHandlerTimeout
 	return nlm, fakeStream
 }
 

--- a/platform/fabricx/core/finality/provider.go
+++ b/platform/fabricx/core/finality/provider.go
@@ -63,13 +63,30 @@ func NewListenerManagerProvider(grpcClientProvider GRPCClientProvider, configPro
 // Provider implements ListenerManagerProvider and manages ListenerManager instances.
 // IMPORTANT: Initialize method MUST be called once during service setup before calling NewManager method.
 type Provider struct {
-	newNotificationManager func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error)
+	newNotificationManager func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error)
 	configProvider         ServiceConfigProvider
 	grpcClientProvider     GRPCClientProvider
 	managers               map[string]ListenerManager // map: "network:channel" -> ListenerManager instance
 	managersMu             sync.Mutex
 	baseCtx                context.Context // The root context for all ListenerManager goroutines. MUST be set via Initialize().
 	initOnce               sync.Once       // Ensures the provider is initialized only once
+}
+
+// resolveConfig looks up the notification service config for network, falling
+// back to config.DefaultConfig() when the Provider has no configProvider (as in
+// unit tests that never reach a real network). Deliberately not called while
+// holding managersMu: resolving configuration can be relatively expensive
+// (a network round-trip in some ServiceConfigProvider implementations), and it
+// must not be done while blocking every other network/channel's NewManager call.
+func (p *Provider) resolveConfig(network string) (config.Config, error) {
+	if p.configProvider == nil {
+		return config.DefaultConfig(), nil
+	}
+	cfg, err := p.configProvider.NotificationServiceConfig(network)
+	if err != nil {
+		return config.Config{}, errors.Wrapf(err, "get notification service config [network=%s]", network)
+	}
+	return *cfg, nil
 }
 
 // Initialize sets the base context for the provider. This context is used as the parent
@@ -95,25 +112,21 @@ func (p *Provider) NewManager(network, channel string) (ListenerManager, error) 
 
 	key := network + ":" + channel
 
+	// 1. Check if manager already exists. Locked separately from the resolve/create
+	// steps below so that config resolution -- potentially expensive -- never runs
+	// while every other network/channel's NewManager call is blocked on managersMu.
 	p.managersMu.Lock()
-	defer p.managersMu.Unlock()
-
-	// 1. Check if manager already exists
 	if lm, ok := p.managers[key]; ok {
+		p.managersMu.Unlock()
 		logger.Debugf("manager is already created for %s", key)
 		return lm, nil
 	}
+	p.managersMu.Unlock()
 
-	// 2. Resolve the notification service config for this network. configProvider
-	// is nil in some unit tests that never reach here for a real network; nil cfg
-	// is what newNotifiWithGRPC below maps to today's hardcoded defaults.
-	var cfg *config.Config
-	if p.configProvider != nil {
-		var err error
-		cfg, err = p.configProvider.NotificationServiceConfig(network)
-		if err != nil {
-			return nil, errors.Wrapf(err, "get notification service config [network=%s]", network)
-		}
+	// 2. Resolve the notification service config for this network.
+	cfg, err := p.resolveConfig(network)
+	if err != nil {
+		return nil, err
 	}
 
 	// 3. Create the concrete ListenerManager
@@ -122,10 +135,23 @@ func (p *Provider) NewManager(network, channel string) (ListenerManager, error) 
 		return nil, err
 	}
 
-	// 4. Register the newly created instance
+	p.managersMu.Lock()
+	defer p.managersMu.Unlock()
+
+	// 4. Another caller may have created (and registered) a manager for this
+	// same key while we were resolving config / constructing lm above -- the
+	// singleton-per-key guarantee is enforced here, not by serializing the
+	// whole method. Discard ours and return theirs rather than running two
+	// managers (and two listen() streams) for the same network/channel.
+	if existing, ok := p.managers[key]; ok {
+		logger.Debugf("manager is already created for %s, discarding redundant one", key)
+		return existing, nil
+	}
+
+	// 5. Register the newly created instance
 	p.managers[key] = lm
 
-	// 5. Start listening in background
+	// 6. Start listening in background
 	// lm.listen() is a blocking method that establishes and maintains a stream connection
 	// to receive finality notifications.
 	go func() {
@@ -147,7 +173,9 @@ func (p *Provider) NewManager(network, channel string) (ListenerManager, error) 
 }
 
 // newNotifiWithGRPC creates and initializes a notificationListenerManager using the GRPCClientProvider.
-func newNotifiWithGRPC(network string, grpcClientProvider GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
+// cfg is expected to already be fully resolved (see config.NewNotificationServiceConfig /
+// config.DefaultConfig) -- every field is used as-is, with no further nil or zero-value handling.
+func newNotifiWithGRPC(network string, grpcClientProvider GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
 	cc, err := grpcClientProvider.NotificationServiceClient(network)
 	if err != nil {
 		return nil, errors.Wrapf(err, "get grpc client for notification service [network=%s]", network)
@@ -156,25 +184,15 @@ func newNotifiWithGRPC(network string, grpcClientProvider GRPCClientProvider, cf
 	// Create the gRPC client stub for the Notifier service
 	notifyClient := committerpb.NewNotifierClient(cc)
 
-	handlerTimeout, listenerTTL, sweepInterval := DefaultHandlerTimeout, DefaultListenerTTL, DefaultSweepInterval
-	if cfg != nil {
-		listenerTTL = cfg.ListenerTTL
-		if cfg.HandlerTimeout > 0 {
-			handlerTimeout = cfg.HandlerTimeout
-		}
-		if cfg.SweepInterval > 0 {
-			sweepInterval = cfg.SweepInterval
-		}
-	}
-
 	nlm := &notificationListenerManager{
 		notifyClient:   notifyClient,
 		requestQueue:   make(chan *committerpb.NotificationRequest),  // Queue for outgoing requests to the committer
 		responseQueue:  make(chan *committerpb.NotificationResponse), // Queue for incoming responses/notifications
 		handlers:       make(map[driver.TxID]*handlerEntry),          // Map: txID -> listeners + local expiry deadline
-		handlerTimeout: handlerTimeout,
-		listenerTTL:    listenerTTL,
-		sweepInterval:  sweepInterval,
+		handlerTimeout: cfg.HandlerTimeout,
+		requestTimeout: cfg.RequestTimeout,
+		listenerTTL:    cfg.ListenerTTL,
+		sweepInterval:  cfg.SweepInterval,
 	}
 
 	return nlm, nil

--- a/platform/fabricx/core/finality/provider.go
+++ b/platform/fabricx/core/finality/provider.go
@@ -63,7 +63,7 @@ func NewListenerManagerProvider(grpcClientProvider GRPCClientProvider, configPro
 // Provider implements ListenerManagerProvider and manages ListenerManager instances.
 // IMPORTANT: Initialize method MUST be called once during service setup before calling NewManager method.
 type Provider struct {
-	newNotificationManager func(network string, gcp GRPCClientProvider) (*notificationListenerManager, error)
+	newNotificationManager func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error)
 	configProvider         ServiceConfigProvider
 	grpcClientProvider     GRPCClientProvider
 	managers               map[string]ListenerManager // map: "network:channel" -> ListenerManager instance
@@ -104,16 +104,28 @@ func (p *Provider) NewManager(network, channel string) (ListenerManager, error) 
 		return lm, nil
 	}
 
-	// 2. Create the concrete ListenerManager
-	lm, err := p.newNotificationManager(network, p.grpcClientProvider)
+	// 2. Resolve the notification service config for this network. configProvider
+	// is nil in some unit tests that never reach here for a real network; nil cfg
+	// is what newNotifiWithGRPC below maps to today's hardcoded defaults.
+	var cfg *config.Config
+	if p.configProvider != nil {
+		var err error
+		cfg, err = p.configProvider.NotificationServiceConfig(network)
+		if err != nil {
+			return nil, errors.Wrapf(err, "get notification service config [network=%s]", network)
+		}
+	}
+
+	// 3. Create the concrete ListenerManager
+	lm, err := p.newNotificationManager(network, p.grpcClientProvider, cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	// 3. Register the newly created instance
+	// 4. Register the newly created instance
 	p.managers[key] = lm
 
-	// 4. Start listening in background
+	// 5. Start listening in background
 	// lm.listen() is a blocking method that establishes and maintains a stream connection
 	// to receive finality notifications.
 	go func() {
@@ -135,7 +147,7 @@ func (p *Provider) NewManager(network, channel string) (ListenerManager, error) 
 }
 
 // newNotifiWithGRPC creates and initializes a notificationListenerManager using the GRPCClientProvider.
-func newNotifiWithGRPC(network string, grpcClientProvider GRPCClientProvider) (*notificationListenerManager, error) {
+func newNotifiWithGRPC(network string, grpcClientProvider GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
 	cc, err := grpcClientProvider.NotificationServiceClient(network)
 	if err != nil {
 		return nil, errors.Wrapf(err, "get grpc client for notification service [network=%s]", network)
@@ -144,19 +156,25 @@ func newNotifiWithGRPC(network string, grpcClientProvider GRPCClientProvider) (*
 	// Create the gRPC client stub for the Notifier service
 	notifyClient := committerpb.NewNotifierClient(cc)
 
-	// TODO: make handlerTimeout, listenerTTL and sweepInterval configurable via
-	// core.yaml rather than hardcoding the defaults here. Provider already carries
-	// a ServiceConfigProvider, and committer/config.Config would be the natural
-	// home for the fields; newNotifiWithGRPC would then take the resolved config.
-	// Tracked in #1641.
+	handlerTimeout, listenerTTL, sweepInterval := DefaultHandlerTimeout, DefaultListenerTTL, DefaultSweepInterval
+	if cfg != nil {
+		listenerTTL = cfg.ListenerTTL
+		if cfg.HandlerTimeout > 0 {
+			handlerTimeout = cfg.HandlerTimeout
+		}
+		if cfg.SweepInterval > 0 {
+			sweepInterval = cfg.SweepInterval
+		}
+	}
+
 	nlm := &notificationListenerManager{
 		notifyClient:   notifyClient,
 		requestQueue:   make(chan *committerpb.NotificationRequest),  // Queue for outgoing requests to the committer
 		responseQueue:  make(chan *committerpb.NotificationResponse), // Queue for incoming responses/notifications
 		handlers:       make(map[driver.TxID]*handlerEntry),          // Map: txID -> listeners + local expiry deadline
-		handlerTimeout: DefaultHandlerTimeout,
-		listenerTTL:    DefaultListenerTTL,
-		sweepInterval:  DefaultSweepInterval,
+		handlerTimeout: handlerTimeout,
+		listenerTTL:    listenerTTL,
+		sweepInterval:  sweepInterval,
 	}
 
 	return nlm, nil

--- a/platform/fabricx/core/finality/provider.go
+++ b/platform/fabricx/core/finality/provider.go
@@ -112,21 +112,23 @@ func (p *Provider) NewManager(network, channel string) (ListenerManager, error) 
 
 	key := network + ":" + channel
 
-	// 1. Check if manager already exists. Locked separately from the resolve/create
-	// steps below so that config resolution -- potentially expensive -- never runs
-	// while every other network/channel's NewManager call is blocked on managersMu.
-	p.managersMu.Lock()
-	if lm, ok := p.managers[key]; ok {
-		p.managersMu.Unlock()
-		logger.Debugf("manager is already created for %s", key)
-		return lm, nil
-	}
-	p.managersMu.Unlock()
-
-	// 2. Resolve the notification service config for this network.
+	// 1. Resolve the notification service config for this network. Deliberately
+	// done before acquiring managersMu: resolving configuration can be relatively
+	// expensive (a network round-trip in some ServiceConfigProvider
+	// implementations), and it must not be done while blocking every other
+	// network/channel's NewManager call.
 	cfg, err := p.resolveConfig(network)
 	if err != nil {
 		return nil, err
+	}
+
+	p.managersMu.Lock()
+	defer p.managersMu.Unlock()
+
+	// 2. Check if manager already exists
+	if lm, ok := p.managers[key]; ok {
+		logger.Debugf("manager is already created for %s", key)
+		return lm, nil
 	}
 
 	// 3. Create the concrete ListenerManager
@@ -135,23 +137,10 @@ func (p *Provider) NewManager(network, channel string) (ListenerManager, error) 
 		return nil, err
 	}
 
-	p.managersMu.Lock()
-	defer p.managersMu.Unlock()
-
-	// 4. Another caller may have created (and registered) a manager for this
-	// same key while we were resolving config / constructing lm above -- the
-	// singleton-per-key guarantee is enforced here, not by serializing the
-	// whole method. Discard ours and return theirs rather than running two
-	// managers (and two listen() streams) for the same network/channel.
-	if existing, ok := p.managers[key]; ok {
-		logger.Debugf("manager is already created for %s, discarding redundant one", key)
-		return existing, nil
-	}
-
-	// 5. Register the newly created instance
+	// 4. Register the newly created instance
 	p.managers[key] = lm
 
-	// 6. Start listening in background
+	// 5. Start listening in background
 	// lm.listen() is a blocking method that establishes and maintains a stream connection
 	// to receive finality notifications.
 	go func() {

--- a/platform/fabricx/core/finality/provider_test.go
+++ b/platform/fabricx/core/finality/provider_test.go
@@ -175,7 +175,7 @@ func TestProvider_NewManager(t *testing.T) {
 		listenStarted := make(chan struct{})
 
 		// Mock with stream that blocks until context is done
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					close(listenStarted)
@@ -215,7 +215,7 @@ func TestProvider_NewManager(t *testing.T) {
 		provider := NewListenerManagerProvider(mockGRPC, nil)
 
 		// Mock with stream that blocks
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					<-ctx.Done()
@@ -247,7 +247,7 @@ func TestProvider_NewManager(t *testing.T) {
 		mockGRPC := &mockGRPCClientProvider{}
 		provider := NewListenerManagerProvider(mockGRPC, nil)
 
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					<-ctx.Done()
@@ -284,7 +284,7 @@ func TestProvider_NewManager(t *testing.T) {
 		listenStarted := make(chan struct{})
 
 		// Mock stream that returns error immediately
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					close(listenStarted)
@@ -319,7 +319,7 @@ func TestProvider_NewManager(t *testing.T) {
 		listenStarted := make(chan struct{})
 
 		// Mock stream that blocks until context canceled
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					close(listenStarted)
@@ -358,7 +358,7 @@ func TestProvider_NewManager(t *testing.T) {
 		expectedErr := errors.New("failed to create manager")
 
 		// Mock that returns error
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
 			return nil, expectedErr
 		}
 
@@ -384,7 +384,7 @@ func TestProvider_NewManager(t *testing.T) {
 		mockGRPC := &mockGRPCClientProvider{}
 		provider := NewListenerManagerProvider(mockGRPC, nil)
 
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					<-ctx.Done()
@@ -430,8 +430,8 @@ func TestProvider_NewManager(t *testing.T) {
 
 		provider := NewListenerManagerProvider(mockGRPC, fakeConfigProvider)
 
-		var receivedCfg *config.Config
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
+		var receivedCfg config.Config
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
 			receivedCfg = cfg
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
@@ -449,17 +449,17 @@ func TestProvider_NewManager(t *testing.T) {
 
 		require.Equal(t, 1, fakeConfigProvider.callCount())
 		require.Equal(t, "network1", fakeConfigProvider.argForCall(0))
-		require.Same(t, expectedCfg, receivedCfg, "resolved config must be threaded into newNotificationManager")
+		require.Equal(t, *expectedCfg, receivedCfg, "resolved config must be threaded into newNotificationManager")
 	})
 
-	t.Run("Passes_Nil_Config_When_ConfigProvider_Is_Nil", func(t *testing.T) {
+	t.Run("Uses_Default_Config_When_ConfigProvider_Is_Nil", func(t *testing.T) {
 		t.Parallel()
 		mockGRPC := &mockGRPCClientProvider{}
 		provider := NewListenerManagerProvider(mockGRPC, nil)
 
-		var receivedCfg *config.Config
+		var receivedCfg config.Config
 		var called bool
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
 			called = true
 			receivedCfg = cfg
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
@@ -476,7 +476,7 @@ func TestProvider_NewManager(t *testing.T) {
 		_, err := provider.NewManager("network1", "channel1")
 		require.NoError(t, err)
 		require.True(t, called)
-		require.Nil(t, receivedCfg, "no configProvider means newNotificationManager must receive a nil config")
+		require.Equal(t, config.DefaultConfig(), receivedCfg, "no configProvider means newNotificationManager must receive the fully-defaulted config")
 	})
 
 	t.Run("Returns_Error_When_ConfigProvider_Fails", func(t *testing.T) {
@@ -487,7 +487,7 @@ func TestProvider_NewManager(t *testing.T) {
 		fakeConfigProvider.setReturns(nil, expectedErr)
 
 		provider := NewListenerManagerProvider(mockGRPC, fakeConfigProvider)
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
 			t.Fatal("newNotificationManager must not be called when config resolution fails")
 			return nil, nil
 		}
@@ -516,7 +516,7 @@ func TestGetListenerManager(t *testing.T) {
 
 		mockGRPC := &mockGRPCClientProvider{}
 		provider := NewListenerManagerProvider(mockGRPC, nil)
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					<-ctx.Done()
@@ -569,7 +569,7 @@ func TestGetListenerManager(t *testing.T) {
 		provider := NewListenerManagerProvider(mockGRPC, nil)
 		expectedErr := errors.New("creation failed")
 
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
 			return nil, expectedErr
 		}
 

--- a/platform/fabricx/core/finality/provider_test.go
+++ b/platform/fabricx/core/finality/provider_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/config"
 	mock2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/finality/mock"
 )
 
@@ -40,6 +41,39 @@ func (m *mockGRPCClientProvider) NotificationServiceClient(network string) (*grp
 		return m.notificationServiceClientFunc(network)
 	}
 	return nil, nil
+}
+
+// fakeServiceConfigProvider is a hand-written stand-in for ServiceConfigProvider.
+type fakeServiceConfigProvider struct {
+	mu          sync.Mutex
+	argsForCall []string
+	returnsCfg  *config.Config
+	returnsErr  error
+}
+
+func (f *fakeServiceConfigProvider) NotificationServiceConfig(network string) (*config.Config, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.argsForCall = append(f.argsForCall, network)
+	return f.returnsCfg, f.returnsErr
+}
+
+func (f *fakeServiceConfigProvider) setReturns(cfg *config.Config, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.returnsCfg, f.returnsErr = cfg, err
+}
+
+func (f *fakeServiceConfigProvider) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.argsForCall)
+}
+
+func (f *fakeServiceConfigProvider) argForCall(i int) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.argsForCall[i]
 }
 
 // setupMockNotificationManager creates a notificationListenerManager with mocked gRPC components
@@ -141,7 +175,7 @@ func TestProvider_NewManager(t *testing.T) {
 		listenStarted := make(chan struct{})
 
 		// Mock with stream that blocks until context is done
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					close(listenStarted)
@@ -181,7 +215,7 @@ func TestProvider_NewManager(t *testing.T) {
 		provider := NewListenerManagerProvider(mockGRPC, nil)
 
 		// Mock with stream that blocks
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					<-ctx.Done()
@@ -213,7 +247,7 @@ func TestProvider_NewManager(t *testing.T) {
 		mockGRPC := &mockGRPCClientProvider{}
 		provider := NewListenerManagerProvider(mockGRPC, nil)
 
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					<-ctx.Done()
@@ -250,7 +284,7 @@ func TestProvider_NewManager(t *testing.T) {
 		listenStarted := make(chan struct{})
 
 		// Mock stream that returns error immediately
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					close(listenStarted)
@@ -285,7 +319,7 @@ func TestProvider_NewManager(t *testing.T) {
 		listenStarted := make(chan struct{})
 
 		// Mock stream that blocks until context canceled
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					close(listenStarted)
@@ -324,7 +358,7 @@ func TestProvider_NewManager(t *testing.T) {
 		expectedErr := errors.New("failed to create manager")
 
 		// Mock that returns error
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
 			return nil, expectedErr
 		}
 
@@ -350,7 +384,7 @@ func TestProvider_NewManager(t *testing.T) {
 		mockGRPC := &mockGRPCClientProvider{}
 		provider := NewListenerManagerProvider(mockGRPC, nil)
 
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					<-ctx.Done()
@@ -386,6 +420,91 @@ func TestProvider_NewManager(t *testing.T) {
 		// Should only create manager once
 		require.Len(t, provider.managers, 1, "Should create manager only once even with concurrent access")
 	})
+
+	t.Run("Resolves_Config_From_ConfigProvider_And_Passes_It_Through", func(t *testing.T) {
+		t.Parallel()
+		mockGRPC := &mockGRPCClientProvider{}
+		fakeConfigProvider := &fakeServiceConfigProvider{}
+		expectedCfg := &config.Config{ListenerTTL: 3 * time.Minute}
+		fakeConfigProvider.setReturns(expectedCfg, nil)
+
+		provider := NewListenerManagerProvider(mockGRPC, fakeConfigProvider)
+
+		var receivedCfg *config.Config
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
+			receivedCfg = cfg
+			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
+				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
+					<-ctx.Done()
+					return nil, ctx.Err()
+				}
+			}), nil
+		}
+
+		ctx := t.Context()
+		provider.Initialize(ctx)
+
+		_, err := provider.NewManager("network1", "channel1")
+		require.NoError(t, err)
+
+		require.Equal(t, 1, fakeConfigProvider.callCount())
+		require.Equal(t, "network1", fakeConfigProvider.argForCall(0))
+		require.Same(t, expectedCfg, receivedCfg, "resolved config must be threaded into newNotificationManager")
+	})
+
+	t.Run("Passes_Nil_Config_When_ConfigProvider_Is_Nil", func(t *testing.T) {
+		t.Parallel()
+		mockGRPC := &mockGRPCClientProvider{}
+		provider := NewListenerManagerProvider(mockGRPC, nil)
+
+		var receivedCfg *config.Config
+		var called bool
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
+			called = true
+			receivedCfg = cfg
+			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
+				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
+					<-ctx.Done()
+					return nil, ctx.Err()
+				}
+			}), nil
+		}
+
+		ctx := t.Context()
+		provider.Initialize(ctx)
+
+		_, err := provider.NewManager("network1", "channel1")
+		require.NoError(t, err)
+		require.True(t, called)
+		require.Nil(t, receivedCfg, "no configProvider means newNotificationManager must receive a nil config")
+	})
+
+	t.Run("Returns_Error_When_ConfigProvider_Fails", func(t *testing.T) {
+		t.Parallel()
+		mockGRPC := &mockGRPCClientProvider{}
+		fakeConfigProvider := &fakeServiceConfigProvider{}
+		expectedErr := errors.New("config lookup failed")
+		fakeConfigProvider.setReturns(nil, expectedErr)
+
+		provider := NewListenerManagerProvider(mockGRPC, fakeConfigProvider)
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
+			t.Fatal("newNotificationManager must not be called when config resolution fails")
+			return nil, nil
+		}
+
+		ctx := t.Context()
+		provider.Initialize(ctx)
+
+		manager, err := provider.NewManager("network1", "channel1")
+		require.Error(t, err)
+		require.Nil(t, manager)
+		require.ErrorIs(t, err, expectedErr)
+
+		provider.managersMu.Lock()
+		_, exists := provider.managers["network1:channel1"]
+		provider.managersMu.Unlock()
+		require.False(t, exists, "failed manager must not be stored")
+	})
 }
 
 func TestGetListenerManager(t *testing.T) {
@@ -397,7 +516,7 @@ func TestGetListenerManager(t *testing.T) {
 
 		mockGRPC := &mockGRPCClientProvider{}
 		provider := NewListenerManagerProvider(mockGRPC, nil)
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					<-ctx.Done()
@@ -450,7 +569,7 @@ func TestGetListenerManager(t *testing.T) {
 		provider := NewListenerManagerProvider(mockGRPC, nil)
 		expectedErr := errors.New("creation failed")
 
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg *config.Config) (*notificationListenerManager, error) {
 			return nil, expectedErr
 		}
 


### PR DESCRIPTION
Add HandlerTimeout, ListenerTTL, and SweepInterval to the notification service config so operators can tune the finality listener's local expiry backstop via core.yaml instead of relying on hardcoded defaults. Unset values fall back to the existing defaults; an explicit listenerTTL of zero continues to disable local expiry.

Also drop the hardcoded 10s outbound request timeout in AddFinalityListener, leaving it unset so the committer applies its own configured default per notify.proto.

Fixes #1641