### PR TITLE
ci(tests): cancel superseded pull request runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,16 @@ on:
       - '.gitignore'
   workflow_dispatch:
 
+# A newer push to the same pull request makes the in-flight run obsolete, so
+# cancel it -- this workflow fans out to the whole itest matrix, so a superseded
+# run holds a large share of the concurrency allowance. Non-pull-request events
+# (pushes to main, manual dispatch) fall back to run_id, which is unique per run,
+# so they each get their own group and are never cancelled by -- or queued behind
+# -- another run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   utest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #1681 

### Description

Adds a workflow-level concurrency group to `tests.yml`, so a new push to a pull request cancels the run it supersedes. This is the follow-up to #1678, which applied the same pattern to `codeql-analysis.yml`.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
  cancel-in-progress: true
```

It matters more here than it did for CodeQL: this workflow starts 19 jobs at once and runs for ~13 minutes, so a superseded run occupies most of the concurrency allowance while producing nothing.

Pushes to `main` and `workflow_dispatch` runs key off `run_id`, which is unique per run, so they are never cancelled or queued behind each other.

### Testing

YAML parses and all six jobs are unchanged; cancellation behaviour can only be exercised by pushing.

### Note

Cancelling skips `publish-coverage`, so the Coveralls parallel build for the superseded commit is never closed. The next push opens its own build and `fail-on-error: false` means nothing fails, but it is worth a look at the Coveralls project after the first cancelled run.

The remaining workflows (the bot ones, `git.yml`, `gofix.yml`) still have no concurrency group. They are cheap, so they are left for a later pass.