### PR TITLE
refactor(msp): hold the default identity behind a guarded holder

### DIFF
--- a/platform/fabric/core/configstate/holder.go
+++ b/platform/fabric/core/configstate/holder.go
@@ -139,3 +139,25 @@ func (h *Holder[T]) Update(fn func(current T, loaded bool) (T, error)) error {
 	h.rejected = nil
 	return nil
 }
+
+// Reset returns the holder to the state it was constructed in: nothing held,
+// and no record of a refusal.
+//
+// For an owner that rebuilds what it holds from scratch rather than replacing it
+// in one step — clearing its caches, reloading, and installing whatever the
+// reload produces. Without this, a reload that fails to produce anything would
+// leave the previous value in place and Get would keep answering with it, and
+// because a refusal is only recorded while nothing is held, the reason the
+// reload produced nothing would be discarded too.
+//
+// Callers that can replace the value in a single Update should do that instead:
+// this opens a window in which Get reports driver.ErrNotInitialized.
+func (h *Holder[T]) Reset() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	var zero T
+	h.value = zero
+	h.loaded = false
+	h.rejected = nil
+}

--- a/platform/fabric/core/configstate/holder_test.go
+++ b/platform/fabric/core/configstate/holder_test.go
@@ -220,3 +220,41 @@ func TestConcurrentAccessIsRaceFree(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "x", v.id)
 }
+
+// TestResetReturnsToEmpty asserts that Reset discards both a held value and a
+// recorded refusal, so an owner that rebuilds what it holds starts from the same
+// state it was constructed in.
+func TestResetReturnsToEmpty(t *testing.T) {
+	t.Parallel()
+
+	t.Run("after a value was held", func(t *testing.T) {
+		t.Parallel()
+		h := configstate.NewHolder[*config]("channel [mychannel] configuration")
+		require.NoError(t, h.Update(func(*config, bool) (*config, error) {
+			return &config{id: "first"}, nil
+		}))
+
+		h.Reset()
+
+		v, err := h.Get()
+		require.Nil(t, v)
+		require.True(t, errors.Is(err, driver.ErrNotInitialized))
+		_, ok := h.TryGet()
+		require.False(t, ok)
+	})
+
+	t.Run("after a refusal was recorded", func(t *testing.T) {
+		t.Parallel()
+		h := configstate.NewHolder[*config]("channel [mychannel] configuration")
+		require.Error(t, h.Update(func(*config, bool) (*config, error) {
+			return nil, errors.New("boom")
+		}))
+
+		h.Reset()
+
+		_, err := h.Get()
+		require.True(t, errors.Is(err, driver.ErrNotInitialized),
+			"a reset holder must not keep reporting the old refusal")
+		require.False(t, errors.Is(err, driver.ErrConfigRejected))
+	})
+}

