### PR TITLE
refactor(fabric)!: remove unused private chaincode support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -477,8 +477,6 @@ fabric:
         chaincodes:
             # chaincode id
           - name: mychaincode
-            # whether it is a fabric private chaincode or not
-            private: false
 
     # ----------------------- Fabric Driver Configuration ---------------------------
     # Internal vault used to keep track of the RW sets assembled by this node during in progress transactions

--- a/integration/nwo/fabric/network/network.go
+++ b/integration/nwo/fabric/network/network.go
@@ -225,9 +225,7 @@ func (n *Network) PostRun(load bool) {
 				for _, ccp := range n.ccps {
 					chaincode = ccp.Process(n, chaincode)
 				}
-				if !chaincode.Private {
-					n.DeployChaincode(chaincode)
-				}
+				n.DeployChaincode(chaincode)
 			}
 		}
 	}

--- a/integration/nwo/fabric/topology/chaincode.go
+++ b/integration/nwo/fabric/topology/chaincode.go
@@ -41,13 +41,6 @@ func (c *Chaincode) SetPackageIDFromPackageFile() {
 	c.PackageID = c.Label + ":" + hashStr
 }
 
-type PrivateChaincode struct {
-	Image           string
-	SGXMode         string
-	SGXDevicesPaths []string
-	MREnclave       string
-}
-
 type namespace struct {
 	cc *ChannelChaincode
 }

--- a/integration/nwo/fabric/topology/core_template.go
+++ b/integration/nwo/fabric/topology/core_template.go
@@ -318,7 +318,6 @@ fabric:
           parallelism: 5
         chaincodes: {{range Chaincodes .Name }}
           - name: {{ .Chaincode.Name }}
-            private: {{ .Private }}
         {{- end }}
     {{- end }}
     vault:

