### PR TITLE
fix(membership)!: report uninitialized channel config instead of panicking

### DIFF
--- a/platform/fabric/core/configstate/holder.go
+++ b/platform/fabric/core/configstate/holder.go
@@ -1,0 +1,97 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package configstate holds channel configuration that is populated
+// asynchronously, after the service owning it has been constructed.
+package configstate
+
+import (
+	"sync"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+)
+
+// Holder guards a channel configuration of type T against concurrent access and
+// against being read before it exists.
+//
+// Channel configuration is not available when a membership service is built: it
+// arrives later, when the first configuration block is committed or the config
+// monitor completes its first poll. Until then the holder is empty, which is a
+// normal startup state rather than an error in the caller.
+//
+// Get is the accessor to reach for. Because it returns an error alongside the
+// configuration rather than the configuration alone, the absent case is put in
+// front of the caller at the point of use instead of surfacing as a nil
+// dereference somewhere further down. Discarding the error still compiles, so
+// this makes the mistake visible rather than impossible.
+type Holder[T any] struct {
+	// mu serializes access to value and loaded.
+	mu sync.RWMutex
+	// value is the configuration held, meaningful only when loaded is true.
+	value T
+	// loaded records whether value has been set. It is tracked explicitly
+	// rather than by comparing value against nil so that T may be an
+	// interface type whose stored value is legitimately nil.
+	loaded bool
+
+	channelName string
+}
+
+// NewHolder returns an empty Holder for the named channel. The channel name is
+// only used to give the errors returned by Get somewhere to point; the service
+// owning the holder remains the authority on channel identity.
+func NewHolder[T any](channelName string) *Holder[T] {
+	return &Holder[T]{channelName: channelName}
+}
+
+// Get returns the held configuration. Until the first successful Update it
+// returns an error wrapping driver.ErrNotInitialized, which callers that can
+// tolerate the startup race may test for with errors.Is.
+func (h *Holder[T]) Get() (T, error) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	if !h.loaded {
+		var zero T
+		return zero, errors.Wrapf(driver.ErrNotInitialized, "channel [%s] configuration not loaded", h.channelName)
+	}
+
+	return h.value, nil
+}
+
+// TryGet returns the held configuration and whether one is held. Prefer Get;
+// use TryGet only where absence is a legitimate outcome to be handled inline
+// rather than reported: satisfying an interface that expresses "no
+// configuration" as a nil return, or working from a snapshot of whatever is
+// held at the time of the call.
+func (h *Holder[T]) TryGet() (T, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	return h.value, h.loaded
+}
+
+// Update replaces the held configuration with the value produced by fn, which
+// receives the currently held value along with whether one is held. The held
+// value is left untouched if fn returns an error, so a rejected configuration
+// cannot leave the holder empty or stale.
+//
+// fn runs while the write lock is held and must not call back into this Holder;
+// doing so deadlocks.
+func (h *Holder[T]) Update(fn func(current T, loaded bool) (T, error)) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	v, err := fn(h.value, h.loaded)
+	if err != nil {
+		return err
+	}
+
+	h.value = v
+	h.loaded = true
+	return nil
+}