--- a/platform/fabric/core/generic/msp/service.go
+++ b/platform/fabric/core/generic/msp/service.go
@@ -55,6 +55,26 @@ type service struct {
 	// it apart from a network with no default.
 	defaults *configstate.Holder[defaultIdentity]
 
+	// defaultMSP holds the identifier of the MSP whose identity becomes the
+	// network default. It is resolved by loadLocalMSPs, from the configured
+	// value or, when nothing is configured, from the first MSP in the list, so
+	// it is not the same as the configured value that Config.DefaultMSP
+	// reports.
+	//
+	// Held rather than guarded by mspsMutex because SetDefaultIdentity reads it
+	// and is reachable through the exported driver.Manager interface: identity
+	// loaders are a dependency-injection extension point, so a loader outside
+	// this repository can hold a Manager and call it from a goroutine that owns
+	// no lock of ours. A holder is safe for any caller, whereas taking
+	// mspsMutex there would deadlock the in-tree loaders, which are already
+	// inside that critical section.
+	//
+	// Get also distinguishes "not resolved yet" from a real identifier, which
+	// an empty string cannot: MSP identifiers are nowhere validated as
+	// non-empty, so before loadLocalMSPs has run an empty id would otherwise
+	// compare equal and install itself as the default.
+	defaultMSP *configstate.Holder[string]
+
 	signerService       driver.SignerService
 	binderService       driver.BinderService
 	deserializerManager driver.DeserializerManager
@@ -62,14 +82,12 @@ type service struct {
 	KVS                 KVS
 	config              driver.Config
 
-	// mspsMutex guards the fields below. defaultMSP is the one worth spelling
-	// out: it is written by loadLocalMSPs under the write lock and read by
-	// SetDefaultIdentity, which an identity loader calls from inside that same
-	// critical section, on the same goroutine. So that read takes no lock, and
+	// mspsMutex guards the fields below. They are written by loadLocalMSPs and
+	// by AddMSP, which an identity loader calls from inside that same critical
+	// section on the same goroutine, so AddMSP takes no lock of its own and
 	// must not start taking one — sync.RWMutex is not reentrant and it would
-	// deadlock. AddMSP already relies on this same calling convention.
+	// deadlock.
 	mspsMutex           sync.RWMutex
-	defaultMSP          string
 	identityLoaders     map[string]driver.IdentityLoader
 	msps                []*driver.MSP
 	mspsByName          map[string]*driver.MSP
@@ -90,6 +108,7 @@ func NewLocalMSPManager(
 ) *service {
 	s := &service{
 		defaults:            configstate.NewHolder[defaultIdentity]("default identity"),
+		defaultMSP:          configstate.NewHolder[string]("default MSP"),
 		config:              config,
 		KVS:                 KVS,
 		signerService:       signerService,
@@ -139,13 +158,22 @@ func (s *service) CacheSize() int {
 }
 
 // SetDefaultIdentity installs id's identity as the network default, if id is the
-// MSP the configuration nominates as default. Identities from any other MSP are
-// ignored, and an empty identity is refused.
+// MSP resolved as the default one. Identities from any other MSP are ignored,
+// and an empty identity is refused.
 //
-// Called by identity loaders from inside loadLocalMSPs, so mspsMutex is already
-// held and defaultMSP is read directly. See the mspsMutex comment above.
+// Identity loaders call this from inside loadLocalMSPs, but the method is also
+// reachable through driver.Manager, so it holds no assumption about which locks
+// its caller owns; see the defaultMSP field.
 func (s *service) SetDefaultIdentity(id string, identity view.Identity, signing driver.SigningIdentity) {
-	if id != s.defaultMSP {
+	defaultMSP, err := s.defaultMSP.Get()
+	if err != nil {
+		// Called before loadLocalMSPs resolved which MSP is the default, so
+		// there is nothing to compare id against yet.
+		logger.Warnf("ignoring default identity from MSP [%s]: %v", id, err)
+		return
+	}
+
+	if id != defaultMSP {
 		return
 	}
 
@@ -413,16 +441,24 @@ func (s *service) loadLocalMSPs() error {
 	if err != nil {
 		return errors.WithMessagef(err, "failed loading local MSP configs")
 	}
-	s.defaultMSP = s.config.DefaultMSP()
-	if len(s.defaultMSP) == 0 {
+	defaultMSP := s.config.DefaultMSP()
+	if len(defaultMSP) == 0 {
 		if len(configs) == 0 {
 			return errors.New("default MSP not configured and no MSPs set")
 		}
 		logger.Warnf("default MSP not configured, set it to [%s]", configs[0].ID)
-		s.defaultMSP = configs[0].ID
+		defaultMSP = configs[0].ID
 	}
 
-	logger.Debugf("Local Local [%d] MSPS using default [%s]", len(configs), s.defaultMSP)
+	// Resolved before the loaders run, because each of them calls
+	// SetDefaultIdentity, which needs it to decide whether its MSP is the one.
+	if err := s.defaultMSP.Update(func(string, bool) (string, error) {
+		return defaultMSP, nil
+	}); err != nil {
+		return errors.WithMessagef(err, "failed setting default MSP to [%s]", defaultMSP)
+	}
+
+	logger.Debugf("Local Local [%d] MSPS using default [%s]", len(configs), defaultMSP)
 	for _, config := range configs {
 		loader, ok := s.identityLoaders[config.MSPType]
 		if !ok {

--- a/platform/fabric/core/generic/msp/service.go
+++ b/platform/fabric/core/generic/msp/service.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/configstate"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/idemix"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/x509"
@@ -35,17 +36,38 @@ type KVS interface {
 	Get(ctx context.Context, id string, state any) error
 }
 
-type service struct {
-	defaultIdentityMutex   sync.RWMutex
-	defaultIdentity        view.Identity
-	defaultSigningIdentity driver.SigningIdentity
-	signerService          driver.SignerService
-	binderService          driver.BinderService
-	deserializerManager    driver.DeserializerManager
-	defaultViewIdentity    view.Identity
-	KVS                    KVS
-	config                 driver.Config
+// defaultIdentity pairs the network's default identity with the signing identity
+// that goes with it. SetDefaultIdentity installs the two together and they are
+// meaningless apart, so they are held together rather than as two fields that
+// could drift.
+type defaultIdentity struct {
+	id      view.Identity
+	signing driver.SigningIdentity
+}
 
+type service struct {
+	// defaults holds the default identity once an identity loader has supplied
+	// one and it was accepted. It is not available when the service is built: it
+	// arrives while loadLocalMSPs walks the configured MSPs, so until then the
+	// holder is empty and reports which kind of empty it is — never offered one,
+	// or offered one and refused it. loadLocalMSPs turns either into a startup
+	// failure rather than letting a nil identity reach a caller that cannot tell
+	// it apart from a network with no default.
+	defaults *configstate.Holder[defaultIdentity]
+
+	signerService       driver.SignerService
+	binderService       driver.BinderService
+	deserializerManager driver.DeserializerManager
+	defaultViewIdentity view.Identity
+	KVS                 KVS
+	config              driver.Config
+
+	// mspsMutex guards the fields below. defaultMSP is the one worth spelling
+	// out: it is written by loadLocalMSPs under the write lock and read by
+	// SetDefaultIdentity, which an identity loader calls from inside that same
+	// critical section, on the same goroutine. So that read takes no lock, and
+	// must not start taking one — sync.RWMutex is not reentrant and it would
+	// deadlock. AddMSP already relies on this same calling convention.
 	mspsMutex           sync.RWMutex
 	defaultMSP          string
 	identityLoaders     map[string]driver.IdentityLoader
@@ -67,6 +89,7 @@ func NewLocalMSPManager(
 	cacheSize int,
 ) *service {
 	s := &service{
+		defaults:            configstate.NewHolder[defaultIdentity]("default identity"),
 		config:              config,
 		KVS:                 KVS,
 		signerService:       signerService,
@@ -115,25 +138,39 @@ func (s *service) CacheSize() int {
 	return s.cacheSize
 }
 
-func (s *service) SetDefaultIdentity(id string, defaultIdentity view.Identity, defaultSigningIdentity driver.SigningIdentity) {
-	s.defaultIdentityMutex.Lock()
-	defer s.defaultIdentityMutex.Unlock()
-
-	if id == s.defaultMSP {
-		if s.defaultIdentity == nil {
-			logger.Debugf("setting default identity to [%s]", id)
-		}
-
-		// set default
-		s.defaultIdentity = defaultIdentity
-		s.defaultSigningIdentity = defaultSigningIdentity
+// SetDefaultIdentity installs id's identity as the network default, if id is the
+// MSP the configuration nominates as default. Identities from any other MSP are
+// ignored, and an empty identity is refused.
+//
+// Called by identity loaders from inside loadLocalMSPs, so mspsMutex is already
+// held and defaultMSP is read directly. See the mspsMutex comment above.
+func (s *service) SetDefaultIdentity(id string, identity view.Identity, signing driver.SigningIdentity) {
+	if id != s.defaultMSP {
+		return
 	}
+
+	// Refusing the update leaves the holder empty and records why, so
+	// loadLocalMSPs fails with that reason. Installing an empty identity instead
+	// would satisfy its check and hand nil to every caller of DefaultIdentity,
+	// turning a startup failure into a signing failure much later on.
+	if err := s.defaults.Update(func(defaultIdentity, bool) (defaultIdentity, error) {
+		if identity.IsNone() {
+			return defaultIdentity{}, errors.Errorf("MSP [%s] supplied an empty identity", id)
+		}
+		return defaultIdentity{id: identity, signing: signing}, nil
+	}); err != nil {
+		logger.Warnf("refused default identity: %v", err)
+		return
+	}
+
+	logger.Debugf("set default identity to [%s]", id)
 }
 
+// DefaultIdentity returns the network's default identity, or nil if no identity
+// loader has supplied one yet.
 func (s *service) DefaultIdentity() view.Identity {
-	s.defaultIdentityMutex.RLock()
-	defer s.defaultIdentityMutex.RUnlock()
-	return s.defaultIdentity
+	d, _ := s.defaults.TryGet()
+	return d.id
 }
 
 func (s *service) AnonymousIdentity() (view.Identity, error) {
@@ -159,10 +196,11 @@ func (s *service) IsMe(ctx context.Context, id view.Identity) bool {
 	return s.signerService.IsMe(ctx, id)
 }
 
+// DefaultSigningIdentity returns the signing identity that goes with the
+// network's default identity, or nil if no identity loader has supplied one yet.
 func (s *service) DefaultSigningIdentity() fdriver.SigningIdentity {
-	s.defaultIdentityMutex.RLock()
-	defer s.defaultIdentityMutex.RUnlock()
-	return s.defaultSigningIdentity
+	d, _ := s.defaults.TryGet()
+	return d.signing
 }
 
 func (s *service) GetIdentityInfoByLabel(mspType, label string) *fdriver.IdentityInfo {
@@ -375,17 +413,14 @@ func (s *service) loadLocalMSPs() error {
 	if err != nil {
 		return errors.WithMessagef(err, "failed loading local MSP configs")
 	}
-	s.defaultIdentityMutex.Lock()
 	s.defaultMSP = s.config.DefaultMSP()
 	if len(s.defaultMSP) == 0 {
 		if len(configs) == 0 {
-			s.defaultIdentityMutex.Unlock()
 			return errors.New("default MSP not configured and no MSPs set")
 		}
 		logger.Warnf("default MSP not configured, set it to [%s]", configs[0].ID)
 		s.defaultMSP = configs[0].ID
 	}
-	s.defaultIdentityMutex.Unlock()
 
 	logger.Debugf("Local Local [%d] MSPS using default [%s]", len(configs), s.defaultMSP)
 	for _, config := range configs {
@@ -399,11 +434,30 @@ func (s *service) loadLocalMSPs() error {
 		}
 	}
 
-	s.defaultIdentityMutex.RLock()
-	defer s.defaultIdentityMutex.RUnlock()
-	if s.defaultIdentity == nil {
+	return s.defaultIdentityError()
+}
+
+// defaultIdentityError reports why the loaders left no default identity behind,
+// or nil if they installed one.
+//
+// Both outcomes are a permanent misconfiguration, so the holder's error is
+// folded in as text rather than wrapped: an unoffered default carries
+// driver.ErrNotInitialized, which callers read as "still starting up, retry",
+// and no retry produces a default the loaders did not supply on this pass.
+//
+// Refresh does not clear the holder, so on that path a default accepted by an
+// earlier load still satisfies this check.
+func (s *service) defaultIdentityError() error {
+	_, err := s.defaults.Get()
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, fdriver.ErrConfigRejected):
+		// The default MSP did offer an identity and it was refused. Say why.
+		return errors.Errorf("no usable default identity for network [%s]: %s", s.config.NetworkName(), err)
+	default:
+		// No loader offered one: the configured default MSP has no identity, or
+		// no loader recognised its type.
 		return errors.Errorf("no default identity set for network [%s]", s.config.NetworkName())
 	}
-
-	return nil
 }

--- a/platform/fabric/core/generic/msp/service.go
+++ b/platform/fabric/core/generic/msp/service.go
@@ -87,6 +87,14 @@ type service struct {
 	// section on the same goroutine, so AddMSP takes no lock of its own and
 	// must not start taking one — sync.RWMutex is not reentrant and it would
 	// deadlock.
+	//
+	// That is a known hole rather than a safe convention. AddMSP is on the
+	// exported driver.Manager interface and identity loaders are a
+	// dependency-injection extension point, so a loader outside this repository
+	// can retain a Manager and call AddMSP from a goroutine holding no lock of
+	// ours, racing the readers below — a concurrent map write, which is fatal
+	// rather than merely wrong. Fixing it means giving AddMSP a lock that
+	// loadLocalMSPs does not already hold, which is a change of its own.
 	mspsMutex           sync.RWMutex
 	identityLoaders     map[string]driver.IdentityLoader
 	msps                []*driver.MSP
@@ -182,8 +190,15 @@ func (s *service) SetDefaultIdentity(id string, identity view.Identity, signing 
 	// would satisfy its check and hand nil to every caller of DefaultIdentity,
 	// turning a startup failure into a signing failure much later on.
 	if err := s.defaults.Update(func(defaultIdentity, bool) (defaultIdentity, error) {
+		// Both halves are checked, because both are handed out: an identity
+		// without its signer would satisfy loadLocalMSPs and then fail at the
+		// first signature instead, in whatever component called
+		// DefaultSigningIdentity.
 		if identity.IsNone() {
 			return defaultIdentity{}, errors.Errorf("MSP [%s] supplied an empty identity", id)
+		}
+		if signing == nil {
+			return defaultIdentity{}, errors.Errorf("MSP [%s] supplied no signing identity", id)
 		}
 		return defaultIdentity{id: identity, signing: signing}, nil
 	}); err != nil {
@@ -353,23 +368,27 @@ func (s *service) RegisterX509MSP(id, path, mspID string) error {
 	return nil
 }
 
+// Refresh discards everything derived from the configured MSPs and builds it
+// again, so that identities added or removed since the last load are picked up.
+//
+// It fails, leaving the service without a default identity, if the reload cannot
+// produce one. Keeping the previous identity across a reload that dropped its
+// MSP would leave the service signing as an MSP it no longer knows about, and
+// would also hide the reason the reload produced nothing, since the holder only
+// records a refusal while nothing is held.
 func (s *service) Refresh() error {
 	s.mspsMutex.Lock()
 	defer s.mspsMutex.Unlock()
 
-	// clean cashes
+	// clean caches
 	s.msps = nil
 	s.mspsByTypeAndName = map[string]*driver.MSP{}
 	s.bccspMspsByIdentity = map[string]*driver.MSP{}
 	s.mspsByEnrollmentID = map[string]*driver.MSP{}
 	s.mspsByName = map[string]*driver.MSP{}
+	s.defaults.Reset()
 
-	// reload
-	if err := s.loadLocalMSPs(); err != nil {
-		return err
-	}
-
-	return nil
+	return s.loadLocalMSPs()
 }
 
 func (s *service) AddMSP(name, mspType, enrollmentID string, IdentityGetter fdriver.GetIdentityFunc) error {
@@ -452,11 +471,11 @@ func (s *service) loadLocalMSPs() error {
 
 	// Resolved before the loaders run, because each of them calls
 	// SetDefaultIdentity, which needs it to decide whether its MSP is the one.
-	if err := s.defaultMSP.Update(func(string, bool) (string, error) {
+	// The error is discarded because this update cannot fail: it accepts
+	// whatever was resolved above.
+	_ = s.defaultMSP.Update(func(string, bool) (string, error) {
 		return defaultMSP, nil
-	}); err != nil {
-		return errors.WithMessagef(err, "failed setting default MSP to [%s]", defaultMSP)
-	}
+	})
 
 	logger.Debugf("Local Local [%d] MSPS using default [%s]", len(configs), defaultMSP)
 	for _, config := range configs {

--- a/platform/fabric/core/generic/msp/service_internal_test.go
+++ b/platform/fabric/core/generic/msp/service_internal_test.go
@@ -10,9 +10,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/driver"
 	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
@@ -27,9 +29,19 @@ import (
 type testConfig struct {
 	driver.Config
 	networkName string
+	defaultMSP  string
+	msps        []config.MSP
 }
 
-func (c *testConfig) NetworkName() string { return c.networkName }
+func (c *testConfig) NetworkName() string           { return c.networkName }
+func (c *testConfig) DefaultMSP() string            { return c.defaultMSP }
+func (c *testConfig) MSPs() ([]config.MSP, error)   { return c.msps, nil }
+func (c *testConfig) TranslatePath(p string) string { return p }
+
+// loaderFunc turns a function into a driver.IdentityLoader.
+type loaderFunc func(manager driver.Manager, c config.MSP) error
+
+func (f loaderFunc) Load(manager driver.Manager, c config.MSP) error { return f(manager, c) }
 
 func newInternalTestService(t *testing.T, defaultMSP string) *service {
 	t.Helper()
@@ -86,6 +98,23 @@ func TestSetDefaultIdentityRefusesEmptyIdentity(t *testing.T) {
 	}
 }
 
+// TestSetDefaultIdentityRefusesMissingSigner asserts that an identity without
+// the signing identity that goes with it is refused. Installing the pair
+// half-built would pass every startup check and then fail at the first
+// signature, in whatever component called DefaultSigningIdentity.
+func TestSetDefaultIdentityRefusesMissingSigner(t *testing.T) {
+	t.Parallel()
+	s := newInternalTestService(t, "SampleOrg")
+
+	s.SetDefaultIdentity("SampleOrg", view.Identity("me"), nil)
+
+	_, err := s.defaults.Get()
+	require.ErrorIs(t, err, fdriver.ErrConfigRejected)
+	require.ErrorContains(t, err, "supplied no signing identity")
+	require.Nil(t, s.DefaultIdentity())
+	require.Nil(t, s.DefaultSigningIdentity())
+}
+
 // TestSetDefaultIdentityKeepsExistingOnEmpty asserts that a later empty identity
 // does not clear a default that was already accepted.
 func TestSetDefaultIdentityKeepsExistingOnEmpty(t *testing.T) {
@@ -127,9 +156,12 @@ func TestDefaultIdentityHalvesAreInstalledTogether(t *testing.T) {
 	for range 4 {
 		wg.Go(func() {
 			// Either both halves are present or neither is, never one alone.
+			// assert, not require: require calls t.FailNow, which is only valid
+			// on the test's own goroutine and would Goexit this one instead of
+			// failing the test.
 			if d, loaded := s.defaults.TryGet(); loaded {
-				require.Equal(t, view.Identity("me"), d.id)
-				require.Same(t, signing, d.signing)
+				assert.Equal(t, view.Identity("me"), d.id)
+				assert.Same(t, signing, d.signing)
 			}
 		})
 	}
@@ -214,4 +246,41 @@ func TestSetDefaultIdentityIsSafeWithoutHoldingMspsMutex(t *testing.T) {
 
 type fakeSigningIdentity struct {
 	driver.SigningIdentity
+}
+
+// TestRefreshWithoutAUsableDefaultIdentityFails asserts that a reload which
+// cannot re-establish a default identity is reported as a failure, rather than
+// leaving the service claiming success while it serves the identity of an MSP
+// the reload just removed.
+//
+// Refresh clears everything derived from the configured MSPs, and the default
+// identity is derived from them, so it has to be cleared too. Leaving it in
+// place would also hide the refusal: the holder only records why an update was
+// refused while nothing has been accepted.
+func TestRefreshWithoutAUsableDefaultIdentityFails(t *testing.T) {
+	t.Parallel()
+
+	identity := view.Identity("me")
+	cfg := &testConfig{
+		networkName: "testnet",
+		defaultMSP:  "SampleOrg",
+		msps:        []config.MSP{{ID: "SampleOrg", MSPType: "test"}},
+	}
+	s := NewLocalMSPManager(cfg, nil, nil, nil, nil, nil, 0)
+	s.PutIdentityLoader("test", loaderFunc(func(m driver.Manager, c config.MSP) error {
+		m.SetDefaultIdentity(c.ID, identity, &fakeSigningIdentity{})
+		return nil
+	}))
+
+	require.NoError(t, s.Load())
+	require.Equal(t, identity, s.DefaultIdentity())
+
+	// The MSP is still configured, but this time it has no usable identity.
+	s.PutIdentityLoader("test", loaderFunc(func(m driver.Manager, c config.MSP) error {
+		m.SetDefaultIdentity(c.ID, nil, nil)
+		return nil
+	}))
+
+	require.Error(t, s.Refresh(), "a reload that cannot establish a default identity must fail")
+	require.Nil(t, s.DefaultIdentity(), "the stale identity must not survive the reload")
 }

--- a/platform/fabric/core/generic/msp/service_internal_test.go
+++ b/platform/fabric/core/generic/msp/service_internal_test.go
@@ -42,7 +42,9 @@ func newInternalTestService(t *testing.T, defaultMSP string) *service {
 		nil, // deserializerManager
 		0,   // cacheSize
 	)
-	s.defaultMSP = defaultMSP
+	require.NoError(t, s.defaultMSP.Update(func(string, bool) (string, error) {
+		return defaultMSP, nil
+	}))
 	return s
 }
 
@@ -172,6 +174,42 @@ func TestLoadLocalMSPsErrorIsNotRetryable(t *testing.T) {
 
 		require.NoError(t, s.defaultIdentityError())
 	})
+}
+
+// TestSetDefaultIdentityBeforeDefaultMSPIsResolved asserts that a caller that
+// arrives before loadLocalMSPs has resolved the default MSP installs nothing.
+// An empty identifier must not compare equal to an unresolved one: MSP
+// identifiers are nowhere validated as non-empty.
+func TestSetDefaultIdentityBeforeDefaultMSPIsResolved(t *testing.T) {
+	t.Parallel()
+	s := NewLocalMSPManager(&testConfig{networkName: "testnet"}, nil, nil, nil, nil, nil, 0)
+
+	s.SetDefaultIdentity("", view.Identity("me"), &fakeSigningIdentity{})
+
+	_, err := s.defaults.Get()
+	require.ErrorIs(t, err, fdriver.ErrNotInitialized,
+		"an empty id must not match an unresolved default MSP")
+	require.Nil(t, s.DefaultIdentity())
+}
+
+// TestSetDefaultIdentityIsSafeWithoutHoldingMspsMutex pins what the holder buys
+// over a field guarded by mspsMutex. SetDefaultIdentity is reachable through the
+// exported driver.Manager interface, and identity loaders are a
+// dependency-injection extension point, so a loader outside this repository can
+// retain a Manager and call it from a goroutine holding none of our locks -
+// concurrently with a Refresh that is re-resolving the default MSP.
+func TestSetDefaultIdentityIsSafeWithoutHoldingMspsMutex(t *testing.T) {
+	t.Parallel()
+	s := newInternalTestService(t, "SampleOrg")
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		// Stands in for loadLocalMSPs re-resolving the default MSP.
+		_ = s.defaultMSP.Update(func(string, bool) (string, error) { return "SampleOrg", nil })
+	})
+	wg.Go(func() { s.SetDefaultIdentity("SampleOrg", view.Identity("me"), &fakeSigningIdentity{}) })
+	wg.Go(func() { _ = s.DefaultIdentity() })
+	wg.Wait()
 }
 
 type fakeSigningIdentity struct {

--- a/platform/fabric/core/generic/msp/service_internal_test.go
+++ b/platform/fabric/core/generic/msp/service_internal_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package msp
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/driver"
+	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
+
+// These tests reach into the service to check the three states the exported
+// accessors cannot tell apart, since DefaultIdentity returns nil for all of
+// them: no loader has run yet, a loader offered an identity that was refused,
+// and an identity is held. See service_test.go for the exported behaviour.
+
+// testConfig is the minimum driver.Config the service constructor touches.
+type testConfig struct {
+	driver.Config
+	networkName string
+}
+
+func (c *testConfig) NetworkName() string { return c.networkName }
+
+func newInternalTestService(t *testing.T, defaultMSP string) *service {
+	t.Helper()
+	s := NewLocalMSPManager(
+		&testConfig{networkName: "testnet"},
+		nil, // KVS
+		nil, // signerService
+		nil, // binderService
+		nil, // defaultViewIdentity
+		nil, // deserializerManager
+		0,   // cacheSize
+	)
+	s.defaultMSP = defaultMSP
+	return s
+}
+
+// TestDefaultsBeforeAnyLoader asserts that a service whose identity loaders have
+// not run yet reports the absence as a startup state, not as a refusal.
+func TestDefaultsBeforeAnyLoader(t *testing.T) {
+	t.Parallel()
+	s := newInternalTestService(t, "SampleOrg")
+
+	_, err := s.defaults.Get()
+	require.ErrorIs(t, err, fdriver.ErrNotInitialized)
+
+	// The exported accessors keep their nil-returning contract.
+	require.Nil(t, s.DefaultIdentity())
+	require.Nil(t, s.DefaultSigningIdentity())
+}
+
+// TestSetDefaultIdentityRefusesEmptyIdentity asserts that an empty identity from
+// the default MSP is refused rather than installed, and that the holder reports
+// it as a refusal so loadLocalMSPs can explain the failure instead of inviting a
+// retry that cannot help.
+func TestSetDefaultIdentityRefusesEmptyIdentity(t *testing.T) {
+	t.Parallel()
+
+	for name, empty := range map[string]view.Identity{"nil": nil, "zero-length": {}} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			s := newInternalTestService(t, "SampleOrg")
+
+			s.SetDefaultIdentity("SampleOrg", empty, &fakeSigningIdentity{})
+
+			_, err := s.defaults.Get()
+			require.ErrorIs(t, err, fdriver.ErrConfigRejected,
+				"an empty identity must be refused, not installed")
+			require.ErrorContains(t, err, "SampleOrg")
+			require.Nil(t, s.DefaultIdentity())
+			require.Nil(t, s.DefaultSigningIdentity())
+		})
+	}
+}
+
+// TestSetDefaultIdentityKeepsExistingOnEmpty asserts that a later empty identity
+// does not clear a default that was already accepted.
+func TestSetDefaultIdentityKeepsExistingOnEmpty(t *testing.T) {
+	t.Parallel()
+	s := newInternalTestService(t, "SampleOrg")
+	signing := &fakeSigningIdentity{}
+
+	s.SetDefaultIdentity("SampleOrg", view.Identity("me"), signing)
+	s.SetDefaultIdentity("SampleOrg", nil, nil)
+
+	require.Equal(t, view.Identity("me"), s.DefaultIdentity())
+	require.Same(t, signing, s.DefaultSigningIdentity())
+}
+
+// TestSetDefaultIdentityIgnoresOtherMSPs asserts that an identity from a
+// non-default MSP is neither installed nor recorded as a refusal: it is not this
+// MSP's business to nominate the default, so the holder stays untouched.
+func TestSetDefaultIdentityIgnoresOtherMSPs(t *testing.T) {
+	t.Parallel()
+	s := newInternalTestService(t, "SampleOrg")
+
+	s.SetDefaultIdentity("OtherOrg", nil, nil)
+
+	_, err := s.defaults.Get()
+	require.ErrorIs(t, err, fdriver.ErrNotInitialized,
+		"a non-default MSP must not leave the holder in the refused state")
+}
+
+// TestDefaultIdentityHalvesAreInstalledTogether asserts that a reader racing an
+// install never observes the identity without its signing identity. It relies on
+// the race detector for the concurrency; the assertion covers the pairing.
+func TestDefaultIdentityHalvesAreInstalledTogether(t *testing.T) {
+	t.Parallel()
+	s := newInternalTestService(t, "SampleOrg")
+	signing := &fakeSigningIdentity{}
+
+	var wg sync.WaitGroup
+	wg.Go(func() { s.SetDefaultIdentity("SampleOrg", view.Identity("me"), signing) })
+	for range 4 {
+		wg.Go(func() {
+			// Either both halves are present or neither is, never one alone.
+			if d, loaded := s.defaults.TryGet(); loaded {
+				require.Equal(t, view.Identity("me"), d.id)
+				require.Same(t, signing, d.signing)
+			}
+		})
+	}
+	wg.Wait()
+
+	require.Equal(t, view.Identity("me"), s.DefaultIdentity())
+	require.Same(t, signing, s.DefaultSigningIdentity())
+}
+
+// TestLoadLocalMSPsErrorIsNotRetryable asserts that a startup failure for want of
+// a default identity is reported as permanent. driver.ErrNotInitialized means
+// "still starting up, retry", and no retry will produce a default that the
+// loaders did not supply.
+func TestLoadLocalMSPsErrorIsNotRetryable(t *testing.T) {
+	t.Parallel()
+
+	t.Run("never offered", func(t *testing.T) {
+		t.Parallel()
+		s := newInternalTestService(t, "SampleOrg")
+
+		err := s.defaultIdentityError()
+		require.ErrorContains(t, err, "no default identity set for network [testnet]")
+		require.False(t, errors.Is(err, fdriver.ErrNotInitialized),
+			"a permanent misconfiguration must not look like a startup race")
+	})
+
+	t.Run("refused", func(t *testing.T) {
+		t.Parallel()
+		s := newInternalTestService(t, "SampleOrg")
+		s.SetDefaultIdentity("SampleOrg", nil, nil)
+
+		err := s.defaultIdentityError()
+		require.ErrorContains(t, err, "no usable default identity for network [testnet]")
+		require.ErrorContains(t, err, "supplied an empty identity", "the refusal reason must survive")
+		require.False(t, errors.Is(err, fdriver.ErrNotInitialized))
+	})
+
+	t.Run("installed", func(t *testing.T) {
+		t.Parallel()
+		s := newInternalTestService(t, "SampleOrg")
+		s.SetDefaultIdentity("SampleOrg", view.Identity("me"), &fakeSigningIdentity{})
+
+		require.NoError(t, s.defaultIdentityError())
+	})
+}
+
+type fakeSigningIdentity struct {
+	driver.SigningIdentity
+}


### PR DESCRIPTION
Closes #1672

### Description

The default identity of a local MSP manager is not available when the service is built: it arrives while `loadLocalMSPs` walks the configured MSPs and an identity loader calls `SetDefaultIdentity`. Two fields tracked it, guarded by a hand-rolled RWMutex, with each accessor expected to remember the lock.

Both now live in a single `configstate.Holder`. The identity and the signing identity that goes with it are installed as one value, so a reader can no longer observe one without the other, and the lock is taken by the holder rather than by convention. `loadLocalMSPs` takes its "no default identity" error from the holder instead of re-reading the field to test it for nil, so it can now say *why* there is none — never offered, or offered and refused.

`defaultMSP` is held the same way. It is read by `SetDefaultIdentity`, which is on the exported `driver.Manager` interface, and identity loaders are a dependency-injection extension point (`group:"identity-loaders"`) — so a loader outside this repository can retain a `Manager` and call it from a goroutine owning none of our locks. Guarding it with `mspsMutex` is not an option, because the in-tree loaders are already inside that critical section when they call it and `sync.RWMutex` is not reentrant. A holder carries its own lock and is safe for any caller.

### Behaviour changes

Two configurations that used to start now fail at startup instead. Both turn a latent nil into an explicit error, but they are breaks:

- **An identity with no signing identity is refused.** `loadLocalMSPs` only ever checked `defaultIdentity`, never `defaultSigningIdentity`, so a loader supplying one without the other passed startup and handed `nil` to whoever called `DefaultSigningIdentity` — e.g. `platform/fabricx/core/channel/provider.go:84`. The pair is documented as meaningless apart; it is now validated as a pair.
- **An empty MSP identifier no longer nominates the default.** `defaultMSP` was `""` until `loadLocalMSPs` resolved it, and MSP identifiers are nowhere validated as non-empty, so `SetDefaultIdentity("", ...)` compared equal and installed itself. The holder distinguishes "not resolved yet" from a real identifier.

Otherwise unchanged: `DefaultIdentity` and `DefaultSigningIdentity` still return `nil` before a loader has supplied one. Telling that apart from a network with no default identity needs those accessors to return an error, which is a break across roughly forty call sites and is left for its own change.

### Also in this PR

- **`configstate.Holder` gains `Reset`.** `Refresh` rebuilds everything derived from the configured MSPs, and the default identity is derived from them, so it has to be cleared too — otherwise a reload that cannot produce one keeps serving the identity of an MSP it just dropped, and reports success. `Update` alone cannot express "start again". Mirrors `lazy.Holder.Reset`.
- **The `mspsMutex` comment now records `AddMSP`'s calling convention as a known hole rather than a rule.** `AddMSP` has the same shape as the problem fixed above — exported on `driver.Manager`, no lock of its own, writes four maps — and is the more dangerous of the two, since a concurrent map write is fatal rather than merely wrong. It predates this PR and wants its own fix.