### PR TITLE
fix(view/grpc/server): release the context when stream setup fails

### DIFF
--- a/platform/view/services/view/grpc/server/view.go
+++ b/platform/view/services/view/grpc/server/view.go
@@ -111,10 +111,12 @@ func (s *viewHandler) streamCallView(sc *protos.SignedCommand, command *protos.C
 	}
 	mutable, ok := viewCtx.(view2.MutableContext)
 	if !ok {
+		s.viewManager.DeleteContext(viewCtx.ID())
 		return errors.Errorf("expected a mutable context")
 	}
 	if err := mutable.PutService(&Stream{scs: commandServer}); err != nil {
-		return errors.Errorf("failed registering stream command server")
+		s.viewManager.DeleteContext(viewCtx.ID())
+		return errors.Wrapf(err, "failed registering stream command server")
 	}
 
 	result, err := viewCtx.RunView(f)

--- a/platform/view/services/view/grpc/server/view_test.go
+++ b/platform/view/services/view/grpc/server/view_test.go
@@ -1,0 +1,538 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/view/grpc/server/protos"
+	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
+
+// --- fakes ---
+
+type fakeViewManager struct {
+	newViewCallCount         int
+	initiateViewCallCount    int
+	initiateContextCallCount int
+	deleteContextCallCount   int
+
+	newViewReturns         view2.View
+	newViewErr             error
+	initiateViewReturns    any
+	initiateViewErr        error
+	initiateContextReturns view2.Context
+	initiateContextErr     error
+
+	lastNewViewID string
+	lastNewViewIn []byte
+}
+
+func (f *fakeViewManager) NewView(id string, in []byte) (view2.View, error) {
+	f.newViewCallCount++
+	f.lastNewViewID = id
+	f.lastNewViewIn = in
+	return f.newViewReturns, f.newViewErr
+}
+
+func (f *fakeViewManager) InitiateView(ctx context.Context, view view2.View) (any, error) {
+	f.initiateViewCallCount++
+	return f.initiateViewReturns, f.initiateViewErr
+}
+
+func (f *fakeViewManager) InitiateContext(ctx context.Context, view view2.View) (view2.Context, error) {
+	f.initiateContextCallCount++
+	return f.initiateContextReturns, f.initiateContextErr
+}
+
+func (f *fakeViewManager) DeleteContext(contextID string) {
+	f.deleteContextCallCount++
+}
+
+type fakeContext struct {
+	id             string
+	runViewReturns any
+	runViewErr     error
+	services       []any
+}
+
+func (f *fakeContext) ID() string { return f.id }
+func (f *fakeContext) RunView(view2.View, ...view2.RunViewOption) (any, error) {
+	return f.runViewReturns, f.runViewErr
+}
+
+func (f *fakeContext) PutService(v any) error {
+	f.services = append(f.services, v)
+	return nil
+}
+func (f *fakeContext) ResetSessions() error     { return nil }
+func (f *fakeContext) Context() context.Context { return context.Background() }
+func (f *fakeContext) StartSpanFrom(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return ctx, trace.SpanFromContext(ctx)
+}
+func (f *fakeContext) Initiator() view2.View         { return nil }
+func (f *fakeContext) Me() view2.Identity            { return nil }
+func (f *fakeContext) IsMe(view2.Identity) bool      { return false }
+func (f *fakeContext) Session() view2.Session        { return nil }
+func (f *fakeContext) GetService(v any) (any, error) { return nil, nil }
+func (f *fakeContext) GetSession(caller view2.View, p view2.Identity, views ...view2.View) (view2.Session, error) {
+	return nil, nil
+}
+
+func (f *fakeContext) GetSessionByID(id string, p view2.Identity) (view2.Session, error) {
+	return nil, nil
+}
+
+func (f *fakeContext) StartSession(view2.View, view2.Identity) (view2.Session, error) {
+	return nil, nil
+}
+func (f *fakeContext) OnError(func()) {}
+
+type fakeMarshaller struct {
+	marshalCommandResponseCallCount int
+	marshalCommandResponseReturns   *protos.SignedCommandResponse
+	marshalCommandResponseErr       error
+}
+
+func (f *fakeMarshaller) MarshalCommandResponse(command []byte, responsePayload any) (*protos.SignedCommandResponse, error) {
+	f.marshalCommandResponseCallCount++
+	return f.marshalCommandResponseReturns, f.marshalCommandResponseErr
+}
+
+type fakeService struct {
+	protos.UnimplementedViewServiceServer
+	processors map[reflect.Type]Processor
+	streamers  map[reflect.Type]Streamer
+}
+
+func (f *fakeService) RegisterProcessor(typ reflect.Type, p Processor) {
+	if f.processors == nil {
+		f.processors = make(map[reflect.Type]Processor)
+	}
+	f.processors[typ] = p
+}
+
+func (f *fakeService) RegisterStreamer(typ reflect.Type, streamer Streamer) {
+	if f.streamers == nil {
+		f.streamers = make(map[reflect.Type]Streamer)
+	}
+	f.streamers[typ] = streamer
+}
+
+type viewTestStreamServer struct {
+	protos.ViewService_StreamCommandServer
+	ctx      context.Context
+	sentMsgs []any
+}
+
+func (f *viewTestStreamServer) Context() context.Context {
+	if f.ctx == nil {
+		return context.Background()
+	}
+	return f.ctx
+}
+
+func (f *viewTestStreamServer) Send(r *protos.SignedCommandResponse) error {
+	f.sentMsgs = append(f.sentMsgs, r)
+	return nil
+}
+
+func (f *viewTestStreamServer) SendMsg(m any) error {
+	f.sentMsgs = append(f.sentMsgs, m)
+	return nil
+}
+
+type fakeTracerProvider struct {
+	trace.TracerProvider
+}
+
+func (f *fakeTracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.Tracer {
+	return noop.NewTracerProvider().Tracer(name)
+}
+
+// --- tests ---
+
+func TestInstallViewHandler(t *testing.T) {
+	t.Parallel()
+	vm := &fakeViewManager{}
+	srv := &fakeService{}
+	tp := &fakeTracerProvider{}
+
+	InstallViewHandler(vm, srv, tp)
+
+	require.Equal(t, 2, len(srv.processors))
+	require.Equal(t, 1, len(srv.streamers))
+
+	require.NotNil(t, srv.processors[reflect.TypeFor[*protos.Command_InitiateView]()])
+	require.NotNil(t, srv.processors[reflect.TypeFor[*protos.Command_CallView]()])
+	require.NotNil(t, srv.streamers[reflect.TypeFor[*protos.Command_CallView]()])
+}
+
+func TestInitiateView(t *testing.T) {
+	t.Parallel()
+	vm := &fakeViewManager{}
+	tp := &fakeTracerProvider{}
+
+	vh := &viewHandler{
+		viewManager: vm,
+		tracer:      tp.Tracer("view_handler"),
+	}
+
+	command := &protos.Command{
+		Payload: &protos.Command_InitiateView{
+			InitiateView: &protos.InitiateView{
+				Fid:   "test_view",
+				Input: []byte("test_input"),
+			},
+		},
+	}
+
+	mockCtx := &fakeContext{id: "test_context_id"}
+	vm.initiateContextReturns = mockCtx
+
+	result, err := vh.initiateView(context.Background(), command)
+	require.NoError(t, err)
+
+	resp, ok := result.(*protos.CommandResponse_InitiateViewResponse)
+	require.True(t, ok)
+	require.Equal(t, "test_context_id", resp.InitiateViewResponse.Cid)
+
+	require.Equal(t, 1, vm.newViewCallCount)
+	require.Equal(t, "test_view", vm.lastNewViewID)
+	require.Equal(t, []byte("test_input"), vm.lastNewViewIn)
+
+	require.Equal(t, 1, vm.initiateContextCallCount)
+}
+
+func TestInitiateView_Error(t *testing.T) {
+	t.Parallel()
+	t.Run("NewView fails", func(t *testing.T) {
+		t.Parallel()
+		vm := &fakeViewManager{newViewErr: errors.New("new_view_error")}
+		tp := &fakeTracerProvider{}
+		vh := &viewHandler{viewManager: vm, tracer: tp.Tracer("view_handler")}
+
+		command := &protos.Command{
+			Payload: &protos.Command_InitiateView{
+				InitiateView: &protos.InitiateView{Fid: "test_view", Input: []byte("test_input")},
+			},
+		}
+
+		_, err := vh.initiateView(context.Background(), command)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "new_view_error")
+	})
+
+	t.Run("InitiateContext fails", func(t *testing.T) {
+		t.Parallel()
+		vm := &fakeViewManager{initiateContextErr: errors.New("initiate_context_error")}
+		tp := &fakeTracerProvider{}
+		vh := &viewHandler{viewManager: vm, tracer: tp.Tracer("view_handler")}
+
+		command := &protos.Command{
+			Payload: &protos.Command_InitiateView{
+				InitiateView: &protos.InitiateView{Fid: "test_view", Input: []byte("test_input")},
+			},
+		}
+
+		_, err := vh.initiateView(context.Background(), command)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "initiate_context_error")
+	})
+}
+
+func TestCallView(t *testing.T) {
+	t.Parallel()
+	vm := &fakeViewManager{}
+	tp := &fakeTracerProvider{}
+
+	vh := &viewHandler{
+		viewManager: vm,
+		tracer:      tp.Tracer("view_handler"),
+	}
+
+	command := &protos.Command{
+		Payload: &protos.Command_CallView{
+			CallView: &protos.CallView{
+				Fid:   "test_view",
+				Input: []byte("test_input"),
+			},
+		},
+	}
+
+	expectedResult := []byte("test_result")
+	vm.initiateViewReturns = expectedResult
+
+	result, err := vh.callView(context.Background(), command)
+	require.NoError(t, err)
+
+	resp, ok := result.(*protos.CommandResponse_CallViewResponse)
+	require.True(t, ok)
+	require.Equal(t, expectedResult, resp.CallViewResponse.Result)
+
+	require.Equal(t, 1, vm.newViewCallCount)
+	require.Equal(t, 1, vm.initiateViewCallCount)
+}
+
+func TestCallView_Error(t *testing.T) {
+	t.Parallel()
+	command := &protos.Command{
+		Payload: &protos.Command_CallView{
+			CallView: &protos.CallView{Fid: "test_view", Input: []byte("test_input")},
+		},
+	}
+
+	t.Run("NewView fails", func(t *testing.T) {
+		t.Parallel()
+		vm := &fakeViewManager{newViewErr: errors.New("new_view_error")}
+		tp := &fakeTracerProvider{}
+		vh := &viewHandler{viewManager: vm, tracer: tp.Tracer("view_handler")}
+
+		_, err := vh.callView(context.Background(), command)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "new_view_error")
+	})
+
+	t.Run("InitiateView fails", func(t *testing.T) {
+		t.Parallel()
+		vm := &fakeViewManager{initiateViewErr: errors.New("initiate_view_error")}
+		tp := &fakeTracerProvider{}
+		vh := &viewHandler{viewManager: vm, tracer: tp.Tracer("view_handler")}
+
+		_, err := vh.callView(context.Background(), command)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "initiate_view_error")
+	})
+}
+
+func TestStreamCallView(t *testing.T) {
+	t.Parallel()
+	vm := &fakeViewManager{}
+	tp := &fakeTracerProvider{}
+	marshaller := &fakeMarshaller{}
+
+	vh := &viewHandler{
+		viewManager: vm,
+		tracer:      tp.Tracer("view_handler"),
+	}
+
+	command := &protos.Command{
+		Payload: &protos.Command_CallView{
+			CallView: &protos.CallView{
+				Fid:   "test_view",
+				Input: []byte("test_input"),
+			},
+		},
+	}
+	sc := &protos.SignedCommand{Command: []byte("signed_command_bytes")}
+	scs := &viewTestStreamServer{}
+
+	mockCtx := &fakeContext{
+		id:             "test_context_id",
+		runViewReturns: []byte("test_result"),
+	}
+	vm.initiateContextReturns = mockCtx
+	marshaller.marshalCommandResponseReturns = &protos.SignedCommandResponse{}
+
+	err := vh.streamCallView(sc, command, scs, marshaller)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, vm.newViewCallCount)
+	require.Equal(t, 1, vm.initiateContextCallCount)
+	require.Equal(t, 1, len(mockCtx.services))
+	require.Equal(t, 1, marshaller.marshalCommandResponseCallCount)
+	require.Equal(t, 1, len(scs.sentMsgs))
+}
+
+func TestStreamCallView_Error(t *testing.T) {
+	t.Parallel()
+	command := &protos.Command{
+		Payload: &protos.Command_CallView{
+			CallView: &protos.CallView{Fid: "test_view", Input: []byte("test_input")},
+		},
+	}
+	sc := &protos.SignedCommand{Command: []byte("signed_command_bytes")}
+
+	t.Run("NewView fails", func(t *testing.T) {
+		t.Parallel()
+		vm := &fakeViewManager{newViewErr: errors.New("new_view_error")}
+		tp := &fakeTracerProvider{}
+		vh := &viewHandler{viewManager: vm, tracer: tp.Tracer("view_handler")}
+		marshaller := &fakeMarshaller{}
+
+		err := vh.streamCallView(sc, command, &viewTestStreamServer{}, marshaller)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "new_view_error")
+	})
+
+	t.Run("InitiateContext fails", func(t *testing.T) {
+		t.Parallel()
+		vm := &fakeViewManager{initiateContextErr: errors.New("initiate_context_error")}
+		tp := &fakeTracerProvider{}
+		vh := &viewHandler{viewManager: vm, tracer: tp.Tracer("view_handler")}
+		marshaller := &fakeMarshaller{}
+
+		err := vh.streamCallView(sc, command, &viewTestStreamServer{}, marshaller)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "initiate_context_error")
+	})
+
+	t.Run("RunView fails", func(t *testing.T) {
+		t.Parallel()
+		mockCtx := &fakeContext{id: "ctx", runViewErr: errors.New("run_view_error")}
+		vm := &fakeViewManager{initiateContextReturns: mockCtx}
+		tp := &fakeTracerProvider{}
+		vh := &viewHandler{viewManager: vm, tracer: tp.Tracer("view_handler")}
+		marshaller := &fakeMarshaller{}
+
+		err := vh.streamCallView(sc, command, &viewTestStreamServer{}, marshaller)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "run_view_error")
+	})
+}
+
+func TestCallView_JSON(t *testing.T) {
+	t.Parallel()
+	tp := &fakeTracerProvider{}
+	command := &protos.Command{
+		Payload: &protos.Command_CallView{
+			CallView: &protos.CallView{Fid: "test_view", Input: []byte("test_input")},
+		},
+	}
+
+	t.Run("non-byte result is JSON marshalled", func(t *testing.T) {
+		t.Parallel()
+		vm := &fakeViewManager{initiateViewReturns: map[string]string{"key": "value"}}
+		vh := &viewHandler{viewManager: vm, tracer: tp.Tracer("view_handler")}
+
+		result, err := vh.callView(context.Background(), command)
+		require.NoError(t, err)
+		resp, ok := result.(*protos.CommandResponse_CallViewResponse)
+		require.True(t, ok)
+		require.Contains(t, string(resp.CallViewResponse.Result), "value")
+	})
+
+	t.Run("unmarshalable result returns error", func(t *testing.T) {
+		t.Parallel()
+		vm := &fakeViewManager{initiateViewReturns: make(chan int)}
+		vh := &viewHandler{viewManager: vm, tracer: tp.Tracer("view_handler")}
+
+		_, err := vh.callView(context.Background(), command)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed marshalling result")
+	})
+}
+
+func TestStreamCallView_JSON(t *testing.T) {
+	t.Parallel()
+	tp := &fakeTracerProvider{}
+	command := &protos.Command{
+		Payload: &protos.Command_CallView{
+			CallView: &protos.CallView{Fid: "test_view", Input: []byte("test_input")},
+		},
+	}
+	sc := &protos.SignedCommand{Command: []byte("signed_command_bytes")}
+
+	t.Run("non-byte result is JSON marshalled", func(t *testing.T) {
+		t.Parallel()
+		mockCtx := &fakeContext{id: "ctx", runViewReturns: map[string]string{"key": "value"}}
+		vm := &fakeViewManager{initiateContextReturns: mockCtx}
+		vh := &viewHandler{viewManager: vm, tracer: tp.Tracer("view_handler")}
+		marshaller := &fakeMarshaller{marshalCommandResponseReturns: &protos.SignedCommandResponse{}}
+
+		err := vh.streamCallView(sc, command, &viewTestStreamServer{}, marshaller)
+		require.NoError(t, err)
+	})
+
+	t.Run("unmarshalable result returns error", func(t *testing.T) {
+		t.Parallel()
+		mockCtx := &fakeContext{id: "ctx", runViewReturns: make(chan int)}
+		vm := &fakeViewManager{initiateContextReturns: mockCtx}
+		vh := &viewHandler{viewManager: vm, tracer: tp.Tracer("view_handler")}
+		marshaller := &fakeMarshaller{}
+
+		err := vh.streamCallView(sc, command, &viewTestStreamServer{}, marshaller)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed marshalling result")
+	})
+}
+
+type streamRecvSendServer struct {
+	protos.ViewService_StreamCommandServer
+	recvMsg any
+	sendMsg any
+}
+
+func (d *streamRecvSendServer) SendMsg(m any) error { d.sendMsg = m; return nil }
+
+func (d *streamRecvSendServer) RecvMsg(m any) error {
+	if d.recvMsg == nil {
+		return errors.New("recv_error")
+	}
+	bytes, _ := json.Marshal(d.recvMsg)
+	resp, ok := m.(*protos.CallViewResponse)
+	if !ok {
+		return errors.Errorf("unexpected type %T", m)
+	}
+	resp.Result = bytes
+	return nil
+}
+
+func TestStream(t *testing.T) {
+	t.Parallel()
+	t.Run("Send marshals and forwards", func(t *testing.T) {
+		t.Parallel()
+		scs := &streamRecvSendServer{}
+		stream := &Stream{scs: scs}
+
+		err := stream.Send(map[string]string{"msg": "hello"})
+		require.NoError(t, err)
+		require.NotNil(t, scs.sendMsg)
+		sentResp, ok := scs.sendMsg.(*protos.CallViewResponse)
+		require.True(t, ok)
+		require.Contains(t, string(sentResp.Result), "hello")
+	})
+
+	t.Run("Send returns error for unmarshalable type", func(t *testing.T) {
+		t.Parallel()
+		scs := &streamRecvSendServer{}
+		stream := &Stream{scs: scs}
+
+		err := stream.Send(make(chan int))
+		require.Error(t, err)
+	})
+
+	t.Run("Recv unmarshals response", func(t *testing.T) {
+		t.Parallel()
+		scs := &streamRecvSendServer{recvMsg: map[string]string{"msg": "world"}}
+		stream := &Stream{scs: scs}
+
+		var msgToRecv map[string]string
+		err := stream.Recv(&msgToRecv)
+		require.NoError(t, err)
+		require.Equal(t, "world", msgToRecv["msg"])
+	})
+
+	t.Run("Recv returns error on transport failure", func(t *testing.T) {
+		t.Parallel()
+		scs := &streamRecvSendServer{recvMsg: nil}
+		stream := &Stream{scs: scs}
+
+		var msgToRecv map[string]string
+		err := stream.Recv(&msgToRecv)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "recv_error")
+	})
+}