--- a/integration/nwo/fabric/topology/ds.go
+++ b/integration/nwo/fabric/topology/ds.go
@@ -89,11 +89,9 @@ type PostRunInvocation struct {
 
 type ChannelChaincode struct {
 	Chaincode          Chaincode           `yaml:"chaincode,omitempty"`
-	PrivateChaincode   PrivateChaincode    `yaml:"privatechaincode,omitempty"`
 	Path               string              `yaml:"path,omitempty"`
 	Channel            string              `yaml:"channel,omitempty"`
 	Peers              []string            `yaml:"peers,omitempty"`
-	Private            bool                `yaml:"private,omitempty"`
 	PostRunInvocations []PostRunInvocation `yaml:"postruninvocations,omitempty"`
 }
 

--- a/platform/fabric/chaincode.go
+++ b/platform/fabric/chaincode.go
@@ -79,10 +79,6 @@ func (c *Chaincode) IsAvailable() (bool, error) {
 	return c.chaincode.IsAvailable()
 }
 
-func (c *Chaincode) IsPrivate() bool {
-	return c.chaincode.IsPrivate()
-}
-
 // Version returns the version of this chaincode.
 // It returns an error if a failure happens during the computation.
 func (c *Chaincode) Version() (string, error) {

--- a/platform/fabric/core/generic/chaincode/chaincode.go
+++ b/platform/fabric/core/generic/chaincode/chaincode.go
@@ -118,20 +118,6 @@ func (c *Chaincode) IsAvailable() (bool, error) {
 	return len(ids) != 0, nil
 }
 
-func (c *Chaincode) IsPrivate() bool {
-	channel := c.ConfigService.Channel(c.ChannelID)
-	if channel == nil {
-		return false
-	}
-	for _, chaincode := range channel.ChaincodeConfigs() {
-		if chaincode.ID() == c.name {
-			return chaincode.IsPrivate()
-		}
-	}
-	// Nothing was found
-	return false
-}
-
 // Version returns the version of this chaincode.
 // It uses discovery to extract this information from the endorsers
 func (c *Chaincode) Version() (string, error) {

--- a/platform/fabric/core/generic/chaincode/chaincode_test.go
+++ b/platform/fabric/core/generic/chaincode/chaincode_test.go
@@ -294,37 +294,6 @@ func TestNewChaincode(t *testing.T) {
 	require.NotNil(t, disc)
 }
 
-func TestChaincodeIsPrivate(t *testing.T) {
-	t.Parallel()
-	t.Run("channel nil", func(t *testing.T) {
-		t.Parallel()
-		fix := setupTestChaincode(t)
-		fix.ConfigService.ChannelReturns(nil)
-		require.False(t, fix.Chaincode.IsPrivate())
-	})
-
-	t.Run("chaincode not found", func(t *testing.T) {
-		t.Parallel()
-		fix := setupTestChaincode(t)
-		mockChan := &mock.ChannelConfig{}
-		mockChan.ChaincodeConfigsReturns(nil) // empty
-		fix.ConfigService.ChannelReturns(mockChan)
-		require.False(t, fix.Chaincode.IsPrivate())
-	})
-
-	t.Run("chaincode found", func(t *testing.T) {
-		t.Parallel()
-		fix := setupTestChaincode(t)
-		mockChan := &mock.ChannelConfig{}
-		mockCCConf := &mock.ChaincodeConfig{}
-		mockCCConf.IDReturns("test-chaincode")
-		mockCCConf.IsPrivateReturns(true)
-		mockChan.ChaincodeConfigsReturns([]driver.ChaincodeConfig{mockCCConf})
-		fix.ConfigService.ChannelReturns(mockChan)
-		require.True(t, fix.Chaincode.IsPrivate())
-	})
-}
-
 func TestManager(t *testing.T) {
 	t.Parallel()
 	fix := setupTestChaincode(t)

--- a/platform/fabric/core/generic/chaincode/mock/chaincode_config.go
+++ b/platform/fabric/core/generic/chaincode/mock/chaincode_config.go
@@ -18,16 +18,6 @@ type ChaincodeConfig struct {
 	iDReturnsOnCall map[int]struct {
 		result1 string
 	}
-	IsPrivateStub        func() bool
-	isPrivateMutex       sync.RWMutex
-	isPrivateArgsForCall []struct {
-	}
-	isPrivateReturns struct {
-		result1 bool
-	}
-	isPrivateReturnsOnCall map[int]struct {
-		result1 bool
-	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -82,59 +72,6 @@ func (fake *ChaincodeConfig) IDReturnsOnCall(i int, result1 string) {
 	}
 	fake.iDReturnsOnCall[i] = struct {
 		result1 string
-	}{result1}
-}
-
-func (fake *ChaincodeConfig) IsPrivate() bool {
-	fake.isPrivateMutex.Lock()
-	ret, specificReturn := fake.isPrivateReturnsOnCall[len(fake.isPrivateArgsForCall)]
-	fake.isPrivateArgsForCall = append(fake.isPrivateArgsForCall, struct {
-	}{})
-	stub := fake.IsPrivateStub
-	fakeReturns := fake.isPrivateReturns
-	fake.recordInvocation("IsPrivate", []interface{}{})
-	fake.isPrivateMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *ChaincodeConfig) IsPrivateCallCount() int {
-	fake.isPrivateMutex.RLock()
-	defer fake.isPrivateMutex.RUnlock()
-	return len(fake.isPrivateArgsForCall)
-}
-
-func (fake *ChaincodeConfig) IsPrivateCalls(stub func() bool) {
-	fake.isPrivateMutex.Lock()
-	defer fake.isPrivateMutex.Unlock()
-	fake.IsPrivateStub = stub
-}
-
-func (fake *ChaincodeConfig) IsPrivateReturns(result1 bool) {
-	fake.isPrivateMutex.Lock()
-	defer fake.isPrivateMutex.Unlock()
-	fake.IsPrivateStub = nil
-	fake.isPrivateReturns = struct {
-		result1 bool
-	}{result1}
-}
-
-func (fake *ChaincodeConfig) IsPrivateReturnsOnCall(i int, result1 bool) {
-	fake.isPrivateMutex.Lock()
-	defer fake.isPrivateMutex.Unlock()
-	fake.IsPrivateStub = nil
-	if fake.isPrivateReturnsOnCall == nil {
-		fake.isPrivateReturnsOnCall = make(map[int]struct {
-			result1 bool
-		})
-	}
-	fake.isPrivateReturnsOnCall[i] = struct {
-		result1 bool
 	}{result1}
 }
 

--- a/platform/fabric/core/generic/config/ds.go
+++ b/platform/fabric/core/generic/config/ds.go
@@ -82,16 +82,11 @@ type TLS struct {
 type ConnectionConfig = grpc.ConnectionConfig
 
 type Chaincode struct {
-	Name    string `yaml:"Name,omitempty"`
-	Private bool   `yaml:"Private,omitempty"`
+	Name string `yaml:"Name,omitempty"`
 }
 
 func (c Chaincode) ID() string {
 	return c.Name
-}
-
-func (c Chaincode) IsPrivate() bool {
-	return c.Private
 }
 
 type Finality struct {

--- a/platform/fabric/core/generic/config/service_test.go
+++ b/platform/fabric/core/generic/config/service_test.go
@@ -135,7 +135,7 @@ func TestChannelHelpers(t *testing.T) {
 	require.Equal(t, time.Minute, ch.FinalityForPartiesWaitTimeout())
 
 	// ChaincodeConfigs should convert to driver.ChaincodeConfig
-	cc := &cfg.Chaincode{Name: "cc1", Private: true}
+	cc := &cfg.Chaincode{Name: "cc1"}
 	c := &cfg.Channel{Chaincodes: []*cfg.Chaincode{cc}}
 	arr := c.ChaincodeConfigs()
 	require.Len(t, arr, 1)

--- a/platform/fabric/core/generic/config/testdata/core.yaml
+++ b/platform/fabric/core/generic/config/testdata/core.yaml
@@ -98,7 +98,6 @@ fabric:
         default: true
         chaincodes:
           - name: iou
-            private: false
     vault:
       txidstore:
         cache:

--- a/platform/fabric/core/generic/ledger/mock/chaincode.go
+++ b/platform/fabric/core/generic/ledger/mock/chaincode.go
@@ -20,16 +20,6 @@ type Chaincode struct {
 		result1 bool
 		result2 error
 	}
-	IsPrivateStub        func() bool
-	isPrivateMutex       sync.RWMutex
-	isPrivateArgsForCall []struct {
-	}
-	isPrivateReturns struct {
-		result1 bool
-	}
-	isPrivateReturnsOnCall map[int]struct {
-		result1 bool
-	}
 	NewDiscoverStub        func() driver.ChaincodeDiscover
 	newDiscoverMutex       sync.RWMutex
 	newDiscoverArgsForCall []struct {
@@ -122,59 +112,6 @@ func (fake *Chaincode) IsAvailableReturnsOnCall(i int, result1 bool, result2 err
 		result1 bool
 		result2 error
 	}{result1, result2}
-}
-
-func (fake *Chaincode) IsPrivate() bool {
-	fake.isPrivateMutex.Lock()
-	ret, specificReturn := fake.isPrivateReturnsOnCall[len(fake.isPrivateArgsForCall)]
-	fake.isPrivateArgsForCall = append(fake.isPrivateArgsForCall, struct {
-	}{})
-	stub := fake.IsPrivateStub
-	fakeReturns := fake.isPrivateReturns
-	fake.recordInvocation("IsPrivate", []interface{}{})
-	fake.isPrivateMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *Chaincode) IsPrivateCallCount() int {
-	fake.isPrivateMutex.RLock()
-	defer fake.isPrivateMutex.RUnlock()
-	return len(fake.isPrivateArgsForCall)
-}
-
-func (fake *Chaincode) IsPrivateCalls(stub func() bool) {
-	fake.isPrivateMutex.Lock()
-	defer fake.isPrivateMutex.Unlock()
-	fake.IsPrivateStub = stub
-}
-
-func (fake *Chaincode) IsPrivateReturns(result1 bool) {
-	fake.isPrivateMutex.Lock()
-	defer fake.isPrivateMutex.Unlock()
-	fake.IsPrivateStub = nil
-	fake.isPrivateReturns = struct {
-		result1 bool
-	}{result1}
-}
-
-func (fake *Chaincode) IsPrivateReturnsOnCall(i int, result1 bool) {
-	fake.isPrivateMutex.Lock()
-	defer fake.isPrivateMutex.Unlock()
-	fake.IsPrivateStub = nil
-	if fake.isPrivateReturnsOnCall == nil {
-		fake.isPrivateReturnsOnCall = make(map[int]struct {
-			result1 bool
-		})
-	}
-	fake.isPrivateReturnsOnCall[i] = struct {
-		result1 bool
-	}{result1}
 }
 
 func (fake *Chaincode) NewDiscover() driver.ChaincodeDiscover {

--- a/platform/fabric/core/generic/transaction/mock/chaincode.go
+++ b/platform/fabric/core/generic/transaction/mock/chaincode.go
@@ -20,16 +20,6 @@ type Chaincode struct {
 		result1 bool
 		result2 error
 	}
-	IsPrivateStub        func() bool
-	isPrivateMutex       sync.RWMutex
-	isPrivateArgsForCall []struct {
-	}
-	isPrivateReturns struct {
-		result1 bool
-	}
-	isPrivateReturnsOnCall map[int]struct {
-		result1 bool
-	}
 	NewDiscoverStub        func() driver.ChaincodeDiscover
 	newDiscoverMutex       sync.RWMutex
 	newDiscoverArgsForCall []struct {
@@ -122,59 +112,6 @@ func (fake *Chaincode) IsAvailableReturnsOnCall(i int, result1 bool, result2 err
 		result1 bool
 		result2 error
 	}{result1, result2}
-}
-
-func (fake *Chaincode) IsPrivate() bool {
-	fake.isPrivateMutex.Lock()
-	ret, specificReturn := fake.isPrivateReturnsOnCall[len(fake.isPrivateArgsForCall)]
-	fake.isPrivateArgsForCall = append(fake.isPrivateArgsForCall, struct {
-	}{})
-	stub := fake.IsPrivateStub
-	fakeReturns := fake.isPrivateReturns
-	fake.recordInvocation("IsPrivate", []interface{}{})
-	fake.isPrivateMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *Chaincode) IsPrivateCallCount() int {
-	fake.isPrivateMutex.RLock()
-	defer fake.isPrivateMutex.RUnlock()
-	return len(fake.isPrivateArgsForCall)
-}
-
-func (fake *Chaincode) IsPrivateCalls(stub func() bool) {
-	fake.isPrivateMutex.Lock()
-	defer fake.isPrivateMutex.Unlock()
-	fake.IsPrivateStub = stub
-}
-
-func (fake *Chaincode) IsPrivateReturns(result1 bool) {
-	fake.isPrivateMutex.Lock()
-	defer fake.isPrivateMutex.Unlock()
-	fake.IsPrivateStub = nil
-	fake.isPrivateReturns = struct {
-		result1 bool
-	}{result1}
-}
-
-func (fake *Chaincode) IsPrivateReturnsOnCall(i int, result1 bool) {
-	fake.isPrivateMutex.Lock()
-	defer fake.isPrivateMutex.Unlock()
-	fake.IsPrivateStub = nil
-	if fake.isPrivateReturnsOnCall == nil {
-		fake.isPrivateReturnsOnCall = make(map[int]struct {
-			result1 bool
-		})
-	}
-	fake.isPrivateReturnsOnCall[i] = struct {
-		result1 bool
-	}{result1}
 }
 
 func (fake *Chaincode) NewDiscover() driver.ChaincodeDiscover {

--- a/platform/fabric/driver/chaincode.go
+++ b/platform/fabric/driver/chaincode.go
@@ -83,7 +83,6 @@ type Chaincode interface {
 	NewInvocation(function string, args ...any) ChaincodeInvocation
 	NewDiscover() ChaincodeDiscover
 	IsAvailable() (bool, error)
-	IsPrivate() bool
 	// Version returns the version of this chaincode.
 	// It returns an error if a failure happens during the computation.
 	Version() (string, error)

--- a/platform/fabric/driver/config.go
+++ b/platform/fabric/driver/config.go
@@ -32,7 +32,6 @@ const (
 
 type ChaincodeConfig interface {
 	ID() string
-	IsPrivate() bool
 }
 
 type ListenerManagerProvider driver.ListenerManagerProvider[ValidationCode]

--- a/platform/fabric/services/chaincode/chaincode.go
+++ b/platform/fabric/services/chaincode/chaincode.go
@@ -36,7 +36,6 @@ type Query interface {
 }
 
 type Chaincode interface {
-	IsPrivate() bool
 	Endorse(function string, args ...any) Endorse
 	Query(function string, args ...any) Query
 }
@@ -120,10 +119,6 @@ func (s *stdQuery) WithRetrySleep(duration time.Duration) {
 
 type stdChaincode struct {
 	ch *fabric.Chaincode
-}
-
-func (s *stdChaincode) IsPrivate() bool {
-	return s.ch.IsPrivate()
 }
 
 func (s *stdChaincode) Endorse(function string, args ...any) Endorse {


### PR DESCRIPTION
Closes #1667

## Description
The private-chaincode hooks are leftovers from the dropped Fabric Private Chaincode integration. Nothing in the tree sets `ChannelChaincode.Private` or populates `topology.PrivateChaincode`, so `Chaincode.IsPrivate() ` has always returned false and the deploy gate in `Network.PostRun` has always been taken.

Removed:
- `IsPrivate` from `fabric.Chaincode`, `driver.Chaincode`, `driver.ChaincodeConfig`, `services/chaincode.Chaincode`
- Private field + `IsPrivate` accessor on `config.Chaincode`, and the private: key emitted into the FSC node `core.yaml`
- `topology.PrivateChaincode`, `ChannelChaincode.{PrivateChaincode,Private}`, and the deploy gate reading it

BREAKING CHANGE: IsPrivate is gone from the exported fabric.Chaincode, driver.Chaincode, driver.ChaincodeConfig and services/chaincode.Chaincode interfaces, and the `Private` chaincode key is no longer read from core.yaml. Downstream implementations of those interfaces must drop the method; the key can be deleted from configuration files.