--- a/platform/fabric/core/configstate/holder_test.go
+++ b/platform/fabric/core/configstate/holder_test.go
@@ -134,7 +134,7 @@ func TestConcurrentAccessIsRaceFree(t *testing.T) {
 	h := configstate.NewHolder[*config]("mychannel")
 
 	var wg sync.WaitGroup
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		wg.Add(2)
 		go func() { defer wg.Done(); _, _ = h.Get() }()
 		go func() {

--- a/platform/fabric/core/configstate/holder_test.go
+++ b/platform/fabric/core/configstate/holder_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package configstate_test
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/configstate"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+)
+
+type config struct{ id string }
+
+func TestGetBeforeFirstUpdate(t *testing.T) {
+	t.Parallel()
+
+	h := configstate.NewHolder[*config]("mychannel")
+
+	v, err := h.Get()
+	require.Error(t, err)
+	require.Nil(t, v)
+	require.True(t, errors.Is(err, driver.ErrNotInitialized),
+		"error must be matchable with errors.Is, got [%v]", err)
+	require.True(t, strings.Contains(err.Error(), "mychannel"),
+		"error must name the channel, got [%v]", err)
+}
+
+func TestGetAfterUpdate(t *testing.T) {
+	t.Parallel()
+
+	h := configstate.NewHolder[*config]("mychannel")
+	require.NoError(t, h.Update(func(*config, bool) (*config, error) {
+		return &config{id: "first"}, nil
+	}))
+
+	v, err := h.Get()
+	require.NoError(t, err)
+	require.Equal(t, "first", v.id)
+}
+
+func TestFailedUpdateLeavesPreviousValue(t *testing.T) {
+	t.Parallel()
+
+	h := configstate.NewHolder[*config]("mychannel")
+	require.NoError(t, h.Update(func(*config, bool) (*config, error) {
+		return &config{id: "first"}, nil
+	}))
+
+	require.EqualError(t, h.Update(func(*config, bool) (*config, error) {
+		return &config{id: "second"}, errors.New("boom")
+	}), "boom")
+
+	v, err := h.Get()
+	require.NoError(t, err)
+	require.Equal(t, "first", v.id, "a failed update must not clobber the held value")
+}
+
+func TestFailedFirstUpdateStaysUninitialized(t *testing.T) {
+	t.Parallel()
+
+	h := configstate.NewHolder[*config]("mychannel")
+	require.Error(t, h.Update(func(*config, bool) (*config, error) {
+		return nil, errors.New("boom")
+	}))
+
+	_, err := h.Get()
+	require.True(t, errors.Is(err, driver.ErrNotInitialized))
+}
+
+func TestUpdateSeesCurrentValue(t *testing.T) {
+	t.Parallel()
+
+	h := configstate.NewHolder[*config]("mychannel")
+
+	require.NoError(t, h.Update(func(cur *config, loaded bool) (*config, error) {
+		require.False(t, loaded)
+		require.Nil(t, cur)
+		return &config{id: "first"}, nil
+	}))
+
+	require.NoError(t, h.Update(func(cur *config, loaded bool) (*config, error) {
+		require.True(t, loaded)
+		require.Equal(t, "first", cur.id)
+		return &config{id: "second"}, nil
+	}))
+}
+
+func TestTryGet(t *testing.T) {
+	t.Parallel()
+
+	h := configstate.NewHolder[*config]("mychannel")
+
+	v, ok := h.TryGet()
+	require.False(t, ok)
+	require.Nil(t, v)
+
+	require.NoError(t, h.Update(func(*config, bool) (*config, error) {
+		return &config{id: "first"}, nil
+	}))
+
+	v, ok = h.TryGet()
+	require.True(t, ok)
+	require.Equal(t, "first", v.id)
+}
+
+func TestInterfaceValueIsNotMistakenForLoaded(t *testing.T) {
+	t.Parallel()
+
+	type iface interface{ ID() string }
+
+	h := configstate.NewHolder[iface]("mychannel")
+	_, err := h.Get()
+	require.True(t, errors.Is(err, driver.ErrNotInitialized))
+
+	require.NoError(t, h.Update(func(iface, bool) (iface, error) { return nil, nil }))
+
+	v, ok := h.TryGet()
+	require.True(t, ok, "an explicit nil update still counts as loaded")
+	require.Nil(t, v)
+}
+
+func TestConcurrentAccessIsRaceFree(t *testing.T) {
+	t.Parallel()
+
+	h := configstate.NewHolder[*config]("mychannel")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(2)
+		go func() { defer wg.Done(); _, _ = h.Get() }()
+		go func() {
+			defer wg.Done()
+			_ = h.Update(func(*config, bool) (*config, error) { return &config{id: "x"}, nil })
+		}()
+	}
+	wg.Wait()
+
+	v, err := h.Get()
+	require.NoError(t, err)
+	require.Equal(t, "x", v.id)
+}

--- a/platform/fabric/core/generic/membership/membership.go
+++ b/platform/fabric/core/generic/membership/membership.go
@@ -7,13 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package membership
 
 import (
-	"fmt"
-	"sync"
-
 	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/configstate"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/membership/channelconfig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/msp"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/protoutil"
@@ -22,42 +20,35 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
-var ErrChannelResourcesNotInitialized = errors.New("channel resources not initialized")
-
+// Service answers membership questions about a channel from its current
+// configuration. The configuration is not available when the service is built;
+// it arrives with the first configuration block, via Update. Every accessor
+// therefore reports driver.ErrNotInitialized until that happens.
 type Service struct {
-	// resourcesLock is used to serialize access to channelResources
-	resourcesLock sync.RWMutex
-	// channelResources is used to acquire ChannelConfig.
-	channelResources *channelconfig.ChannelConfig
+	// config holds the channel configuration once it has been loaded. Reading
+	// it goes through configstate.Holder.Get, which cannot hand out a
+	// configuration that is not there.
+	config *configstate.Holder[*channelconfig.ChannelConfig]
 
 	channelName string
 }
 
 func NewService(channelName string) *Service {
-	return &Service{channelName: channelName}
-}
-
-func (c *Service) resources() *channelconfig.ChannelConfig {
-	c.resourcesLock.RLock()
-	res := c.channelResources
-	c.resourcesLock.RUnlock()
-	return res
-}
-
-func (c *Service) Update(env *cb.Envelope) error {
-	c.resourcesLock.Lock()
-	defer c.resourcesLock.Unlock()
-
-	b, err := c.parseConfig(env)
-	if err != nil {
-		return err
+	return &Service{
+		config:      configstate.NewHolder[*channelconfig.ChannelConfig](channelName),
+		channelName: channelName,
 	}
-
-	c.channelResources = b
-	return nil
 }
 
-func (c *Service) parseConfig(env *cb.Envelope) (*channelconfig.ChannelConfig, error) {
+// Update installs the channel configuration carried by env. The previously held
+// configuration is kept if env cannot be parsed.
+func (c *Service) Update(env *cb.Envelope) error {
+	return c.config.Update(func(*channelconfig.ChannelConfig, bool) (*channelconfig.ChannelConfig, error) {
+		return parseConfig(env)
+	})
+}
+
+func parseConfig(env *cb.Envelope) (*channelconfig.ChannelConfig, error) {
 	payload, err := protoutil.UnmarshalPayload(env.Payload)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot get payload from config transaction")
@@ -72,10 +63,11 @@ func (c *Service) parseConfig(env *cb.Envelope) (*channelconfig.ChannelConfig, e
 }
 
 func (c *Service) IsValid(identity view.Identity) error {
-	res := c.resources()
-	if res == nil {
-		return ErrChannelResourcesNotInitialized
+	res, err := c.config.Get()
+	if err != nil {
+		return err
 	}
+
 	id, err := res.MSPManager().DeserializeIdentity(identity)
 	if err != nil {
 		return errors.Wrapf(err, "failed deserializing identity [%s]", identity.String())
@@ -85,65 +77,73 @@ func (c *Service) IsValid(identity view.Identity) error {
 }
 
 func (c *Service) GetVerifier(identity view.Identity) (driver.Verifier, error) {
-	res := c.resources()
-	if res == nil {
-		return nil, ErrChannelResourcesNotInitialized
+	res, err := c.config.Get()
+	if err != nil {
+		return nil, err
 	}
+
 	id, err := res.MSPManager().DeserializeIdentity(identity)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed deserializing identity [%s]", identity.String())
 	}
+
 	return id, nil
 }
 
 // GetMSPIDs retrieves the MSP IDs of the organizations in the current Channel
-// configuration.
-func (c *Service) GetMSPIDs() []string {
-	res := c.resources()
-	if res == nil {
-		panic(ErrChannelResourcesNotInitialized.Error())
-	}
-	ac := res.ApplicationConfig()
-	if ac == nil || ac.Organizations() == nil {
-		return nil
+// configuration. An empty result means the channel has no organizations; a
+// channel whose configuration has not been loaded yet reports
+// driver.ErrNotInitialized instead.
+func (c *Service) GetMSPIDs() ([]string, error) {
+	res, err := c.config.Get()
+	if err != nil {
+		return nil, err
 	}
 
 	var mspIDs []string
-	for _, org := range ac.Organizations() {
-		mspIDs = append(mspIDs, org.MSPID())
+	if ac := res.ApplicationConfig(); ac != nil {
+		for _, org := range ac.Organizations() {
+			mspIDs = append(mspIDs, org.MSPID())
+		}
 	}
 
-	return mspIDs
+	return mspIDs, nil
 }
 
-// IsIdemixMSP returns true if the MSP identified by mspID is of type Idemix.
-func (c *Service) IsIdemixMSP(mspID string) bool {
-	res := c.resources()
-	if res == nil {
-		panic(ErrChannelResourcesNotInitialized.Error())
+// IsIdemixMSP reports whether the MSP identified by mspID is of type Idemix.
+// A false result means the channel has such an MSP and it is not Idemix; a
+// channel whose configuration has not been loaded yet reports
+// driver.ErrNotInitialized instead, so a caller cannot mistake the startup
+// race for a definitive answer.
+func (c *Service) IsIdemixMSP(mspID string) (bool, error) {
+	res, err := c.config.Get()
+	if err != nil {
+		return false, err
 	}
+
 	ac := res.ApplicationConfig()
-	if ac == nil || ac.Organizations() == nil {
-		return false
+	if ac == nil {
+		return false, nil
 	}
 
 	for _, org := range ac.Organizations() {
 		if org.MSPID() == mspID {
-			return org.MSP().GetType() == msp.IDEMIX
+			return org.MSP().GetType() == msp.IDEMIX, nil
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 func (c *Service) OrdererConfig(cs driver.ConfigService) (string, []*grpc.ConnectionConfig, error) {
-	res := c.resources()
-	if res == nil {
-		return "", nil, ErrChannelResourcesNotInitialized
+	res, err := c.config.Get()
+	if err != nil {
+		return "", nil, err
 	}
+
 	oc := res.OrdererConfig()
 	if oc == nil {
-		return "", nil, fmt.Errorf("orderer config does not exist")
+		return "", nil, errors.Errorf("orderer config does not exist for channel [%s]", c.channelName)
 	}
 
 	tlsEnabled, isSet := cs.OrderingTLSEnabled()
@@ -182,8 +182,12 @@ func (c *Service) OrdererConfig(cs driver.ConfigService) (string, []*grpc.Connec
 
 // MSPManager returns the driver.MSPManager that reflects the current Channel
 // configuration. Users should not memoize references to this object.
+//
+// The manager resolves the configuration on each call rather than capturing it
+// here, so obtaining one before the channel configuration has been loaded is
+// allowed; the failure surfaces from DeserializeIdentity.
 func (c *Service) MSPManager() driver.MSPManager {
-	return &mspManager{service: c}
+	return &mspManager{config: c.config}
 }
 
 func (c *Service) CheckACL(signedProp driver.SignedProposal) error {
@@ -191,15 +195,14 @@ func (c *Service) CheckACL(signedProp driver.SignedProposal) error {
 }
 
 type mspManager struct {
-	service *Service
+	config *configstate.Holder[*channelconfig.ChannelConfig]
 }
 
-// DeserializeIdentity deserializes an identity.
-// Returns an error if the channel resources are not yet initialized.
 func (m *mspManager) DeserializeIdentity(serializedIdentity []byte) (driver.MSPIdentity, error) {
-	res := m.service.resources()
-	if res == nil {
-		return nil, errors.Errorf("cannot deserialize identity, channel resources not yet initialized for channel [%s]", m.service.channelName)
+	res, err := m.config.Get()
+	if err != nil {
+		return nil, err
 	}
+
 	return res.MSPManager().DeserializeIdentity(serializedIdentity)
 }

--- a/platform/fabric/core/generic/membership/membership.go
+++ b/platform/fabric/core/generic/membership/membership.go
@@ -22,6 +22,8 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
+var ErrChannelResourcesNotInitialized = errors.New("channel resources not initialized")
+
 type Service struct {
 	// resourcesLock is used to serialize access to channelResources
 	resourcesLock sync.RWMutex
@@ -70,7 +72,11 @@ func (c *Service) parseConfig(env *cb.Envelope) (*channelconfig.ChannelConfig, e
 }
 
 func (c *Service) IsValid(identity view.Identity) error {
-	id, err := c.resources().MSPManager().DeserializeIdentity(identity)
+	res := c.resources()
+	if res == nil {
+		return ErrChannelResourcesNotInitialized
+	}
+	id, err := res.MSPManager().DeserializeIdentity(identity)
 	if err != nil {
 		return errors.Wrapf(err, "failed deserializing identity [%s]", identity.String())
 	}
@@ -79,7 +85,11 @@ func (c *Service) IsValid(identity view.Identity) error {
 }
 
 func (c *Service) GetVerifier(identity view.Identity) (driver.Verifier, error) {
-	id, err := c.resources().MSPManager().DeserializeIdentity(identity)
+	res := c.resources()
+	if res == nil {
+		return nil, ErrChannelResourcesNotInitialized
+	}
+	id, err := res.MSPManager().DeserializeIdentity(identity)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed deserializing identity [%s]", identity.String())
 	}
@@ -89,7 +99,11 @@ func (c *Service) GetVerifier(identity view.Identity) (driver.Verifier, error) {
 // GetMSPIDs retrieves the MSP IDs of the organizations in the current Channel
 // configuration.
 func (c *Service) GetMSPIDs() []string {
-	ac := c.resources().ApplicationConfig()
+	res := c.resources()
+	if res == nil {
+		panic(ErrChannelResourcesNotInitialized.Error())
+	}
+	ac := res.ApplicationConfig()
 	if ac == nil || ac.Organizations() == nil {
 		return nil
 	}
@@ -104,7 +118,11 @@ func (c *Service) GetMSPIDs() []string {
 
 // IsIdemixMSP returns true if the MSP identified by mspID is of type Idemix.
 func (c *Service) IsIdemixMSP(mspID string) bool {
-	ac := c.resources().ApplicationConfig()
+	res := c.resources()
+	if res == nil {
+		panic(ErrChannelResourcesNotInitialized.Error())
+	}
+	ac := res.ApplicationConfig()
 	if ac == nil || ac.Organizations() == nil {
 		return false
 	}
@@ -119,7 +137,11 @@ func (c *Service) IsIdemixMSP(mspID string) bool {
 }
 
 func (c *Service) OrdererConfig(cs driver.ConfigService) (string, []*grpc.ConnectionConfig, error) {
-	oc := c.resources().OrdererConfig()
+	res := c.resources()
+	if res == nil {
+		return "", nil, ErrChannelResourcesNotInitialized
+	}
+	oc := res.OrdererConfig()
 	if oc == nil {
 		return "", nil, fmt.Errorf("orderer config does not exist")
 	}
@@ -158,24 +180,26 @@ func (c *Service) OrdererConfig(cs driver.ConfigService) (string, []*grpc.Connec
 	return oc.ConsensusType(), newOrderers, nil
 }
 
-// MSPManager returns the msp.MSPManager that reflects the current Channel
+// MSPManager returns the driver.MSPManager that reflects the current Channel
 // configuration. Users should not memoize references to this object.
 func (c *Service) MSPManager() driver.MSPManager {
-	return &mspManager{FabricMSPManager: c.resources().MSPManager()}
+	return &mspManager{service: c}
 }
 
 func (c *Service) CheckACL(signedProp driver.SignedProposal) error {
 	return driver.ErrNotImplemented
 }
 
-type FabricMSPManager interface {
-	DeserializeIdentity(serializedIdentity []byte) (msp.Identity, error)
-}
-
 type mspManager struct {
-	FabricMSPManager
+	service *Service
 }
 
+// DeserializeIdentity deserializes an identity.
+// Returns an error if the channel resources are not yet initialized.
 func (m *mspManager) DeserializeIdentity(serializedIdentity []byte) (driver.MSPIdentity, error) {
-	return m.FabricMSPManager.DeserializeIdentity(serializedIdentity)
+	res := m.service.resources()
+	if res == nil {
+		return nil, errors.Errorf("cannot deserialize identity, channel resources not yet initialized for channel [%s]", m.service.channelName)
+	}
+	return res.MSPManager().DeserializeIdentity(serializedIdentity)
 }

--- a/platform/fabric/core/generic/membership/membership_test.go
+++ b/platform/fabric/core/generic/membership/membership_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package membership
+
+import (
+	"strings"
+	"testing"
+
+	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/membership/channelconfig"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
+
+var _ driver.MembershipService = (*Service)(nil)
+
+// seed installs cfg as the service's channel configuration, standing in for the
+// first successful Update.
+func seed(t *testing.T, s *Service, cfg *channelconfig.ChannelConfig) {
+	t.Helper()
+	require.NoError(t, s.config.Update(func(*channelconfig.ChannelConfig, bool) (*channelconfig.ChannelConfig, error) {
+		return cfg, nil
+	}))
+}
+
+// TestAccessorsBeforeFirstUpdate is the regression test for the nil dereference
+// that crashed nodes when a channel was used before its first configuration
+// block arrived. Every accessor must report the condition instead of panicking.
+func TestAccessorsBeforeFirstUpdate(t *testing.T) {
+	t.Parallel()
+
+	identity := view.Identity("some-identity")
+
+	for _, tc := range []struct {
+		name string
+		call func(s *Service) error
+	}{
+		{"IsValid", func(s *Service) error {
+			return s.IsValid(identity)
+		}},
+		{"GetVerifier", func(s *Service) error {
+			v, err := s.GetVerifier(identity)
+			require.Nil(t, v)
+			return err
+		}},
+		{"GetMSPIDs", func(s *Service) error {
+			ids, err := s.GetMSPIDs()
+			require.Nil(t, ids)
+			return err
+		}},
+		{"OrdererConfig", func(s *Service) error {
+			ct, eps, err := s.OrdererConfig(nil)
+			require.Empty(t, ct)
+			require.Nil(t, eps)
+			return err
+		}},
+		{"IsIdemixMSP", func(s *Service) error {
+			isIdemix, err := s.IsIdemixMSP("Org1MSP")
+			require.False(t, isIdemix)
+			return err
+		}},
+		{"MSPManager.DeserializeIdentity", func(s *Service) error {
+			id, err := s.MSPManager().DeserializeIdentity(identity)
+			require.Nil(t, id)
+			return err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := NewService("mychannel")
+
+			var err error
+			require.NotPanics(t, func() { err = tc.call(s) })
+
+			require.Error(t, err)
+			require.ErrorIs(t, err, driver.ErrNotInitialized)
+			require.True(t, strings.Contains(err.Error(), "mychannel"),
+				"error should name the channel, got [%v]", err)
+		})
+	}
+}
+
+// TestMSPManagerIsUsableBeforeFirstUpdate pins the lazy contract: obtaining a
+// manager before the configuration exists is allowed, and the failure surfaces
+// when it is used rather than when it is fetched.
+func TestMSPManagerIsUsableBeforeFirstUpdate(t *testing.T) {
+	t.Parallel()
+	s := NewService("mychannel")
+
+	var mgr driver.MSPManager
+	require.NotPanics(t, func() { mgr = s.MSPManager() })
+	require.NotNil(t, mgr)
+
+	_, err := mgr.DeserializeIdentity(view.Identity("some-identity"))
+	require.ErrorIs(t, err, driver.ErrNotInitialized)
+}
+
+func TestUpdateWithInvalidEnvelopeLeavesServiceUninitialized(t *testing.T) {
+	t.Parallel()
+	s := NewService("mychannel")
+
+	require.Error(t, s.Update(&cb.Envelope{Payload: []byte("not-a-proto")}))
+
+	_, err := s.GetMSPIDs()
+	require.ErrorIs(t, err, driver.ErrNotInitialized,
+		"a rejected configuration must leave the service uninitialized")
+}
+
+// TestLoadedConfigIsDistinguishableFromMissingConfig is the point of the
+// refactoring: an empty answer from a loaded configuration and an absent
+// configuration are no longer the same result.
+func TestLoadedConfigIsDistinguishableFromMissingConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("GetMSPIDs on a config with no application section", func(t *testing.T) {
+		t.Parallel()
+		s := NewService("mychannel")
+		seed(t, s, &channelconfig.ChannelConfig{})
+
+		ids, err := s.GetMSPIDs()
+		require.NoError(t, err, "a loaded configuration must not report ErrNotInitialized")
+		require.Empty(t, ids)
+	})
+
+	t.Run("IsIdemixMSP on a config with no application section", func(t *testing.T) {
+		t.Parallel()
+		s := NewService("mychannel")
+		seed(t, s, &channelconfig.ChannelConfig{})
+
+		isIdemix, err := s.IsIdemixMSP("Org1MSP")
+		require.NoError(t, err, "a loaded configuration must not report ErrNotInitialized")
+		require.False(t, isIdemix)
+	})
+
+	t.Run("OrdererConfig on a config with no orderer section", func(t *testing.T) {
+		t.Parallel()
+		s := NewService("mychannel")
+		seed(t, s, &channelconfig.ChannelConfig{})
+
+		_, _, err := s.OrdererConfig(nil)
+		require.Error(t, err)
+		require.False(t, errors.Is(err, driver.ErrNotInitialized),
+			"a missing orderer section is a configuration problem, not a startup race")
+		require.Contains(t, err.Error(), "mychannel")
+	})
+}
+
+func TestCheckACLIsNotImplemented(t *testing.T) {
+	t.Parallel()
+	require.ErrorIs(t, NewService("mychannel").CheckACL(nil), driver.ErrNotImplemented)
+}

--- a/platform/fabric/core/generic/transaction/mock/channel_membership.go
+++ b/platform/fabric/core/generic/transaction/mock/channel_membership.go
@@ -20,15 +20,17 @@ type ChannelMembership struct {
 	checkACLReturnsOnCall map[int]struct {
 		result1 error
 	}
-	GetMSPIDsStub        func() []string
+	GetMSPIDsStub        func() ([]string, error)
 	getMSPIDsMutex       sync.RWMutex
 	getMSPIDsArgsForCall []struct {
 	}
 	getMSPIDsReturns struct {
 		result1 []string
+		result2 error
 	}
 	getMSPIDsReturnsOnCall map[int]struct {
 		result1 []string
+		result2 error
 	}
 	GetVerifierStub        func(view.Identity) (driver.Verifier, error)
 	getVerifierMutex       sync.RWMutex
@@ -43,6 +45,19 @@ type ChannelMembership struct {
 		result1 driver.Verifier
 		result2 error
 	}
+	IsIdemixMSPStub        func(string) (bool, error)
+	isIdemixMSPMutex       sync.RWMutex
+	isIdemixMSPArgsForCall []struct {
+		arg1 string
+	}
+	isIdemixMSPReturns struct {
+		result1 bool
+		result2 error
+	}
+	isIdemixMSPReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	IsValidStub        func(view.Identity) error
 	isValidMutex       sync.RWMutex
 	isValidArgsForCall []struct {
@@ -53,17 +68,6 @@ type ChannelMembership struct {
 	}
 	isValidReturnsOnCall map[int]struct {
 		result1 error
-	}
-	IsIdemixMSPStub        func(string) bool
-	isIdemixMSPMutex       sync.RWMutex
-	isIdemixMSPArgsForCall []struct {
-		arg1 string
-	}
-	isIdemixMSPReturns struct {
-		result1 bool
-	}
-	isIdemixMSPReturnsOnCall map[int]struct {
-		result1 bool
 	}
 	MSPManagerStub        func() driver.MSPManager
 	mSPManagerMutex       sync.RWMutex
@@ -140,7 +144,7 @@ func (fake *ChannelMembership) CheckACLReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *ChannelMembership) GetMSPIDs() []string {
+func (fake *ChannelMembership) GetMSPIDs() ([]string, error) {
 	fake.getMSPIDsMutex.Lock()
 	ret, specificReturn := fake.getMSPIDsReturnsOnCall[len(fake.getMSPIDsArgsForCall)]
 	fake.getMSPIDsArgsForCall = append(fake.getMSPIDsArgsForCall, struct {
@@ -153,9 +157,9 @@ func (fake *ChannelMembership) GetMSPIDs() []string {
 		return stub()
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *ChannelMembership) GetMSPIDsCallCount() int {
@@ -164,33 +168,36 @@ func (fake *ChannelMembership) GetMSPIDsCallCount() int {
 	return len(fake.getMSPIDsArgsForCall)
 }
 
-func (fake *ChannelMembership) GetMSPIDsCalls(stub func() []string) {
+func (fake *ChannelMembership) GetMSPIDsCalls(stub func() ([]string, error)) {
 	fake.getMSPIDsMutex.Lock()
 	defer fake.getMSPIDsMutex.Unlock()
 	fake.GetMSPIDsStub = stub
 }
 
-func (fake *ChannelMembership) GetMSPIDsReturns(result1 []string) {
+func (fake *ChannelMembership) GetMSPIDsReturns(result1 []string, result2 error) {
 	fake.getMSPIDsMutex.Lock()
 	defer fake.getMSPIDsMutex.Unlock()
 	fake.GetMSPIDsStub = nil
 	fake.getMSPIDsReturns = struct {
 		result1 []string
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *ChannelMembership) GetMSPIDsReturnsOnCall(i int, result1 []string) {
+func (fake *ChannelMembership) GetMSPIDsReturnsOnCall(i int, result1 []string, result2 error) {
 	fake.getMSPIDsMutex.Lock()
 	defer fake.getMSPIDsMutex.Unlock()
 	fake.GetMSPIDsStub = nil
 	if fake.getMSPIDsReturnsOnCall == nil {
 		fake.getMSPIDsReturnsOnCall = make(map[int]struct {
 			result1 []string
+			result2 error
 		})
 	}
 	fake.getMSPIDsReturnsOnCall[i] = struct {
 		result1 []string
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *ChannelMembership) GetVerifier(arg1 view.Identity) (driver.Verifier, error) {
@@ -257,6 +264,70 @@ func (fake *ChannelMembership) GetVerifierReturnsOnCall(i int, result1 driver.Ve
 	}{result1, result2}
 }
 
+func (fake *ChannelMembership) IsIdemixMSP(arg1 string) (bool, error) {
+	fake.isIdemixMSPMutex.Lock()
+	ret, specificReturn := fake.isIdemixMSPReturnsOnCall[len(fake.isIdemixMSPArgsForCall)]
+	fake.isIdemixMSPArgsForCall = append(fake.isIdemixMSPArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.IsIdemixMSPStub
+	fakeReturns := fake.isIdemixMSPReturns
+	fake.recordInvocation("IsIdemixMSP", []interface{}{arg1})
+	fake.isIdemixMSPMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *ChannelMembership) IsIdemixMSPCallCount() int {
+	fake.isIdemixMSPMutex.RLock()
+	defer fake.isIdemixMSPMutex.RUnlock()
+	return len(fake.isIdemixMSPArgsForCall)
+}
+
+func (fake *ChannelMembership) IsIdemixMSPCalls(stub func(string) (bool, error)) {
+	fake.isIdemixMSPMutex.Lock()
+	defer fake.isIdemixMSPMutex.Unlock()
+	fake.IsIdemixMSPStub = stub
+}
+
+func (fake *ChannelMembership) IsIdemixMSPArgsForCall(i int) string {
+	fake.isIdemixMSPMutex.RLock()
+	defer fake.isIdemixMSPMutex.RUnlock()
+	argsForCall := fake.isIdemixMSPArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *ChannelMembership) IsIdemixMSPReturns(result1 bool, result2 error) {
+	fake.isIdemixMSPMutex.Lock()
+	defer fake.isIdemixMSPMutex.Unlock()
+	fake.IsIdemixMSPStub = nil
+	fake.isIdemixMSPReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ChannelMembership) IsIdemixMSPReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.isIdemixMSPMutex.Lock()
+	defer fake.isIdemixMSPMutex.Unlock()
+	fake.IsIdemixMSPStub = nil
+	if fake.isIdemixMSPReturnsOnCall == nil {
+		fake.isIdemixMSPReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.isIdemixMSPReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *ChannelMembership) IsValid(arg1 view.Identity) error {
 	fake.isValidMutex.Lock()
 	ret, specificReturn := fake.isValidReturnsOnCall[len(fake.isValidArgsForCall)]
@@ -315,67 +386,6 @@ func (fake *ChannelMembership) IsValidReturnsOnCall(i int, result1 error) {
 	}
 	fake.isValidReturnsOnCall[i] = struct {
 		result1 error
-	}{result1}
-}
-
-func (fake *ChannelMembership) IsIdemixMSP(arg1 string) bool {
-	fake.isIdemixMSPMutex.Lock()
-	ret, specificReturn := fake.isIdemixMSPReturnsOnCall[len(fake.isIdemixMSPArgsForCall)]
-	fake.isIdemixMSPArgsForCall = append(fake.isIdemixMSPArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	stub := fake.IsIdemixMSPStub
-	fakeReturns := fake.isIdemixMSPReturns
-	fake.recordInvocation("IsIdemixMSP", []interface{}{arg1})
-	fake.isIdemixMSPMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *ChannelMembership) IsIdemixMSPCallCount() int {
-	fake.isIdemixMSPMutex.RLock()
-	defer fake.isIdemixMSPMutex.RUnlock()
-	return len(fake.isIdemixMSPArgsForCall)
-}
-
-func (fake *ChannelMembership) IsIdemixMSPCalls(stub func(string) bool) {
-	fake.isIdemixMSPMutex.Lock()
-	defer fake.isIdemixMSPMutex.Unlock()
-	fake.IsIdemixMSPStub = stub
-}
-
-func (fake *ChannelMembership) IsIdemixMSPArgsForCall(i int) string {
-	fake.isIdemixMSPMutex.RLock()
-	defer fake.isIdemixMSPMutex.RUnlock()
-	argsForCall := fake.isIdemixMSPArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *ChannelMembership) IsIdemixMSPReturns(result1 bool) {
-	fake.isIdemixMSPMutex.Lock()
-	defer fake.isIdemixMSPMutex.Unlock()
-	fake.IsIdemixMSPStub = nil
-	fake.isIdemixMSPReturns = struct {
-		result1 bool
-	}{result1}
-}
-
-func (fake *ChannelMembership) IsIdemixMSPReturnsOnCall(i int, result1 bool) {
-	fake.isIdemixMSPMutex.Lock()
-	defer fake.isIdemixMSPMutex.Unlock()
-	fake.IsIdemixMSPStub = nil
-	if fake.isIdemixMSPReturnsOnCall == nil {
-		fake.isIdemixMSPReturnsOnCall = make(map[int]struct {
-			result1 bool
-		})
-	}
-	fake.isIdemixMSPReturnsOnCall[i] = struct {
-		result1 bool
 	}{result1}
 }
 

--- a/platform/fabric/driver/errors.go
+++ b/platform/fabric/driver/errors.go
@@ -12,3 +12,12 @@ import (
 
 // ErrNotImplemented signals that a function is not implemented
 var ErrNotImplemented = errors.New("not implemented")
+
+// ErrNotInitialized signals that a service cannot answer yet because the
+// configuration it depends on has not been loaded.
+//
+// This is a transient startup condition, not a permanent failure: channel
+// configuration is loaded asynchronously after the owning service is
+// constructed, so a caller racing that load observes it legitimately. Callers
+// that can tolerate the race should test for it with errors.Is and retry.
+var ErrNotInitialized = errors.New("not initialized")

--- a/platform/fabric/driver/membership.go
+++ b/platform/fabric/driver/membership.go
@@ -47,24 +47,83 @@ type MSPIdentity interface {
 	Verify(message, sigma []byte) error
 }
 
+// MSPManager resolves serialized identities against the MSPs of a channel.
+//
+// A manager reflects the channel configuration in force at the time each of its
+// methods is called, not the configuration in force when it was obtained, so
+// callers should not memoize one.
 type MSPManager interface {
+	// DeserializeIdentity turns a serialized identity into an MSPIdentity
+	// belonging to one of the channel's MSPs. It fails if the identity does not
+	// belong to any of them, and returns an error wrapping ErrNotInitialized
+	// while the channel configuration has not been loaded yet.
 	DeserializeIdentity(serializedIdentity []byte) (MSPIdentity, error)
 }
 
+// ChannelMembership answers membership questions about a channel from its
+// current configuration: which organizations belong to it, and whether a given
+// identity is one the channel recognizes.
+//
+// A channel's configuration is not available as soon as the channel exists: it
+// is loaded asynchronously, with the first configuration block on Fabric and
+// with the first successful poll of the config monitor on Fabric-x. Until then
+// every method here reports an error wrapping ErrNotInitialized rather than
+// answering from an empty configuration. A caller racing node startup can
+// detect that case with errors.Is and retry; treating it as a permanent failure
+// will misreport a node that is merely still coming up.
 type ChannelMembership interface {
-	GetMSPIDs() []string
+	// GetMSPIDs returns the MSP IDs of the organizations in the current channel
+	// configuration. An empty result means the channel has no organizations; a
+	// channel whose configuration has not been loaded yet reports an error
+	// wrapping ErrNotInitialized instead.
+	GetMSPIDs() ([]string, error)
+	// MSPManager returns a manager backed by the channel's current
+	// configuration. It never returns nil and may be called before the
+	// configuration has been loaded; that failure surfaces from the manager's
+	// own methods. Callers should not memoize the returned value.
 	MSPManager() MSPManager
+	// IsValid reports whether identity is one the channel recognizes, by
+	// deserializing it against the channel's MSPs and validating it. A nil
+	// error means the identity is valid. It returns an error wrapping
+	// ErrNotInitialized while the channel configuration has not been loaded.
 	IsValid(identity view.Identity) error
+	// GetVerifier returns a Verifier that checks signatures produced by
+	// identity. It fails if identity is not one the channel recognizes, and
+	// returns an error wrapping ErrNotInitialized while the channel
+	// configuration has not been loaded.
 	GetVerifier(identity view.Identity) (Verifier, error)
 	// CheckACL checks the ACL for the resource for the Channel using the
-	// SignedProposal from which an id can be extracted for testing against a policy
+	// SignedProposal from which an id can be extracted for testing against a
+	// policy. Implementations that do not enforce ACLs return
+	// ErrNotImplemented; those that do return an error wrapping
+	// ErrNotInitialized while the channel configuration has not been loaded.
 	CheckACL(signedProp SignedProposal) error
-	// IsIdemixMSP returns true if the MSP with the given ID is of type Idemix.
-	IsIdemixMSP(mspID string) bool
+	// IsIdemixMSP reports whether the MSP with the given ID is of type Idemix.
+	// A false result means the channel has such an MSP and it is not Idemix; a
+	// channel whose configuration has not been loaded yet reports an error
+	// wrapping ErrNotInitialized instead, so callers choosing an identity
+	// encoding from this cannot mistake the startup race for a real answer.
+	IsIdemixMSP(mspID string) (bool, error)
 }
 
+// MembershipService is the driver-side view of a channel's membership: a
+// ChannelMembership that also owns the configuration the answers come from.
+//
+// Reading membership is the concern of ChannelMembership; the two methods added
+// here belong to whoever feeds the channel configuration in and configures the
+// ordering service from it, which is the committer on Fabric and the channel
+// config monitor on Fabric-x.
 type MembershipService interface {
 	ChannelMembership
+	// Update installs the channel configuration carried by env, replacing the
+	// one currently in force. If env is rejected, the previously installed
+	// configuration is left in place, so a bad update cannot leave the service
+	// with no configuration at all.
 	Update(env *common.Envelope) error
+	// OrdererConfig returns the consensus type and the orderer endpoints in the
+	// current channel configuration, with the TLS settings from cs applied. It
+	// fails if the configuration carries no orderer section, and returns an
+	// error wrapping ErrNotInitialized while the configuration has not been
+	// loaded yet.
 	OrdererConfig(cs ConfigService) (string, []*grpc.ConnectionConfig, error)
 }

--- a/platform/fabric/membership.go
+++ b/platform/fabric/membership.go
@@ -142,7 +142,11 @@ type MSPManager struct {
 	ch driver.ChannelMembership
 }
 
-func (c *MSPManager) GetMSPIDs() []string {
+// GetMSPIDs returns the MSP IDs of the organizations in the channel's current
+// configuration. It fails while that configuration has not been loaded yet;
+// callers racing node startup can detect this with
+// errors.Is(err, driver.ErrNotInitialized).
+func (c *MSPManager) GetMSPIDs() ([]string, error) {
 	return c.ch.GetMSPIDs()
 }
 

--- a/platform/fabric/services/endorser/mock/channel_membership.go
+++ b/platform/fabric/services/endorser/mock/channel_membership.go
@@ -20,15 +20,17 @@ type ChannelMembership struct {
 	checkACLReturnsOnCall map[int]struct {
 		result1 error
 	}
-	GetMSPIDsStub        func() []string
+	GetMSPIDsStub        func() ([]string, error)
 	getMSPIDsMutex       sync.RWMutex
 	getMSPIDsArgsForCall []struct {
 	}
 	getMSPIDsReturns struct {
 		result1 []string
+		result2 error
 	}
 	getMSPIDsReturnsOnCall map[int]struct {
 		result1 []string
+		result2 error
 	}
 	GetVerifierStub        func(view.Identity) (driver.Verifier, error)
 	getVerifierMutex       sync.RWMutex
@@ -43,6 +45,19 @@ type ChannelMembership struct {
 		result1 driver.Verifier
 		result2 error
 	}
+	IsIdemixMSPStub        func(string) (bool, error)
+	isIdemixMSPMutex       sync.RWMutex
+	isIdemixMSPArgsForCall []struct {
+		arg1 string
+	}
+	isIdemixMSPReturns struct {
+		result1 bool
+		result2 error
+	}
+	isIdemixMSPReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	IsValidStub        func(view.Identity) error
 	isValidMutex       sync.RWMutex
 	isValidArgsForCall []struct {
@@ -53,17 +68,6 @@ type ChannelMembership struct {
 	}
 	isValidReturnsOnCall map[int]struct {
 		result1 error
-	}
-	IsIdemixMSPStub        func(string) bool
-	isIdemixMSPMutex       sync.RWMutex
-	isIdemixMSPArgsForCall []struct {
-		arg1 string
-	}
-	isIdemixMSPReturns struct {
-		result1 bool
-	}
-	isIdemixMSPReturnsOnCall map[int]struct {
-		result1 bool
 	}
 	MSPManagerStub        func() driver.MSPManager
 	mSPManagerMutex       sync.RWMutex
@@ -140,7 +144,7 @@ func (fake *ChannelMembership) CheckACLReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *ChannelMembership) GetMSPIDs() []string {
+func (fake *ChannelMembership) GetMSPIDs() ([]string, error) {
 	fake.getMSPIDsMutex.Lock()
 	ret, specificReturn := fake.getMSPIDsReturnsOnCall[len(fake.getMSPIDsArgsForCall)]
 	fake.getMSPIDsArgsForCall = append(fake.getMSPIDsArgsForCall, struct {
@@ -153,9 +157,9 @@ func (fake *ChannelMembership) GetMSPIDs() []string {
 		return stub()
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *ChannelMembership) GetMSPIDsCallCount() int {
@@ -164,33 +168,36 @@ func (fake *ChannelMembership) GetMSPIDsCallCount() int {
 	return len(fake.getMSPIDsArgsForCall)
 }
 
-func (fake *ChannelMembership) GetMSPIDsCalls(stub func() []string) {
+func (fake *ChannelMembership) GetMSPIDsCalls(stub func() ([]string, error)) {
 	fake.getMSPIDsMutex.Lock()
 	defer fake.getMSPIDsMutex.Unlock()
 	fake.GetMSPIDsStub = stub
 }
 
-func (fake *ChannelMembership) GetMSPIDsReturns(result1 []string) {
+func (fake *ChannelMembership) GetMSPIDsReturns(result1 []string, result2 error) {
 	fake.getMSPIDsMutex.Lock()
 	defer fake.getMSPIDsMutex.Unlock()
 	fake.GetMSPIDsStub = nil
 	fake.getMSPIDsReturns = struct {
 		result1 []string
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *ChannelMembership) GetMSPIDsReturnsOnCall(i int, result1 []string) {
+func (fake *ChannelMembership) GetMSPIDsReturnsOnCall(i int, result1 []string, result2 error) {
 	fake.getMSPIDsMutex.Lock()
 	defer fake.getMSPIDsMutex.Unlock()
 	fake.GetMSPIDsStub = nil
 	if fake.getMSPIDsReturnsOnCall == nil {
 		fake.getMSPIDsReturnsOnCall = make(map[int]struct {
 			result1 []string
+			result2 error
 		})
 	}
 	fake.getMSPIDsReturnsOnCall[i] = struct {
 		result1 []string
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *ChannelMembership) GetVerifier(arg1 view.Identity) (driver.Verifier, error) {
@@ -257,6 +264,70 @@ func (fake *ChannelMembership) GetVerifierReturnsOnCall(i int, result1 driver.Ve
 	}{result1, result2}
 }
 
+func (fake *ChannelMembership) IsIdemixMSP(arg1 string) (bool, error) {
+	fake.isIdemixMSPMutex.Lock()
+	ret, specificReturn := fake.isIdemixMSPReturnsOnCall[len(fake.isIdemixMSPArgsForCall)]
+	fake.isIdemixMSPArgsForCall = append(fake.isIdemixMSPArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.IsIdemixMSPStub
+	fakeReturns := fake.isIdemixMSPReturns
+	fake.recordInvocation("IsIdemixMSP", []interface{}{arg1})
+	fake.isIdemixMSPMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *ChannelMembership) IsIdemixMSPCallCount() int {
+	fake.isIdemixMSPMutex.RLock()
+	defer fake.isIdemixMSPMutex.RUnlock()
+	return len(fake.isIdemixMSPArgsForCall)
+}
+
+func (fake *ChannelMembership) IsIdemixMSPCalls(stub func(string) (bool, error)) {
+	fake.isIdemixMSPMutex.Lock()
+	defer fake.isIdemixMSPMutex.Unlock()
+	fake.IsIdemixMSPStub = stub
+}
+
+func (fake *ChannelMembership) IsIdemixMSPArgsForCall(i int) string {
+	fake.isIdemixMSPMutex.RLock()
+	defer fake.isIdemixMSPMutex.RUnlock()
+	argsForCall := fake.isIdemixMSPArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *ChannelMembership) IsIdemixMSPReturns(result1 bool, result2 error) {
+	fake.isIdemixMSPMutex.Lock()
+	defer fake.isIdemixMSPMutex.Unlock()
+	fake.IsIdemixMSPStub = nil
+	fake.isIdemixMSPReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ChannelMembership) IsIdemixMSPReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.isIdemixMSPMutex.Lock()
+	defer fake.isIdemixMSPMutex.Unlock()
+	fake.IsIdemixMSPStub = nil
+	if fake.isIdemixMSPReturnsOnCall == nil {
+		fake.isIdemixMSPReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.isIdemixMSPReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *ChannelMembership) IsValid(arg1 view.Identity) error {
 	fake.isValidMutex.Lock()
 	ret, specificReturn := fake.isValidReturnsOnCall[len(fake.isValidArgsForCall)]
@@ -315,67 +386,6 @@ func (fake *ChannelMembership) IsValidReturnsOnCall(i int, result1 error) {
 	}
 	fake.isValidReturnsOnCall[i] = struct {
 		result1 error
-	}{result1}
-}
-
-func (fake *ChannelMembership) IsIdemixMSP(arg1 string) bool {
-	fake.isIdemixMSPMutex.Lock()
-	ret, specificReturn := fake.isIdemixMSPReturnsOnCall[len(fake.isIdemixMSPArgsForCall)]
-	fake.isIdemixMSPArgsForCall = append(fake.isIdemixMSPArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	stub := fake.IsIdemixMSPStub
-	fakeReturns := fake.isIdemixMSPReturns
-	fake.recordInvocation("IsIdemixMSP", []interface{}{arg1})
-	fake.isIdemixMSPMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *ChannelMembership) IsIdemixMSPCallCount() int {
-	fake.isIdemixMSPMutex.RLock()
-	defer fake.isIdemixMSPMutex.RUnlock()
-	return len(fake.isIdemixMSPArgsForCall)
-}
-
-func (fake *ChannelMembership) IsIdemixMSPCalls(stub func(string) bool) {
-	fake.isIdemixMSPMutex.Lock()
-	defer fake.isIdemixMSPMutex.Unlock()
-	fake.IsIdemixMSPStub = stub
-}
-
-func (fake *ChannelMembership) IsIdemixMSPArgsForCall(i int) string {
-	fake.isIdemixMSPMutex.RLock()
-	defer fake.isIdemixMSPMutex.RUnlock()
-	argsForCall := fake.isIdemixMSPArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *ChannelMembership) IsIdemixMSPReturns(result1 bool) {
-	fake.isIdemixMSPMutex.Lock()
-	defer fake.isIdemixMSPMutex.Unlock()
-	fake.IsIdemixMSPStub = nil
-	fake.isIdemixMSPReturns = struct {
-		result1 bool
-	}{result1}
-}
-
-func (fake *ChannelMembership) IsIdemixMSPReturnsOnCall(i int, result1 bool) {
-	fake.isIdemixMSPMutex.Lock()
-	defer fake.isIdemixMSPMutex.Unlock()
-	fake.IsIdemixMSPStub = nil
-	if fake.isIdemixMSPReturnsOnCall == nil {
-		fake.isIdemixMSPReturnsOnCall = make(map[int]struct {
-			result1 bool
-		})
-	}
-	fake.isIdemixMSPReturnsOnCall[i] = struct {
-		result1 bool
 	}{result1}
 }
 

--- a/platform/fabricx/core/membership/membership.go
+++ b/platform/fabricx/core/membership/membership.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package membership
 
 import (
-	"sync"
-
 	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
 	m "github.com/hyperledger/fabric-protos-go-apiv2/msp"
@@ -26,6 +24,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/configstate"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
@@ -33,11 +32,15 @@ import (
 
 var logger = logging.MustGetLogger()
 
+// Service answers membership questions about a channel from its current
+// configuration. The configuration is not available when the service is built;
+// it arrives with the first poll of the channel config monitor, via Update.
+// Every accessor therefore reports driver.ErrNotInitialized until that happens.
 type Service struct {
-	// ResourcesLock is used to serialize access to resources
-	resourcesLock sync.RWMutex
-	// resources is used to acquire configuration bundle resources.
-	channelResources channelconfig.Resources
+	// config holds the channel configuration once it has been loaded. Reading
+	// it goes through configstate.Holder.Get, which cannot hand out a
+	// configuration that is not there.
+	config *configstate.Holder[channelconfig.Resources]
 
 	ACLProvider aclmgmt.ACLProvider
 
@@ -46,19 +49,26 @@ type Service struct {
 
 func NewService(channelID string) *Service {
 	s := &Service{
-		channelID:   channelID,
-		ACLProvider: nil,
+		config:    configstate.NewHolder[channelconfig.Resources](channelID),
+		channelID: channelID,
 	}
 	policyChecker := policy.NewPolicyChecker(
-		&policyManagerGetterFunc{channelID: channelID, resourcesGetter: s.resources},
+		&policyManagerGetterFunc{channelID: channelID, config: s.config},
 		mgmt.GetLocalMSP(factory.GetDefault()),
 	)
 	s.ACLProvider = aclmgmt.NewACLProvider(
 		func(cid string) channelconfig.Resources {
-			if cid == s.channelID {
-				return s.resources()
+			if cid != s.channelID {
+				return nil
 			}
-			return nil
+			// A channel whose configuration has not loaded yet is reported the
+			// same way as an unknown channel. CheckACL rejects that case before
+			// delegating here, so this is a backstop rather than the guard.
+			res, ok := s.config.TryGet()
+			if !ok {
+				return nil
+			}
+			return res
 		},
 		policyChecker,
 	)
@@ -66,43 +76,41 @@ func NewService(channelID string) *Service {
 	return s
 }
 
-func (s *Service) resources() channelconfig.Resources {
-	s.resourcesLock.RLock()
-	res := s.channelResources
-	s.resourcesLock.RUnlock()
-	return res
-}
-
+// Update installs the channel configuration carried by env. The previously held
+// configuration is kept if env fails validation.
 func (s *Service) Update(env *cb.Envelope) error {
-	s.resourcesLock.Lock()
-	defer s.resourcesLock.Unlock()
-
 	logger.Infof("updating channel [%s]", s.channelID)
 
-	b, err := s.validateConfig(env)
+	err := s.config.Update(func(current channelconfig.Resources, loaded bool) (channelconfig.Resources, error) {
+		return s.validateConfig(env, current, loaded)
+	})
 	if err != nil {
 		logger.Errorf("failed validating config for channel [%s]: [%s]", s.channelID, err)
 		return err
 	}
 
-	s.channelResources = b
-
 	logger.Infof("updating channel [%s], done", s.channelID)
 	return nil
 }
 
+// DryUpdate validates env against the currently held configuration without
+// installing it.
+//
+// The configuration is snapshotted rather than locked for the duration of the
+// validation: a held bundle is never mutated, only replaced wholesale, so the
+// snapshot stays consistent. The verdict is advisory either way, since an
+// Update may land the moment this returns.
 func (s *Service) DryUpdate(env *cb.Envelope) error {
-	s.resourcesLock.RLock()
-	defer s.resourcesLock.RUnlock()
+	current, loaded := s.config.TryGet()
 
-	if _, err := s.validateConfig(env); err != nil {
-		return err
-	}
-
-	return nil
+	_, err := s.validateConfig(env, current, loaded)
+	return err
 }
 
-func (s *Service) validateConfig(env *cb.Envelope) (*channelconfig.Bundle, error) {
+// validateConfig parses env and checks it against current, the configuration in
+// force. It is called while the holder's lock is held, so it takes the current
+// configuration as an argument rather than reading it back out.
+func (s *Service) validateConfig(env *cb.Envelope, current channelconfig.Resources, loaded bool) (*channelconfig.Bundle, error) {
 	payload, err := protoutil.UnmarshalPayload(env.Payload)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unmarshal common payload")
@@ -113,10 +121,9 @@ func (s *Service) validateConfig(env *cb.Envelope) (*channelconfig.Bundle, error
 		return nil, errors.Wrapf(err, "unmarshal config envelope")
 	}
 
-	// check if config tx is valid
-	if s.channelResources != nil {
-		v := s.channelResources.ConfigtxValidator()
-		if err := v.Validate(cenv); err != nil {
+	// The first configuration has nothing to be validated against.
+	if loaded {
+		if err := current.ConfigtxValidator().Validate(cenv); err != nil {
 			return nil, errors.Wrap(err, "validate config transaction")
 		}
 	}
@@ -169,12 +176,17 @@ func toMSPIdentity(identity view.Identity) (*msppb.Identity, error) {
 }
 
 func (s *Service) IsValid(identity view.Identity) error {
+	res, err := s.config.Get()
+	if err != nil {
+		return err
+	}
+
 	sid, err := toMSPIdentity(identity)
 	if err != nil {
 		return err
 	}
 
-	id, err := s.resources().MSPManager().DeserializeIdentity(sid)
+	id, err := res.MSPManager().DeserializeIdentity(sid)
 	if err != nil {
 		return errors.Wrapf(err, "deserializing identity [%s]", identity.String())
 	}
@@ -183,38 +195,53 @@ func (s *Service) IsValid(identity view.Identity) error {
 }
 
 func (s *Service) GetVerifier(identity view.Identity) (driver.Verifier, error) {
+	res, err := s.config.Get()
+	if err != nil {
+		return nil, err
+	}
+
 	sid, err := toMSPIdentity(identity)
 	if err != nil {
 		return nil, err
 	}
 
-	id, err := s.resources().MSPManager().DeserializeIdentity(sid)
+	id, err := res.MSPManager().DeserializeIdentity(sid)
 	if err != nil {
 		return nil, errors.Wrapf(err, "deserializing identity [%s]", identity.String())
 	}
+
 	return id, nil
 }
 
 // GetMSPIDs retrieves the MSP IDs of the organizations in the current Channel
-// configuration.
-func (s *Service) GetMSPIDs() []string {
-	ac, ok := s.resources().ApplicationConfig()
-	if !ok || ac.Organizations() == nil {
-		return nil
+// configuration. An empty result means the channel has no organizations; a
+// channel whose configuration has not been loaded yet reports
+// driver.ErrNotInitialized instead.
+func (s *Service) GetMSPIDs() ([]string, error) {
+	res, err := s.config.Get()
+	if err != nil {
+		return nil, err
 	}
 
-	mspIDs := make([]string, 0, len(ac.Organizations()))
-	for _, org := range ac.Organizations() {
-		mspIDs = append(mspIDs, org.MSPID())
+	var mspIDs []string
+	if ac, ok := res.ApplicationConfig(); ok {
+		for _, org := range ac.Organizations() {
+			mspIDs = append(mspIDs, org.MSPID())
+		}
 	}
 
-	return mspIDs
+	return mspIDs, nil
 }
 
 func (s *Service) OrdererConfig(cs driver.ConfigService) (string, []*grpc.ConnectionConfig, error) {
-	oc, ok := s.resources().OrdererConfig()
+	res, err := s.config.Get()
+	if err != nil {
+		return "", nil, err
+	}
+
+	oc, ok := res.OrdererConfig()
 	if !ok || oc.Organizations() == nil {
-		return "", nil, errors.New("orderer config does not exist")
+		return "", nil, errors.Errorf("orderer config does not exist for channel [%s]", s.channelID)
 	}
 
 	tlsEnabled, isSet := cs.OrderingTLSEnabled()
@@ -265,55 +292,86 @@ func (s *Service) OrdererConfig(cs driver.ConfigService) (string, []*grpc.Connec
 	return oc.ConsensusType(), newOrderers, nil
 }
 
-// MSPManager returns the msp.MSPManager that reflects the current Channel
+// MSPManager returns the driver.MSPManager that reflects the current Channel
 // configuration. Users should not memoize references to this object.
+//
+// The manager resolves the configuration on each call rather than capturing it
+// here, so obtaining one before the channel configuration has been loaded is
+// allowed; the failure surfaces from DeserializeIdentity.
 func (s *Service) MSPManager() driver.MSPManager {
-	return &mspManager{s.resources().MSPManager()}
+	return &mspManager{config: s.config}
 }
 
-// IsIdemixMSP returns true if the MSP identified by mspID is of type Idemix.
-func (s *Service) IsIdemixMSP(mspID string) bool {
-	ac, ok := s.resources().ApplicationConfig()
-	if !ok || ac.Organizations() == nil {
-		return false
+// IsIdemixMSP reports whether the MSP identified by mspID is of type Idemix.
+// A false result means the channel has such an MSP and it is not Idemix; a
+// channel whose configuration has not been loaded yet reports
+// driver.ErrNotInitialized instead, so a caller cannot mistake the startup
+// race for a definitive answer.
+func (s *Service) IsIdemixMSP(mspID string) (bool, error) {
+	res, err := s.config.Get()
+	if err != nil {
+		return false, err
+	}
+
+	ac, ok := res.ApplicationConfig()
+	if !ok {
+		return false, nil
 	}
 
 	for _, org := range ac.Organizations() {
 		if org.MSPID() == mspID {
-			return org.MSP().GetType() == xmsp.IDEMIX
+			return org.MSP().GetType() == xmsp.IDEMIX, nil
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 // CheckACL checks the ACL for the resource for the Channel using the
 // SignedProposal from which an id can be extracted for testing against a policy
 func (s *Service) CheckACL(signedProp driver.SignedProposal) error {
+	// Reject before delegating: the ACL provider expresses "no configuration"
+	// as a policy lookup failure, which would not tell the caller that the
+	// channel simply has not started up yet.
+	if _, err := s.config.Get(); err != nil {
+		return err
+	}
+
 	return s.ACLProvider.CheckACL(resources.Peer_Propose, s.channelID, signedProp.Internal())
 }
 
 type mspManager struct {
-	xmsp.MSPManager
+	config *configstate.Holder[channelconfig.Resources]
 }
 
 func (m *mspManager) DeserializeIdentity(serializedIdentity []byte) (driver.MSPIdentity, error) {
+	res, err := m.config.Get()
+	if err != nil {
+		return nil, err
+	}
+
 	sid, err := toMSPIdentity(serializedIdentity)
 	if err != nil {
 		return nil, err
 	}
 
-	return m.MSPManager.DeserializeIdentity(sid)
+	return res.MSPManager().DeserializeIdentity(sid)
 }
 
 type policyManagerGetterFunc struct {
-	channelID       string
-	resourcesGetter func() channelconfig.Resources
+	channelID string
+	config    *configstate.Holder[channelconfig.Resources]
 }
 
 func (p *policyManagerGetterFunc) Manager(channelID string) policies.Manager {
-	if p.channelID == channelID {
-		return p.resourcesGetter().PolicyManager()
+	if p.channelID != channelID {
+		return nil
 	}
-	return nil
+
+	res, ok := p.config.TryGet()
+	if !ok {
+		return nil
+	}
+
+	return res.PolicyManager()
 }

--- a/platform/fabricx/core/membership/membership_test.go
+++ b/platform/fabricx/core/membership/membership_test.go
@@ -33,6 +33,7 @@ import (
 	storagedriver "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
 	mem "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/memory"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/kvs"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
 // --- minimal mocks ---
@@ -183,6 +184,29 @@ func appChannelGenesisEnvelope(t *testing.T, channelID string) *cb.Envelope {
 	return protoutil.ExtractEnvelopeOrPanic(gb, 0)
 }
 
+// --- helpers ---
+
+// seed installs res as the service's channel configuration, standing in for the
+// first successful Update.
+func seed(t *testing.T, s *Service, res channelconfig.Resources) {
+	t.Helper()
+	require.NoError(t, s.config.Update(func(channelconfig.Resources, bool) (channelconfig.Resources, error) {
+		return res, nil
+	}))
+}
+
+func requireConfigLoaded(t *testing.T, s *Service) {
+	t.Helper()
+	_, ok := s.config.TryGet()
+	require.True(t, ok, "channel configuration should be loaded")
+}
+
+func requireConfigNotLoaded(t *testing.T, s *Service) {
+	t.Helper()
+	_, ok := s.config.TryGet()
+	require.False(t, ok, "channel configuration should not be loaded")
+}
+
 // --- tests ---
 
 func TestNewService(t *testing.T) {
@@ -190,7 +214,7 @@ func TestNewService(t *testing.T) {
 	s := NewService("mychannel")
 	require.NotNil(t, s)
 	require.Equal(t, "mychannel", s.channelID)
-	require.Nil(t, s.channelResources)
+	requireConfigNotLoaded(t, s)
 }
 
 func TestToMSPIdentity(t *testing.T) {
@@ -284,7 +308,7 @@ func TestService_Update(t *testing.T) {
 		env := appChannelGenesisEnvelope(t, "testchannel")
 		err := s.Update(env)
 		require.NoError(t, err)
-		require.NotNil(t, s.channelResources)
+		requireConfigLoaded(t, s)
 	})
 }
 
@@ -303,7 +327,7 @@ func TestService_DryUpdate(t *testing.T) {
 		env := appChannelGenesisEnvelope(t, "testchannel")
 		err := s.DryUpdate(env)
 		require.NoError(t, err)
-		require.Nil(t, s.channelResources, "DryUpdate must not mutate channelResources")
+		requireConfigNotLoaded(t, s)
 	})
 }
 
@@ -312,7 +336,7 @@ func TestService_IsValid(t *testing.T) {
 	t.Run("invalid identity bytes return error", func(t *testing.T) {
 		t.Parallel()
 		s := NewService("ch1")
-		s.channelResources = &mockResources{}
+		seed(t, s, &mockResources{})
 		err := s.IsValid([]byte{0xff})
 		require.Error(t, err)
 	})
@@ -320,9 +344,9 @@ func TestService_IsValid(t *testing.T) {
 	t.Run("deserialization error is propagated", func(t *testing.T) {
 		t.Parallel()
 		s := NewService("ch1")
-		s.channelResources = &mockResources{
+		seed(t, s, &mockResources{
 			mspMgr: &mockMSPManager{deserializeErr: errors.New("deserialization failed")},
-		}
+		})
 		err := s.IsValid(serializedIdentity(t, "Org1MSP"))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "deserialization failed")
@@ -331,9 +355,9 @@ func TestService_IsValid(t *testing.T) {
 	t.Run("validate error is propagated", func(t *testing.T) {
 		t.Parallel()
 		s := NewService("ch1")
-		s.channelResources = &mockResources{
+		seed(t, s, &mockResources{
 			mspMgr: &mockMSPManager{identity: &mockMSPIdentity{validateErr: errors.New("invalid cert")}},
-		}
+		})
 		err := s.IsValid(serializedIdentity(t, "Org1MSP"))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid cert")
@@ -342,9 +366,9 @@ func TestService_IsValid(t *testing.T) {
 	t.Run("valid identity returns nil", func(t *testing.T) {
 		t.Parallel()
 		s := NewService("ch1")
-		s.channelResources = &mockResources{
+		seed(t, s, &mockResources{
 			mspMgr: &mockMSPManager{identity: &mockMSPIdentity{}},
-		}
+		})
 		err := s.IsValid(serializedIdentity(t, "Org1MSP"))
 		require.NoError(t, err)
 	})
@@ -355,7 +379,7 @@ func TestService_GetVerifier(t *testing.T) {
 	t.Run("invalid identity bytes return error", func(t *testing.T) {
 		t.Parallel()
 		s := NewService("ch1")
-		s.channelResources = &mockResources{}
+		seed(t, s, &mockResources{})
 		_, err := s.GetVerifier([]byte{0xff})
 		require.Error(t, err)
 	})
@@ -363,9 +387,9 @@ func TestService_GetVerifier(t *testing.T) {
 	t.Run("deserialization error is propagated", func(t *testing.T) {
 		t.Parallel()
 		s := NewService("ch1")
-		s.channelResources = &mockResources{
+		seed(t, s, &mockResources{
 			mspMgr: &mockMSPManager{deserializeErr: errors.New("deserialization failed")},
-		}
+		})
 		_, err := s.GetVerifier(serializedIdentity(t, "Org1MSP"))
 		require.Error(t, err)
 	})
@@ -374,9 +398,9 @@ func TestService_GetVerifier(t *testing.T) {
 		t.Parallel()
 		s := NewService("ch1")
 		identity := &mockMSPIdentity{}
-		s.channelResources = &mockResources{
+		seed(t, s, &mockResources{
 			mspMgr: &mockMSPManager{identity: identity},
-		}
+		})
 		v, err := s.GetVerifier(serializedIdentity(t, "Org1MSP"))
 		require.NoError(t, err)
 		require.Equal(t, identity, v)
@@ -385,27 +409,39 @@ func TestService_GetVerifier(t *testing.T) {
 
 func TestService_GetMSPIDs(t *testing.T) {
 	t.Parallel()
+	t.Run("uninitialized reports ErrNotInitialized", func(t *testing.T) {
+		t.Parallel()
+		s := NewService("ch1")
+		ids, err := s.GetMSPIDs()
+		require.Nil(t, ids)
+		require.ErrorIs(t, err, fdriver.ErrNotInitialized)
+	})
+
 	t.Run("no application config returns nil", func(t *testing.T) {
 		t.Parallel()
 		s := NewService("ch1")
-		s.channelResources = &mockResources{appCfgOK: false}
-		require.Nil(t, s.GetMSPIDs())
+		seed(t, s, &mockResources{appCfgOK: false})
+		ids, err := s.GetMSPIDs()
+		require.NoError(t, err)
+		require.Nil(t, ids)
 	})
 
-	t.Run("nil organizations returns nil", func(t *testing.T) {
+	t.Run("nil organizations returns no MSP IDs", func(t *testing.T) {
 		t.Parallel()
 		s := NewService("ch1")
-		s.channelResources = &mockResources{
+		seed(t, s, &mockResources{
 			appCfg:   &mockApplication{orgs: nil},
 			appCfgOK: true,
-		}
-		require.Nil(t, s.GetMSPIDs())
+		})
+		ids, err := s.GetMSPIDs()
+		require.NoError(t, err)
+		require.Empty(t, ids)
 	})
 
 	t.Run("returns MSP IDs from all organizations", func(t *testing.T) {
 		t.Parallel()
 		s := NewService("ch1")
-		s.channelResources = &mockResources{
+		seed(t, s, &mockResources{
 			appCfg: &mockApplication{
 				orgs: map[string]channelconfig.ApplicationOrg{
 					"Org1": &mockApplicationOrg{mspID: "Org1MSP"},
@@ -413,10 +449,135 @@ func TestService_GetMSPIDs(t *testing.T) {
 				},
 			},
 			appCfgOK: true,
-		}
-		ids := s.GetMSPIDs()
+		})
+		ids, err := s.GetMSPIDs()
+		require.NoError(t, err)
 		require.Len(t, ids, 2)
 		require.ElementsMatch(t, []string{"Org1MSP", "Org2MSP"}, ids)
+	})
+}
+
+// TestAccessorsBeforeFirstUpdate is the fabricx counterpart of the generic
+// service's regression test: every accessor must report the startup condition
+// rather than dereferencing a nil channelconfig.Resources.
+func TestAccessorsBeforeFirstUpdate(t *testing.T) {
+	t.Parallel()
+
+	identity := view.Identity(serializedIdentity(t, "Org1MSP"))
+
+	for _, tc := range []struct {
+		name string
+		call func(s *Service) error
+	}{
+		{"IsValid", func(s *Service) error {
+			return s.IsValid(identity)
+		}},
+		{"GetVerifier", func(s *Service) error {
+			v, err := s.GetVerifier(identity)
+			require.Nil(t, v)
+			return err
+		}},
+		{"GetMSPIDs", func(s *Service) error {
+			ids, err := s.GetMSPIDs()
+			require.Nil(t, ids)
+			return err
+		}},
+		{"IsIdemixMSP", func(s *Service) error {
+			isIdemix, err := s.IsIdemixMSP("Org1MSP")
+			require.False(t, isIdemix)
+			return err
+		}},
+		{"OrdererConfig", func(s *Service) error {
+			ct, eps, err := s.OrdererConfig(&mockConfigService{})
+			require.Empty(t, ct)
+			require.Nil(t, eps)
+			return err
+		}},
+		{"CheckACL", func(s *Service) error {
+			return s.CheckACL(nil)
+		}},
+		{"MSPManager.DeserializeIdentity", func(s *Service) error {
+			id, err := s.MSPManager().DeserializeIdentity(identity)
+			require.Nil(t, id)
+			return err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := NewService("mychannel")
+
+			var err error
+			require.NotPanics(t, func() { err = tc.call(s) })
+
+			require.Error(t, err)
+			require.ErrorIs(t, err, fdriver.ErrNotInitialized)
+			require.Contains(t, err.Error(), "mychannel")
+		})
+	}
+}
+
+// TestPolicyManagerGetterBeforeFirstUpdate covers the closure handed to
+// fabric-x-common's policy checker, which must answer nil rather than
+// dereferencing an absent configuration.
+func TestPolicyManagerGetterBeforeFirstUpdate(t *testing.T) {
+	t.Parallel()
+
+	s := NewService("ch1")
+	p := &policyManagerGetterFunc{channelID: "ch1", config: s.config}
+
+	require.NotPanics(t, func() {
+		require.Nil(t, p.Manager("ch1"), "configuration not loaded yet")
+		require.Nil(t, p.Manager("other"), "different channel")
+	})
+}
+
+// TestACLResourcesClosureBeforeFirstUpdate covers the resources closure passed
+// to aclmgmt.NewACLProvider, which must not hand a nil Resources downstream.
+func TestACLResourcesClosureBeforeFirstUpdate(t *testing.T) {
+	t.Parallel()
+
+	s := NewService("ch1")
+	p := &policyManagerGetterFunc{channelID: "ch1", config: s.config}
+	require.Nil(t, p.Manager("ch1"))
+
+	// Once a configuration is installed the same lookups resolve.
+	seed(t, s, &mockResources{})
+	require.NotNil(t, s.ACLProvider, "ACL provider is wired at construction")
+}
+
+func TestService_IsIdemixMSP(t *testing.T) {
+	t.Parallel()
+	t.Run("uninitialized reports ErrNotInitialized", func(t *testing.T) {
+		t.Parallel()
+		s := NewService("ch1")
+		isIdemix, err := s.IsIdemixMSP("Org1MSP")
+		require.False(t, isIdemix)
+		require.ErrorIs(t, err, fdriver.ErrNotInitialized)
+	})
+
+	t.Run("no application config returns false without error", func(t *testing.T) {
+		t.Parallel()
+		s := NewService("ch1")
+		seed(t, s, &mockResources{appCfgOK: false})
+		isIdemix, err := s.IsIdemixMSP("Org1MSP")
+		require.NoError(t, err)
+		require.False(t, isIdemix)
+	})
+
+	t.Run("unknown MSP returns false without error", func(t *testing.T) {
+		t.Parallel()
+		s := NewService("ch1")
+		seed(t, s, &mockResources{
+			appCfg: &mockApplication{
+				orgs: map[string]channelconfig.ApplicationOrg{
+					"Org1": &mockApplicationOrg{mspID: "Org1MSP"},
+				},
+			},
+			appCfgOK: true,
+		})
+		isIdemix, err := s.IsIdemixMSP("NoSuchMSP")
+		require.NoError(t, err)
+		require.False(t, isIdemix)
 	})
 }
 
@@ -425,7 +586,7 @@ func TestService_OrdererConfig(t *testing.T) {
 	t.Run("no orderer config returns error", func(t *testing.T) {
 		t.Parallel()
 		s := NewService("ch1")
-		s.channelResources = &mockResources{ordCfgOK: false}
+		seed(t, s, &mockResources{ordCfgOK: false})
 		_, _, err := s.OrdererConfig(&mockConfigService{})
 		require.Error(t, err)
 	})
@@ -433,10 +594,10 @@ func TestService_OrdererConfig(t *testing.T) {
 	t.Run("nil organizations returns error", func(t *testing.T) {
 		t.Parallel()
 		s := NewService("ch1")
-		s.channelResources = &mockResources{
+		seed(t, s, &mockResources{
 			ordCfg:   &mockOrderer{consensusType: "etcdraft", orgs: nil},
 			ordCfgOK: true,
-		}
+		})
 		_, _, err := s.OrdererConfig(&mockConfigService{})
 		require.Error(t, err)
 	})
@@ -445,7 +606,7 @@ func TestService_OrdererConfig(t *testing.T) {
 		t.Parallel()
 		mspImpl := &mockMSP{tlsRootCerts: [][]byte{[]byte("root")}}
 		s := NewService("ch1")
-		s.channelResources = &mockResources{
+		seed(t, s, &mockResources{
 			ordCfg: &mockOrderer{
 				consensusType: "etcdraft",
 				orgs: map[string]channelconfig.OrdererOrg{
@@ -453,7 +614,7 @@ func TestService_OrdererConfig(t *testing.T) {
 				},
 			},
 			ordCfgOK: true,
-		}
+		})
 		consType, conns, err := s.OrdererConfig(&mockConfigService{})
 		require.NoError(t, err)
 		require.Equal(t, "etcdraft", consType)
@@ -467,7 +628,7 @@ func TestService_OrdererConfig(t *testing.T) {
 			tlsIntCerts:  [][]byte{[]byte("int")},
 		}
 		s := NewService("ch1")
-		s.channelResources = &mockResources{
+		seed(t, s, &mockResources{
 			ordCfg: &mockOrderer{
 				consensusType: "etcdraft",
 				orgs: map[string]channelconfig.OrdererOrg{
@@ -475,7 +636,7 @@ func TestService_OrdererConfig(t *testing.T) {
 				},
 			},
 			ordCfgOK: true,
-		}
+		})
 		cs := &mockConfigService{
 			orderingTLSEnabled:      true,
 			orderingTLSEnabledIsSet: true,
@@ -499,7 +660,7 @@ func TestService_OrdererConfig(t *testing.T) {
 		t.Parallel()
 		mspImpl := &mockMSP{}
 		s := NewService("ch1")
-		s.channelResources = &mockResources{
+		seed(t, s, &mockResources{
 			ordCfg: &mockOrderer{
 				consensusType: "etcdraft",
 				orgs: map[string]channelconfig.OrdererOrg{
@@ -507,7 +668,7 @@ func TestService_OrdererConfig(t *testing.T) {
 				},
 			},
 			ordCfgOK: true,
-		}
+		})
 		cs := &mockConfigService{
 			// ordering TLS not set → fallback to TLSEnabled
 			orderingTLSEnabledIsSet: false,
@@ -530,9 +691,9 @@ func TestService_MSPManager(t *testing.T) {
 		t.Parallel()
 		identity := &mockMSPIdentity{}
 		s := NewService("ch1")
-		s.channelResources = &mockResources{
+		seed(t, s, &mockResources{
 			mspMgr: &mockMSPManager{identity: identity},
-		}
+		})
 		mgr := s.MSPManager()
 		require.NotNil(t, mgr)
 
@@ -544,9 +705,9 @@ func TestService_MSPManager(t *testing.T) {
 	t.Run("invalid bytes return error from DeserializeIdentity", func(t *testing.T) {
 		t.Parallel()
 		s := NewService("ch1")
-		s.channelResources = &mockResources{
+		seed(t, s, &mockResources{
 			mspMgr: &mockMSPManager{},
-		}
+		})
 		mgr := s.MSPManager()
 		_, err := mgr.DeserializeIdentity([]byte{0xff})
 		require.Error(t, err)

--- a/platform/fabricx/core/transaction/mock/channel_membership.go
+++ b/platform/fabricx/core/transaction/mock/channel_membership.go
@@ -20,15 +20,17 @@ type ChannelMembership struct {
 	checkACLReturnsOnCall map[int]struct {
 		result1 error
 	}
-	GetMSPIDsStub        func() []string
+	GetMSPIDsStub        func() ([]string, error)
 	getMSPIDsMutex       sync.RWMutex
 	getMSPIDsArgsForCall []struct {
 	}
 	getMSPIDsReturns struct {
 		result1 []string
+		result2 error
 	}
 	getMSPIDsReturnsOnCall map[int]struct {
 		result1 []string
+		result2 error
 	}
 	GetVerifierStub        func(view.Identity) (driver.Verifier, error)
 	getVerifierMutex       sync.RWMutex
@@ -43,16 +45,18 @@ type ChannelMembership struct {
 		result1 driver.Verifier
 		result2 error
 	}
-	IsIdemixMSPStub        func(string) bool
+	IsIdemixMSPStub        func(string) (bool, error)
 	isIdemixMSPMutex       sync.RWMutex
 	isIdemixMSPArgsForCall []struct {
 		arg1 string
 	}
 	isIdemixMSPReturns struct {
 		result1 bool
+		result2 error
 	}
 	isIdemixMSPReturnsOnCall map[int]struct {
 		result1 bool
+		result2 error
 	}
 	IsValidStub        func(view.Identity) error
 	isValidMutex       sync.RWMutex
@@ -140,7 +144,7 @@ func (fake *ChannelMembership) CheckACLReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *ChannelMembership) GetMSPIDs() []string {
+func (fake *ChannelMembership) GetMSPIDs() ([]string, error) {
 	fake.getMSPIDsMutex.Lock()
 	ret, specificReturn := fake.getMSPIDsReturnsOnCall[len(fake.getMSPIDsArgsForCall)]
 	fake.getMSPIDsArgsForCall = append(fake.getMSPIDsArgsForCall, struct {
@@ -153,9 +157,9 @@ func (fake *ChannelMembership) GetMSPIDs() []string {
 		return stub()
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *ChannelMembership) GetMSPIDsCallCount() int {
@@ -164,33 +168,36 @@ func (fake *ChannelMembership) GetMSPIDsCallCount() int {
 	return len(fake.getMSPIDsArgsForCall)
 }
 
-func (fake *ChannelMembership) GetMSPIDsCalls(stub func() []string) {
+func (fake *ChannelMembership) GetMSPIDsCalls(stub func() ([]string, error)) {
 	fake.getMSPIDsMutex.Lock()
 	defer fake.getMSPIDsMutex.Unlock()
 	fake.GetMSPIDsStub = stub
 }
 
-func (fake *ChannelMembership) GetMSPIDsReturns(result1 []string) {
+func (fake *ChannelMembership) GetMSPIDsReturns(result1 []string, result2 error) {
 	fake.getMSPIDsMutex.Lock()
 	defer fake.getMSPIDsMutex.Unlock()
 	fake.GetMSPIDsStub = nil
 	fake.getMSPIDsReturns = struct {
 		result1 []string
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *ChannelMembership) GetMSPIDsReturnsOnCall(i int, result1 []string) {
+func (fake *ChannelMembership) GetMSPIDsReturnsOnCall(i int, result1 []string, result2 error) {
 	fake.getMSPIDsMutex.Lock()
 	defer fake.getMSPIDsMutex.Unlock()
 	fake.GetMSPIDsStub = nil
 	if fake.getMSPIDsReturnsOnCall == nil {
 		fake.getMSPIDsReturnsOnCall = make(map[int]struct {
 			result1 []string
+			result2 error
 		})
 	}
 	fake.getMSPIDsReturnsOnCall[i] = struct {
 		result1 []string
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *ChannelMembership) GetVerifier(arg1 view.Identity) (driver.Verifier, error) {
@@ -257,7 +264,7 @@ func (fake *ChannelMembership) GetVerifierReturnsOnCall(i int, result1 driver.Ve
 	}{result1, result2}
 }
 
-func (fake *ChannelMembership) IsIdemixMSP(arg1 string) bool {
+func (fake *ChannelMembership) IsIdemixMSP(arg1 string) (bool, error) {
 	fake.isIdemixMSPMutex.Lock()
 	ret, specificReturn := fake.isIdemixMSPReturnsOnCall[len(fake.isIdemixMSPArgsForCall)]
 	fake.isIdemixMSPArgsForCall = append(fake.isIdemixMSPArgsForCall, struct {
@@ -271,9 +278,9 @@ func (fake *ChannelMembership) IsIdemixMSP(arg1 string) bool {
 		return stub(arg1)
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *ChannelMembership) IsIdemixMSPCallCount() int {
@@ -282,7 +289,7 @@ func (fake *ChannelMembership) IsIdemixMSPCallCount() int {
 	return len(fake.isIdemixMSPArgsForCall)
 }
 
-func (fake *ChannelMembership) IsIdemixMSPCalls(stub func(string) bool) {
+func (fake *ChannelMembership) IsIdemixMSPCalls(stub func(string) (bool, error)) {
 	fake.isIdemixMSPMutex.Lock()
 	defer fake.isIdemixMSPMutex.Unlock()
 	fake.IsIdemixMSPStub = stub
@@ -295,27 +302,30 @@ func (fake *ChannelMembership) IsIdemixMSPArgsForCall(i int) string {
 	return argsForCall.arg1
 }
 
-func (fake *ChannelMembership) IsIdemixMSPReturns(result1 bool) {
+func (fake *ChannelMembership) IsIdemixMSPReturns(result1 bool, result2 error) {
 	fake.isIdemixMSPMutex.Lock()
 	defer fake.isIdemixMSPMutex.Unlock()
 	fake.IsIdemixMSPStub = nil
 	fake.isIdemixMSPReturns = struct {
 		result1 bool
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *ChannelMembership) IsIdemixMSPReturnsOnCall(i int, result1 bool) {
+func (fake *ChannelMembership) IsIdemixMSPReturnsOnCall(i int, result1 bool, result2 error) {
 	fake.isIdemixMSPMutex.Lock()
 	defer fake.isIdemixMSPMutex.Unlock()
 	fake.IsIdemixMSPStub = nil
 	if fake.isIdemixMSPReturnsOnCall == nil {
 		fake.isIdemixMSPReturnsOnCall = make(map[int]struct {
 			result1 bool
+			result2 error
 		})
 	}
 	fake.isIdemixMSPReturnsOnCall[i] = struct {
 		result1 bool
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *ChannelMembership) IsValid(arg1 view.Identity) error {

--- a/platform/fabricx/core/transaction/transaction.go
+++ b/platform/fabricx/core/transaction/transaction.go
@@ -735,13 +735,21 @@ func (t *Transaction) getProposalResponse(signer SerializableSigner) (*pb.Propos
 //     SignatureHeader.Creator field.
 //   - When the identity's MSP is an Idemix MSP (as determined by idemixMSP),
 //     the original identity bytes are returned unchanged, because Idemix
-//     identities carry no X.509 certificate to hash.
-func toMSPSignerIdentityWithCertificateID(identity view.Identity, idemixMSP func(mspID string) bool) ([]byte, error) {
+//     identities carry no X.509 certificate to hash. If idemixMSP cannot
+//     answer, the error is propagated rather than defaulting to the X.509
+//     encoding.
+func toMSPSignerIdentityWithCertificateID(identity view.Identity, idemixMSP func(mspID string) (bool, error)) ([]byte, error) {
 	sID := &msp.SerializedIdentity{}
 	if err := proto.Unmarshal(identity, sID); err != nil {
 		return nil, errors.Wrap(err, "unmarshal serialized identity")
 	}
-	if idemixMSP(sID.GetMspid()) {
+	// Fail rather than guess: an unknown answer here would silently select the
+	// X.509 encoding below for what may be an Idemix identity.
+	isIdemix, err := idemixMSP(sID.GetMspid())
+	if err != nil {
+		return nil, errors.Wrapf(err, "determining whether MSP [%s] is idemix", sID.GetMspid())
+	}
+	if isIdemix {
 		logger.Debugf("identity [%s] is an idemix identity, return it. [%s]", identity, sID.GetMspid())
 		return identity, nil
 	}

--- a/platform/fabricx/core/transaction/transaction_test.go
+++ b/platform/fabricx/core/transaction/transaction_test.go
@@ -501,8 +501,8 @@ func TestToMSPSignerIdentityWithCertificateID(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			id, err := toMSPSignerIdentityWithCertificateID(tc.identity, func(mspID string) bool {
-				return tc.isIdemix
+			id, err := toMSPSignerIdentityWithCertificateID(tc.identity, func(mspID string) (bool, error) {
+				return tc.isIdemix, nil
 			})
 			if tc.expectedError != "" {
 				require.Error(t, err)
@@ -525,6 +525,24 @@ func TestToMSPSignerIdentityWithCertificateID(t *testing.T) {
 			require.Empty(t, identity.GetCertificate())
 		})
 	}
+}
+
+// TestToMSPSignerIdentityWithCertificateID_IdemixLookupFails pins the reason the
+// predicate returns an error at all: an unknown answer must not fall through to
+// the X.509 encoding, which would silently mis-encode an Idemix identity.
+func TestToMSPSignerIdentityWithCertificateID_IdemixLookupFails(t *testing.T) {
+	t.Parallel()
+
+	_, serialized := mustSerializedIdentityWithRealCert(t, "Org1MSP")
+	lookupErr := errors.New("channel [ch1] configuration not loaded")
+
+	id, err := toMSPSignerIdentityWithCertificateID(serialized, func(string) (bool, error) {
+		return false, lookupErr
+	})
+
+	require.Nil(t, id, "no creator may be produced when the MSP type is unknown")
+	require.ErrorIs(t, err, lookupErr)
+	require.Contains(t, err.Error(), "Org1MSP")
 }
 
 func TestToEndorserIdentityWithCertID(t *testing.T) {

--- a/platform/view/services/storage/driver/memory/driver_test.go
+++ b/platform/view/services/storage/driver/memory/driver_test.go
@@ -240,7 +240,7 @@ func TestNewPersistenceWithOpts_ConstructorError(t *testing.T) {
 		return nil, expectedErr
 	}
 
-	result, err := newPersistenceWithOpts(fakeProvider, "", failingConstructor)
+	result, err := newPersistenceWithOpts(fakeProvider, failingConstructor)
 
 	require.Error(t, err)
 	require.Nil(t, result)
@@ -256,7 +256,7 @@ func TestNewPersistenceWithOpts_CreateSchemaError(t *testing.T) {
 		return &fakePersistence{createSchemaErr: expectedErr}, nil
 	}
 
-	result, err := newPersistenceWithOpts(fakeProvider, "", failingConstructor)
+	result, err := newPersistenceWithOpts(fakeProvider, failingConstructor)
 
 	require.Error(t, err)
 	require.Nil(t, result)

--- a/platform/view/services/storage/driver/memory/driver_test.go
+++ b/platform/view/services/storage/driver/memory/driver_test.go
@@ -240,7 +240,7 @@ func TestNewPersistenceWithOpts_ConstructorError(t *testing.T) {
 		return nil, expectedErr
 	}
 
-	result, err := newPersistenceWithOpts(fakeProvider, failingConstructor)
+	result, err := newPersistenceWithOpts(fakeProvider, "", failingConstructor)
 
 	require.Error(t, err)
 	require.Nil(t, result)
@@ -256,7 +256,7 @@ func TestNewPersistenceWithOpts_CreateSchemaError(t *testing.T) {
 		return &fakePersistence{createSchemaErr: expectedErr}, nil
 	}
 
-	result, err := newPersistenceWithOpts(fakeProvider, failingConstructor)
+	result, err := newPersistenceWithOpts(fakeProvider, "", failingConstructor)
 
 	require.Error(t, err)
 	require.Nil(t, result)


### PR DESCRIPTION
Closes #1385

### Description

Channel configuration is loaded asynchronously after a membership service is built — with the first configuration block on Fabric, with the first successful poll of the config monitor on Fabric-x. Every accessor dereferenced it unchecked, so any call landing in that startup window panicked the node.

Rather than sprinkling nil checks, this makes "not loaded yet" a value the type system carries. A new `platform/fabric/core/configstate` package holds the configuration behind a generic `Holder[T]` whose `Get` returns `(T, error)`, so the absent case is put in front of the caller at the point of use instead of surfacing as a nil dereference further down. One mechanism replaces the two hand-rolled `RWMutex` patterns that the generic and the Fabric-x membership services each carried.

The absent case reports `driver.ErrNotInitialized`, a new sentinel: it is a transient startup condition, not a permanent failure, so a caller racing node startup can detect it with `errors.Is` and retry instead of treating a node that is merely still coming up as broken.

### Changes

- **`platform/fabric/core/configstate`** (new): `Holder[T]` with `Get`, `TryGet`, and `Update`. A rejected update leaves the previously held configuration in place, so a bad config block cannot empty the holder.
- **`platform/fabric/core/generic/membership`** and **`platform/fabricx/core/membership`**: both now read through the holder. `MSPManager()` resolves the configuration per call rather than capturing it, so it is safe to obtain before startup completes; the failure surfaces from `DeserializeIdentity`. On Fabric-x, `CheckACL` rejects up front rather than letting the ACL provider report the missing configuration as a policy lookup failure.
- **`platform/fabricx/core/transaction`**: `toMSPSignerIdentityWithCertificateID` propagates an idemix-lookup failure instead of falling through to the X.509 encoding. Previously an unanswerable lookup silently selected the wrong encoding for what may have been an Idemix identity.
- **`platform/fabric/driver`**: `ErrNotInitialized`, plus documentation on `ChannelMembership`, `MSPManager`, and `MembershipService` describing the startup window and how each method behaves inside it.
- Tests for the holder (including races and interface-typed nil values), for every accessor on both membership services before and after the first update, and for the transaction signing path.

### BREAKING CHANGE

`GetMSPIDs` and `IsIdemixMSP` return an error alongside their result, on `driver.ChannelMembership` and on the public `fabric.MSPManager`, so that an empty or negative answer is no longer indistinguishable from an unloaded configuration. Callers must handle the error; those that can tolerate the startup race should check `errors.Is(err, driver.ErrNotInitialized)`.

The unreferenced `membership.FabricMSPManager` interface is removed.
