### PR TITLE
fix: correct mutable context error

### DIFF
--- a/platform/view/services/view/grpc/server/view.go
+++ b/platform/view/services/view/grpc/server/view.go
@@ -111,7 +111,7 @@ func (s *viewHandler) streamCallView(sc *protos.SignedCommand, command *protos.C
 	}
 	mutable, ok := viewCtx.(view2.MutableContext)
 	if !ok {
-		return errors.Errorf("expected a mutable contexdt")
+		return errors.Errorf("expected a mutable context")
 	}
 	if err := mutable.PutService(&Stream{scs: commandServer}); err != nil {
 		return errors.Errorf("failed registering stream command server")


### PR DESCRIPTION
## Type of change

- Spelling fix

## Description

Addresses issue #1415.

Correct the user-facing runtime error from `expected a mutable contexdt` to `expected a mutable context` in the gRPC stream view handler.

## Additional details

This is a one-line message correction. No runtime behavior changes.

Validation:
- Confirmed no remaining `contexdt` occurrences in the checkout.
- - `git diff --check` passed.
## Related issues

Closes #1415.