### PR TITLE
fix(fabricx): bound finality handler concurrency with errgroup SetLimit

### DIFF
--- a/docs/platform/fabric-x/README.md
+++ b/docs/platform/fabric-x/README.md
@@ -52,10 +52,20 @@ Obtain a `ListenerManager` via `finality.GetListenerManager(sp, network, channel
 
 The `OnStatus` callback receives one of: `fdriver.Valid` (committed), `fdriver.Invalid` (rejected), or `fdriver.Unknown` (undetermined / timeout).
 
+> [!WARNING]
+> `OnStatus` implementations MUST observe `ctx.Done()` and return promptly.
+> Callbacks run on an `errgroup` limited to `handlerWorkers` (default 16) concurrent
+> calls, so one that blocks forever holds a slot indefinitely — and once all slots are
+> held, finality notifications stop being delivered. Hand slow work to your own queue
+> and return. See [the notification service tuning
+> guide](configuration.md#notification-service-tuning) for the full failure mode.
+
 ### Limitations
 
 - **No automatic reconnection**: if the stream breaks, the manager is removed and registered listeners are lost. A new manager is created on the next `GetListenerManager` call.
-- **Handler timeout**: callbacks that exceed 5 seconds (`DefaultHandlerTimeout`) are abandoned with a warning. Handlers that ignore context cancellation will leak a goroutine but won't block other listeners.
+- **Bounded handler concurrency**: callbacks run on an `errgroup` with `SetLimit(handlerWorkers)` (default 16), started via `TryGo`. `handlerTimeout` (default 5s) only cancels the callback's context — it cannot force a return, so a callback that ignores cancellation holds its slot indefinitely. With every slot held, callbacks are dropped with a warning and the affected listeners are settled with `Unknown` by the `listenerTTL` sweeper. This bounds the blast radius of a misbehaving listener to throughput rather than memory; see [notification service tuning](configuration.md#notification-service-tuning).
+- **No queue in front of the limit**: `TryGo` never blocks the dispatcher, so a notification batch larger than `handlerWorkers` loses its overflow even when every listener is fast. Raise `handlerWorkers` above the largest expected batch if that matters; see [bursts and `handlerWorkers`](configuration.md#bursts-and-handlerworkers).
+- **Teardown does not wait on stuck handlers**: in-flight callbacks get a bounded window to finish after the stream stops; one still inside an unresponsive listener can outlive the stream, so a single bad listener cannot hang node shutdown. Such callbacks are capped at `handlerWorkers`.
 
 ### Configuration
 
@@ -66,6 +76,7 @@ fabric:
   <network>:
     notificationService:
       requestTimeout: 30s
+      handlerWorkers: 16
       endpoints:
         - address: "committer.example.com:9090"
           connectionTimeout: 5s

--- a/docs/platform/fabric-x/README.md
+++ b/docs/platform/fabric-x/README.md
@@ -53,18 +53,17 @@ Obtain a `ListenerManager` via `finality.GetListenerManager(sp, network, channel
 The `OnStatus` callback receives one of: `fdriver.Valid` (committed), `fdriver.Invalid` (rejected), or `fdriver.Unknown` (undetermined / timeout).
 
 > [!WARNING]
-> `OnStatus` implementations MUST observe `ctx.Done()` and return promptly.
-> Callbacks run on an `errgroup` limited to `handlerWorkers` (default 16) concurrent
-> calls, so one that blocks forever holds a slot indefinitely — and once all slots are
-> held, finality notifications stop being delivered. Hand slow work to your own queue
-> and return. See [the notification service tuning
+> `OnStatus` implementations MUST observe `ctx.Done()` and return promptly. At most
+> `handlerWorkers` (default 16) callbacks run at once, so one that blocks forever
+> occupies a slot indefinitely — and once all slots are occupied, finality
+> notifications stop being delivered. Hand slow work to your own queue and return.
+> See [the notification service tuning
 > guide](configuration.md#notification-service-tuning) for the full failure mode.
 
 ### Limitations
 
 - **No automatic reconnection**: if the stream breaks, the manager is removed and registered listeners are lost. A new manager is created on the next `GetListenerManager` call.
-- **Bounded handler concurrency**: callbacks run on an `errgroup` with `SetLimit(handlerWorkers)` (default 16), started via `TryGo`. `handlerTimeout` (default 5s) only cancels the callback's context — it cannot force a return, so a callback that ignores cancellation holds its slot indefinitely. With every slot held, callbacks are dropped with a warning and the affected listeners are settled with `Unknown` by the `listenerTTL` sweeper. This bounds the blast radius of a misbehaving listener to throughput rather than memory; see [notification service tuning](configuration.md#notification-service-tuning).
-- **No queue in front of the limit**: `TryGo` never blocks the dispatcher, so a notification batch larger than `handlerWorkers` loses its overflow even when every listener is fast. Raise `handlerWorkers` above the largest expected batch if that matters; see [bursts and `handlerWorkers`](configuration.md#bursts-and-handlerworkers).
+- **Bounded handler concurrency**: at most `handlerWorkers` (default 16) callbacks run concurrently, buffered by a queue of `handlerQueueSize` (default 1000) so bursts larger than the limit are still delivered in full. `handlerTimeout` (default 5s) only cancels the callback's context — it cannot force a return, so a callback that ignores cancellation occupies its slot indefinitely. Once every slot is occupied and the queue fills, callbacks are dropped with a warning and the affected listeners are settled with `Unknown` by the `listenerTTL` sweeper. This bounds the blast radius of a misbehaving listener to throughput rather than memory; see [notification service tuning](configuration.md#notification-service-tuning).
 - **Teardown does not wait on stuck handlers**: in-flight callbacks get a bounded window to finish after the stream stops; one still inside an unresponsive listener can outlive the stream, so a single bad listener cannot hang node shutdown. Such callbacks are capped at `handlerWorkers`.
 
 ### Configuration
@@ -77,6 +76,7 @@ fabric:
     notificationService:
       requestTimeout: 30s
       handlerWorkers: 16
+      handlerQueueSize: 1000
       endpoints:
         - address: "committer.example.com:9090"
           connectionTimeout: 5s

--- a/docs/platform/fabric-x/configuration.md
+++ b/docs/platform/fabric-x/configuration.md
@@ -25,11 +25,57 @@ Both services support endpoint-based gRPC connectivity and optional TLS or mutua
 | `endpoints[].connectionTimeout` | `30s` | Minimum timeout for establishing the gRPC connection to that endpoint. |
 | `endpoints[].tls` | disabled | TLS settings for that endpoint: `enabled`, `rootCerts` (server TLS), plus `clientKey` / `clientCert` (mutual TLS) and `serverNameOverride`. |
 | `requestTimeout` | `30s` | How long the committer waits for a subscribed transaction before answering. It is sent to the committer as the subscription's timeout, so the committer reports the outcomes it does have and flags only the still-pending transactions as timed out — rather than the client giving up locally and treating the whole batch as `Unknown`. In practice this is how long a finality listener waits before it is settled. |
-| `handlerTimeout` | `5s` | How long a single `OnStatus` callback may run before it is abandoned so it cannot block the dispatcher. Callbacks that ignore context cancellation leak a goroutine. |
+| `handlerTimeout` | `5s` | The deadline set on the context handed to a single `OnStatus` callback. Advisory: it cancels the context, but only the callback itself can decide to return. A callback still running past it is reported with a warning. |
+| `handlerWorkers` | `16` | How many `OnStatus` callbacks may run concurrently. There is no queue behind it: a callback that cannot start immediately is dropped, not buffered. See the warning below. |
 | `listenerTTL` | `2m` | Local backstop: how long a listener may wait without hearing anything at all — a dead or silent stream — before FSC settles it locally with `Unknown`. Keep it comfortably above `requestTimeout`; the committer's timeout is documented non-strict, so a late notification can still arrive after it passes. `listenerTTL: 0` disables the local backstop entirely. |
 | `sweepInterval` | `30s` | How often expired listeners are collected. A listener's worst-case lifetime is `listenerTTL + sweepInterval`. Ignored when `listenerTTL` is `0`. |
 
 Note that `Unknown` does not mean the transaction failed — only that there is no outcome yet for it within the configured bounds. A caller that needs certainty should query the transaction status directly.
+
+> [!WARNING]
+> **`OnStatus` must return promptly.** Finality listeners run on an `errgroup`
+> limited to `handlerWorkers` concurrent callbacks. A listener that blocks
+> indefinitely — on a full channel, a stalled store call, a contended lock — holds
+> its slot for as long as it runs. `handlerTimeout` cancels the context handed to
+> the callback, but nothing can force a callback to return; honoring cancellation is
+> the listener's responsibility.
+>
+> Once all `handlerWorkers` slots are held this way, finality notifications stop
+> being delivered on that stream. Affected listeners are settled with `Unknown` by
+> the `listenerTTL` sweeper instead of receiving their real outcome.
+>
+> This is a deliberate trade: a misbehaving listener degrades notification
+> throughput in a bounded, logged way rather than growing goroutines without limit.
+> If a deployment has listeners that are legitimately slow, raise `handlerWorkers`
+> — but the durable fix is for the listener to hand slow work to its own queue and
+> return.
+>
+> Symptoms to look for in the logs:
+>
+> - `OnStatus handler for txID=… did not return before its deadline` — a listener is
+>   ignoring cancellation and holding a slot.
+> - `dropped N of M finality callbacks: all … handler slots in use` — callbacks
+>   could not be started and those listeners will fall back to `Unknown`.
+
+### Bursts and `handlerWorkers`
+
+Callbacks are started with the `errgroup`'s `TryGo`, which either starts a callback
+immediately or reports that it cannot. There is deliberately **no queue** in front of
+the limit, so that saturation is visible at once rather than hidden behind a
+backlog. The dispatcher never blocks — it shares a goroutine with the notification
+stream reader and the expiry sweeper, so blocking there would stall both.
+
+The cost is that a burst can lose callbacks even when no listener misbehaves. A
+single notification response may carry many transactions, and they are dispatched in
+a tight loop; `TryGo` reserves a slot on the dispatching goroutine while the callback
+runs on a newly spawned one, so calls submitted before the runtime has scheduled the
+previous callbacks are refused. At the default `handlerWorkers: 16`, a 200-transaction
+response with instantly-returning listeners delivered roughly a third of its callbacks
+in testing. The remainder are settled with `Unknown` after `listenerTTL`.
+
+If a deployment routinely sees `dropped N of M finality callbacks` while its listeners
+are known to be fast, raise `handlerWorkers`: sized above the largest expected
+notification batch, bursts stop being refused.
 
 Complete example:
 
@@ -49,6 +95,7 @@ fabric:
             # clientCert: /path/to/client.crt
       requestTimeout: 30s
       handlerTimeout: 5s
+      handlerWorkers: 16
       listenerTTL: 2m
       sweepInterval: 30s
 ```
@@ -60,7 +107,7 @@ Invalid timeouts are omitted, in which case the default above applies. Two zero 
 - `requestTimeout: 0` delegates the subscription timeout to the committer's own
   configuration rather than to the `30s` above.
 
-`handlerTimeout: 0` and `sweepInterval: 0` have no such meaning and fall back to their defaults.
+`handlerTimeout: 0`, `handlerWorkers: 0` and `sweepInterval: 0` have no such meaning and fall back to their defaults.
 
 ## Related Documentation
 

--- a/docs/platform/fabric-x/configuration.md
+++ b/docs/platform/fabric-x/configuration.md
@@ -26,23 +26,23 @@ Both services support endpoint-based gRPC connectivity and optional TLS or mutua
 | `endpoints[].tls` | disabled | TLS settings for that endpoint: `enabled`, `rootCerts` (server TLS), plus `clientKey` / `clientCert` (mutual TLS) and `serverNameOverride`. |
 | `requestTimeout` | `30s` | How long the committer waits for a subscribed transaction before answering. It is sent to the committer as the subscription's timeout, so the committer reports the outcomes it does have and flags only the still-pending transactions as timed out — rather than the client giving up locally and treating the whole batch as `Unknown`. In practice this is how long a finality listener waits before it is settled. |
 | `handlerTimeout` | `5s` | The deadline set on the context handed to a single `OnStatus` callback. Advisory: it cancels the context, but only the callback itself can decide to return. A callback still running past it is reported with a warning. |
-| `handlerWorkers` | `16` | How many `OnStatus` callbacks may run concurrently. There is no queue behind it: a callback that cannot start immediately is dropped, not buffered. See the warning below. |
+| `handlerWorkers` | `16` | How many `OnStatus` callbacks may run concurrently. A concurrency limit, not a rate limit: healthy callbacks return their slots immediately, so far more than this are delivered per second. See the warning below. |
+| `handlerQueueSize` | `1000` | How many pending `OnStatus` invocations are buffered while every slot is busy. This is what lets a notification batch larger than `handlerWorkers` be delivered in full. Beyond it, callbacks are dropped with a warning. |
 | `listenerTTL` | `2m` | Local backstop: how long a listener may wait without hearing anything at all — a dead or silent stream — before FSC settles it locally with `Unknown`. Keep it comfortably above `requestTimeout`; the committer's timeout is documented non-strict, so a late notification can still arrive after it passes. `listenerTTL: 0` disables the local backstop entirely. |
 | `sweepInterval` | `30s` | How often expired listeners are collected. A listener's worst-case lifetime is `listenerTTL + sweepInterval`. Ignored when `listenerTTL` is `0`. |
 
 Note that `Unknown` does not mean the transaction failed — only that there is no outcome yet for it within the configured bounds. A caller that needs certainty should query the transaction status directly.
 
 > [!WARNING]
-> **`OnStatus` must return promptly.** Finality listeners run on an `errgroup`
-> limited to `handlerWorkers` concurrent callbacks. A listener that blocks
-> indefinitely — on a full channel, a stalled store call, a contended lock — holds
-> its slot for as long as it runs. `handlerTimeout` cancels the context handed to
-> the callback, but nothing can force a callback to return; honoring cancellation is
-> the listener's responsibility.
+> **`OnStatus` must return promptly.** At most `handlerWorkers` callbacks run at
+> once. A listener that blocks indefinitely — on a full channel, a stalled store
+> call, a contended lock — occupies its slot for as long as it runs.
+> `handlerTimeout` cancels the context handed to the callback, but nothing can force
+> a callback to return; honoring cancellation is the listener's responsibility.
 >
-> Once all `handlerWorkers` slots are held this way, finality notifications stop
-> being delivered on that stream. Affected listeners are settled with `Unknown` by
-> the `listenerTTL` sweeper instead of receiving their real outcome.
+> Once every slot is occupied this way, the queue fills and finality notifications
+> stop being delivered on that stream. Affected listeners are settled with `Unknown`
+> by the `listenerTTL` sweeper instead of receiving their real outcome.
 >
 > This is a deliberate trade: a misbehaving listener degrades notification
 > throughput in a bounded, logged way rather than growing goroutines without limit.
@@ -53,29 +53,29 @@ Note that `Unknown` does not mean the transaction failed — only that there is 
 > Symptoms to look for in the logs:
 >
 > - `OnStatus handler for txID=… did not return before its deadline` — a listener is
->   ignoring cancellation and holding a slot.
-> - `dropped N of M finality callbacks: all … handler slots in use` — callbacks
->   could not be started and those listeners will fall back to `Unknown`.
+>   ignoring cancellation and occupying a slot.
+> - `dropped N of M finality callbacks` — the queue filled, and those listeners will
+>   fall back to `Unknown`.
 
-### Bursts and `handlerWorkers`
+### Sizing the handler pool
 
-Callbacks are started with the `errgroup`'s `TryGo`, which either starts a callback
-immediately or reports that it cannot. There is deliberately **no queue** in front of
-the limit, so that saturation is visible at once rather than hidden behind a
-backlog. The dispatcher never blocks — it shares a goroutine with the notification
-stream reader and the expiry sweeper, so blocking there would stall both.
+`handlerWorkers` and `handlerQueueSize` do different jobs, and both matter.
 
-The cost is that a burst can lose callbacks even when no listener misbehaves. A
-single notification response may carry many transactions, and they are dispatched in
-a tight loop; `TryGo` reserves a slot on the dispatching goroutine while the callback
-runs on a newly spawned one, so calls submitted before the runtime has scheduled the
-previous callbacks are refused. At the default `handlerWorkers: 16`, a 200-transaction
-response with instantly-returning listeners delivered roughly a third of its callbacks
-in testing. The remainder are settled with `Unknown` after `listenerTTL`.
+`handlerWorkers` bounds how many listeners run at once, which is what keeps a
+misbehaving listener from growing goroutines without limit. It is *not* a limit on
+throughput: a callback that returns immediately hands its slot straight back, so a
+single notification response carrying hundreds of transactions is delivered in full
+against the default limit of 16.
 
-If a deployment routinely sees `dropped N of M finality callbacks` while its listeners
-are known to be fast, raise `handlerWorkers`: sized above the largest expected
-notification batch, bursts stop being refused.
+`handlerQueueSize` is what makes that true. Notifications arrive in batches, and a
+batch is handed to the pool faster than the pool can retire it; the queue holds the
+remainder until slots free. Without it, everything past the limit would be dropped
+even though the listeners were healthy.
+
+Raise `handlerWorkers` when listeners are legitimately slow and you want more of them
+running in parallel. Raise `handlerQueueSize` when notification batches are large and
+bursty. If `dropped N of M finality callbacks` appears while listeners are known to be
+fast, the queue is the setting to increase.
 
 Complete example:
 
@@ -96,6 +96,7 @@ fabric:
       requestTimeout: 30s
       handlerTimeout: 5s
       handlerWorkers: 16
+      handlerQueueSize: 1000
       listenerTTL: 2m
       sweepInterval: 30s
 ```
@@ -107,7 +108,7 @@ Invalid timeouts are omitted, in which case the default above applies. Two zero 
 - `requestTimeout: 0` delegates the subscription timeout to the committer's own
   configuration rather than to the `30s` above.
 
-`handlerTimeout: 0`, `handlerWorkers: 0` and `sweepInterval: 0` have no such meaning and fall back to their defaults.
+`handlerTimeout: 0`, `handlerWorkers: 0`, `handlerQueueSize: 0` and `sweepInterval: 0` have no such meaning and fall back to their defaults.
 
 ## Related Documentation
 

--- a/platform/common/driver/committer.go
+++ b/platform/common/driver/committer.go
@@ -16,6 +16,20 @@ type TransactionFilter interface {
 
 // FinalityListener is the interface that must be implemented to receive transaction status notifications
 type FinalityListener[V comparable] interface {
-	// OnStatus is called when the status of a transaction changes, or it is already valid or invalid
+	// OnStatus is called when the status of a transaction changes, or it is already valid or invalid.
+	//
+	// WARNING: OnStatus MUST observe ctx.Done() and return promptly. Drivers invoke
+	// it with bounded concurrency, so an implementation that blocks indefinitely --
+	// on a full channel, a stalled store call, a contended lock -- holds one of a
+	// fixed number of slots for as long as it runs. Once every slot is held, no
+	// further finality notification can be delivered, and further ones are dropped
+	// with a warning. The ctx carries a deadline, but nothing can force a return:
+	// honoring it is the implementation's responsibility.
+	//
+	// Do slow or blocking work by handing it to your own queue and returning, not
+	// by blocking here. Both drivers dispatch from a bounded pool: the generic
+	// committer's eventQueueWorkers (platform/common/core/generic/committer) and
+	// the fabricx notification service's handlerWorkers
+	// (platform/fabricx/core/finality).
 	OnStatus(ctx context.Context, txID TxID, status V, statusMessage string)
 }

--- a/platform/common/driver/committer.go
+++ b/platform/common/driver/committer.go
@@ -29,7 +29,7 @@ type FinalityListener[V comparable] interface {
 	// Do slow or blocking work by handing it to your own queue and returning, not
 	// by blocking here. Both drivers dispatch from a bounded pool: the generic
 	// committer's eventQueueWorkers (platform/common/core/generic/committer) and
-	// the fabricx notification service's handlerWorkers
+	// the fabricx notification service's handlerWorkers / handlerQueueSize
 	// (platform/fabricx/core/finality).
 	OnStatus(ctx context.Context, txID TxID, status V, statusMessage string)
 }

--- a/platform/fabricx/core/committer/config/config.go
+++ b/platform/fabricx/core/committer/config/config.go
@@ -15,12 +15,25 @@ import (
 // DefaultRequestTimeout is the default timeout for gRPC requests.
 const DefaultRequestTimeout = 30 * time.Second
 
-// DefaultHandlerTimeout is the maximum time allowed for a single finality
-// listener OnStatus callback to run before it is abandoned. If a handler
-// exceeds this timeout, a warning is logged and the handler is abandoned.
-// Note: handlers that ignore context cancellation will leak goroutines, but
-// this is preferable to blocking the dispatcher.
+// DefaultHandlerTimeout is the deadline set on the context handed to a single
+// finality listener OnStatus callback. It is advisory: it is the callback's own
+// responsibility to observe cancellation and return. A callback that ignores it
+// holds its concurrency slot for as long as it runs -- see DefaultHandlerWorkers.
 const DefaultHandlerTimeout = 5 * time.Second
+
+// DefaultHandlerWorkers is how many finality listener OnStatus callbacks may run
+// concurrently. It is the limit set on the handler errgroup via SetLimit, so a
+// callback that blocks forever permanently holds one slot: once all slots are
+// held, TryGo can no longer start a callback and further notifications are
+// dropped with a warning. This bounds the damage a misbehaving listener can do to
+// throughput rather than letting it grow goroutines without limit, but it does
+// make "OnStatus must respect its context and return promptly" a requirement
+// rather than a suggestion.
+//
+// There is no queue in front of the limit: TryGo either starts the callback
+// immediately or reports that it cannot, which is what makes the drop visible
+// instead of deferred.
+const DefaultHandlerWorkers = 16
 
 // DefaultListenerTTL bounds how long a finality listener may wait locally for
 // a notification that may never arrive before being settled with Unknown. It
@@ -43,6 +56,7 @@ func DefaultConfig() Config {
 	return Config{
 		RequestTimeout: DefaultRequestTimeout,
 		HandlerTimeout: DefaultHandlerTimeout,
+		HandlerWorkers: DefaultHandlerWorkers,
 		ListenerTTL:    DefaultListenerTTL,
 		SweepInterval:  DefaultSweepInterval,
 	}
@@ -54,10 +68,16 @@ type Config struct {
 	Endpoints []Endpoint `yaml:"endpoints,omitempty"`
 	// RequestTimeout is the timeout for gRPC requests.
 	RequestTimeout time.Duration `yaml:"requestTimeout,omitempty"`
-	// HandlerTimeout is the maximum time allowed for a single finality listener
-	// OnStatus callback to run before it is abandoned. Only meaningful for the
-	// notification service. A value of zero falls back to DefaultHandlerTimeout.
+	// HandlerTimeout is the deadline set on the context handed to a single
+	// finality listener OnStatus callback. Only meaningful for the notification
+	// service. A value of zero falls back to DefaultHandlerTimeout.
 	HandlerTimeout time.Duration `yaml:"handlerTimeout,omitempty"`
+	// HandlerWorkers is how many finality listener OnStatus callbacks may run
+	// concurrently (the handler errgroup's SetLimit). Only meaningful for the
+	// notification service. A value of zero falls back to DefaultHandlerWorkers.
+	// Raise it when a deployment has legitimately slow listeners; see
+	// DefaultHandlerWorkers for what happens when every slot is held.
+	HandlerWorkers int `yaml:"handlerWorkers,omitempty"`
 	// ListenerTTL bounds how long a finality listener may wait locally for a
 	// notification before being settled with Unknown. Only meaningful for the
 	// notification service. Explicitly setting it to zero disables local expiry;
@@ -114,13 +134,14 @@ type ServiceBackend interface {
 // NewNotificationServiceConfig creates a new Config instance by unmarshaling the "notificationService" key
 // from the provided ServiceBackend. It returns an error if the unmarshaling fails.
 //
-// The returned Config is fully resolved: HandlerTimeout, ListenerTTL and
-// SweepInterval are pre-seeded with their defaults before unmarshaling, so a
-// deployment that omits them keeps today's behavior, and HandlerTimeout /
-// SweepInterval fall back to their defaults if explicitly set to zero too --
-// unlike ListenerTTL, they have no "zero disables it" meaning, so a zero value
-// would otherwise hand every listener an already-expired context. Callers can
-// use every field as-is, with no further nil or zero-value handling.
+// The returned Config is fully resolved: HandlerTimeout, HandlerWorkers,
+// ListenerTTL and SweepInterval are pre-seeded with their
+// defaults before unmarshaling, so a deployment that omits them keeps today's
+// behavior. All of them except ListenerTTL also fall back to their defaults if
+// explicitly set to zero -- unlike ListenerTTL, they have no "zero disables it"
+// meaning, and a zero value would otherwise hand every listener an already-expired
+// context or a pool that can never run anything. Callers can use every field
+// as-is, with no further nil or zero-value handling.
 func NewNotificationServiceConfig(configService ServiceBackend) (*Config, error) {
 	defaults := DefaultConfig()
 	config := &defaults
@@ -132,6 +153,9 @@ func NewNotificationServiceConfig(configService ServiceBackend) (*Config, error)
 
 	if config.HandlerTimeout <= 0 {
 		config.HandlerTimeout = DefaultHandlerTimeout
+	}
+	if config.HandlerWorkers <= 0 {
+		config.HandlerWorkers = DefaultHandlerWorkers
 	}
 	if config.SweepInterval <= 0 {
 		config.SweepInterval = DefaultSweepInterval

--- a/platform/fabricx/core/committer/config/config.go
+++ b/platform/fabricx/core/committer/config/config.go
@@ -24,16 +24,27 @@ const DefaultHandlerTimeout = 5 * time.Second
 // DefaultHandlerWorkers is how many finality listener OnStatus callbacks may run
 // concurrently. It is the limit set on the handler errgroup via SetLimit, so a
 // callback that blocks forever permanently holds one slot: once all slots are
-// held, TryGo can no longer start a callback and further notifications are
-// dropped with a warning. This bounds the damage a misbehaving listener can do to
-// throughput rather than letting it grow goroutines without limit, but it does
-// make "OnStatus must respect its context and return promptly" a requirement
-// rather than a suggestion.
+// held, nothing else can run and queued callbacks are eventually dropped. This
+// bounds the damage a misbehaving listener can do to throughput rather than letting
+// it grow goroutines without limit, but it does make "OnStatus must respect its
+// context and return promptly" a requirement rather than a suggestion.
 //
-// There is no queue in front of the limit: TryGo either starts the callback
-// immediately or reports that it cannot, which is what makes the drop visible
-// instead of deferred.
+// Note this is a concurrency limit, not a rate limit: healthy callbacks return
+// their slots immediately, so a batch far larger than this is delivered in full via
+// HandlerQueueSize.
 const DefaultHandlerWorkers = 16
+
+// DefaultHandlerQueueSize is how many pending OnStatus invocations may be buffered
+// while every handler slot is busy. It matches the generic committer's event queue
+// (platform/common/core/generic/committer/finality.go).
+//
+// The queue exists to absorb bursts: one notification response can carry many more
+// transactions than there are slots, and without a buffer everything past the limit
+// would be dropped even though the listeners are healthy and about to free their
+// slots. A full queue therefore signals something worse than a burst -- callbacks
+// produced faster than the pool retires them for as long as the buffer took to fill
+// -- and only then is a callback dropped, with a warning.
+const DefaultHandlerQueueSize = 1000
 
 // DefaultListenerTTL bounds how long a finality listener may wait locally for
 // a notification that may never arrive before being settled with Unknown. It
@@ -54,11 +65,12 @@ const DefaultSweepInterval = 30 * time.Second
 // Config is still required.
 func DefaultConfig() Config {
 	return Config{
-		RequestTimeout: DefaultRequestTimeout,
-		HandlerTimeout: DefaultHandlerTimeout,
-		HandlerWorkers: DefaultHandlerWorkers,
-		ListenerTTL:    DefaultListenerTTL,
-		SweepInterval:  DefaultSweepInterval,
+		RequestTimeout:   DefaultRequestTimeout,
+		HandlerTimeout:   DefaultHandlerTimeout,
+		HandlerWorkers:   DefaultHandlerWorkers,
+		HandlerQueueSize: DefaultHandlerQueueSize,
+		ListenerTTL:      DefaultListenerTTL,
+		SweepInterval:    DefaultSweepInterval,
 	}
 }
 
@@ -78,6 +90,10 @@ type Config struct {
 	// Raise it when a deployment has legitimately slow listeners; see
 	// DefaultHandlerWorkers for what happens when every slot is held.
 	HandlerWorkers int `yaml:"handlerWorkers,omitempty"`
+	// HandlerQueueSize is how many pending OnStatus invocations may be buffered
+	// while every handler slot is busy. Only meaningful for the notification
+	// service. A value of zero falls back to DefaultHandlerQueueSize.
+	HandlerQueueSize int `yaml:"handlerQueueSize,omitempty"`
 	// ListenerTTL bounds how long a finality listener may wait locally for a
 	// notification before being settled with Unknown. Only meaningful for the
 	// notification service. Explicitly setting it to zero disables local expiry;
@@ -135,7 +151,7 @@ type ServiceBackend interface {
 // from the provided ServiceBackend. It returns an error if the unmarshaling fails.
 //
 // The returned Config is fully resolved: HandlerTimeout, HandlerWorkers,
-// ListenerTTL and SweepInterval are pre-seeded with their
+// HandlerQueueSize, ListenerTTL and SweepInterval are pre-seeded with their
 // defaults before unmarshaling, so a deployment that omits them keeps today's
 // behavior. All of them except ListenerTTL also fall back to their defaults if
 // explicitly set to zero -- unlike ListenerTTL, they have no "zero disables it"
@@ -156,6 +172,9 @@ func NewNotificationServiceConfig(configService ServiceBackend) (*Config, error)
 	}
 	if config.HandlerWorkers <= 0 {
 		config.HandlerWorkers = DefaultHandlerWorkers
+	}
+	if config.HandlerQueueSize <= 0 {
+		config.HandlerQueueSize = DefaultHandlerQueueSize
 	}
 	if config.SweepInterval <= 0 {
 		config.SweepInterval = DefaultSweepInterval

--- a/platform/fabricx/core/committer/config/config_test.go
+++ b/platform/fabricx/core/committer/config/config_test.go
@@ -59,6 +59,7 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 		cfg, err := config.NewNotificationServiceConfig(fakeConfigService)
 		require.NoError(t, err)
 		require.Equal(t, config.DefaultHandlerTimeout, cfg.HandlerTimeout)
+		require.Equal(t, config.DefaultHandlerWorkers, cfg.HandlerWorkers)
 		require.Equal(t, config.DefaultListenerTTL, cfg.ListenerTTL)
 		require.Equal(t, config.DefaultSweepInterval, cfg.SweepInterval)
 	})
@@ -78,12 +79,13 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 		require.Zero(t, cfg.ListenerTTL, "an explicit zero must override the default, not be treated as unset")
 	})
 
-	t.Run("explicit zero handlerTimeout and sweepInterval fall back to defaults", func(t *testing.T) {
+	t.Run("explicit zero handler and interval settings fall back to defaults", func(t *testing.T) {
 		t.Parallel()
 		fakeConfigService := &mock.ServiceBackend{}
 		fakeConfigService.UnmarshalKeyStub = func(key string, rawVal any) error {
 			if cfg, ok := rawVal.(**config.Config); ok {
 				(*cfg).HandlerTimeout = 0
+				(*cfg).HandlerWorkers = 0
 				(*cfg).SweepInterval = 0
 			}
 			return nil
@@ -93,6 +95,25 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, config.DefaultHandlerTimeout, cfg.HandlerTimeout, "unlike ListenerTTL, zero has no special meaning here")
 		require.Equal(t, config.DefaultSweepInterval, cfg.SweepInterval, "unlike ListenerTTL, zero has no special meaning here")
+		// A zero limit would make every errgroup TryGo fail, so no callback would
+		// ever run: that cannot be a usable "disabled".
+		require.Equal(t, config.DefaultHandlerWorkers, cfg.HandlerWorkers, "a zero handler limit would deliver nothing")
+	})
+
+	t.Run("negative handlerWorkers falls back to default", func(t *testing.T) {
+		t.Parallel()
+		fakeConfigService := &mock.ServiceBackend{}
+		fakeConfigService.UnmarshalKeyStub = func(key string, rawVal any) error {
+			if cfg, ok := rawVal.(**config.Config); ok {
+				(*cfg).HandlerWorkers = -1
+			}
+			return nil
+		}
+
+		cfg, err := config.NewNotificationServiceConfig(fakeConfigService)
+		require.NoError(t, err)
+		// errgroup.SetLimit panics on a negative limit, so this must be sanitized.
+		require.Equal(t, config.DefaultHandlerWorkers, cfg.HandlerWorkers)
 	})
 
 	t.Run("configured finality durations are preserved", func(t *testing.T) {
@@ -101,6 +122,7 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 		fakeConfigService.UnmarshalKeyStub = func(key string, rawVal any) error {
 			if cfg, ok := rawVal.(**config.Config); ok {
 				(*cfg).HandlerTimeout = 7 * time.Second
+				(*cfg).HandlerWorkers = 4
 				(*cfg).ListenerTTL = 3 * time.Minute
 				(*cfg).SweepInterval = 45 * time.Second
 			}
@@ -110,6 +132,7 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 		cfg, err := config.NewNotificationServiceConfig(fakeConfigService)
 		require.NoError(t, err)
 		require.Equal(t, 7*time.Second, cfg.HandlerTimeout)
+		require.Equal(t, 4, cfg.HandlerWorkers)
 		require.Equal(t, 3*time.Minute, cfg.ListenerTTL)
 		require.Equal(t, 45*time.Second, cfg.SweepInterval)
 	})
@@ -131,6 +154,7 @@ func TestDefaultConfig(t *testing.T) {
 	cfg := config.DefaultConfig()
 	require.Equal(t, config.DefaultRequestTimeout, cfg.RequestTimeout)
 	require.Equal(t, config.DefaultHandlerTimeout, cfg.HandlerTimeout)
+	require.Equal(t, config.DefaultHandlerWorkers, cfg.HandlerWorkers)
 	require.Equal(t, config.DefaultListenerTTL, cfg.ListenerTTL)
 	require.Equal(t, config.DefaultSweepInterval, cfg.SweepInterval)
 }

--- a/platform/fabricx/core/committer/config/config_test.go
+++ b/platform/fabricx/core/committer/config/config_test.go
@@ -60,6 +60,7 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, config.DefaultHandlerTimeout, cfg.HandlerTimeout)
 		require.Equal(t, config.DefaultHandlerWorkers, cfg.HandlerWorkers)
+		require.Equal(t, config.DefaultHandlerQueueSize, cfg.HandlerQueueSize)
 		require.Equal(t, config.DefaultListenerTTL, cfg.ListenerTTL)
 		require.Equal(t, config.DefaultSweepInterval, cfg.SweepInterval)
 	})
@@ -86,6 +87,7 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 			if cfg, ok := rawVal.(**config.Config); ok {
 				(*cfg).HandlerTimeout = 0
 				(*cfg).HandlerWorkers = 0
+				(*cfg).HandlerQueueSize = 0
 				(*cfg).SweepInterval = 0
 			}
 			return nil
@@ -98,6 +100,7 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 		// A zero limit would make every errgroup TryGo fail, so no callback would
 		// ever run: that cannot be a usable "disabled".
 		require.Equal(t, config.DefaultHandlerWorkers, cfg.HandlerWorkers, "a zero handler limit would deliver nothing")
+		require.Equal(t, config.DefaultHandlerQueueSize, cfg.HandlerQueueSize, "a zero-capacity queue would drop every burst")
 	})
 
 	t.Run("negative handlerWorkers falls back to default", func(t *testing.T) {
@@ -112,8 +115,24 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 
 		cfg, err := config.NewNotificationServiceConfig(fakeConfigService)
 		require.NoError(t, err)
-		// errgroup.SetLimit panics on a negative limit, so this must be sanitized.
 		require.Equal(t, config.DefaultHandlerWorkers, cfg.HandlerWorkers)
+	})
+
+	t.Run("negative handlerQueueSize falls back to default", func(t *testing.T) {
+		t.Parallel()
+		fakeConfigService := &mock.ServiceBackend{}
+		fakeConfigService.UnmarshalKeyStub = func(key string, rawVal any) error {
+			if cfg, ok := rawVal.(**config.Config); ok {
+				(*cfg).HandlerQueueSize = -1
+			}
+			return nil
+		}
+
+		cfg, err := config.NewNotificationServiceConfig(fakeConfigService)
+		require.NoError(t, err)
+		// make() panics on a negative buffer size, so this must never reach the
+		// manager's constructor.
+		require.Equal(t, config.DefaultHandlerQueueSize, cfg.HandlerQueueSize)
 	})
 
 	t.Run("configured finality durations are preserved", func(t *testing.T) {
@@ -123,6 +142,7 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 			if cfg, ok := rawVal.(**config.Config); ok {
 				(*cfg).HandlerTimeout = 7 * time.Second
 				(*cfg).HandlerWorkers = 4
+				(*cfg).HandlerQueueSize = 64
 				(*cfg).ListenerTTL = 3 * time.Minute
 				(*cfg).SweepInterval = 45 * time.Second
 			}
@@ -133,6 +153,7 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 7*time.Second, cfg.HandlerTimeout)
 		require.Equal(t, 4, cfg.HandlerWorkers)
+		require.Equal(t, 64, cfg.HandlerQueueSize)
 		require.Equal(t, 3*time.Minute, cfg.ListenerTTL)
 		require.Equal(t, 45*time.Second, cfg.SweepInterval)
 	})
@@ -155,6 +176,7 @@ func TestDefaultConfig(t *testing.T) {
 	require.Equal(t, config.DefaultRequestTimeout, cfg.RequestTimeout)
 	require.Equal(t, config.DefaultHandlerTimeout, cfg.HandlerTimeout)
 	require.Equal(t, config.DefaultHandlerWorkers, cfg.HandlerWorkers)
+	require.Equal(t, config.DefaultHandlerQueueSize, cfg.HandlerQueueSize)
 	require.Equal(t, config.DefaultListenerTTL, cfg.ListenerTTL)
 	require.Equal(t, config.DefaultSweepInterval, cfg.SweepInterval)
 }

--- a/platform/fabricx/core/finality/nlm.go
+++ b/platform/fabricx/core/finality/nlm.go
@@ -32,6 +32,12 @@ var logger = logging.MustGetLogger()
 // the notification service's configurable defaults; this package consumes them via
 // config.Config rather than defining its own copies.
 
+// slotPollInterval is how often the queue feeder re-checks for a free handler slot
+// while every slot is busy. Only reached when the pool is saturated, so it trades a
+// little latency in an already-degraded state for keeping cancellation observable;
+// see the feeder in listen().
+const slotPollInterval = 2 * time.Millisecond
+
 // handlerCall is one OnStatus invocation: the unit of work handed to the handler
 // errgroup.
 type handlerCall struct {
@@ -59,6 +65,20 @@ type notificationListenerManager struct {
 	// how many stuck listeners it takes to stop delivering notifications on this
 	// stream entirely.
 	handlerWorkers int
+
+	// callQueue buffers callbacks between the dispatcher and the handler pool.
+	//
+	// The queue and the limit do different jobs, and both are needed. The limit
+	// bounds how many listeners run at once, which is what stops a misbehaving
+	// listener from growing goroutines without end. The queue absorbs bursts: one
+	// notification response can carry far more transactions than there are slots,
+	// and without a buffer everything past the limit would be dropped even though
+	// the listeners are perfectly healthy and about to free their slots.
+	//
+	// Sends are non-blocking (see enqueueHandler): the only goroutine that enqueues
+	// is also the one draining the notification stream and running the expiry
+	// sweeper, so blocking here would stall both.
+	callQueue chan handlerCall
 
 	// handlerGroup runs listener callbacks, capped at handlerWorkers via SetLimit.
 	// Deliberately a SEPARATE errgroup from the one listen() uses for its three
@@ -122,10 +142,9 @@ func (n *notificationListenerManager) listen(ctx context.Context) error {
 	// listen() call replaces it with a fresh, live gCtx.
 	n.streamCtx.Store(&gCtx)
 
-	// Set up the handler errgroup: SetLimit caps concurrent OnStatus callbacks, and
-	// enqueueHandler uses TryGo so a saturated limit reports back instead of
-	// blocking or queueing. See the handlerGroup field for why this is a separate
-	// group from g.
+	// Set up the handler errgroup: SetLimit caps concurrent OnStatus callbacks. See
+	// the handlerGroup field for why this is a separate group from g, and callQueue
+	// for why a queue sits in front of the limit.
 	//
 	// hCtx strips cancellation from ctx and relies on stopHandlers instead: a
 	// callback that is mid-flight when ctx is canceled would otherwise be handed an
@@ -141,6 +160,34 @@ func (n *notificationListenerManager) listen(ctx context.Context) error {
 	n.handlerGroup = hg
 	n.handlerCtx = hgCtx
 	n.handlerGroupMu.Unlock()
+
+	// Spawn the queue feeder: it moves buffered callbacks into the handler group,
+	// waiting for a free slot rather than dropping. Waiting is correct *here* --
+	// this is a dedicated goroutine, not the dispatcher, so it costs nothing but the
+	// feeder's own progress. It is what lets a burst larger than handlerWorkers
+	// still be delivered in full.
+	g.Go(func() error {
+		for {
+			var c handlerCall
+			select {
+			case <-gCtx.Done():
+				return gCtx.Err()
+			case c = <-n.callQueue:
+			}
+
+			for !hg.TryGo(func() error {
+				n.callHandler(hgCtx, c)
+				return nil
+			}) {
+				// All slots busy. Wait for one to free, but stay cancellable.
+				select {
+				case <-gCtx.Done():
+					return gCtx.Err()
+				case <-time.After(slotPollInterval):
+				}
+			}
+		}
+	})
 
 	// spawn stream receiver
 	g.Go(func() error {
@@ -439,35 +486,21 @@ func (n *notificationListenerManager) RemoveFinalityListener(txID string, listen
 	return nil
 }
 
-// enqueueHandler starts one OnStatus invocation on the handler errgroup via
-// TryGo. It never blocks: the caller is the dispatcher goroutine, which also
-// drains the notification stream and runs the expiry sweeper, so blocking here
-// would stall notification delivery for every other transaction as well.
+// enqueueHandler buffers one OnStatus invocation for the handler pool. It never
+// blocks: the caller is the dispatcher goroutine, which also drains the
+// notification stream and runs the expiry sweeper, so blocking here would stall
+// notification delivery for every other transaction as well.
 //
-// TryGo returning false means all handlerWorkers slots are in use, so the
-// invocation is dropped. There is no queue: the limit is the only buffer, which is
-// what makes saturation visible immediately rather than deferred behind a backlog.
+// The queue is what makes a burst survivable. One notification response can carry
+// many more transactions than there are handler slots, and they are dispatched in a
+// tight loop; buffering them lets the feeder hand them to the pool as slots free,
+// so a batch far larger than handlerWorkers is still delivered in full as long as
+// the listeners themselves return.
 //
-// KNOWN AND ACCEPTED CONSEQUENCE: TryGo reserves a slot on the *calling* goroutine
-// while the callback runs on a newly spawned one. Dispatching a batch in a tight
-// loop therefore refuses work that would have succeeded moments later, because the
-// slots are held by callbacks the runtime has not scheduled yet -- not because any
-// listener is slow. In the extreme, submitting N calls with no yield between them
-// can start none of them.
-//
-// The practical effect is that a notification response carrying more txIDs than
-// there are slots loses the overflow even when every listener returns instantly:
-// measured at handlerWorkers=16 with such listeners, a 200-txID batch delivered
-// roughly a third of its callbacks. The dropped listeners are settled with Unknown
-// by the listenerTTL sweeper, so callers still get an answer, just later and less
-// precise. Pinned by Burst_Larger_Than_Limit_Drops_The_Overflow.
-//
-// This is the deliberate price of a dispatcher that never blocks: the same
-// goroutine drains the notification stream and runs the expiry sweeper, so a
-// blocking send here would stall both. If burst loss ever needs to be eliminated,
-// the two options are a larger handlerWorkers (sizing the limit as a buffer), or
-// switching to a blocking Go for the batch under a bounded time budget, falling
-// back to TryGo once that budget is spent.
+// A full queue therefore means something worse than a burst: callbacks are being
+// produced faster than the pool can retire them for as long as the buffer took to
+// fill, which in practice means listeners are slow or stuck. Only then is the
+// invocation dropped.
 //
 // A dropped invocation is not recovered: both callers have already deleted the
 // handlers entry under the lock by this point, so the listener never receives a
@@ -475,48 +508,39 @@ func (n *notificationListenerManager) RemoveFinalityListener(txID string, listen
 // context deadline -- or to the listenerTTL sweeper's Unknown, whichever comes
 // first.
 //
-// Returns whether the callback was started, so callers can aggregate drops into a
+// Returns whether the callback was queued, so callers can aggregate drops into a
 // single warning per batch rather than one line per txID; see logDrops.
 func (n *notificationListenerManager) enqueueHandler(c handlerCall) bool {
-	n.handlerGroupMu.RLock()
-	hg, hCtx := n.handlerGroup, n.handlerCtx
-	n.handlerGroupMu.RUnlock()
-
-	if hg == nil {
-		// No stream has started, so there is nothing to run callbacks. Reachable
-		// only from a direct dispatch/sweep call outside listen(), i.e. in tests.
-		logger.Warnf("no handler group, dropping OnStatus for txID=%s", c.txID)
+	if n.callQueue == nil {
+		// No queue, so nothing will ever run this. Reachable only from a direct
+		// dispatch/sweep call on a manager built outside newNotifiWithGRPC.
+		logger.Warnf("no handler queue, dropping OnStatus for txID=%s", c.txID)
 		return false
 	}
 
-	// The func returns nil unconditionally: a listener callback has no error to
-	// report, and a non-nil return would cancel the handler group's context and so
-	// every other in-flight callback with it.
-	started := hg.TryGo(func() error {
-		n.callHandler(hCtx, c)
-		return nil
-	})
-
-	if !started {
-		// Logged at debug, not warn: a saturated limit drops every remaining call in
-		// the batch, so warning here would emit one near-identical line per txID at
-		// the notification rate. The caller aggregates into a single warning -- see
+	select {
+	case n.callQueue <- c:
+		return true
+	default:
+		// Logged at debug, not warn: a full queue drops every remaining call in the
+		// batch, so warning here would emit one near-identical line per txID at the
+		// notification rate. The caller aggregates into a single warning -- see
 		// logDrops.
-		logger.Debugf("handler slots full, dropped OnStatus for txID=%s", c.txID)
+		logger.Debugf("handler queue full, dropped OnStatus for txID=%s", c.txID)
+		return false
 	}
-	return started
 }
 
 // logDrops emits one aggregated warning for a batch in which some callbacks could
-// not be started. Aggregated on purpose: a saturated limit refuses every remaining
-// call, so per-txID warnings would flood the log at the notification rate exactly
-// when an operator most needs to read it. Individual txIDs are at debug level.
+// not be queued. Aggregated on purpose: a full queue drops every remaining call, so
+// per-txID warnings would flood the log at the notification rate exactly when an
+// operator most needs to read it. Individual txIDs are at debug level.
 func (n *notificationListenerManager) logDrops(dropped, total int) {
 	if dropped == 0 {
 		return
 	}
 	logger.Warnf(
-		"dropped %d of %d finality callbacks: all %d handler slots in use. "+
+		"dropped %d of %d finality callbacks: queue full with %d handler slots. "+
 			"Either listeners are not keeping up (raise handlerWorkers), one is ignoring "+
 			"its context, or this batch was larger than the limit. Affected listeners will "+
 			"be settled with Unknown after listenerTTL.",

--- a/platform/fabricx/core/finality/nlm.go
+++ b/platform/fabricx/core/finality/nlm.go
@@ -27,10 +27,18 @@ import (
 
 var logger = logging.MustGetLogger()
 
-// DefaultHandlerTimeout, DefaultListenerTTL and DefaultSweepInterval live in
-// committer/config, the single source of truth for the notification service's
-// configurable defaults; this package consumes them via config.Config rather
-// than defining its own copies.
+// DefaultHandlerTimeout, DefaultHandlerWorkers, DefaultListenerTTL and
+// DefaultSweepInterval live in committer/config, the single source of truth for
+// the notification service's configurable defaults; this package consumes them via
+// config.Config rather than defining its own copies.
+
+// handlerCall is one OnStatus invocation: the unit of work handed to the handler
+// errgroup.
+type handlerCall struct {
+	handler fabric.FinalityListener
+	txID    string
+	status  int
+}
 
 // handlerEntry holds the listeners waiting on one transaction, together with the
 // deadline after which they are settled locally. A zero expiresAt means the entry
@@ -45,6 +53,31 @@ type notificationListenerManager struct {
 	requestQueue   chan *committerpb.NotificationRequest
 	responseQueue  chan *committerpb.NotificationResponse
 	handlerTimeout time.Duration
+
+	// handlerWorkers is the limit set on the handler errgroup (see handlerGroup),
+	// so it is how many OnStatus callbacks may run at once -- and therefore also
+	// how many stuck listeners it takes to stop delivering notifications on this
+	// stream entirely.
+	handlerWorkers int
+
+	// handlerGroup runs listener callbacks, capped at handlerWorkers via SetLimit.
+	// Deliberately a SEPARATE errgroup from the one listen() uses for its three
+	// stream goroutines, for two reasons:
+	//
+	//   - Wait(): a listener that ignores cancellation and never returns keeps its
+	//     goroutine alive forever. Were it in the stream group, that group's Wait()
+	//     could never return, so listen() would never return and node shutdown
+	//     would hang on one misbehaving callback.
+	//   - Errors and limits: errgroup cancels its context on the first error and
+	//     shares one limit across the whole group. Sharing would let handlers
+	//     starve the stream goroutines of slots, and let a handler's error tear
+	//     down the stream.
+	//
+	// Set up by listen() and nil until then; enqueueHandler tolerates that.
+	// handlerCtx is the context callbacks receive, guarded by the same mutex.
+	handlerGroup   *errgroup.Group
+	handlerCtx     context.Context
+	handlerGroupMu sync.RWMutex
 
 	// requestTimeout is sent to the committer as the outbound NotificationRequest's
 	// Timeout, so it gives up and replies once it passes rather than us aborting the
@@ -88,6 +121,26 @@ func (n *notificationListenerManager) listen(ctx context.Context) error {
 	// "this stream is dead" signal AddFinalityListener needs until a new
 	// listen() call replaces it with a fresh, live gCtx.
 	n.streamCtx.Store(&gCtx)
+
+	// Set up the handler errgroup: SetLimit caps concurrent OnStatus callbacks, and
+	// enqueueHandler uses TryGo so a saturated limit reports back instead of
+	// blocking or queueing. See the handlerGroup field for why this is a separate
+	// group from g.
+	//
+	// hCtx strips cancellation from ctx and relies on stopHandlers instead: a
+	// callback that is mid-flight when ctx is canceled would otherwise be handed an
+	// already-dead context, and callHandler's timeout would expire instantly,
+	// delivering nothing.
+	hCtx, stopHandlers := context.WithCancel(context.WithoutCancel(ctx))
+	defer stopHandlers()
+
+	hg, hgCtx := errgroup.WithContext(hCtx)
+	hg.SetLimit(n.handlerWorkers)
+
+	n.handlerGroupMu.Lock()
+	n.handlerGroup = hg
+	n.handlerCtx = hgCtx
+	n.handlerGroupMu.Unlock()
 
 	// spawn stream receiver
 	g.Go(func() error {
@@ -140,15 +193,26 @@ func (n *notificationListenerManager) listen(ctx context.Context) error {
 			case <-gCtx.Done():
 				return gCtx.Err()
 			case <-ticker.C:
-				n.sweepExpired(gCtx)
+				n.sweepExpired()
 			case resp := <-n.responseQueue:
-				n.dispatch(gCtx, resp)
+				n.dispatch(resp)
 			}
 		}
 	})
 
 	err = g.Wait()
 	logger.Debugf("Notification listener stream stopped.")
+
+	// Cancel the handler context so in-flight callbacks that do observe
+	// cancellation wind down, then give them a bounded window to finish.
+	//
+	// hg.Wait() is deliberately NOT waited on unconditionally: it returns only once
+	// every callback has returned, and a listener that ignores cancellation never
+	// does. Waiting with a timeout keeps the common case tidy (callbacks finish,
+	// their goroutines are reaped before listen() returns) without letting one
+	// misbehaving listener block shutdown indefinitely.
+	stopHandlers()
+	n.waitHandlers()
 
 	// The stream is gone, so nothing will ever notify these listeners. Settle them
 	// with Unknown instead of dropping them silently, so anyone blocked in IsFinal
@@ -167,6 +231,20 @@ func (n *notificationListenerManager) listen(ctx context.Context) error {
 // settleAllAndClear empties the handlers map, invoking every listener still in it
 // with the given status. Used on stream teardown, where no notification can
 // arrive any more.
+//
+// Does not go through the handler errgroup: this runs after listen() has already
+// cancelled the handler context and waited out the in-flight callbacks, so its
+// slots may still be held by listeners that ignored cancellation. Routing these
+// final callbacks through TryGo would see those held slots and drop the very
+// notifications this function exists to deliver.
+//
+// Each listener is therefore invoked directly, in its own goroutine, and waited
+// for only up to handlerTimeout. Waiting inline instead would let a single
+// listener that ignores its context block listen() from ever returning, hanging
+// node shutdown -- the same failure the separate handler group avoids (see
+// listen). The goroutines here are bounded by the number of listeners still
+// unresolved at teardown, which happens once per stream death, so this is not a
+// path that can grow without limit.
 func (n *notificationListenerManager) settleAllAndClear(ctx context.Context, status int) {
 	type pending struct {
 		txID      string
@@ -191,8 +269,28 @@ func (n *notificationListenerManager) settleAllAndClear(ctx context.Context, sta
 
 	for _, p := range batch {
 		for _, h := range p.listeners {
-			n.invokeHandler(ctx, h, p.txID, status)
+			n.callHandlerBounded(ctx, handlerCall{handler: h, txID: p.txID, status: status})
 		}
+	}
+}
+
+// callHandlerBounded invokes one listener and gives up waiting for it after
+// handlerTimeout, so a listener that ignores cancellation cannot block the caller
+// indefinitely. Used only on the teardown path, where the handler pool is already
+// stopped; the live paths get their bound from the pool's fixed size instead.
+func (n *notificationListenerManager) callHandlerBounded(ctx context.Context, c handlerCall) {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		n.callHandler(ctx, c)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(n.handlerTimeout):
+		logger.Warnf(
+			"OnStatus handler for txID=%s did not return within %s on stream teardown; abandoning the wait",
+			c.txID, n.handlerTimeout)
 	}
 }
 
@@ -341,28 +439,145 @@ func (n *notificationListenerManager) RemoveFinalityListener(txID string, listen
 	return nil
 }
 
-// invokeHandler calls one listener in its own goroutine, bounded by
-// handlerTimeout. If a handler ignores context cancellation and never returns,
-// its goroutine leaks -- which is preferable to blocking the dispatcher. Shared
-// by the notification path and the expiry sweeper so both get the same isolation.
-func (n *notificationListenerManager) invokeHandler(ctx context.Context, h fabric.FinalityListener, txID string, status int) {
+// enqueueHandler starts one OnStatus invocation on the handler errgroup via
+// TryGo. It never blocks: the caller is the dispatcher goroutine, which also
+// drains the notification stream and runs the expiry sweeper, so blocking here
+// would stall notification delivery for every other transaction as well.
+//
+// TryGo returning false means all handlerWorkers slots are in use, so the
+// invocation is dropped. There is no queue: the limit is the only buffer, which is
+// what makes saturation visible immediately rather than deferred behind a backlog.
+//
+// KNOWN AND ACCEPTED CONSEQUENCE: TryGo reserves a slot on the *calling* goroutine
+// while the callback runs on a newly spawned one. Dispatching a batch in a tight
+// loop therefore refuses work that would have succeeded moments later, because the
+// slots are held by callbacks the runtime has not scheduled yet -- not because any
+// listener is slow. In the extreme, submitting N calls with no yield between them
+// can start none of them.
+//
+// The practical effect is that a notification response carrying more txIDs than
+// there are slots loses the overflow even when every listener returns instantly:
+// measured at handlerWorkers=16 with such listeners, a 200-txID batch delivered
+// roughly a third of its callbacks. The dropped listeners are settled with Unknown
+// by the listenerTTL sweeper, so callers still get an answer, just later and less
+// precise. Pinned by Burst_Larger_Than_Limit_Drops_The_Overflow.
+//
+// This is the deliberate price of a dispatcher that never blocks: the same
+// goroutine drains the notification stream and runs the expiry sweeper, so a
+// blocking send here would stall both. If burst loss ever needs to be eliminated,
+// the two options are a larger handlerWorkers (sizing the limit as a buffer), or
+// switching to a blocking Go for the batch under a bounded time budget, falling
+// back to TryGo once that budget is spent.
+//
+// A dropped invocation is not recovered: both callers have already deleted the
+// handlers entry under the lock by this point, so the listener never receives a
+// callback and whoever is waiting on it (e.g. IsFinal) falls back to its own
+// context deadline -- or to the listenerTTL sweeper's Unknown, whichever comes
+// first.
+//
+// Returns whether the callback was started, so callers can aggregate drops into a
+// single warning per batch rather than one line per txID; see logDrops.
+func (n *notificationListenerManager) enqueueHandler(c handlerCall) bool {
+	n.handlerGroupMu.RLock()
+	hg, hCtx := n.handlerGroup, n.handlerCtx
+	n.handlerGroupMu.RUnlock()
+
+	if hg == nil {
+		// No stream has started, so there is nothing to run callbacks. Reachable
+		// only from a direct dispatch/sweep call outside listen(), i.e. in tests.
+		logger.Warnf("no handler group, dropping OnStatus for txID=%s", c.txID)
+		return false
+	}
+
+	// The func returns nil unconditionally: a listener callback has no error to
+	// report, and a non-nil return would cancel the handler group's context and so
+	// every other in-flight callback with it.
+	started := hg.TryGo(func() error {
+		n.callHandler(hCtx, c)
+		return nil
+	})
+
+	if !started {
+		// Logged at debug, not warn: a saturated limit drops every remaining call in
+		// the batch, so warning here would emit one near-identical line per txID at
+		// the notification rate. The caller aggregates into a single warning -- see
+		// logDrops.
+		logger.Debugf("handler slots full, dropped OnStatus for txID=%s", c.txID)
+	}
+	return started
+}
+
+// logDrops emits one aggregated warning for a batch in which some callbacks could
+// not be started. Aggregated on purpose: a saturated limit refuses every remaining
+// call, so per-txID warnings would flood the log at the notification rate exactly
+// when an operator most needs to read it. Individual txIDs are at debug level.
+func (n *notificationListenerManager) logDrops(dropped, total int) {
+	if dropped == 0 {
+		return
+	}
+	logger.Warnf(
+		"dropped %d of %d finality callbacks: all %d handler slots in use. "+
+			"Either listeners are not keeping up (raise handlerWorkers), one is ignoring "+
+			"its context, or this batch was larger than the limit. Affected listeners will "+
+			"be settled with Unknown after listenerTTL.",
+		dropped, total, n.handlerWorkers)
+}
+
+// waitHandlers waits for in-flight callbacks to finish, but only up to
+// handlerTimeout. See the call site in listen() for why the wait is bounded.
+func (n *notificationListenerManager) waitHandlers() {
+	n.handlerGroupMu.RLock()
+	hg := n.handlerGroup
+	n.handlerGroupMu.RUnlock()
+
+	if hg == nil {
+		return
+	}
+
+	done := make(chan struct{})
 	go func() {
-		timeoutCtx, cancel := context.WithTimeout(ctx, n.handlerTimeout)
-		defer cancel()
-
-		done := make(chan struct{})
-		go func() {
-			h.OnStatus(timeoutCtx, txID, status, "")
-			close(done)
-		}()
-
-		select {
-		case <-done:
-			// Handler completed within timeout
-		case <-timeoutCtx.Done():
-			logger.Warnf("OnStatus handler timed out for txID=%s (timeout=%s)", txID, n.handlerTimeout)
-		}
+		defer close(done)
+		_ = hg.Wait() // the callbacks never return an error; see enqueueHandler
 	}()
+
+	select {
+	case <-done:
+		logger.Debugf("all finality handler callbacks finished")
+	case <-time.After(n.handlerTimeout):
+		logger.Warnf(
+			"finality handler callbacks still running after %s on stream teardown; "+
+				"abandoning the wait (a listener is ignoring its context)",
+			n.handlerTimeout)
+	}
+}
+
+// callHandler invokes one listener synchronously, with a context bounded by
+// handlerTimeout.
+//
+// The timeout is advisory: it cancels the context handed to the listener, but
+// nothing forces a listener that ignores cancellation to return. Such a listener
+// occupies this worker for as long as it runs, and once every worker is occupied
+// no notification can be delivered on this stream. That is deliberate -- it
+// bounds a misbehaving listener's cost to throughput rather than letting it grow
+// goroutines without limit -- but it is why OnStatus implementations MUST observe
+// ctx.Done() and return promptly.
+func (n *notificationListenerManager) callHandler(ctx context.Context, c handlerCall) {
+	timeoutCtx, cancel := context.WithTimeout(ctx, n.handlerTimeout)
+	defer cancel()
+
+	start := time.Now()
+	c.handler.OnStatus(timeoutCtx, c.txID, c.status, "")
+
+	// Warn only when the handler was still running after its deadline passed, i.e.
+	// it ignored cancellation for a while. Checking the context rather than the
+	// elapsed time keeps this quiet for handlers that return promptly, and correct
+	// when handlerTimeout is zero.
+	if timeoutCtx.Err() != nil {
+		logger.Warnf(
+			"OnStatus handler for txID=%s did not return before its deadline (took %s, timeout=%s), "+
+				"blocking one of %d handler workers for that long; OnStatus must observe ctx.Done() and return promptly",
+			c.txID, time.Since(start), n.handlerTimeout, n.handlerWorkers)
+	}
 }
 
 // expiryFor returns the local deadline for an entry created at now, or the zero
@@ -380,13 +595,9 @@ func (n *notificationListenerManager) expiryFor(now time.Time) time.Time {
 // deletes happen while handlersMu is held. Runs on the dispatcher goroutine,
 // which is what lets sweepExpired share the same map without either path being
 // able to settle a listener the other already settled.
-func (n *notificationListenerManager) dispatch(ctx context.Context, resp *committerpb.NotificationResponse) {
-	type handlerCall struct {
-		handler fabric.FinalityListener
-		txID    string
-		status  int
-	}
-
+// Takes no context: it only mutates the map and enqueues, and the enqueued work
+// runs under the pool's own context rather than the dispatcher's.
+func (n *notificationListenerManager) dispatch(resp *committerpb.NotificationResponse) {
 	var calls []handlerCall
 
 	n.handlersMu.Lock()
@@ -402,9 +613,13 @@ func (n *notificationListenerManager) dispatch(ctx context.Context, resp *commit
 	}
 	n.handlersMu.Unlock()
 
+	dropped := 0
 	for _, c := range calls {
-		n.invokeHandler(ctx, c.handler, c.txID, c.status)
+		if !n.enqueueHandler(c) {
+			dropped++
+		}
 	}
+	n.logDrops(dropped, len(calls))
 }
 
 // sweepExpired settles listeners whose local deadline has passed.
@@ -428,7 +643,8 @@ func (n *notificationListenerManager) dispatch(ctx context.Context, resp *commit
 // sweep and a dispatch can never interleave and one listener can never be settled
 // twice. Keep it that way -- moving this off the dispatcher would make
 // double-invoke merely preventable rather than impossible.
-func (n *notificationListenerManager) sweepExpired(ctx context.Context) {
+// Takes no context, for the same reason as dispatch.
+func (n *notificationListenerManager) sweepExpired() {
 	if n.listenerTTL <= 0 {
 		return
 	}
@@ -459,9 +675,14 @@ func (n *notificationListenerManager) sweepExpired(ctx context.Context) {
 
 	logger.Debugf("Settling %d expired finality listener(s) with Unknown", len(batch))
 
+	dropped, total := 0, 0
 	for _, e := range batch {
 		for _, h := range e.listeners {
-			n.invokeHandler(ctx, h, e.txID, fdriver.Unknown)
+			total++
+			if !n.enqueueHandler(handlerCall{handler: h, txID: e.txID, status: fdriver.Unknown}) {
+				dropped++
+			}
 		}
 	}
+	n.logDrops(dropped, total)
 }

--- a/platform/fabricx/core/finality/nlm_group_test.go
+++ b/platform/fabricx/core/finality/nlm_group_test.go
@@ -128,9 +128,10 @@ func TestHandlerGroup(t *testing.T) {
 	})
 
 	t.Run("Blocked_Listeners_Admit_At_Most_The_Limit", func(t *testing.T) {
-		// With every slot held by a listener that never returns, TryGo must refuse
-		// the rest rather than start them. Total admitted work is therefore the
-		// limit itself -- not the notification count.
+		// With every slot held by a listener that never returns, nothing retires, so
+		// admitted work stays at the limit no matter how many notifications arrive.
+		// The queue absorbs the rest and then drops; either way OnStatus is never
+		// entered more than `limit` times.
 		//
 		// Deliberately avoids runtime.NumGoroutine(): it is process-global, so
 		// parallel sibling tests running their own managers make it meaningless.
@@ -175,15 +176,17 @@ func TestHandlerGroup(t *testing.T) {
 			limit, batches*perBatch)
 	})
 
-	t.Run("TryGo_Refusal_Drops_Without_Blocking_Dispatcher", func(t *testing.T) {
-		// A saturated limit must not stall the dispatcher: it keeps draining
-		// responseQueue and keeps sweeping. Refused calls are logged and dropped
-		// rather than queued or spawned.
+	t.Run("Saturation_Does_Not_Block_Dispatcher", func(t *testing.T) {
+		// A saturated pool must not stall the dispatcher: it keeps draining
+		// responseQueue and keeps sweeping. Once the queue fills, further calls are
+		// dropped with a warning rather than blocking.
 		t.Parallel()
 
 		nlm, fakeStream := setupTest(t)
 		nlm.handlerTimeout = config.DefaultHandlerTimeout
 		nlm.handlerWorkers = 1
+		// Tiny queue so the flood below actually saturates it.
+		nlm.callQueue = make(chan handlerCall, 2)
 
 		blocker := newCountingBlockingListener()
 		t.Cleanup(func() { close(blocker.block) })
@@ -204,13 +207,13 @@ func TestHandlerGroup(t *testing.T) {
 		}, timeout, tick, "the single handler slot should be held")
 
 		// The dispatcher must have finished the whole batch (all entries removed
-		// from the map) even though almost all of it was refused by TryGo.
+		// from the map) even though almost all of it was dropped.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			nlm.handlersMu.RLock()
 			remaining := len(nlm.handlers)
 			nlm.handlersMu.RUnlock()
 			assert.Zero(collect, remaining,
-				"dispatcher must drain the batch even when TryGo refuses")
+				"dispatcher must drain the batch even when the queue is full")
 		}, timeout, tick)
 	})
 
@@ -224,11 +227,9 @@ func TestHandlerGroup(t *testing.T) {
 		// are slots*. That is the property worth pinning: it can only hold if slots
 		// are released back to the limit as callbacks return.
 		//
-		// It deliberately does NOT assert that every batch is delivered. TryGo
-		// reserves a slot on the calling goroutine while the callback runs on a
-		// freshly spawned one, so a submission made before the runtime has scheduled
-		// the previous callback can still be refused even at a low rate. That race is
-		// the same one Burst_Larger_Than_Limit_Drops_The_Overflow documents.
+		// With the queue in front of the limit, every batch should be delivered: the
+		// feeder waits for a slot rather than dropping, so a low arrival rate against
+		// a small limit loses nothing.
 		t.Parallel()
 
 		const limit = 2
@@ -253,36 +254,46 @@ func TestHandlerGroup(t *testing.T) {
 		feedResponses(t.Context(), fakeStream, responses...)
 		runManager(t, nlm)
 
-		// Strictly more than the limit proves slots are reused; without release the
-		// total would be capped at limit forever.
+		// All of them, not merely more than the limit: slots are released as callbacks
+		// return and the feeder keeps handing work over.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			assert.Greater(collect, calls.Load(), int32(limit))
+			assert.Equal(collect, int32(batches), calls.Load())
 		}, timeout, tick,
-			"callbacks must keep running after the first %d: slots are not being returned to the limit", limit)
+			"every batch must be delivered; slots are not being returned to the limit")
 	})
 
-	t.Run("Burst_Larger_Than_Limit_Drops_The_Overflow", func(t *testing.T) {
-		// Documents an accepted consequence of using TryGo with no queue in front
-		// of it: a single notification response carrying more txIDs than there are
-		// slots loses the overflow, even when every listener returns immediately.
+	t.Run("Burst_Larger_Than_Limit_Is_Delivered_In_Full", func(t *testing.T) {
+		// The reason a queue sits in front of the limit. One notification response
+		// can carry far more transactions than there are handler slots, and they are
+		// dispatched in a tight loop. Without a buffer, everything past the limit is
+		// dropped even though the listeners are healthy and free their slots at once.
 		//
-		// This is the deliberate trade for a dispatcher that never blocks. The
-		// dropped listeners are settled with Unknown by the listenerTTL sweeper, so
-		// callers still get an answer -- just a later and less precise one. If this
-		// ever needs to change, the options are a larger handlerWorkers or a
-		// bounded blocking Go for the batch; both are noted in enqueueHandler.
+		// With the queue, the feeder hands work to the pool as slots free, so the
+		// whole burst lands. Concurrency is still capped -- see peak below -- so this
+		// does not reintroduce unbounded goroutine growth.
 		t.Parallel()
 
 		const limit = 4
-		const burst = 40
+		const burst = 200
 
 		nlm, fakeStream := setupTest(t)
 		nlm.handlerTimeout = config.DefaultHandlerTimeout
 		nlm.handlerWorkers = limit
 
 		var ran atomic.Int32
+		var inFlight, peak atomic.Int32
 		// Returns immediately: nothing here is misbehaving.
-		listener := &funcListener{fn: func(context.Context, string, int, string) { ran.Add(1) }}
+		listener := &funcListener{fn: func(context.Context, string, int, string) {
+			cur := inFlight.Add(1)
+			for {
+				p := peak.Load()
+				if cur <= p || peak.CompareAndSwap(p, cur) {
+					break
+				}
+			}
+			ran.Add(1)
+			inFlight.Add(-1)
+		}}
 
 		txIDs := make([]string, 0, burst)
 		for i := range burst {
@@ -294,24 +305,16 @@ func TestHandlerGroup(t *testing.T) {
 		feedResponses(t.Context(), fakeStream, respFor(txIDs...))
 		runManager(t, nlm)
 
-		// The dispatcher must still have drained the whole batch...
+		// Every callback in the burst must run -- none dropped.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			nlm.handlersMu.RLock()
-			remaining := len(nlm.handlers)
-			nlm.handlersMu.RUnlock()
-			assert.Zero(collect, remaining)
-		}, timeout, tick, "dispatcher must drain the batch regardless of drops")
-
-		time.Sleep(shortWait)
-
-		// ...while delivering only part of it. Asserting a range rather than an
-		// exact count: how many slots recycle mid-burst is a scheduling detail.
-		delivered := ran.Load()
-		require.Positive(t, delivered, "fast listeners should still be served")
-		require.Less(t, delivered, int32(burst),
-			"a burst of %d against a limit of %d is expected to lose the overflow; "+
-				"if this now passes, the no-queue trade-off has changed and the docs need updating",
+			assert.Equal(collect, int32(burst), ran.Load())
+		}, timeout, tick,
+			"a burst of %d against a limit of %d must be delivered in full: the queue exists to absorb it",
 			burst, limit)
+
+		// ...and the limit must still have held throughout.
+		require.LessOrEqual(t, peak.Load(), int32(limit),
+			"delivering the burst must not exceed the concurrency limit")
 	})
 
 	t.Run("Slow_Listener_Does_Not_Stall_Other_TxIDs", func(t *testing.T) {
@@ -359,7 +362,9 @@ func TestHandlerGroup(t *testing.T) {
 		nlm.handlerTimeout = 100 * time.Millisecond
 		nlm.handlerWorkers = 4
 
-		ctx, cancel := context.WithCancel(context.Background())
+		// Derived from t.Context() so the test's own deadline or failure also
+		// tears this down; cancel() is what drives the teardown under test.
+		ctx, cancel := context.WithCancel(t.Context())
 		stuck := newCountingBlockingListener()
 		t.Cleanup(func() { close(stuck.block) })
 		seedHandlers(nlm, "tx_stuck_in_flight", stuck)
@@ -393,7 +398,9 @@ func TestHandlerGroup(t *testing.T) {
 		// One slot, and it will be held forever by the stuck callback below.
 		nlm.handlerWorkers = 1
 
-		ctx, cancel := context.WithCancel(context.Background())
+		// Derived from t.Context() so the test's own deadline or failure also
+		// tears this down; cancel() is what drives the teardown under test.
+		ctx, cancel := context.WithCancel(t.Context())
 
 		stuck := newCountingBlockingListener()
 		t.Cleanup(func() { close(stuck.block) })

--- a/platform/fabricx/core/finality/nlm_group_test.go
+++ b/platform/fabricx/core/finality/nlm_group_test.go
@@ -1,0 +1,441 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package finality
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/config"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/finality/mock"
+)
+
+// countingBlockingListener blocks forever on every call and records how many
+// calls are in flight, so a test can assert the errgroup's limit is respected.
+type countingBlockingListener struct {
+	block    chan struct{}
+	inFlight atomic.Int32
+	peak     atomic.Int32
+	// admitted counts every OnStatus entry over the listener's lifetime, i.e.
+	// how much work the manager actually let through.
+	admitted atomic.Int32
+}
+
+func newCountingBlockingListener() *countingBlockingListener {
+	return &countingBlockingListener{block: make(chan struct{})}
+}
+
+func (c *countingBlockingListener) OnStatus(_ context.Context, _ string, _ int, _ string) {
+	c.admitted.Add(1)
+	n := c.inFlight.Add(1)
+	for {
+		peak := c.peak.Load()
+		if n <= peak || c.peak.CompareAndSwap(peak, n) {
+			break
+		}
+	}
+	<-c.block
+	c.inFlight.Add(-1)
+}
+
+// funcListener adapts a function to the FinalityListener interface.
+type funcListener struct {
+	fn func(ctx context.Context, txID string, status int, statusMessage string)
+}
+
+func (f *funcListener) OnStatus(ctx context.Context, txID string, status int, statusMessage string) {
+	f.fn(ctx, txID, status, statusMessage)
+}
+
+// respFor builds a notification response marking every txID as committed.
+func respFor(txIDs ...string) *committerpb.NotificationResponse {
+	events := make([]*committerpb.TxStatus, 0, len(txIDs))
+	for _, txID := range txIDs {
+		events = append(events, &committerpb.TxStatus{
+			Ref:    &committerpb.TxRef{TxId: txID},
+			Status: committerpb.Status_COMMITTED,
+		})
+	}
+	return &committerpb.NotificationResponse{TxStatusEvents: events}
+}
+
+// feedResponses makes Recv return each response once, in order, then park until
+// the context is done.
+func feedResponses(ctx context.Context, fakeStream *mock.Notifier_OpenNotificationStreamClient, responses ...*committerpb.NotificationResponse) {
+	var idx atomic.Int32
+	fakeStream.RecvStub = func() (*committerpb.NotificationResponse, error) {
+		i := int(idx.Add(1)) - 1
+		if i < len(responses) {
+			return responses[i], nil
+		}
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+}
+
+func TestHandlerGroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SetLimit_Caps_Concurrent_Callbacks", func(t *testing.T) {
+		// The regression test for the unbounded-goroutine bug. Before the limit,
+		// every (txID, listener) pair got its own pair of goroutines, so concurrent
+		// OnStatus calls tracked the notification count. Now errgroup's SetLimit is
+		// the ceiling, whatever the rate.
+		t.Parallel()
+
+		const limit = 4
+		const notifications = 40
+
+		nlm, fakeStream := setupTest(t)
+		nlm.handlerTimeout = config.DefaultHandlerTimeout
+		nlm.handlerWorkers = limit
+
+		listener := newCountingBlockingListener()
+		t.Cleanup(func() { close(listener.block) })
+
+		txIDs := make([]string, 0, notifications)
+		for i := range notifications {
+			txID := "tx_capped_" + strconv.Itoa(i)
+			txIDs = append(txIDs, txID)
+			seedHandlers(nlm, txID, listener)
+		}
+
+		feedResponses(t.Context(), fakeStream, respFor(txIDs...))
+		runManager(t, nlm)
+
+		// Wait until the limit is saturated.
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			assert.Equal(collect, int32(limit), listener.inFlight.Load())
+		}, timeout, tick, "all handler slots should be held by the blocked listener")
+
+		// Give the dispatcher room to misbehave, then assert it did not.
+		time.Sleep(shortWait)
+		require.LessOrEqual(t, listener.peak.Load(), int32(limit),
+			"concurrent OnStatus calls must never exceed the errgroup limit")
+	})
+
+	t.Run("Blocked_Listeners_Admit_At_Most_The_Limit", func(t *testing.T) {
+		// With every slot held by a listener that never returns, TryGo must refuse
+		// the rest rather than start them. Total admitted work is therefore the
+		// limit itself -- not the notification count.
+		//
+		// Deliberately avoids runtime.NumGoroutine(): it is process-global, so
+		// parallel sibling tests running their own managers make it meaningless.
+		t.Parallel()
+
+		const limit = 2
+
+		nlm, fakeStream := setupTest(t)
+		nlm.handlerTimeout = config.DefaultHandlerTimeout
+		nlm.handlerWorkers = limit
+
+		listener := newCountingBlockingListener()
+		t.Cleanup(func() { close(listener.block) })
+
+		const batches = 10
+		const perBatch = 20
+		responses := make([]*committerpb.NotificationResponse, 0, batches)
+		for b := range batches {
+			txIDs := make([]string, 0, perBatch)
+			for i := range perBatch {
+				txID := "tx_flat_" + strconv.Itoa(b) + "_" + strconv.Itoa(i)
+				txIDs = append(txIDs, txID)
+				seedHandlers(nlm, txID, listener)
+			}
+			responses = append(responses, respFor(txIDs...))
+		}
+
+		feedResponses(t.Context(), fakeStream, responses...)
+		runManager(t, nlm)
+
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			assert.Equal(collect, int32(limit), listener.inFlight.Load())
+		}, timeout, tick, "handler slots should be held")
+
+		// Give the dispatcher ample time to push all 200 notifications through.
+		time.Sleep(shortWait)
+
+		require.LessOrEqual(t, listener.peak.Load(), int32(limit),
+			"concurrent OnStatus calls must never exceed the errgroup limit")
+		require.LessOrEqual(t, listener.admitted.Load(), int32(limit),
+			"with every slot held forever, admitted work must stay at the limit (%d), not track the %d notifications delivered",
+			limit, batches*perBatch)
+	})
+
+	t.Run("TryGo_Refusal_Drops_Without_Blocking_Dispatcher", func(t *testing.T) {
+		// A saturated limit must not stall the dispatcher: it keeps draining
+		// responseQueue and keeps sweeping. Refused calls are logged and dropped
+		// rather than queued or spawned.
+		t.Parallel()
+
+		nlm, fakeStream := setupTest(t)
+		nlm.handlerTimeout = config.DefaultHandlerTimeout
+		nlm.handlerWorkers = 1
+
+		blocker := newCountingBlockingListener()
+		t.Cleanup(func() { close(blocker.block) })
+
+		const floodSize = 50
+		floodTxIDs := make([]string, 0, floodSize)
+		for i := range floodSize {
+			txID := "tx_flood_" + strconv.Itoa(i)
+			floodTxIDs = append(floodTxIDs, txID)
+			seedHandlers(nlm, txID, blocker)
+		}
+
+		feedResponses(t.Context(), fakeStream, respFor(floodTxIDs...))
+		runManager(t, nlm)
+
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			assert.Equal(collect, int32(1), blocker.inFlight.Load())
+		}, timeout, tick, "the single handler slot should be held")
+
+		// The dispatcher must have finished the whole batch (all entries removed
+		// from the map) even though almost all of it was refused by TryGo.
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			nlm.handlersMu.RLock()
+			remaining := len(nlm.handlers)
+			nlm.handlersMu.RUnlock()
+			assert.Zero(collect, remaining,
+				"dispatcher must drain the batch even when TryGo refuses")
+		}, timeout, tick)
+	})
+
+	t.Run("Slots_Are_Reused_Across_Batches", func(t *testing.T) {
+		// The limit is a ceiling on concurrency, not a lifetime quota: once a
+		// callback returns, its slot must be reusable by a later notification.
+		// Without this the manager would deliver exactly handlerWorkers callbacks
+		// and then go silent forever.
+		//
+		// Sends one txID per batch and asserts that *more callbacks run than there
+		// are slots*. That is the property worth pinning: it can only hold if slots
+		// are released back to the limit as callbacks return.
+		//
+		// It deliberately does NOT assert that every batch is delivered. TryGo
+		// reserves a slot on the calling goroutine while the callback runs on a
+		// freshly spawned one, so a submission made before the runtime has scheduled
+		// the previous callback can still be refused even at a low rate. That race is
+		// the same one Burst_Larger_Than_Limit_Drops_The_Overflow documents.
+		t.Parallel()
+
+		const limit = 2
+		const batches = 24
+
+		nlm, fakeStream := setupTest(t)
+		nlm.handlerTimeout = config.DefaultHandlerTimeout
+		nlm.handlerWorkers = limit
+
+		var calls atomic.Int32
+		listener := &funcListener{fn: func(context.Context, string, int, string) {
+			calls.Add(1)
+		}}
+
+		responses := make([]*committerpb.NotificationResponse, 0, batches)
+		for i := range batches {
+			txID := "tx_reuse_" + strconv.Itoa(i)
+			seedHandlers(nlm, txID, listener)
+			responses = append(responses, respFor(txID))
+		}
+
+		feedResponses(t.Context(), fakeStream, responses...)
+		runManager(t, nlm)
+
+		// Strictly more than the limit proves slots are reused; without release the
+		// total would be capped at limit forever.
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			assert.Greater(collect, calls.Load(), int32(limit))
+		}, timeout, tick,
+			"callbacks must keep running after the first %d: slots are not being returned to the limit", limit)
+	})
+
+	t.Run("Burst_Larger_Than_Limit_Drops_The_Overflow", func(t *testing.T) {
+		// Documents an accepted consequence of using TryGo with no queue in front
+		// of it: a single notification response carrying more txIDs than there are
+		// slots loses the overflow, even when every listener returns immediately.
+		//
+		// This is the deliberate trade for a dispatcher that never blocks. The
+		// dropped listeners are settled with Unknown by the listenerTTL sweeper, so
+		// callers still get an answer -- just a later and less precise one. If this
+		// ever needs to change, the options are a larger handlerWorkers or a
+		// bounded blocking Go for the batch; both are noted in enqueueHandler.
+		t.Parallel()
+
+		const limit = 4
+		const burst = 40
+
+		nlm, fakeStream := setupTest(t)
+		nlm.handlerTimeout = config.DefaultHandlerTimeout
+		nlm.handlerWorkers = limit
+
+		var ran atomic.Int32
+		// Returns immediately: nothing here is misbehaving.
+		listener := &funcListener{fn: func(context.Context, string, int, string) { ran.Add(1) }}
+
+		txIDs := make([]string, 0, burst)
+		for i := range burst {
+			txID := "tx_burst_" + strconv.Itoa(i)
+			txIDs = append(txIDs, txID)
+			seedHandlers(nlm, txID, listener)
+		}
+
+		feedResponses(t.Context(), fakeStream, respFor(txIDs...))
+		runManager(t, nlm)
+
+		// The dispatcher must still have drained the whole batch...
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			nlm.handlersMu.RLock()
+			remaining := len(nlm.handlers)
+			nlm.handlersMu.RUnlock()
+			assert.Zero(collect, remaining)
+		}, timeout, tick, "dispatcher must drain the batch regardless of drops")
+
+		time.Sleep(shortWait)
+
+		// ...while delivering only part of it. Asserting a range rather than an
+		// exact count: how many slots recycle mid-burst is a scheduling detail.
+		delivered := ran.Load()
+		require.Positive(t, delivered, "fast listeners should still be served")
+		require.Less(t, delivered, int32(burst),
+			"a burst of %d against a limit of %d is expected to lose the overflow; "+
+				"if this now passes, the no-queue trade-off has changed and the docs need updating",
+			burst, limit)
+	})
+
+	t.Run("Slow_Listener_Does_Not_Stall_Other_TxIDs", func(t *testing.T) {
+		// One slow-but-completing listener must not delay other txIDs, as long as
+		// a slot is free.
+		t.Parallel()
+
+		nlm, fakeStream := setupTest(t)
+		nlm.handlerTimeout = config.DefaultHandlerTimeout
+		nlm.handlerWorkers = 4
+
+		slow := &delayedListener{delay: 300 * time.Millisecond}
+		slow.expect(1)
+		fast := &mockListener{}
+		fast.expect(1)
+
+		seedHandlers(nlm, "tx_slow", slow)
+		seedHandlers(nlm, "tx_fast", fast)
+
+		feedResponses(t.Context(), fakeStream, respFor("tx_slow", "tx_fast"))
+		runManager(t, nlm)
+
+		// fast must land well before slow's delay elapses.
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			txID, status := fast.getStatus()
+			assert.Equal(collect, "tx_fast", txID)
+			assert.Equal(collect, fdriver.Valid, status)
+		}, 200*time.Millisecond, tick, "fast listener must not wait behind the slow one")
+
+		// slow still completes.
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			txID, status := slow.getStatus()
+			assert.Equal(collect, "tx_slow", txID)
+			assert.Equal(collect, fdriver.Valid, status)
+		}, timeout, tick, "slow listener should still complete")
+	})
+
+	t.Run("Teardown_Not_Blocked_By_Stuck_Callback", func(t *testing.T) {
+		// This is why the handler group is separate from listen()'s stream group: a
+		// callback that ignores cancellation keeps its goroutine alive, so a Wait()
+		// on the stream group would never return. listen() must still return.
+		t.Parallel()
+
+		nlm, fakeStream := setupTest(t)
+		nlm.handlerTimeout = 100 * time.Millisecond
+		nlm.handlerWorkers = 4
+
+		ctx, cancel := context.WithCancel(context.Background())
+		stuck := newCountingBlockingListener()
+		t.Cleanup(func() { close(stuck.block) })
+		seedHandlers(nlm, "tx_stuck_in_flight", stuck)
+
+		feedResponses(ctx, fakeStream, respFor("tx_stuck_in_flight"))
+
+		listenErr := make(chan error, 1)
+		go func() { listenErr <- nlm.listen(ctx) }()
+
+		// Wait until the callback is actually inside OnStatus.
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			assert.Equal(collect, int32(1), stuck.inFlight.Load())
+		}, timeout, tick, "the stuck callback should be in flight")
+
+		cancel()
+		select {
+		case <-listenErr:
+		case <-time.After(2 * time.Second):
+			t.Fatal("listen() did not return: teardown blocked on a callback that ignores its context")
+		}
+	})
+
+	t.Run("Teardown_Settles_Listeners_While_Slot_Held", func(t *testing.T) {
+		// Listeners left in the map when the stream dies must be settled, even
+		// though the handler group's slots may be held by stuck callbacks -- which
+		// is why that path invokes them directly rather than through TryGo.
+		t.Parallel()
+
+		nlm, fakeStream := setupTest(t)
+		nlm.handlerTimeout = 100 * time.Millisecond
+		// One slot, and it will be held forever by the stuck callback below.
+		nlm.handlerWorkers = 1
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		stuck := newCountingBlockingListener()
+		t.Cleanup(func() { close(stuck.block) })
+		seedHandlers(nlm, "tx_holds_the_only_slot", stuck)
+
+		// These are still registered at teardown, when the only slot is held.
+		const pending = 5
+		var settled atomic.Int32
+		var wg sync.WaitGroup
+		wg.Add(pending)
+		for i := range pending {
+			seedHandlers(nlm, "tx_teardown_"+strconv.Itoa(i), &funcListener{
+				fn: func(context.Context, string, int, string) {
+					settled.Add(1)
+					wg.Done()
+				},
+			})
+		}
+
+		feedResponses(ctx, fakeStream, respFor("tx_holds_the_only_slot"))
+
+		listenErr := make(chan error, 1)
+		go func() { listenErr <- nlm.listen(ctx) }()
+
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			assert.Equal(collect, int32(1), stuck.inFlight.Load())
+		}, timeout, tick, "the stuck callback should hold the only slot")
+
+		cancel()
+		select {
+		case <-listenErr:
+		case <-time.After(2 * time.Second):
+			t.Fatal("listen() did not return")
+		}
+
+		finished := make(chan struct{})
+		go func() { wg.Wait(); close(finished) }()
+		select {
+		case <-finished:
+		case <-time.After(timeout):
+			t.Fatalf("teardown settled only %d of %d listeners while a callback held the only slot",
+				settled.Load(), pending)
+		}
+	})
+}

--- a/platform/fabricx/core/finality/nlm_test.go
+++ b/platform/fabricx/core/finality/nlm_test.go
@@ -83,8 +83,8 @@ func (m *mockListener) getStatus() (string, int) {
 
 // blockingListener simulates a handler that blocks forever (ignores context).
 // Used to test deadline detection and the dispatcher's resilience to a listener
-// that never returns. Such a listener permanently consumes one handler-pool
-// worker; see TestHandlerPool for the tests that pin down that bound.
+// that never returns. Such a listener permanently occupies one handler slot; see
+// TestHandlerGroup for the tests that pin down that bound.
 type blockingListener struct {
 	block    chan struct{} // close this to unblock; leave open to simulate a stuck handler
 	onCalled chan struct{} // closed when OnStatus is entered, so tests can synchronize
@@ -133,16 +133,16 @@ func setupTest(tb testing.TB) (*notificationListenerManager, *mock.Notifier_Open
 	// listenerTTL is deliberately left zero here, which disables local expiry, so
 	// the sweeper stays inert for every test that does not opt in.
 	//
-	// handlerWorkers must be set: it becomes the handler errgroup's SetLimit, and a
-	// limit of zero would make every TryGo fail, so no callback would ever run.
-	// listen() builds the group itself; tests that care about its bounds override
-	// this. Tests that dispatch without calling listen() get the nil-group warning
-	// path in enqueueHandler, which is deliberate.
+	// handlerWorkers and callQueue must both be set: handlerWorkers becomes the
+	// handler errgroup's SetLimit, and a nil callQueue would make every enqueue hit
+	// the drop path in enqueueHandler. listen() builds the group itself; tests that
+	// care about the pool's bounds override these.
 	nlm := &notificationListenerManager{
 		notifyClient:   fakeClient,
 		requestQueue:   make(chan *committerpb.NotificationRequest),
 		responseQueue:  make(chan *committerpb.NotificationResponse),
 		handlers:       make(map[driver.TxID]*handlerEntry),
+		callQueue:      make(chan handlerCall, config.DefaultHandlerQueueSize),
 		handlerWorkers: config.DefaultHandlerWorkers,
 		requestTimeout: testRequestTimeout,
 	}
@@ -558,7 +558,7 @@ func TestNotificationListenerManager(t *testing.T) {
 	t.Run("Shutdown_Graceful_Exit", func(t *testing.T) {
 		t.Parallel()
 		nlm, fakeStream := setupTest(t)
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		// mock Recv to block indefinitely on context
 		fakeStream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 			<-ctx.Done()
@@ -595,7 +595,7 @@ func TestNotificationListenerManager(t *testing.T) {
 		// context from it, and a zero timeout would expire before OnStatus runs.
 		nlm.handlerTimeout = config.DefaultHandlerTimeout
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		fakeStream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 			<-ctx.Done()
 			return nil, ctx.Err()
@@ -986,7 +986,7 @@ func TestNotificationListenerManager(t *testing.T) {
 		//
 		// The leaky handler permanently consumes one worker of the pool, so this
 		// passes because the default pool has workers to spare. See
-		// TestHandlerPool for what happens when every worker is consumed, and for
+		// TestHandlerGroup for what happens when every slot is occupied, and for
 		// the bound on how much work a stuck listener can admit.
 		t.Parallel()
 		nlm, fakeStream := setupTest(t)

--- a/platform/fabricx/core/finality/nlm_test.go
+++ b/platform/fabricx/core/finality/nlm_test.go
@@ -82,7 +82,9 @@ func (m *mockListener) getStatus() (string, int) {
 }
 
 // blockingListener simulates a handler that blocks forever (ignores context).
-// Used to test timeout detection and goroutine leak resilience.
+// Used to test deadline detection and the dispatcher's resilience to a listener
+// that never returns. Such a listener permanently consumes one handler-pool
+// worker; see TestHandlerPool for the tests that pin down that bound.
 type blockingListener struct {
 	block    chan struct{} // close this to unblock; leave open to simulate a stuck handler
 	onCalled chan struct{} // closed when OnStatus is entered, so tests can synchronize
@@ -130,11 +132,18 @@ func setupTest(tb testing.TB) (*notificationListenerManager, *mock.Notifier_Open
 
 	// listenerTTL is deliberately left zero here, which disables local expiry, so
 	// the sweeper stays inert for every test that does not opt in.
+	//
+	// handlerWorkers must be set: it becomes the handler errgroup's SetLimit, and a
+	// limit of zero would make every TryGo fail, so no callback would ever run.
+	// listen() builds the group itself; tests that care about its bounds override
+	// this. Tests that dispatch without calling listen() get the nil-group warning
+	// path in enqueueHandler, which is deliberate.
 	nlm := &notificationListenerManager{
 		notifyClient:   fakeClient,
 		requestQueue:   make(chan *committerpb.NotificationRequest),
 		responseQueue:  make(chan *committerpb.NotificationResponse),
 		handlers:       make(map[driver.TxID]*handlerEntry),
+		handlerWorkers: config.DefaultHandlerWorkers,
 		requestTimeout: testRequestTimeout,
 	}
 
@@ -880,8 +889,11 @@ func TestNotificationListenerManager(t *testing.T) {
 		}
 
 		// The handler is still blocked, but the dispatcher should have moved on.
-		// Verify the handler entry was removed from the map (dispatch cleanup
-		// happens before the goroutine timeout fires).
+		// Note what this does and does not prove now that handlers run on a
+		// bounded pool: the stuck handler holds its worker indefinitely (the
+		// timeout only cancels its context, it cannot force a return), but the
+		// dispatcher merely enqueued the call and is free. Verify the entry was
+		// removed from the map, which happens at dispatch time.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			nlm.handlersMu.RLock()
 			_, exists := nlm.handlers[targetTxID]
@@ -906,7 +918,8 @@ func TestNotificationListenerManager(t *testing.T) {
 		slowML := &delayedListener{delay: 100 * time.Millisecond}
 		slowML.expect(1)
 
-		// stuckListener never returns (exceeds timeout)
+		// stuckListener never returns, so it consumes one pool worker for good;
+		// the other two listeners must still be served by the remaining workers
 		stuckCalled := make(chan struct{})
 		stuckListener := &blockingListener{
 			block:    make(chan struct{}), // never closed
@@ -970,6 +983,11 @@ func TestNotificationListenerManager(t *testing.T) {
 		// Verifies that a handler ignoring context cancellation and never
 		// returning does NOT block the dispatcher from processing subsequent
 		// notifications.
+		//
+		// The leaky handler permanently consumes one worker of the pool, so this
+		// passes because the default pool has workers to spare. See
+		// TestHandlerPool for what happens when every worker is consumed, and for
+		// the bound on how much work a stuck listener can admit.
 		t.Parallel()
 		nlm, fakeStream := setupTest(t)
 		nlm.handlerTimeout = 200 * time.Millisecond

--- a/platform/fabricx/core/finality/provider.go
+++ b/platform/fabricx/core/finality/provider.go
@@ -163,13 +163,7 @@ func (p *Provider) NewManager(network, channel string) (ListenerManager, error) 
 
 // newNotifiWithGRPC creates and initializes a notificationListenerManager using the GRPCClientProvider.
 // cfg is expected to already be fully resolved (see config.NewNotificationServiceConfig /
-// config.DefaultConfig) -- durations are used as-is, with no further nil or zero-value handling.
-//
-// HandlerWorkers is the exception: it is re-checked here rather than trusted. cfg
-// arrives from a ServiceConfigProvider, which is an exported interface anyone can
-// implement, and a non-positive value is not merely suboptimal -- errgroup's
-// SetLimit panics on a negative limit, and a limit of zero would build a manager
-// whose TryGo always fails, so it would silently never deliver a notification.
+// config.DefaultConfig)
 func newNotifiWithGRPC(network string, grpcClientProvider GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
 	cc, err := grpcClientProvider.NotificationServiceClient(network)
 	if err != nil {
@@ -179,19 +173,13 @@ func newNotifiWithGRPC(network string, grpcClientProvider GRPCClientProvider, cf
 	// Create the gRPC client stub for the Notifier service
 	notifyClient := committerpb.NewNotifierClient(cc)
 
-	handlerWorkers := cfg.HandlerWorkers
-	if handlerWorkers <= 0 {
-		logger.Warnf("invalid handlerWorkers=%d for network=%s, falling back to %d",
-			handlerWorkers, network, config.DefaultHandlerWorkers)
-		handlerWorkers = config.DefaultHandlerWorkers
-	}
-
 	nlm := &notificationListenerManager{
 		notifyClient:   notifyClient,
 		requestQueue:   make(chan *committerpb.NotificationRequest),  // Queue for outgoing requests to the committer
 		responseQueue:  make(chan *committerpb.NotificationResponse), // Queue for incoming responses/notifications
 		handlers:       make(map[driver.TxID]*handlerEntry),          // Map: txID -> listeners + local expiry deadline
-		handlerWorkers: handlerWorkers,
+		callQueue:      make(chan handlerCall, cfg.HandlerQueueSize), // Buffers callbacks for the handler pool
+		handlerWorkers: cfg.HandlerWorkers,
 		handlerTimeout: cfg.HandlerTimeout,
 		requestTimeout: cfg.RequestTimeout,
 		listenerTTL:    cfg.ListenerTTL,

--- a/platform/fabricx/core/finality/provider.go
+++ b/platform/fabricx/core/finality/provider.go
@@ -163,7 +163,13 @@ func (p *Provider) NewManager(network, channel string) (ListenerManager, error) 
 
 // newNotifiWithGRPC creates and initializes a notificationListenerManager using the GRPCClientProvider.
 // cfg is expected to already be fully resolved (see config.NewNotificationServiceConfig /
-// config.DefaultConfig) -- every field is used as-is, with no further nil or zero-value handling.
+// config.DefaultConfig) -- durations are used as-is, with no further nil or zero-value handling.
+//
+// HandlerWorkers is the exception: it is re-checked here rather than trusted. cfg
+// arrives from a ServiceConfigProvider, which is an exported interface anyone can
+// implement, and a non-positive value is not merely suboptimal -- errgroup's
+// SetLimit panics on a negative limit, and a limit of zero would build a manager
+// whose TryGo always fails, so it would silently never deliver a notification.
 func newNotifiWithGRPC(network string, grpcClientProvider GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
 	cc, err := grpcClientProvider.NotificationServiceClient(network)
 	if err != nil {
@@ -173,11 +179,19 @@ func newNotifiWithGRPC(network string, grpcClientProvider GRPCClientProvider, cf
 	// Create the gRPC client stub for the Notifier service
 	notifyClient := committerpb.NewNotifierClient(cc)
 
+	handlerWorkers := cfg.HandlerWorkers
+	if handlerWorkers <= 0 {
+		logger.Warnf("invalid handlerWorkers=%d for network=%s, falling back to %d",
+			handlerWorkers, network, config.DefaultHandlerWorkers)
+		handlerWorkers = config.DefaultHandlerWorkers
+	}
+
 	nlm := &notificationListenerManager{
 		notifyClient:   notifyClient,
 		requestQueue:   make(chan *committerpb.NotificationRequest),  // Queue for outgoing requests to the committer
 		responseQueue:  make(chan *committerpb.NotificationResponse), // Queue for incoming responses/notifications
 		handlers:       make(map[driver.TxID]*handlerEntry),          // Map: txID -> listeners + local expiry deadline
+		handlerWorkers: handlerWorkers,
 		handlerTimeout: cfg.HandlerTimeout,
 		requestTimeout: cfg.RequestTimeout,
 		listenerTTL:    cfg.ListenerTTL,

--- a/platform/fabricx/core/finality/provider_test.go
+++ b/platform/fabricx/core/finality/provider_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
@@ -585,5 +586,54 @@ func TestGetListenerManager(t *testing.T) {
 		require.Error(t, err, "Should return error from NewManager")
 		require.Nil(t, manager)
 		require.Equal(t, expectedErr, err)
+	})
+}
+
+func TestNewNotifiWithGRPC_HandlerLimit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resolved config is applied to the handler limit", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.DefaultConfig()
+		cfg.HandlerWorkers = 3
+
+		nlm, err := newNotifiWithGRPC("network1", &mockGRPCClientProvider{}, cfg)
+		require.NoError(t, err)
+		require.Equal(t, 3, nlm.handlerWorkers)
+	})
+
+	t.Run("non-positive handlerWorkers does not produce an unusable manager", func(t *testing.T) {
+		// newNotifiWithGRPC takes a config.Config directly and the interface that
+		// supplies it is exported and mockable, so it must not accept values that
+		// NewNotificationServiceConfig would have sanitized: errgroup's SetLimit
+		// panics on a negative limit, and a limit of zero would make every TryGo
+		// fail, so no notification would ever be delivered.
+		t.Parallel()
+
+		for _, tc := range []struct {
+			name    string
+			workers int
+		}{
+			{name: "zero workers", workers: 0},
+			{name: "negative workers", workers: -1},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				cfg := config.DefaultConfig()
+				cfg.HandlerWorkers = tc.workers
+
+				nlm, err := newNotifiWithGRPC("network1", &mockGRPCClientProvider{}, cfg)
+				require.NoError(t, err)
+				require.Positive(t, nlm.handlerWorkers,
+					"a manager with a non-positive handler limit could never deliver a notification")
+
+				// The limit must also be usable: SetLimit would panic on a negative
+				// value, so prove the group accepts it and runs work.
+				hg, _ := errgroup.WithContext(t.Context())
+				require.NotPanics(t, func() { hg.SetLimit(nlm.handlerWorkers) })
+				require.True(t, hg.TryGo(func() error { return nil }))
+				require.NoError(t, hg.Wait())
+			})
+		}
 	})
 }

--- a/platform/fabricx/core/finality/provider_test.go
+++ b/platform/fabricx/core/finality/provider_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
@@ -141,7 +140,7 @@ func TestProvider_Initialize(t *testing.T) {
 		mockGRPC := &mockGRPCClientProvider{}
 		provider := NewListenerManagerProvider(mockGRPC, nil)
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		var wg sync.WaitGroup
 		for range 100 {
@@ -330,7 +329,7 @@ func TestProvider_NewManager(t *testing.T) {
 			}), nil
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		provider.Initialize(ctx)
 
 		_, err := provider.NewManager("network1", "channel1")
@@ -589,51 +588,18 @@ func TestGetListenerManager(t *testing.T) {
 	})
 }
 
-func TestNewNotifiWithGRPC_HandlerLimit(t *testing.T) {
+func TestNewNotifiWithGRPC_HandlerPool(t *testing.T) {
 	t.Parallel()
 
-	t.Run("resolved config is applied to the handler limit", func(t *testing.T) {
+	t.Run("resolved config is applied to the pool", func(t *testing.T) {
 		t.Parallel()
 		cfg := config.DefaultConfig()
 		cfg.HandlerWorkers = 3
+		cfg.HandlerQueueSize = 7
 
 		nlm, err := newNotifiWithGRPC("network1", &mockGRPCClientProvider{}, cfg)
 		require.NoError(t, err)
 		require.Equal(t, 3, nlm.handlerWorkers)
-	})
-
-	t.Run("non-positive handlerWorkers does not produce an unusable manager", func(t *testing.T) {
-		// newNotifiWithGRPC takes a config.Config directly and the interface that
-		// supplies it is exported and mockable, so it must not accept values that
-		// NewNotificationServiceConfig would have sanitized: errgroup's SetLimit
-		// panics on a negative limit, and a limit of zero would make every TryGo
-		// fail, so no notification would ever be delivered.
-		t.Parallel()
-
-		for _, tc := range []struct {
-			name    string
-			workers int
-		}{
-			{name: "zero workers", workers: 0},
-			{name: "negative workers", workers: -1},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				t.Parallel()
-				cfg := config.DefaultConfig()
-				cfg.HandlerWorkers = tc.workers
-
-				nlm, err := newNotifiWithGRPC("network1", &mockGRPCClientProvider{}, cfg)
-				require.NoError(t, err)
-				require.Positive(t, nlm.handlerWorkers,
-					"a manager with a non-positive handler limit could never deliver a notification")
-
-				// The limit must also be usable: SetLimit would panic on a negative
-				// value, so prove the group accepts it and runs work.
-				hg, _ := errgroup.WithContext(t.Context())
-				require.NotPanics(t, func() { hg.SetLimit(nlm.handlerWorkers) })
-				require.True(t, hg.TryGo(func() error { return nil }))
-				require.NoError(t, hg.Wait())
-			})
-		}
+		require.Equal(t, 7, cap(nlm.callQueue))
 	})
 }


### PR DESCRIPTION
This PR addresses the unbounded goroutine growth reported in #1627.

The notification dispatcher spawned two goroutines per `(txID, listener)` pair: an
outer one to enforce `handlerTimeout` and an inner one to run `OnStatus`. The timeout
bounded only the outer goroutine, so a listener that ignored context cancellation left
the inner one pinned for the lifetime of the process, turning the notification rate
directly into a memory leak.

Listener callbacks now run on a bounded pool: an `errgroup` whose `SetLimit` is the new
`handlerWorkers` setting (default 16), fed by a buffered queue sized by the new
`handlerQueueSize` (default 1000). The two do different jobs. `handlerWorkers` caps how
many callbacks run at once, which is what stops a misbehaving listener from growing
goroutines without end. The queue absorbs bursts: a notification response can carry far
more transactions than there are slots, so without a buffer everything past the limit
would be dropped even though the listeners are healthy and about to free their slots.
The dispatcher never blocks — it shares a goroutine with the stream reader and the
expiry sweeper — so it only enqueues, and a dedicated feeder moves work into the pool as
slots free. Once the queue is full, callbacks are dropped with one aggregated warning
per batch and those listeners are settled with `Unknown` by the `listenerTTL` sweeper.

The callbacks live in a **separate** errgroup from the three stream goroutines, for
three reasons: `Wait()` returns only once every goroutine in the group has returned, so
a stuck listener would hang `listen()` and node shutdown with it; `SetLimit` applies to
the whole group, so handlers filling it would starve the stream goroutines; and errgroup
cancels its context on the first error, so a handler error would tear down the stream.
For the same reason the handler group's own `Wait()` is bounded by `handlerTimeout` on
teardown, and `settleAllAndClear` — which runs after that wait, when slots may still be
held — invokes listeners directly with a per-listener timeout rather than through the
pool.

Because a stuck listener now degrades throughput rather than leaking memory, "`OnStatus`
must observe `ctx.Done()` and return promptly" becomes a requirement rather than advice,
so that warning is now on the `FinalityListener` interface itself.

Tested with eight tests in `nlm_group_test.go` covering the limit, slot reuse, full
delivery of a burst larger than the limit, drops under saturation, and both teardown
paths, plus constructor and config tests for the new keys. Verified with `-race` over
repeated runs; `make lint`, `govet`, `ineffassign` and `staticcheck` report no issues.

Closes #1627
