### PR TITLE
fix(fabricx)!: synchronize provider base context and stop panicking

### DIFF
--- a/platform/fabricx/core/finality/provider.go
+++ b/platform/fabricx/core/finality/provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/configstate"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/config"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services"
 )
@@ -56,20 +57,29 @@ func NewListenerManagerProvider(grpcClientProvider GRPCClientProvider, configPro
 		configProvider:         configProvider,
 		managers:               make(map[string]ListenerManager),
 		newNotificationManager: newNotifiWithGRPC,
-		// Note: baseCtx will be initialized in the Initialize method.
+		baseCtx:                configstate.NewHolder[context.Context]("finality listener manager provider base context"),
 	}
 }
 
 // Provider implements ListenerManagerProvider and manages ListenerManager instances.
-// IMPORTANT: Initialize method MUST be called once during service setup before calling NewManager method.
+//
+// The root context for the listening goroutines is not available when the
+// Provider is built; the SDK supplies it during startup, via Initialize. Until
+// then NewManager reports fabric driver.ErrNotInitialized — the one in
+// platform/fabric/driver, not the platform/common/driver this file imports as
+// driver.
 type Provider struct {
 	newNotificationManager func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error)
 	configProvider         ServiceConfigProvider
 	grpcClientProvider     GRPCClientProvider
 	managers               map[string]ListenerManager // map: "network:channel" -> ListenerManager instance
 	managersMu             sync.Mutex
-	baseCtx                context.Context // The root context for all ListenerManager goroutines. MUST be set via Initialize().
-	initOnce               sync.Once       // Ensures the provider is initialized only once
+
+	// baseCtx holds the root context for all ListenerManager goroutines,
+	// installed by Initialize. A configstate.Holder rather than a plain field
+	// guarded by sync.Once: Once orders its write only against goroutines that
+	// call Do, and NewManager never does, so it left the read racing the write.
+	baseCtx *configstate.Holder[context.Context]
 }
 
 // resolveConfig looks up the notification service config for network, falling