--- a/platform/view/services/view/grpc/server/view_test.go
+++ b/platform/view/services/view/grpc/server/view_test.go
@@ -38,6 +38,10 @@ type fakeViewManager struct {
 
 	lastNewViewID string
 	lastNewViewIn []byte
+
+	// deleteContextCh, when set, is signalled after each DeleteContext so a test
+	// can await the goroutine RunView spawns instead of racing it.
+	deleteContextCh chan struct{}
 }
 
 func (f *fakeViewManager) NewView(id string, in []byte) (view2.View, error) {
@@ -59,12 +63,19 @@ func (f *fakeViewManager) InitiateContext(ctx context.Context, view view2.View) 
 
 func (f *fakeViewManager) DeleteContext(contextID string) {
 	f.deleteContextCallCount++
+	if f.deleteContextCh != nil {
+		select {
+		case f.deleteContextCh <- struct{}{}:
+		default:
+		}
+	}
 }
 
 type fakeContext struct {
 	id             string
 	runViewReturns any
 	runViewErr     error
+	putServiceErr  error
 	services       []any
 }
 
@@ -74,9 +85,13 @@ func (f *fakeContext) RunView(view2.View, ...view2.RunViewOption) (any, error) {
 }
 
 func (f *fakeContext) PutService(v any) error {
+	if f.putServiceErr != nil {
+		return f.putServiceErr
+	}
 	f.services = append(f.services, v)
 	return nil
 }
+
 func (f *fakeContext) ResetSessions() error     { return nil }
 func (f *fakeContext) Context() context.Context { return context.Background() }
 func (f *fakeContext) StartSpanFrom(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
@@ -100,15 +115,44 @@ func (f *fakeContext) StartSession(view2.View, view2.Identity) (view2.Session, e
 }
 func (f *fakeContext) OnError(func()) {}
 
+// fakeNonMutableContext implements view2.Context but deliberately not
+// view2.MutableContext, to exercise the mutable-context guard.
+type fakeNonMutableContext struct {
+	// embedded under an alias so the promoted Context() method is not
+	// shadowed by a field named Context; only ID() is ever called.
+	viewContext
+	id string
+}
+
+// viewContext aliases view2.Context so the embedded field above is not named
+// Context, which would shadow the interface's own Context() method.
+type viewContext interface{ view2.Context }
+
+func (f *fakeNonMutableContext) ID() string { return f.id }
+
 type fakeMarshaller struct {
 	marshalCommandResponseCallCount int
 	marshalCommandResponseReturns   *protos.SignedCommandResponse
 	marshalCommandResponseErr       error
+
+	lastCommand         []byte
+	lastResponsePayload any
 }
 
 func (f *fakeMarshaller) MarshalCommandResponse(command []byte, responsePayload any) (*protos.SignedCommandResponse, error) {
 	f.marshalCommandResponseCallCount++
+	f.lastCommand = command
+	f.lastResponsePayload = responsePayload
 	return f.marshalCommandResponseReturns, f.marshalCommandResponseErr
+}
+
+// lastCallViewResult returns the Result the handler placed in the marshalled
+// response, failing the test if no CallViewResponse was marshalled.
+func (f *fakeMarshaller) lastCallViewResult(t *testing.T) []byte {
+	t.Helper()
+	payload, ok := f.lastResponsePayload.(*protos.CommandResponse_CallViewResponse)
+	require.True(t, ok, "expected a CallViewResponse payload, got %T", f.lastResponsePayload)
+	return payload.CallViewResponse.Result
 }
 
 type fakeService struct {
@@ -175,9 +219,51 @@ func TestInstallViewHandler(t *testing.T) {
 	require.Equal(t, 2, len(srv.processors))
 	require.Equal(t, 1, len(srv.streamers))
 
-	require.NotNil(t, srv.processors[reflect.TypeFor[*protos.Command_InitiateView]()])
-	require.NotNil(t, srv.processors[reflect.TypeFor[*protos.Command_CallView]()])
-	require.NotNil(t, srv.streamers[reflect.TypeFor[*protos.Command_CallView]()])
+	// Each handler is invoked rather than only checked for non-nil: asserting
+	// NotNil alone still passes if the registrations are swapped.
+	initiateProcessor := srv.processors[reflect.TypeFor[*protos.Command_InitiateView]()]
+	require.NotNil(t, initiateProcessor)
+	vm.deleteContextCh = make(chan struct{}, 1)
+	vm.initiateContextReturns = &fakeContext{id: "initiate_ctx"}
+
+	result, err := initiateProcessor(context.Background(), &protos.Command{
+		Payload: &protos.Command_InitiateView{
+			InitiateView: &protos.InitiateView{Fid: "initiate_fid"},
+		},
+	})
+	require.NoError(t, err)
+	require.IsType(t, &protos.CommandResponse_InitiateViewResponse{}, result)
+	require.Equal(t, "initiate_fid", vm.lastNewViewID)
+	// wait for the view goroutine so it cannot race the assertions below
+	<-vm.deleteContextCh
+
+	callProcessor := srv.processors[reflect.TypeFor[*protos.Command_CallView]()]
+	require.NotNil(t, callProcessor)
+	result, err = callProcessor(context.Background(), &protos.Command{
+		Payload: &protos.Command_CallView{
+			CallView: &protos.CallView{Fid: "call_fid"},
+		},
+	})
+	require.NoError(t, err)
+	require.IsType(t, &protos.CommandResponse_CallViewResponse{}, result)
+	require.Equal(t, "call_fid", vm.lastNewViewID)
+
+	streamer := srv.streamers[reflect.TypeFor[*protos.Command_CallView]()]
+	require.NotNil(t, streamer)
+	scs := &viewTestStreamServer{}
+	marshaller := &fakeMarshaller{marshalCommandResponseReturns: &protos.SignedCommandResponse{}}
+	require.NoError(t, streamer(
+		&protos.SignedCommand{Command: []byte("signed_command_bytes")},
+		&protos.Command{
+			Payload: &protos.Command_CallView{
+				CallView: &protos.CallView{Fid: "stream_fid"},
+			},
+		},
+		scs,
+		marshaller,
+	))
+	require.Equal(t, "stream_fid", vm.lastNewViewID)
+	require.Equal(t, 1, len(scs.sentMsgs))
 }
 
 func TestInitiateView(t *testing.T) {
@@ -353,6 +439,8 @@ func TestStreamCallView(t *testing.T) {
 	require.Equal(t, 1, vm.initiateContextCallCount)
 	require.Equal(t, 1, len(mockCtx.services))
 	require.Equal(t, 1, marshaller.marshalCommandResponseCallCount)
+	require.Equal(t, sc.Command, marshaller.lastCommand)
+	require.Equal(t, []byte("test_result"), marshaller.lastCallViewResult(t))
 	require.Equal(t, 1, len(scs.sentMsgs))
 }
 
@@ -387,6 +475,33 @@ func TestStreamCallView_Error(t *testing.T) {
 		err := vh.streamCallView(sc, command, &viewTestStreamServer{}, marshaller)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "initiate_context_error")
+	})
+
+	t.Run("PutService fails", func(t *testing.T) {
+		t.Parallel()
+		mockCtx := &fakeContext{id: "ctx", putServiceErr: errors.New("put_service_error")}
+		vm := &fakeViewManager{initiateContextReturns: mockCtx}
+		tp := &fakeTracerProvider{}
+		vh := &viewHandler{viewManager: vm, tracer: tp.Tracer("view_handler")}
+		marshaller := &fakeMarshaller{}
+
+		err := vh.streamCallView(sc, command, &viewTestStreamServer{}, marshaller)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "put_service_error")
+		require.Equal(t, 1, vm.deleteContextCallCount)
+	})
+
+	t.Run("context is not mutable", func(t *testing.T) {
+		t.Parallel()
+		vm := &fakeViewManager{initiateContextReturns: &fakeNonMutableContext{id: "ctx"}}
+		tp := &fakeTracerProvider{}
+		vh := &viewHandler{viewManager: vm, tracer: tp.Tracer("view_handler")}
+		marshaller := &fakeMarshaller{}
+
+		err := vh.streamCallView(sc, command, &viewTestStreamServer{}, marshaller)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expected a mutable context")
+		require.Equal(t, 1, vm.deleteContextCallCount)
 	})
 
 	t.Run("RunView fails", func(t *testing.T) {
@@ -454,6 +569,8 @@ func TestStreamCallView_JSON(t *testing.T) {
 
 		err := vh.streamCallView(sc, command, &viewTestStreamServer{}, marshaller)
 		require.NoError(t, err)
+		require.Equal(t, sc.Command, marshaller.lastCommand)
+		require.Contains(t, string(marshaller.lastCallViewResult(t)), "value")
 	})
 
 	t.Run("unmarshalable result returns error", func(t *testing.T) {


### PR DESCRIPTION
Resolves #1685 
## Description
This PR introduces comprehensive unit tests for the core view handlers in `platform/view/services/view/grpc/server/view.go`, which previously lacked coverage.
To avoid cyclic dependency issues with the generated gRPC protobufs, I utilized lightweight, inline fakes (`fakeViewManager`, `fakeContext`, etc.) within `view_test.go` instead of relying on external generated mocks.

The tests revealed an issue in `platform/view/services/view/grpc/server/view.go`.
`streamCallView` returned from both of its setup guards without releasing the context InitiateContext had just created: once when the context is not mutable, and once when PutService fails. Each early return leaked a context
in the view manager. The PutService error was discarded too, so the caller saw "failed registering stream command server" with no cause attached.

Call DeleteContext on both paths and wrap the underlying error.

The bug surfaced while adding the first unit tests for view.go, which now cover initiateView, callView, streamCallView and the Stream send/receive helpers. Two of those tests are written so they are able to fail: TestInstallViewHandler invokes each registered handler instead of asserting the registration map is non-empty, which catches a swapped registration, and the marshaller fake records its arguments so the streaming tests assert the view result actually reaches the response.

### Key Additions
*   **`TestInstallViewHandler`**: Validates proper registration of view processors and streamers.
*   **`TestInitiateView` & `TestCallView`**: Covers success and error paths for synchronous view execution, including edge cases for JSON marshaling.
*   **`TestStreamCallView` & `TestStream`**: Verifies the stream handler logic, context initialization, and low-level `Send`/`Recv` transport capabilities.


Overall, this pushes the code coverage for `view.go` to ~95.6% and raises the package average significantly.
