### PR TITLE
fix(ordering): report unset consensus type instead of a bespoke error

### DIFF
--- a/platform/fabric/core/configstate/holder.go
+++ b/platform/fabric/core/configstate/holder.go
@@ -28,8 +28,14 @@ import (
 // front of the caller at the point of use instead of surfacing as a nil
 // dereference somewhere further down. Discarding the error still compiles, so
 // this makes the mistake visible rather than impossible.
+//
+// An empty holder distinguishes two ways of being empty. One has not been
+// offered a configuration yet, and a caller racing that arrival should retry;
+// the other was offered one and refused it, and retrying will not help until a
+// later update is accepted. Get names them with driver.ErrNotInitialized and
+// driver.ErrConfigRejected respectively.
 type Holder[T any] struct {
-	// mu serializes access to value and loaded.
+	// mu serializes access to value, loaded and rejected.
 	mu sync.RWMutex
 	// value is the configuration held, meaningful only when loaded is true.
 	value T
@@ -37,6 +43,11 @@ type Holder[T any] struct {
 	// rather than by comparing value against nil so that T may be an
 	// interface type whose stored value is legitimately nil.
 	loaded bool
+	// rejected is the error from the most recent refused Update, kept only
+	// while no configuration has ever been accepted. Once loaded is true the
+	// holder can answer from value and a refusal is the updater's problem
+	// rather than the reader's, so this is cleared and not consulted.
+	rejected error
 
 	// subject names what is held, as a noun phrase that reads correctly in
 	// front of "not loaded" — "channel [mychannel] configuration", say. It is
@@ -51,15 +62,30 @@ func NewHolder[T any](subject string) *Holder[T] {
 	return &Holder[T]{subject: subject}
 }
 
-// Get returns the held configuration. Until the first successful Update it
-// returns an error wrapping driver.ErrNotInitialized, which callers that can
-// tolerate the startup race may test for with errors.Is.
+// Get returns the held configuration.
+//
+// Before the first successful Update it returns an error instead, naming which
+// kind of empty the holder is in so that callers can tell a startup race from a
+// configuration that was refused:
+//
+//   - driver.ErrNotInitialized, if no update has been attempted. The
+//     configuration is still on its way and a caller that can tolerate the race
+//     may test for this with errors.Is and retry.
+//   - driver.ErrConfigRejected, if every update so far was refused. The error
+//     that refused the most recent one is wrapped, and retrying will not clear
+//     it until a later update is accepted.
+//
+// Once an update has been accepted Get answers from the held value and returns
+// no error, including when a later update is refused; see Update.
 func (h *Holder[T]) Get() (T, error) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
 	if !h.loaded {
 		var zero T
+		if h.rejected != nil {
+			return zero, errors.Wrapf(driver.ErrConfigRejected, "%s rejected: %s", h.subject, h.rejected)
+		}
 		return zero, errors.Wrapf(driver.ErrNotInitialized, "%s not loaded", h.subject)
 	}
 
@@ -71,6 +97,10 @@ func (h *Holder[T]) Get() (T, error) {
 // rather than reported: satisfying an interface that expresses "no
 // configuration" as a nil return, or working from a snapshot of whatever is
 // held at the time of the call.
+//
+// TryGet reports only whether a configuration is held, and a refused update
+// never becomes one. Callers that need to tell a refusal apart from a startup
+// race must use Get.
 func (h *Holder[T]) TryGet() (T, bool) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
@@ -83,6 +113,13 @@ func (h *Holder[T]) TryGet() (T, bool) {
 // value is left untouched if fn returns an error, so a rejected configuration
 // cannot leave the holder empty or stale.
 //
+// What a refusal means to readers depends on whether anything has been accepted
+// yet. With a configuration already in force the holder keeps answering from it
+// and readers see nothing; the refusal is reported to the updater alone, through
+// the error returned here. With nothing in force the holder remembers the
+// refusal, so that Get can report driver.ErrConfigRejected rather than inviting
+// a retry that cannot help. Either way an accepted update clears it.
+//
 // fn runs while the write lock is held and must not call back into this Holder;
 // doing so deadlocks.
 func (h *Holder[T]) Update(fn func(current T, loaded bool) (T, error)) error {
@@ -91,10 +128,14 @@ func (h *Holder[T]) Update(fn func(current T, loaded bool) (T, error)) error {
 
 	v, err := fn(h.value, h.loaded)
 	if err != nil {
+		if !h.loaded {
+			h.rejected = err
+		}
 		return err
 	}
 
 	h.value = v
 	h.loaded = true
+	h.rejected = nil
 	return nil
 }

--- a/platform/fabric/core/configstate/holder.go
+++ b/platform/fabric/core/configstate/holder.go
@@ -38,14 +38,17 @@ type Holder[T any] struct {
 	// interface type whose stored value is legitimately nil.
 	loaded bool
 
-	channelName string
+	// subject names what is held, as a noun phrase that reads correctly in
+	// front of "not loaded" — "channel [mychannel] configuration", say. It is
+	// only used to give the errors returned by Get somewhere to point; the
+	// service owning the holder remains the authority on identity.
+	subject string
 }
 
-// NewHolder returns an empty Holder for the named channel. The channel name is
-// only used to give the errors returned by Get somewhere to point; the service
-// owning the holder remains the authority on channel identity.
-func NewHolder[T any](channelName string) *Holder[T] {
-	return &Holder[T]{channelName: channelName}
+// NewHolder returns an empty Holder for the named subject. See the subject
+// field for how the name is used.
+func NewHolder[T any](subject string) *Holder[T] {
+	return &Holder[T]{subject: subject}
 }
 
 // Get returns the held configuration. Until the first successful Update it
@@ -57,7 +60,7 @@ func (h *Holder[T]) Get() (T, error) {
 
 	if !h.loaded {
 		var zero T
-		return zero, errors.Wrapf(driver.ErrNotInitialized, "channel [%s] configuration not loaded", h.channelName)
+		return zero, errors.Wrapf(driver.ErrNotInitialized, "%s not loaded", h.subject)
 	}
 
 	return h.value, nil

--- a/platform/fabric/core/configstate/holder_test.go
+++ b/platform/fabric/core/configstate/holder_test.go
@@ -23,7 +23,7 @@ type config struct{ id string }
 func TestGetBeforeFirstUpdate(t *testing.T) {
 	t.Parallel()
 
-	h := configstate.NewHolder[*config]("mychannel")
+	h := configstate.NewHolder[*config]("channel [mychannel] configuration")
 
 	v, err := h.Get()
 	require.Error(t, err)
@@ -37,7 +37,7 @@ func TestGetBeforeFirstUpdate(t *testing.T) {
 func TestGetAfterUpdate(t *testing.T) {
 	t.Parallel()
 
-	h := configstate.NewHolder[*config]("mychannel")
+	h := configstate.NewHolder[*config]("channel [mychannel] configuration")
 	require.NoError(t, h.Update(func(*config, bool) (*config, error) {
 		return &config{id: "first"}, nil
 	}))
@@ -50,7 +50,7 @@ func TestGetAfterUpdate(t *testing.T) {
 func TestFailedUpdateLeavesPreviousValue(t *testing.T) {
 	t.Parallel()
 
-	h := configstate.NewHolder[*config]("mychannel")
+	h := configstate.NewHolder[*config]("channel [mychannel] configuration")
 	require.NoError(t, h.Update(func(*config, bool) (*config, error) {
 		return &config{id: "first"}, nil
 	}))
@@ -67,7 +67,7 @@ func TestFailedUpdateLeavesPreviousValue(t *testing.T) {
 func TestFailedFirstUpdateStaysUninitialized(t *testing.T) {
 	t.Parallel()
 
-	h := configstate.NewHolder[*config]("mychannel")
+	h := configstate.NewHolder[*config]("channel [mychannel] configuration")
 	require.Error(t, h.Update(func(*config, bool) (*config, error) {
 		return nil, errors.New("boom")
 	}))
@@ -79,7 +79,7 @@ func TestFailedFirstUpdateStaysUninitialized(t *testing.T) {
 func TestUpdateSeesCurrentValue(t *testing.T) {
 	t.Parallel()
 
-	h := configstate.NewHolder[*config]("mychannel")
+	h := configstate.NewHolder[*config]("channel [mychannel] configuration")
 
 	require.NoError(t, h.Update(func(cur *config, loaded bool) (*config, error) {
 		require.False(t, loaded)
@@ -97,7 +97,7 @@ func TestUpdateSeesCurrentValue(t *testing.T) {
 func TestTryGet(t *testing.T) {
 	t.Parallel()
 
-	h := configstate.NewHolder[*config]("mychannel")
+	h := configstate.NewHolder[*config]("channel [mychannel] configuration")
 
 	v, ok := h.TryGet()
 	require.False(t, ok)
@@ -117,7 +117,7 @@ func TestInterfaceValueIsNotMistakenForLoaded(t *testing.T) {
 
 	type iface interface{ ID() string }
 
-	h := configstate.NewHolder[iface]("mychannel")
+	h := configstate.NewHolder[iface]("channel [mychannel] configuration")
 	_, err := h.Get()
 	require.True(t, errors.Is(err, driver.ErrNotInitialized))
 
@@ -131,7 +131,7 @@ func TestInterfaceValueIsNotMistakenForLoaded(t *testing.T) {
 func TestConcurrentAccessIsRaceFree(t *testing.T) {
 	t.Parallel()
 
-	h := configstate.NewHolder[*config]("mychannel")
+	h := configstate.NewHolder[*config]("channel [mychannel] configuration")
 
 	var wg sync.WaitGroup
 	for range 8 {

--- a/platform/fabric/core/configstate/holder_test.go
+++ b/platform/fabric/core/configstate/holder_test.go
@@ -72,8 +72,80 @@ func TestFailedFirstUpdateStaysUninitialized(t *testing.T) {
 		return nil, errors.New("boom")
 	}))
 
+	v, err := h.Get()
+	require.Nil(t, v)
+	require.Error(t, err)
+}
+
+// TestRejectedFirstUpdateIsNotReportedAsStartup asserts that a holder that was
+// offered a configuration and refused it is distinguishable from one that has
+// not been offered anything. The two are both empty, but only the second is a
+// startup race worth retrying.
+func TestRejectedFirstUpdateIsNotReportedAsStartup(t *testing.T) {
+	t.Parallel()
+
+	h := configstate.NewHolder[*config]("channel [mychannel] configuration")
+	require.Error(t, h.Update(func(*config, bool) (*config, error) {
+		return nil, errors.New("bad consensus type")
+	}))
+
 	_, err := h.Get()
-	require.True(t, errors.Is(err, driver.ErrNotInitialized))
+	require.True(t, errors.Is(err, driver.ErrConfigRejected), "must report the rejection")
+	require.False(t, errors.Is(err, driver.ErrNotInitialized), "must not invite a retry that cannot help")
+	require.ErrorContains(t, err, "bad consensus type", "the reason the update was refused must survive")
+}
+
+// TestRejectionIsClearedByALaterSuccess asserts that a holder recovers when a
+// subsequent configuration is accepted: the earlier rejection must not keep
+// being reported once a good value is in place.
+func TestRejectionIsClearedByALaterSuccess(t *testing.T) {
+	t.Parallel()
+
+	h := configstate.NewHolder[*config]("channel [mychannel] configuration")
+	require.Error(t, h.Update(func(*config, bool) (*config, error) {
+		return nil, errors.New("boom")
+	}))
+	require.NoError(t, h.Update(func(*config, bool) (*config, error) {
+		return &config{id: "good"}, nil
+	}))
+
+	v, err := h.Get()
+	require.NoError(t, err)
+	require.Equal(t, "good", v.id)
+}
+
+// TestRejectionAfterASuccessIsNotReported asserts that a refused update does not
+// mask a configuration already in force. Get keeps answering from the held
+// value, and the caller learns about the refusal from Update's own error.
+func TestRejectionAfterASuccessIsNotReported(t *testing.T) {
+	t.Parallel()
+
+	h := configstate.NewHolder[*config]("channel [mychannel] configuration")
+	require.NoError(t, h.Update(func(*config, bool) (*config, error) {
+		return &config{id: "first"}, nil
+	}))
+	require.Error(t, h.Update(func(*config, bool) (*config, error) {
+		return nil, errors.New("boom")
+	}))
+
+	v, err := h.Get()
+	require.NoError(t, err, "a rejected update must not invalidate the configuration in force")
+	require.Equal(t, "first", v.id)
+}
+
+// TestTryGetIgnoresRejection asserts that TryGet keeps its two-state contract:
+// it reports whether a configuration is held, and a rejection is not one.
+func TestTryGetIgnoresRejection(t *testing.T) {
+	t.Parallel()
+
+	h := configstate.NewHolder[*config]("channel [mychannel] configuration")
+	require.Error(t, h.Update(func(*config, bool) (*config, error) {
+		return nil, errors.New("boom")
+	}))
+
+	v, ok := h.TryGet()
+	require.False(t, ok)
+	require.Nil(t, v)
 }
 
 func TestUpdateSeesCurrentValue(t *testing.T) {

--- a/platform/fabric/core/generic/membership/membership.go
+++ b/platform/fabric/core/generic/membership/membership.go
@@ -22,8 +22,9 @@ import (
 
 // Service answers membership questions about a channel from its current
 // configuration. The configuration is not available when the service is built;
-// it arrives with the first configuration block, via Update. Every accessor
-// therefore reports driver.ErrNotInitialized until that happens.
+// it arrives with the first configuration block, via Update. Until one is in
+// force every accessor reports driver.ErrNotInitialized, or, once a block has
+// arrived and been refused, driver.ErrConfigRejected.
 type Service struct {
 	// config holds the channel configuration once it has been loaded. Reading
 	// it goes through configstate.Holder.Get, which cannot hand out a
@@ -92,8 +93,8 @@ func (c *Service) GetVerifier(identity view.Identity) (driver.Verifier, error) {
 
 // GetMSPIDs retrieves the MSP IDs of the organizations in the current Channel
 // configuration. An empty result means the channel has no organizations; a
-// channel whose configuration has not been loaded yet reports
-// driver.ErrNotInitialized instead.
+// channel with no configuration in force reports driver.ErrNotInitialized or
+// driver.ErrConfigRejected instead.
 func (c *Service) GetMSPIDs() ([]string, error) {
 	res, err := c.config.Get()
 	if err != nil {
@@ -112,9 +113,9 @@ func (c *Service) GetMSPIDs() ([]string, error) {
 
 // IsIdemixMSP reports whether the MSP identified by mspID is of type Idemix.
 // A false result means the channel has such an MSP and it is not Idemix; a
-// channel whose configuration has not been loaded yet reports
-// driver.ErrNotInitialized instead, so a caller cannot mistake the startup
-// race for a definitive answer.
+// channel with no configuration in force reports driver.ErrNotInitialized or
+// driver.ErrConfigRejected instead, so a caller cannot mistake an absent
+// configuration for a definitive answer.
 func (c *Service) IsIdemixMSP(mspID string) (bool, error) {
 	res, err := c.config.Get()
 	if err != nil {

--- a/platform/fabric/core/generic/membership/membership.go
+++ b/platform/fabric/core/generic/membership/membership.go
@@ -35,7 +35,7 @@ type Service struct {
 
 func NewService(channelName string) *Service {
 	return &Service{
-		config:      configstate.NewHolder[*channelconfig.ChannelConfig](channelName),
+		config:      configstate.NewHolder[*channelconfig.ChannelConfig]("channel [" + channelName + "] configuration"),
 		channelName: channelName,
 	}
 }

--- a/platform/fabric/core/generic/membership/membership_test.go
+++ b/platform/fabric/core/generic/membership/membership_test.go
@@ -102,15 +102,32 @@ func TestMSPManagerIsUsableBeforeFirstUpdate(t *testing.T) {
 	require.ErrorIs(t, err, driver.ErrNotInitialized)
 }
 
-func TestUpdateWithInvalidEnvelopeLeavesServiceUninitialized(t *testing.T) {
+func TestUpdateWithInvalidEnvelopeLeavesServiceWithoutConfig(t *testing.T) {
 	t.Parallel()
 	s := NewService("mychannel")
 
 	require.Error(t, s.Update(&cb.Envelope{Payload: []byte("not-a-proto")}))
 
 	_, err := s.GetMSPIDs()
-	require.ErrorIs(t, err, driver.ErrNotInitialized,
-		"a rejected configuration must leave the service uninitialized")
+	require.ErrorIs(t, err, driver.ErrConfigRejected,
+		"a config block the service refused must be reported as a refusal")
+	require.NotErrorIs(t, err, driver.ErrNotInitialized,
+		"a refusal must not be reported as a startup race the caller can retry out of")
+	require.ErrorContains(t, err, "cannot get payload from config transaction",
+		"the reason the block was refused must survive")
+}
+
+// TestServiceRecoversFromARejectedConfig asserts that a service that refused one
+// config block still accepts the next one: a refusal is not a terminal state.
+func TestServiceRecoversFromARejectedConfig(t *testing.T) {
+	t.Parallel()
+	s := NewService("mychannel")
+
+	require.Error(t, s.Update(&cb.Envelope{Payload: []byte("not-a-proto")}))
+	seed(t, s, &channelconfig.ChannelConfig{})
+
+	_, err := s.GetMSPIDs()
+	require.NoError(t, err, "an accepted configuration must clear an earlier refusal")
 }
 
 // TestLoadedConfigIsDistinguishableFromMissingConfig is the point of the

--- a/platform/fabric/core/generic/ordering/ordering.go
+++ b/platform/fabric/core/generic/ordering/ordering.go
@@ -8,13 +8,13 @@ package ordering
 
 import (
 	"context"
-	"sync"
 
 	common2 "github.com/hyperledger/fabric-protos-go-apiv2/common"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/configstate"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/metrics"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
@@ -49,15 +49,30 @@ type BroadcastFnc = func(ctx context.Context, env *common2.Envelope) error
 
 type GetEndorserTransactionServiceFunc = func(channelID string) (driver.EndorserTransactionService, error)
 
+// Service broadcasts envelopes to the ordering service of a network using the
+// broadcaster for the consensus type in force.
+//
+// Which consensus type that is comes from the channel configuration, which is
+// loaded asynchronously after the service is built: the committer feeds it to
+// MembershipService.Update, reads it back with OrdererConfig, and passes it here
+// via Configure. Until that happens the service has no broadcaster and Broadcast
+// reports driver.ErrNotInitialized.
 type Service struct {
 	GetEndorserTransactionService GetEndorserTransactionServiceFunc
 	SigService                    driver.SignerService
 	ConfigService                 driver.ConfigService
 	Metrics                       *metrics.Metrics
 
-	Broadcasters   map[ConsensusType]BroadcastFnc
-	BroadcastMutex sync.RWMutex
-	Broadcaster    BroadcastFnc
+	// Broadcasters holds one broadcaster per supported consensus type. It is
+	// populated by NewService and not written afterwards.
+	Broadcasters map[ConsensusType]BroadcastFnc
+
+	// broadcaster holds the broadcaster selected by SetConsensusType. It is
+	// unexported and reached only through configstate.Holder so that the
+	// "always read under the lock" rule cannot be sidestepped, and so that the
+	// not-yet-selected case reaches the caller as an error rather than as a nil
+	// function value.
+	broadcaster *configstate.Holder[BroadcastFnc]
 }
 
 func NewService(
@@ -72,8 +87,7 @@ func NewService(
 		SigService:                    sigService,
 		Metrics:                       metrics,
 		Broadcasters:                  map[ConsensusType]BroadcastFnc{},
-		BroadcastMutex:                sync.RWMutex{},
-		Broadcaster:                   nil,
+		broadcaster:                   configstate.NewHolder[BroadcastFnc]("network [" + configService.NetworkName() + "] ordering configuration"),
 		ConfigService:                 configService,
 	}
 	s.Broadcasters[BFT] = NewBFTBroadcaster(configService, services, metrics).Broadcast
@@ -109,28 +123,28 @@ func (o *Service) Broadcast(ctx context.Context, blob any) error {
 		return errors.Errorf("invalid blob's type, got [%T]", blob)
 	}
 
-	o.BroadcastMutex.RLock()
 	logger.DebugfContext(ctx, "Acquire broadcaster")
-	broadcaster := o.Broadcaster
-	o.BroadcastMutex.RUnlock()
-	if broadcaster == nil {
-		return errors.Errorf("cannot broadcast yet, no consensus type set")
+	broadcaster, err := o.broadcaster.Get()
+	if err != nil {
+		return errors.WithMessage(err, "cannot broadcast yet, no consensus type set")
 	}
 
 	logger.DebugfContext(ctx, "Broadcast")
 	return broadcaster(ctx, env)
 }
 
+// SetConsensusType selects the broadcaster for consensusType. An unsupported
+// consensus type leaves any previously selected broadcaster in place.
 func (o *Service) SetConsensusType(consensusType ConsensusType) error {
 	logger.Debugf("ordering, setting consensus type to [%s]", consensusType)
-	broadcaster, ok := o.Broadcasters[consensusType]
-	if !ok {
-		return errors.Errorf("no broadcaster found for consensus [%s]", consensusType)
-	}
-	o.BroadcastMutex.Lock()
-	defer o.BroadcastMutex.Unlock()
-	o.Broadcaster = broadcaster
-	return nil
+
+	return o.broadcaster.Update(func(BroadcastFnc, bool) (BroadcastFnc, error) {
+		broadcaster, ok := o.Broadcasters[consensusType]
+		if !ok {
+			return nil, errors.Errorf("no broadcaster found for consensus [%s]", consensusType)
+		}
+		return broadcaster, nil
+	})
 }
 
 func (f *Service) Configure(consensusType string, orderers []*grpc.ConnectionConfig) error {

--- a/platform/fabric/core/generic/ordering/ordering.go
+++ b/platform/fabric/core/generic/ordering/ordering.go
@@ -55,8 +55,14 @@ type GetEndorserTransactionServiceFunc = func(channelID string) (driver.Endorser
 // Which consensus type that is comes from the channel configuration, which is
 // loaded asynchronously after the service is built: the committer feeds it to
 // MembershipService.Update, reads it back with OrdererConfig, and passes it here
-// via Configure. Until that happens the service has no broadcaster and Broadcast
-// reports driver.ErrNotInitialized.
+// via Configure.
+//
+// A service with no broadcaster cannot broadcast, and Broadcast says which of
+// the two reasons applies: driver.ErrNotInitialized while the channel
+// configuration is still on its way, and driver.ErrConfigRejected once it has
+// arrived naming a consensus type this service cannot serve. Only the first is
+// worth retrying; the second clears when the channel configuration next names a
+// consensus type we have a broadcaster for.
 type Service struct {
 	GetEndorserTransactionService GetEndorserTransactionServiceFunc
 	SigService                    driver.SignerService
@@ -69,9 +75,10 @@ type Service struct {
 
 	// broadcaster holds the broadcaster selected by SetConsensusType. It is
 	// unexported and reached only through configstate.Holder so that the
-	// "always read under the lock" rule cannot be sidestepped, and so that the
+	// "always read under the lock" rule cannot be sidestepped, so that the
 	// not-yet-selected case reaches the caller as an error rather than as a nil
-	// function value.
+	// function value, and so that a consensus type we rejected is not reported
+	// as one we have not been told about.
 	broadcaster *configstate.Holder[BroadcastFnc]
 }
 
@@ -124,17 +131,27 @@ func (o *Service) Broadcast(ctx context.Context, blob any) error {
 	}
 
 	logger.DebugfContext(ctx, "Acquire broadcaster")
+	// Deliberately not "cannot broadcast yet": the holder distinguishes waiting
+	// for the channel configuration from having rejected the one that arrived,
+	// and only the first is a "yet".
 	broadcaster, err := o.broadcaster.Get()
 	if err != nil {
-		return errors.WithMessage(err, "cannot broadcast yet, no consensus type set")
+		return errors.WithMessage(err, "cannot broadcast")
 	}
 
 	logger.DebugfContext(ctx, "Broadcast")
 	return broadcaster(ctx, env)
 }
 
-// SetConsensusType selects the broadcaster for consensusType. An unsupported
-// consensus type leaves any previously selected broadcaster in place.
+// SetConsensusType selects the broadcaster for consensusType, and fails if there
+// is none for it.
+//
+// A service already able to broadcast keeps the broadcaster it has, so a channel
+// configuration naming a consensus type we cannot serve does not take a working
+// service down; the caller learns of the rejection from the error returned here.
+// A service not yet able to broadcast records the rejection instead, so that
+// Broadcast can report driver.ErrConfigRejected rather than presenting a
+// configuration we refused as one we are still waiting for.
 func (o *Service) SetConsensusType(consensusType ConsensusType) error {
 	logger.Debugf("ordering, setting consensus type to [%s]", consensusType)
 

--- a/platform/fabric/core/generic/ordering/ordering_test.go
+++ b/platform/fabric/core/generic/ordering/ordering_test.go
@@ -98,6 +98,45 @@ func (m *mockBroadcaster) broadcast(ctx context.Context, env *common.Envelope) e
 	return m.err
 }
 
+// newTestService builds a Service with fake collaborators and no consensus type
+// set, which is the state a Service is in until the channel configuration
+// arrives.
+func newTestService() *Service {
+	return NewService(
+		func(channelID string) (driver.EndorserTransactionService, error) {
+			return &mockEndorserTransactionService{}, nil
+		},
+		&mockSignerService{},
+		&fake.ConfigService{PoolSizeValue: 4, RetriesValue: 3, NetworkNameValue: "test-network"},
+		&metrics.Metrics{},
+		fakeServices{},
+	)
+}
+
+// setBroadcaster registers fn under a test consensus type and selects it, which
+// is how a Service acquires a broadcaster in production too.
+func setBroadcaster(t *testing.T, s *Service, fn BroadcastFnc) {
+	t.Helper()
+	s.Broadcasters[testConsensus] = fn
+	require.NoError(t, s.SetConsensusType(testConsensus))
+}
+
+const testConsensus ConsensusType = "test-consensus"
+
+// requireBroadcaster asserts that a broadcaster has been selected.
+func requireBroadcaster(t *testing.T, s *Service) {
+	t.Helper()
+	_, err := s.broadcaster.Get()
+	require.NoError(t, err)
+}
+
+// requireNoBroadcaster asserts that no broadcaster has been selected yet.
+func requireNoBroadcaster(t *testing.T, s *Service) {
+	t.Helper()
+	_, err := s.broadcaster.Get()
+	require.ErrorIs(t, err, driver.ErrNotInitialized)
+}
+
 // TestNewService tests the Service constructor
 func TestNewService(t *testing.T) {
 	t.Parallel()
@@ -126,7 +165,7 @@ func TestNewService(t *testing.T) {
 	require.NotNil(t, service.Broadcasters[BFT])
 	require.NotNil(t, service.Broadcasters[Raft])
 	require.NotNil(t, service.Broadcasters[Solo])
-	require.Nil(t, service.Broadcaster) // Not set until SetConsensusType is called
+	requireNoBroadcaster(t, service) // Not set until SetConsensusType is called
 }
 
 // TestService_SetConsensusType tests setting the consensus type
@@ -163,15 +202,7 @@ func TestService_SetConsensusType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			service := NewService(
-				func(channelID string) (driver.EndorserTransactionService, error) {
-					return &mockEndorserTransactionService{}, nil
-				},
-				&mockSignerService{},
-				&fake.ConfigService{PoolSizeValue: 4, RetriesValue: 3, NetworkNameValue: "test-network"},
-				&metrics.Metrics{},
-				fakeServices{},
-			)
+			service := newTestService()
 
 			err := service.SetConsensusType(tt.consensusType)
 
@@ -180,7 +211,7 @@ func TestService_SetConsensusType(t *testing.T) {
 				require.Contains(t, err.Error(), "no broadcaster found for consensus")
 			} else {
 				require.NoError(t, err)
-				require.NotNil(t, service.Broadcaster)
+				requireBroadcaster(t, service)
 			}
 		})
 	}
@@ -210,21 +241,13 @@ func TestService_Configure(t *testing.T) {
 
 		err := service.Configure(Raft, orderers)
 		require.NoError(t, err)
-		require.NotNil(t, service.Broadcaster)
+		requireBroadcaster(t, service)
 		require.Equal(t, orderers, configService.Orderers())
 	})
 
 	t.Run("invalid consensus type", func(t *testing.T) {
 		t.Parallel()
-		service := NewService(
-			func(channelID string) (driver.EndorserTransactionService, error) {
-				return &mockEndorserTransactionService{}, nil
-			},
-			&mockSignerService{},
-			&fake.ConfigService{PoolSizeValue: 4, RetriesValue: 3, NetworkNameValue: "test-network"},
-			&metrics.Metrics{},
-			fakeServices{},
-		)
+		service := newTestService()
 
 		orderers := []*grpc.ConnectionConfig{
 			{Address: "orderer1:7050"},
@@ -243,16 +266,8 @@ func TestService_Broadcast(t *testing.T) {
 	t.Run("broadcast with Transaction type", func(t *testing.T) {
 		t.Parallel()
 		mockBroadcaster := &mockBroadcaster{}
-		service := NewService(
-			func(channelID string) (driver.EndorserTransactionService, error) {
-				return &mockEndorserTransactionService{}, nil
-			},
-			&mockSignerService{},
-			&fake.ConfigService{PoolSizeValue: 4, RetriesValue: 3, NetworkNameValue: "test-network"},
-			&metrics.Metrics{},
-			fakeServices{},
-		)
-		service.Broadcaster = mockBroadcaster.broadcast
+		service := newTestService()
+		setBroadcaster(t, service, mockBroadcaster.broadcast)
 
 		// Create a valid envelope bytes
 		validEnvelope := &common.Envelope{
@@ -279,16 +294,8 @@ func TestService_Broadcast(t *testing.T) {
 	t.Run("broadcast with TransactionWithEnvelope type", func(t *testing.T) {
 		t.Parallel()
 		mockBroadcaster := &mockBroadcaster{}
-		service := NewService(
-			func(channelID string) (driver.EndorserTransactionService, error) {
-				return &mockEndorserTransactionService{}, nil
-			},
-			&mockSignerService{},
-			&fake.ConfigService{PoolSizeValue: 4, RetriesValue: 3, NetworkNameValue: "test-network"},
-			&metrics.Metrics{},
-			fakeServices{},
-		)
-		service.Broadcaster = mockBroadcaster.broadcast
+		service := newTestService()
+		setBroadcaster(t, service, mockBroadcaster.broadcast)
 
 		env := &common.Envelope{
 			Payload:   []byte("payload"),
@@ -305,16 +312,8 @@ func TestService_Broadcast(t *testing.T) {
 	t.Run("broadcast with common.Envelope type", func(t *testing.T) {
 		t.Parallel()
 		mockBroadcaster := &mockBroadcaster{}
-		service := NewService(
-			func(channelID string) (driver.EndorserTransactionService, error) {
-				return &mockEndorserTransactionService{}, nil
-			},
-			&mockSignerService{},
-			&fake.ConfigService{PoolSizeValue: 4, RetriesValue: 3, NetworkNameValue: "test-network"},
-			&metrics.Metrics{},
-			fakeServices{},
-		)
-		service.Broadcaster = mockBroadcaster.broadcast
+		service := newTestService()
+		setBroadcaster(t, service, mockBroadcaster.broadcast)
 
 		env := &common.Envelope{
 			Payload:   []byte("payload"),
@@ -330,16 +329,8 @@ func TestService_Broadcast(t *testing.T) {
 	t.Run("broadcast with TODO context", func(t *testing.T) {
 		t.Parallel()
 		mockBroadcaster := &mockBroadcaster{}
-		service := NewService(
-			func(channelID string) (driver.EndorserTransactionService, error) {
-				return &mockEndorserTransactionService{}, nil
-			},
-			&mockSignerService{},
-			&fake.ConfigService{PoolSizeValue: 4, RetriesValue: 3, NetworkNameValue: "test-network"},
-			&metrics.Metrics{},
-			fakeServices{},
-		)
-		service.Broadcaster = mockBroadcaster.broadcast
+		service := newTestService()
+		setBroadcaster(t, service, mockBroadcaster.broadcast)
 
 		env := &common.Envelope{
 			Payload:   []byte("payload"),
@@ -353,18 +344,8 @@ func TestService_Broadcast(t *testing.T) {
 
 	t.Run("broadcast with invalid blob type", func(t *testing.T) {
 		t.Parallel()
-		service := NewService(
-			func(channelID string) (driver.EndorserTransactionService, error) {
-				return &mockEndorserTransactionService{}, nil
-			},
-			&mockSignerService{},
-			&fake.ConfigService{PoolSizeValue: 4, RetriesValue: 3, NetworkNameValue: "test-network"},
-			&metrics.Metrics{},
-			fakeServices{},
-		)
-		service.Broadcaster = func(ctx context.Context, env *common.Envelope) error {
-			return nil
-		}
+		service := newTestService()
+		setBroadcaster(t, service, func(ctx context.Context, env *common.Envelope) error { return nil })
 
 		err := service.Broadcast(t.Context(), "invalid type")
 		require.Error(t, err)
@@ -373,15 +354,7 @@ func TestService_Broadcast(t *testing.T) {
 
 	t.Run("broadcast without broadcaster set", func(t *testing.T) {
 		t.Parallel()
-		service := NewService(
-			func(channelID string) (driver.EndorserTransactionService, error) {
-				return &mockEndorserTransactionService{}, nil
-			},
-			&mockSignerService{},
-			&fake.ConfigService{PoolSizeValue: 4, RetriesValue: 3, NetworkNameValue: "test-network"},
-			&metrics.Metrics{},
-			fakeServices{},
-		)
+		service := newTestService()
 		// Don't set broadcaster
 
 		env := &common.Envelope{
@@ -396,18 +369,8 @@ func TestService_Broadcast(t *testing.T) {
 
 	t.Run("broadcast with transaction envelope error", func(t *testing.T) {
 		t.Parallel()
-		service := NewService(
-			func(channelID string) (driver.EndorserTransactionService, error) {
-				return &mockEndorserTransactionService{}, nil
-			},
-			&mockSignerService{},
-			&fake.ConfigService{PoolSizeValue: 4, RetriesValue: 3, NetworkNameValue: "test-network"},
-			&metrics.Metrics{},
-			fakeServices{},
-		)
-		service.Broadcaster = func(ctx context.Context, env *common.Envelope) error {
-			return nil
-		}
+		service := newTestService()
+		setBroadcaster(t, service, func(ctx context.Context, env *common.Envelope) error { return nil })
 
 		tx := &mockTransaction{
 			id:          "tx1",
@@ -421,18 +384,8 @@ func TestService_Broadcast(t *testing.T) {
 
 	t.Run("broadcast with transaction bytes error", func(t *testing.T) {
 		t.Parallel()
-		service := NewService(
-			func(channelID string) (driver.EndorserTransactionService, error) {
-				return &mockEndorserTransactionService{}, nil
-			},
-			&mockSignerService{},
-			&fake.ConfigService{PoolSizeValue: 4, RetriesValue: 3, NetworkNameValue: "test-network"},
-			&metrics.Metrics{},
-			fakeServices{},
-		)
-		service.Broadcaster = func(ctx context.Context, env *common.Envelope) error {
-			return nil
-		}
+		service := newTestService()
+		setBroadcaster(t, service, func(ctx context.Context, env *common.Envelope) error { return nil })
 
 		tx := &mockTransaction{
 			id: "tx1",
@@ -448,18 +401,8 @@ func TestService_Broadcast(t *testing.T) {
 
 	t.Run("broadcast with invalid envelope bytes", func(t *testing.T) {
 		t.Parallel()
-		service := NewService(
-			func(channelID string) (driver.EndorserTransactionService, error) {
-				return &mockEndorserTransactionService{}, nil
-			},
-			&mockSignerService{},
-			&fake.ConfigService{PoolSizeValue: 4, RetriesValue: 3, NetworkNameValue: "test-network"},
-			&metrics.Metrics{},
-			fakeServices{},
-		)
-		service.Broadcaster = func(ctx context.Context, env *common.Envelope) error {
-			return nil
-		}
+		service := newTestService()
+		setBroadcaster(t, service, func(ctx context.Context, env *common.Envelope) error { return nil })
 
 		tx := &mockTransaction{
 			id: "tx1",
@@ -477,16 +420,8 @@ func TestService_Broadcast(t *testing.T) {
 		t.Parallel()
 		expectedErr := errors.New("broadcast failed")
 		mockBroadcaster := &mockBroadcaster{err: expectedErr}
-		service := NewService(
-			func(channelID string) (driver.EndorserTransactionService, error) {
-				return &mockEndorserTransactionService{}, nil
-			},
-			&mockSignerService{},
-			&fake.ConfigService{PoolSizeValue: 4, RetriesValue: 3, NetworkNameValue: "test-network"},
-			&metrics.Metrics{},
-			fakeServices{},
-		)
-		service.Broadcaster = mockBroadcaster.broadcast
+		service := newTestService()
+		setBroadcaster(t, service, mockBroadcaster.broadcast)
 
 		env := &common.Envelope{
 			Payload:   []byte("payload"),
@@ -505,16 +440,8 @@ func TestService_ConcurrentBroadcast(t *testing.T) {
 	t.Parallel()
 
 	mockBroadcaster := &mockBroadcaster{}
-	service := NewService(
-		func(channelID string) (driver.EndorserTransactionService, error) {
-			return &mockEndorserTransactionService{}, nil
-		},
-		&mockSignerService{},
-		&fake.ConfigService{PoolSizeValue: 4, RetriesValue: 3, NetworkNameValue: "test-network"},
-		&metrics.Metrics{},
-		fakeServices{},
-	)
-	service.Broadcaster = mockBroadcaster.broadcast
+	service := newTestService()
+	setBroadcaster(t, service, mockBroadcaster.broadcast)
 
 	const numGoroutines = 10
 	errChan := make(chan error, numGoroutines)
@@ -542,15 +469,7 @@ func TestService_ConcurrentBroadcast(t *testing.T) {
 func TestService_ConcurrentSetConsensusType(t *testing.T) {
 	t.Parallel()
 
-	service := NewService(
-		func(channelID string) (driver.EndorserTransactionService, error) {
-			return &mockEndorserTransactionService{}, nil
-		},
-		&mockSignerService{},
-		&fake.ConfigService{PoolSizeValue: 4, RetriesValue: 3, NetworkNameValue: "test-network"},
-		&metrics.Metrics{},
-		fakeServices{},
-	)
+	service := newTestService()
 
 	const numGoroutines = 10
 	errChan := make(chan error, numGoroutines)
@@ -571,7 +490,7 @@ func TestService_ConcurrentSetConsensusType(t *testing.T) {
 	}
 
 	// Verify that a broadcaster is set
-	require.NotNil(t, service.Broadcaster)
+	requireBroadcaster(t, service)
 }
 
 // TestConsensusTypeConstants tests the consensus type constants
@@ -581,4 +500,34 @@ func TestConsensusTypeConstants(t *testing.T) {
 	require.Equal(t, "BFT", BFT)
 	require.Equal(t, "etcdraft", Raft)
 	require.Equal(t, "solo", Solo)
+}
+
+// TestService_BroadcastBeforeConsensusTypeIsSet asserts that broadcasting before
+// the channel configuration has told us which consensus type is in force reports
+// driver.ErrNotInitialized, so a caller racing node startup can tell the startup
+// window apart from a permanent failure.
+func TestService_BroadcastBeforeConsensusTypeIsSet(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService()
+
+	err := service.Broadcast(t.Context(), &common.Envelope{Payload: []byte("payload")})
+	require.Error(t, err)
+	require.ErrorIs(t, err, driver.ErrNotInitialized)
+}
+
+// TestService_SetConsensusTypeRejectionKeepsPreviousBroadcaster asserts that a
+// rejected consensus type leaves the service able to broadcast, rather than
+// dropping it back into the uninitialized state.
+func TestService_SetConsensusTypeRejectionKeepsPreviousBroadcaster(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService()
+	mockBroadcaster := &mockBroadcaster{}
+	setBroadcaster(t, service, mockBroadcaster.broadcast)
+
+	require.Error(t, service.SetConsensusType("nope"))
+
+	require.NoError(t, service.Broadcast(t.Context(), &common.Envelope{Payload: []byte("payload")}))
+	require.True(t, mockBroadcaster.called)
 }

--- a/platform/fabric/core/generic/ordering/ordering_test.go
+++ b/platform/fabric/core/generic/ordering/ordering_test.go
@@ -364,7 +364,7 @@ func TestService_Broadcast(t *testing.T) {
 
 		err := service.Broadcast(t.Context(), env)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "cannot broadcast yet, no consensus type set")
+		require.Contains(t, err.Error(), "cannot broadcast")
 	})
 
 	t.Run("broadcast with transaction envelope error", func(t *testing.T) {
@@ -527,6 +527,42 @@ func TestService_SetConsensusTypeRejectionKeepsPreviousBroadcaster(t *testing.T)
 	setBroadcaster(t, service, mockBroadcaster.broadcast)
 
 	require.Error(t, service.SetConsensusType("nope"))
+
+	require.NoError(t, service.Broadcast(t.Context(), &common.Envelope{Payload: []byte("payload")}))
+	require.True(t, mockBroadcaster.called)
+}
+
+// TestService_BroadcastAfterRejectedConsensusType asserts that a channel
+// configuration naming a consensus type we cannot serve is reported as a
+// rejection rather than as a startup race. Both leave the service unable to
+// broadcast, but only the startup race is worth retrying: a caller that treats
+// this one as transient retries forever against a node that will not recover on
+// its own.
+func TestService_BroadcastAfterRejectedConsensusType(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService()
+	require.Error(t, service.SetConsensusType("kafka"))
+
+	err := service.Broadcast(t.Context(), &common.Envelope{Payload: []byte("payload")})
+	require.ErrorIs(t, err, driver.ErrConfigRejected)
+	require.NotErrorIs(t, err, driver.ErrNotInitialized,
+		"a consensus type we refused must not be reported as one we are still waiting for")
+	require.ErrorContains(t, err, "no broadcaster found for consensus [kafka]",
+		"the rejected consensus type must survive into the error")
+}
+
+// TestService_RecoversFromRejectedConsensusType asserts that a rejection is not
+// terminal: a later channel configuration naming a consensus type we can serve
+// puts the service back to work.
+func TestService_RecoversFromRejectedConsensusType(t *testing.T) {
+	t.Parallel()
+
+	service := newTestService()
+	require.Error(t, service.SetConsensusType("kafka"))
+
+	mockBroadcaster := &mockBroadcaster{}
+	setBroadcaster(t, service, mockBroadcaster.broadcast)
 
 	require.NoError(t, service.Broadcast(t.Context(), &common.Envelope{Payload: []byte("payload")}))
 	require.True(t, mockBroadcaster.called)

--- a/platform/fabric/driver/errors.go
+++ b/platform/fabric/driver/errors.go
@@ -20,4 +20,22 @@ var ErrNotImplemented = errors.New("not implemented")
 // configuration is loaded asynchronously after the owning service is
 // constructed, so a caller racing that load observes it legitimately. Callers
 // that can tolerate the race should test for it with errors.Is and retry.
+//
+// A service that was offered a configuration and refused it reports
+// ErrConfigRejected instead, so that a caller acting on this one is never told
+// to retry something that retrying cannot fix.
 var ErrNotInitialized = errors.New("not initialized")
+
+// ErrConfigRejected signals that a service cannot answer because the only
+// configuration it has been offered was refused: a configuration block that
+// would not parse or failed validation, or one naming something the service
+// cannot serve, such as an unsupported consensus type.
+//
+// Unlike ErrNotInitialized this is not a startup race, and retrying the call
+// will not clear it. It is not permanent either: the service recovers as soon as
+// a later configuration update is accepted, so a caller should surface it rather
+// than either retrying in a loop or treating the node as dead.
+//
+// The error returned by the update that was refused is wrapped, so the reason
+// travels with the sentinel.
+var ErrConfigRejected = errors.New("configuration rejected")

--- a/platform/fabric/driver/membership.go
+++ b/platform/fabric/driver/membership.go
@@ -55,8 +55,8 @@ type MSPIdentity interface {
 type MSPManager interface {
 	// DeserializeIdentity turns a serialized identity into an MSPIdentity
 	// belonging to one of the channel's MSPs. It fails if the identity does not
-	// belong to any of them, and returns an error wrapping ErrNotInitialized
-	// while the channel configuration has not been loaded yet.
+	// belong to any of them, and reports ErrNotInitialized or ErrConfigRejected
+	// while the channel has no configuration in force.
 	DeserializeIdentity(serializedIdentity []byte) (MSPIdentity, error)
 }
 
@@ -66,43 +66,51 @@ type MSPManager interface {
 //
 // A channel's configuration is not available as soon as the channel exists: it
 // is loaded asynchronously, with the first configuration block on Fabric and
-// with the first successful poll of the config monitor on Fabric-x. Until then
-// every method here reports an error wrapping ErrNotInitialized rather than
-// answering from an empty configuration. A caller racing node startup can
-// detect that case with errors.Is and retry; treating it as a permanent failure
-// will misreport a node that is merely still coming up.
+// with the first successful poll of the config monitor on Fabric-x. Until a
+// configuration is in force, every method here reports an error rather than
+// answering from an empty one, and names which of two situations applies:
+//
+//   - ErrNotInitialized, while no configuration has arrived. A caller racing
+//     node startup can detect this with errors.Is and retry; treating it as a
+//     permanent failure will misreport a node that is merely still coming up.
+//   - ErrConfigRejected, once one has arrived and been refused. Retrying will
+//     not clear this, so a caller should surface it — but the channel is not
+//     finished either, and recovers if a later configuration is accepted.
+//
+// Both are absent-configuration answers; they differ only in whether retrying
+// can help, so a caller that cannot act on the difference may test for either.
 type ChannelMembership interface {
 	// GetMSPIDs returns the MSP IDs of the organizations in the current channel
 	// configuration. An empty result means the channel has no organizations; a
-	// channel whose configuration has not been loaded yet reports an error
-	// wrapping ErrNotInitialized instead.
+	// channel with no configuration in force reports one of the errors above
+	// instead.
 	GetMSPIDs() ([]string, error)
 	// MSPManager returns a manager backed by the channel's current
-	// configuration. It never returns nil and may be called before the
-	// configuration has been loaded; that failure surfaces from the manager's
-	// own methods. Callers should not memoize the returned value.
+	// configuration. It never returns nil and may be called before a
+	// configuration is in force; that failure surfaces from the manager's own
+	// methods. Callers should not memoize the returned value.
 	MSPManager() MSPManager
 	// IsValid reports whether identity is one the channel recognizes, by
 	// deserializing it against the channel's MSPs and validating it. A nil
-	// error means the identity is valid. It returns an error wrapping
-	// ErrNotInitialized while the channel configuration has not been loaded.
+	// error means the identity is valid. It reports one of the errors above
+	// while the channel has no configuration in force.
 	IsValid(identity view.Identity) error
 	// GetVerifier returns a Verifier that checks signatures produced by
 	// identity. It fails if identity is not one the channel recognizes, and
-	// returns an error wrapping ErrNotInitialized while the channel
-	// configuration has not been loaded.
+	// reports one of the errors above while the channel has no configuration in
+	// force.
 	GetVerifier(identity view.Identity) (Verifier, error)
 	// CheckACL checks the ACL for the resource for the Channel using the
 	// SignedProposal from which an id can be extracted for testing against a
 	// policy. Implementations that do not enforce ACLs return
-	// ErrNotImplemented; those that do return an error wrapping
-	// ErrNotInitialized while the channel configuration has not been loaded.
+	// ErrNotImplemented; those that do report one of the errors above while the
+	// channel has no configuration in force.
 	CheckACL(signedProp SignedProposal) error
 	// IsIdemixMSP reports whether the MSP with the given ID is of type Idemix.
 	// A false result means the channel has such an MSP and it is not Idemix; a
-	// channel whose configuration has not been loaded yet reports an error
-	// wrapping ErrNotInitialized instead, so callers choosing an identity
-	// encoding from this cannot mistake the startup race for a real answer.
+	// channel with no configuration in force reports one of the errors above
+	// instead, so callers choosing an identity encoding from this cannot
+	// mistake an absent configuration for a real answer.
 	IsIdemixMSP(mspID string) (bool, error)
 }
 
@@ -122,8 +130,7 @@ type MembershipService interface {
 	Update(env *common.Envelope) error
 	// OrdererConfig returns the consensus type and the orderer endpoints in the
 	// current channel configuration, with the TLS settings from cs applied. It
-	// fails if the configuration carries no orderer section, and returns an
-	// error wrapping ErrNotInitialized while the configuration has not been
-	// loaded yet.
+	// fails if the configuration carries no orderer section, and reports
+	// ErrNotInitialized or ErrConfigRejected while none is in force.
 	OrdererConfig(cs ConfigService) (string, []*grpc.ConnectionConfig, error)
 }

--- a/platform/fabric/membership.go
+++ b/platform/fabric/membership.go
@@ -143,9 +143,10 @@ type MSPManager struct {
 }
 
 // GetMSPIDs returns the MSP IDs of the organizations in the channel's current
-// configuration. It fails while that configuration has not been loaded yet;
-// callers racing node startup can detect this with
-// errors.Is(err, driver.ErrNotInitialized).
+// configuration. It fails while the channel has no configuration in force:
+// callers racing node startup can detect that with
+// errors.Is(err, driver.ErrNotInitialized), and a configuration that arrived and
+// was refused with errors.Is(err, driver.ErrConfigRejected).
 func (c *MSPManager) GetMSPIDs() ([]string, error) {
 	return c.ch.GetMSPIDs()
 }

--- a/platform/fabricx/core/membership/membership.go
+++ b/platform/fabricx/core/membership/membership.go
@@ -35,7 +35,9 @@ var logger = logging.MustGetLogger()
 // Service answers membership questions about a channel from its current
 // configuration. The configuration is not available when the service is built;
 // it arrives with the first poll of the channel config monitor, via Update.
-// Every accessor therefore reports driver.ErrNotInitialized until that happens.
+// Until one is in force every accessor reports driver.ErrNotInitialized, or,
+// once a configuration has arrived and failed validation,
+// driver.ErrConfigRejected.
 type Service struct {
 	// config holds the channel configuration once it has been loaded. Reading
 	// it goes through configstate.Holder.Get, which cannot hand out a
@@ -215,8 +217,8 @@ func (s *Service) GetVerifier(identity view.Identity) (driver.Verifier, error) {
 
 // GetMSPIDs retrieves the MSP IDs of the organizations in the current Channel
 // configuration. An empty result means the channel has no organizations; a
-// channel whose configuration has not been loaded yet reports
-// driver.ErrNotInitialized instead.
+// channel with no configuration in force reports driver.ErrNotInitialized or
+// driver.ErrConfigRejected instead.
 func (s *Service) GetMSPIDs() ([]string, error) {
 	res, err := s.config.Get()
 	if err != nil {
@@ -304,9 +306,9 @@ func (s *Service) MSPManager() driver.MSPManager {
 
 // IsIdemixMSP reports whether the MSP identified by mspID is of type Idemix.
 // A false result means the channel has such an MSP and it is not Idemix; a
-// channel whose configuration has not been loaded yet reports
-// driver.ErrNotInitialized instead, so a caller cannot mistake the startup
-// race for a definitive answer.
+// channel with no configuration in force reports driver.ErrNotInitialized or
+// driver.ErrConfigRejected instead, so a caller cannot mistake an absent
+// configuration for a definitive answer.
 func (s *Service) IsIdemixMSP(mspID string) (bool, error) {
 	res, err := s.config.Get()
 	if err != nil {

--- a/platform/fabricx/core/membership/membership.go
+++ b/platform/fabricx/core/membership/membership.go
@@ -49,7 +49,7 @@ type Service struct {
 
 func NewService(channelID string) *Service {
 	s := &Service{
-		config:    configstate.NewHolder[channelconfig.Resources](channelID),
+		config:    configstate.NewHolder[channelconfig.Resources]("channel [" + channelID + "] configuration"),
 		channelID: channelID,
 	}
 	policyChecker := policy.NewPolicyChecker(


### PR DESCRIPTION
Closes #1664

### Description

`ordering.Service` gets its broadcaster from the channel configuration, on the same asynchronous path as #1385: the committer feeds the config block to `MembershipService.Update`, reads it back with `OrdererConfig`, and passes the consensus type to `Configure` → `SetConsensusType`. Until that lands, the service has no broadcaster, and `Broadcast` reported it like this:

```go
o.BroadcastMutex.RLock()
broadcaster := o.Broadcaster
o.BroadcastMutex.RUnlock()
if broadcaster == nil {
    return errors.Errorf("cannot broadcast yet, no consensus type set")
}
```

Two problems. The startup window is not detectable — after #1663 a caller recognises the same condition on the membership path with `errors.Is(err, driver.ErrNotInitialized)`, but here it can only string-match, so a node that is merely still coming up looks the same as one that is permanently misconfigured. And the locking invariant is unenforceable: `Broadcaster` and `BroadcastMutex` are both exported, so nothing requires the mutex to be taken — the unit tests assigned the field directly, and did.

### Changes

- **`platform/fabric/core/generic/ordering`**: the broadcaster moves into the `configstate.Holder` added by #1663 and is unexported along with its mutex. `Broadcast` reaches it through `Get`, so a service that cannot broadcast now says which of the two reasons applies:

```
awaited:  cannot broadcast: network [x] ordering configuration not loaded: not initialized
refused:  cannot broadcast: network [x] ordering configuration rejected: no broadcaster found for consensus [kafka]: configuration rejected
```

- `SetConsensusType` selects inside `Holder.Update`. Because `Update` leaves the held value alone when its function fails, an unsupported consensus type can no longer drop a working service back into the uninitialized state.
- `Broadcasters` stays exported: it is written only by `NewService` and read-only afterwards, so it is not the guarded-invariant problem.
- **`platform/fabric/driver`**: new `ErrConfigRejected`. `ErrNotInitialized` is documented as a transient startup condition its callers should retry, so it cannot also stand for a configuration that arrived and was refused — retrying that never helps. The two differ by what unblocks the caller rather than how long they last: `ErrNotInitialized` clears when the configuration arrives, `ErrConfigRejected` when a later update is accepted, and neither means the node is finished.
- **`platform/fabric/core/configstate`**: `NewHolder` took a channel name and hardcoded `"channel [%s] configuration not loaded"`. An ordering service does not hold a channel configuration, so the parameter becomes a `subject` noun phrase and the message becomes `"%s not loaded"`. The two membership call sites pass `"channel [x] configuration"`, leaving their error text unchanged. `Update` additionally records *why* an update was refused while nothing has been accepted, so `Get` can report `ErrConfigRejected` with that reason wrapped. Once a configuration is in force the holder keeps answering from it and a later refusal reaches the updater alone — already the behaviour, now documented.
- **Tests**: `newTestService()` collapses fifteen copies of the same eight-line constructor call, and `setBroadcaster` registers a fake under a test consensus type and calls `SetConsensusType`, so the tests go through the real selection path instead of writing the field. New cases cover broadcasting before a consensus type is set, a rejected `SetConsensusType` keeping the previous broadcaster, broadcasting after a rejected consensus type, and recovery from one. On the holder: that a rejection is not reported as a startup race, that its reason survives, that a later success clears it, that a refusal after a success does not mask the value in force, and that `TryGet` ignores rejections.

Membership accessors now report `ErrConfigRejected` where they reported `ErrNotInitialized` for a config block that failed to parse or validate. That narrows a sentinel added in #1663, which is not in any release tag yet. `Broadcaster` and `BroadcastMutex` had no references anywhere else in the repository.

### Verification

```
go build ./...                                                    ok
go test ./platform/...                                            ok
go test -race -count=2 (ordering, configstate, membership x2)     ok
golangci-lint run ./platform/fabric/... ./platform/fabricx/...    0 issues
```