@@ -92,11 +102,26 @@ func (p *Provider) resolveConfig(network string) (config.Config, error) {
 // Initialize sets the base context for the provider. This context is used as the parent
 // for the listening goroutines of each ListenerManager.
 //
+// A nil context is ignored: installing one would leave the provider looking
+// initialized while every listener goroutine ran on nil, which surfaces as a
+// panic inside gRPC with nothing pointing back here. The provider stays
+// uninitialized instead, so NewManager keeps reporting it.
+//
 // IMPORTANT: This method MUST be called once during service setup before calling NewManager.
 func (p *Provider) Initialize(ctx context.Context) {
-	p.initOnce.Do(func() {
-		p.baseCtx = ctx
+	if ctx == nil {
+		logger.Error("Finality Provider.Initialize called with a nil context, ignoring it")
+		return
+	}
+
+	// The error is discarded because the update function cannot fail; keeping
+	// the first context is expressed by returning it unchanged.
+	_ = p.baseCtx.Update(func(current context.Context, loaded bool) (context.Context, error) {
+		if loaded {
+			return current, nil
+		}
 		logger.Debug("Provider initialized with base context")
+		return ctx, nil
 	})
 }
 
@@ -106,8 +131,12 @@ func (p *Provider) Initialize(ctx context.Context) {
 // If a new manager is created, it starts the manager's blocking listening process
 // in a separate goroutine.
 func (p *Provider) NewManager(network, channel string) (ListenerManager, error) {
-	if p.baseCtx == nil {
-		panic("programming error: Provider is not initialized. The Initialize() method must be called before NewManager.")
+	// Resolved once here and passed to the listening goroutine below, so that
+	// the manager registered in this call and the context its goroutine runs on
+	// come from the same read.
+	baseCtx, err := p.baseCtx.Get()
+	if err != nil {
+		return nil, err
 	}
 
 	key := network + ":" + channel
@@ -145,7 +174,7 @@ func (p *Provider) NewManager(network, channel string) (ListenerManager, error) 
 	// to receive finality notifications.
 	go func() {
 		logger.Debugf("Starting notification listener stream for %s", key)
-		if err := lm.listen(p.baseCtx); err != nil && !errors.Is(err, context.Canceled) {
+		if err := lm.listen(baseCtx); err != nil && !errors.Is(err, context.Canceled) {
 			logger.Errorf("Notification listener stream terminated unexpectedly for %s: %s", key, err)
 		}
 

--- a/platform/fabricx/core/finality/provider_test.go
+++ b/platform/fabricx/core/finality/provider_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/config"
 	mock2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/finality/mock"
 )
@@ -116,7 +117,9 @@ func TestProvider_Initialize(t *testing.T) {
 		ctx := t.Context()
 		provider.Initialize(ctx)
 
-		require.Same(t, ctx, provider.baseCtx, "baseCtx should match the provided context")
+		got, err := provider.baseCtx.Get()
+		require.NoError(t, err)
+		require.Same(t, ctx, got, "baseCtx should match the provided context")
 	})
 
 	t.Run("Initialize_Only_Once_Ignores_Subsequent_Calls", func(t *testing.T) {
@@ -129,10 +132,12 @@ func TestProvider_Initialize(t *testing.T) {
 		t.Cleanup(cancel)
 
 		provider.Initialize(ctx1)
-		provider.Initialize(ctx2) // Should be ignored due to sync.Once
+		provider.Initialize(ctx2) // Should be ignored: the first context wins
 
-		require.Same(t, ctx1, provider.baseCtx, "baseCtx should remain as first initialized value")
-		require.NotSame(t, ctx2, provider.baseCtx, "Second Initialize call should be ignored")
+		got, err := provider.baseCtx.Get()
+		require.NoError(t, err)
+		require.Same(t, ctx1, got, "baseCtx should remain as first initialized value")
+		require.NotSame(t, ctx2, got, "Second Initialize call should be ignored")
 	})
 
 	t.Run("Thread_Safe_Concurrent_Initialize", func(t *testing.T) {
@@ -150,21 +155,74 @@ func TestProvider_Initialize(t *testing.T) {
 		}
 		wg.Wait()
 
-		require.NotNil(t, provider.baseCtx, "baseCtx should be set after concurrent Initialize calls")
+		got, err := provider.baseCtx.Get()
+		require.NoError(t, err, "baseCtx should be set after concurrent Initialize calls")
+		require.NotNil(t, got)
+	})
+
+	t.Run("Nil_Context_Is_Ignored", func(t *testing.T) {
+		t.Parallel()
+		// Installing a nil context would leave the Provider looking initialized
+		// while every listener goroutine ran on nil, surfacing as a panic inside
+		// gRPC with nothing pointing back at the Provider.
+		provider := NewListenerManagerProvider(&mockGRPCClientProvider{}, nil)
+
+		//nolint:staticcheck // passing a nil context is the mistake under test
+		provider.Initialize(nil)
+
+		_, err := provider.baseCtx.Get()
+		require.ErrorIs(t, err, fdriver.ErrNotInitialized,
+			"a nil context must leave the Provider uninitialized")
+
+		lm, err := provider.NewManager("network1", "channel1")
+		require.Nil(t, lm)
+		require.ErrorIs(t, err, fdriver.ErrNotInitialized)
+
+		// A real context afterwards still initializes the Provider.
+		ctx := t.Context()
+		provider.Initialize(ctx)
+		got, err := provider.baseCtx.Get()
+		require.NoError(t, err)
+		require.Same(t, ctx, got)
+	})
+
+	t.Run("Is_Race_Free_With_NewManager", func(t *testing.T) {
+		t.Parallel()
+		// Guarding baseCtx with sync.Once alone was not enough: Once orders its
+		// write only against goroutines that call Do, and NewManager never
+		// does, so the read raced the write.
+		provider := NewListenerManagerProvider(&mockGRPCClientProvider{}, nil)
+		provider.newNotificationManager = func(string, GRPCClientProvider, config.Config) (*notificationListenerManager, error) {
+			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
+				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
+					<-ctx.Done()
+					return nil, ctx.Err()
+				}
+			}), nil
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		var wg sync.WaitGroup
+		wg.Go(func() { provider.Initialize(ctx) })
+		wg.Go(func() { _, _ = provider.NewManager("network1", "channel1") })
+		wg.Wait()
 	})
 }
 
 func TestProvider_NewManager(t *testing.T) {
 	t.Parallel()
-	t.Run("Panics_If_Not_Initialized", func(t *testing.T) {
+	t.Run("Reports_Not_Initialized", func(t *testing.T) {
 		t.Parallel()
 		mockGRPC := &mockGRPCClientProvider{}
 		provider := NewListenerManagerProvider(mockGRPC, nil)
 
 		// Don't call Initialize
-		require.Panics(t, func() {
-			_, _ = provider.NewManager("network1", "channel1")
-		}, "Should panic when Provider is not initialized")
+		lm, err := provider.NewManager("network1", "channel1")
+		require.Nil(t, lm)
+		require.ErrorIs(t, err, fdriver.ErrNotInitialized,
+			"Should report the startup condition when Provider is not initialized")
 	})
 
 	t.Run("Creates_New_Manager_And_Starts_Listen", func(t *testing.T) {

--- a/platform/fabricx/core/ledger/provider.go
+++ b/platform/fabricx/core/ledger/provider.go
@@ -9,13 +9,13 @@ package ledger
 import (
 	"context"
 	"reflect"
-	"sync"
 
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"google.golang.org/grpc"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/lazy"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/configstate"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/committer/queryservice"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services"
@@ -39,12 +39,20 @@ type GRPCClientProvider interface {
 }
 
 // Provider provides ledger implementations to access transactions and blocks on the ledger.
+//
+// The base context the ledgers make their RPC calls on is not available when the
+// Provider is built; the SDK supplies it during startup, via Initialize. Until
+// then NewLedger and Context report driver.ErrNotInitialized.
 type Provider struct {
 	queryServiceProvider queryservice.Provider
 	grpcClientProvider   GRPCClientProvider
 	ledgers              lazy.Provider[string, driver.Ledger]
-	baseCtx              context.Context
-	initOnce             sync.Once
+
+	// baseCtx holds the context installed by Initialize. A configstate.Holder
+	// rather than a plain field guarded by sync.Once: Once orders its write
+	// only against goroutines that call Do, and the readers here never do, so
+	// it left them racing the write.
+	baseCtx *configstate.Holder[context.Context]
 }
 
 // NewProvider creates a new Provider instance with the given gRPC client provider.
@@ -53,6 +61,7 @@ func NewProvider(grpcClientProvider GRPCClientProvider, queryServiceProvider que
 	p := &Provider{
 		grpcClientProvider:   grpcClientProvider,
 		queryServiceProvider: queryServiceProvider,
+		baseCtx:              configstate.NewHolder[context.Context]("ledger provider base context"),
 	}
 	p.ledgers = lazy.NewProvider[string, driver.Ledger](func(s string) (driver.Ledger, error) {
 		return p.newLedger(s)
@@ -62,27 +71,46 @@ func NewProvider(grpcClientProvider GRPCClientProvider, queryServiceProvider que
 
 // Initialize sets the base context for the provider. This method must be called
 // before NewLedger. It is safe to call multiple times; only the first call has effect.
+//
+// A nil context is ignored: installing one would leave the provider looking
+// initialized while every ledger made its RPC calls on nil, which surfaces as a
+// panic inside gRPC with nothing pointing back here. The provider stays
+// uninitialized instead, so NewLedger and Context keep reporting it.
 func (p *Provider) Initialize(ctx context.Context) {
-	p.initOnce.Do(func() {
-		p.baseCtx = ctx
+	if ctx == nil {
+		logger.Error("Ledger Provider.Initialize called with a nil context, ignoring it")
+		return
+	}
+
+	// The error is discarded because the update function cannot fail; keeping
+	// the first context is expressed by returning it unchanged.
+	_ = p.baseCtx.Update(func(current context.Context, loaded bool) (context.Context, error) {
+		if loaded {
+			return current, nil
+		}
 		logger.Debug("Ledger Provider initialized with base context")
+		return ctx, nil
 	})
 }
 
 // NewLedger returns a ledger instance for the specified network.
 // The channel parameter must be empty as FabricX does not support channels.
-// Returns an error if the provider is not initialized or if channel is non-empty.
+// It returns an error wrapping driver.ErrNotInitialized if Initialize has not
+// run yet; newLedger reports that, before it opens any connection, on the first
+// call for a network. Later calls are served from the cache, which cannot hold a
+// ledger unless one was built — so unless Initialize had run.
 func (p *Provider) NewLedger(network, channel string) (driver.Ledger, error) {
-	if p.baseCtx == nil {
-		panic("programming error: Provider is not initialized. The Initialize() method must be called before NewLedger.")
-	}
-
 	return p.ledgers.Get(network)
 }
 
 // newLedger creates a new ledger instance for the specified network.
 // It establishes a gRPC connection and creates the necessary client stubs.
 func (p *Provider) newLedger(network string) (driver.Ledger, error) {
+	baseCtx, err := p.baseCtx.Get()
+	if err != nil {
+		return nil, err
+	}
+
 	cc, err := p.grpcClientProvider.NotificationServiceClient(network)
 	if err != nil {
 		return nil, err
@@ -96,12 +124,14 @@ func (p *Provider) newLedger(network string) (driver.Ledger, error) {
 		return nil, err
 	}
 
-	return New(client, qs, p.baseCtx), nil
+	return New(client, qs, baseCtx), nil
 }
 
-// Context returns the base context used by the provider for RPC calls.
-func (p *Provider) Context() context.Context {
-	return p.baseCtx
+// Context returns the base context used by the provider for RPC calls. It
+// returns an error wrapping driver.ErrNotInitialized if Initialize has not run
+// yet.
+func (p *Provider) Context() (context.Context, error) {
+	return p.baseCtx.Get()
 }
 
 // GetLedgerProvider fetches the Provider for the specified network and channel

--- a/platform/fabricx/core/ledger/provider_test.go
+++ b/platform/fabricx/core/ledger/provider_test.go
@@ -10,11 +10,13 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/ledger"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabricx/core/ledger/mock"
 )
@@ -26,12 +28,16 @@ func TestProvider_Initialize(t *testing.T) {
 	p := ledger.NewProvider(mockGRPC, mockQS)
 	ctx := context.Background()
 	p.Initialize(ctx)
-	require.Equal(t, ctx, p.Context())
+	got, err := p.Context()
+	require.NoError(t, err)
+	require.Equal(t, ctx, got)
 
 	// Second initialization should not change anything
 	ctx2 := t.Context()
 	p.Initialize(ctx2)
-	require.Equal(t, ctx, p.Context())
+	got, err = p.Context()
+	require.NoError(t, err)
+	require.Equal(t, ctx, got)
 }
 
 func TestProvider_NewLedger(t *testing.T) {
@@ -41,10 +47,9 @@ func TestProvider_NewLedger(t *testing.T) {
 	mockGRPC.NotificationServiceClientReturns(&grpc.ClientConn{}, nil)
 	p := ledger.NewProvider(mockGRPC, mockQS)
 
-	// Should panic if not initialized
-	require.Panics(t, func() {
-		_, _ = p.NewLedger("test-net", "test-ch")
-	})
+	// Should report the startup condition if not initialized
+	_, err := p.NewLedger("test-net", "test-ch")
+	require.ErrorIs(t, err, driver.ErrNotInitialized)
 
 	ctx := context.Background()
 	p.Initialize(ctx)
@@ -111,4 +116,69 @@ func TestGetLedgerProvider_Error(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, lp)
 	require.ErrorContains(t, err, "could not find ledger provider")
+}
+
+// TestProvider_NewLedgerBeforeInitialize asserts that reaching a Provider before
+// Initialize has run reports driver.ErrNotInitialized rather than panicking, so
+// a caller racing SDK startup can detect the condition and retry.
+func TestProvider_NewLedgerBeforeInitialize(t *testing.T) {
+	t.Parallel()
+	p := ledger.NewProvider(&mock.GRPCClientProvider{}, &mock.QueryServiceProvider{})
+
+	l, err := p.NewLedger("test-net", "")
+	require.Nil(t, l)
+	require.ErrorIs(t, err, driver.ErrNotInitialized)
+}
+
+// TestProvider_ContextBeforeInitialize asserts the same for the base context
+// accessor.
+func TestProvider_ContextBeforeInitialize(t *testing.T) {
+	t.Parallel()
+	p := ledger.NewProvider(&mock.GRPCClientProvider{}, &mock.QueryServiceProvider{})
+
+	ctx, err := p.Context()
+	require.Nil(t, ctx)
+	require.ErrorIs(t, err, driver.ErrNotInitialized)
+}
+
+// TestProvider_InitializeWithNilContext asserts that a nil context is refused
+// rather than installed. Installing it would leave the Provider looking
+// initialized while handing nil to every ledger's RPC calls, which surfaces as a
+// panic inside gRPC with nothing pointing back at the Provider.
+func TestProvider_InitializeWithNilContext(t *testing.T) {
+	t.Parallel()
+	p := ledger.NewProvider(&mock.GRPCClientProvider{}, &mock.QueryServiceProvider{})
+
+	//nolint:staticcheck // passing a nil context is the mistake under test
+	p.Initialize(nil)
+
+	ctx, err := p.Context()
+	require.Nil(t, ctx)
+	require.ErrorIs(t, err, driver.ErrNotInitialized,
+		"a nil context must leave the Provider uninitialized")
+
+	l, err := p.NewLedger("test-net", "")
+	require.Nil(t, l)
+	require.ErrorIs(t, err, driver.ErrNotInitialized)
+
+	// A real context afterwards still initializes the Provider.
+	p.Initialize(context.Background())
+	ctx, err = p.Context()
+	require.NoError(t, err)
+	require.NotNil(t, ctx)
+}
+
+// TestProvider_InitializeIsRaceFreeWithNewLedger pins the synchronisation of the
+// base context. Guarding it with sync.Once alone was not enough: Once orders the
+// write only against goroutines that call Do, and NewLedger never does, so the
+// read raced the write.
+func TestProvider_InitializeIsRaceFreeWithNewLedger(t *testing.T) {
+	t.Parallel()
+	p := ledger.NewProvider(&mock.GRPCClientProvider{}, &mock.QueryServiceProvider{})
+
+	var wg sync.WaitGroup
+	wg.Go(func() { p.Initialize(context.Background()) })
+	wg.Go(func() { _, _ = p.NewLedger("test-net", "") })
+	wg.Go(func() { _, _ = p.Context() })
+	wg.Wait()
 }


### PR DESCRIPTION
Closes #1671

## Description

The ledger and finality providers each take their base context from the SDK during startup, via Initialize, and each guarded it with `sync.Once` plus a nil check in the reader. Neither half worked.

Once.Do orders its write only against goroutines that also call Do, and none of the readers do, so every read of baseCtx raced the write; the race detector reports it. Today's wiring calls both Initialize methods before SDK.Start, so the race is not reachable in production, but nothing in the type enforces that ordering - which is precisely what the nil check was trying to check for.

And the nil check panicked, on methods that already return an error. Since `driver.ErrNotInitialized` and can be recognised with errors.Is, so a caller racing startup can retry rather than lose the node.

Both providers now hold the context in a configstate.Holder. Update expresses first-write-wins, Get returns the ErrNotInitialized-wrapped error, and one lock covers the write and every read.

**BREAKING CHANGE**: `ledger.Provider.Context` returns `(context.Context, error)`, and `ledger.Provider.NewLedger` and `finality.Provider.NewManager` report an error wrapping `driver.ErrNotInitialized` where they previously panicked.