### PR TITLE
fix(scripts): better git worktree support

### DIFF
--- a/checks.mk
+++ b/checks.mk
@@ -6,14 +6,22 @@ checks: lint
 #########################
 
 # golangci-lint only ever sees a single module, so it has to be run once per
-# module. tools/ is excluded on purpose: it is a build-tagged dependency pin with
-# no buildable package, and golangci-lint fails there with "no go files to
+# module.
+#
+# Modules are discovered through git rather than a filesystem walk: a plain
+# `find` also descends into untracked scratch directories and into nested git
+# worktrees checked out under the repo (e.g. .claude/worktrees/<branch>), and
+# would lint code that is not part of this checkout. That needed an
+# ever-growing list of -not -path exclusions; git needs none.
+#
+# tools/ is excluded on purpose: it is a build-tagged dependency pin with no
+# buildable package, and golangci-lint fails there with "no go files to
 # analyze".
-GO_MODULE_DIRS = $(shell find $(TOP) -name go.mod \
-	-not -path '*/node_modules/*' \
-	-not -path '$(TOP)/.claude/*' \
-	-not -path '$(TOP)/tools/*' \
-	-exec dirname {} \; | sort)
+GO_MODULE_DIRS = $(shell cd $(TOP) && git ls-files \
+	| grep -E '(^|/)go\.mod$$' \
+	| xargs -n1 dirname \
+	| grep -vx tools \
+	| sort)
 
 # run golangci-lint in every module, reporting every module that fails rather
 # than stopping at the first

--- a/scripts/gomate.sh
+++ b/scripts/gomate.sh
@@ -14,7 +14,28 @@ script_name=$(basename "${0}")
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 readonly script_name script_dir
 
-readonly repo_dir="$(pwd)"
+readonly repo_dir="$(git rev-parse --show-toplevel)"
+
+# List the directory of every go module tracked in this repository, one per line.
+#
+# Discovery goes through git rather than a filesystem walk: a plain `find` also
+# descends into untracked scratch directories and into nested git worktrees
+# checked out under the repo (e.g. .claude/worktrees/<branch>), where `go mod
+# tidy` / `go get` would silently rewrite another branch's go.mod and go.sum.
+function module_dirs() {
+  git -C "$repo_dir" ls-files | grep -E '(^|/)go\.mod$' | while IFS= read -r gomod; do
+    printf '%s\n' "$repo_dir/$(dirname "$gomod")"
+  done
+}
+
+# run a command in every module directory
+function in_each_module() {
+  local dir
+  for dir in $(module_dirs); do
+    echo "  -> ${dir#"$repo_dir"/}"
+    (cd "$dir" && "$@")
+  done
+}
 
 # how to use this script
 function usage() {
@@ -34,7 +55,8 @@ Commands:
 function init_work() {
   echo "go work init"
   go work init
-  find "$repo_dir" -iname "go.mod" -exec dirname {} \; | xargs go work use
+  # shellcheck disable=SC2046 # module_dirs emits one path per line, IFS is \t\n
+  go work use $(module_dirs)
 }
 
 # update deps; take as parameter the dependency to update; if empty all deps are updates
@@ -42,18 +64,18 @@ function update() {
   if [[ -z $1 ]]; then
     # check all update
     echo "go get -u everywhere"
-    find "$repo_dir" -iname "go.mod" -execdir sh -c "go get -u" \;
+    in_each_module go get -u
   else
     # check a specific dep
     echo "go get $1 everywhere"
-    find "$repo_dir" -iname "go.mod" -execdir sh -c "go get $1" \;
+    in_each_module go get "$1"
   fi
 }
 
 # run go mod tidy everywhere
 function tidy() {
   echo "go mod tidy everywhere"
-  find "$repo_dir" -iname "go.mod" -execdir sh -c "go mod tidy" \;
+  in_each_module go mod tidy
 }
 
 main() {

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -25,15 +25,20 @@ if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 fi
 
 REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+HEAD="$(git -C "$REPO_ROOT" rev-parse HEAD)"
 
-# Collect all module paths: root first, then submodules excluding tools
+# Collect all module paths: root first, then submodules excluding tools.
+#
+# Modules are discovered from the tree of the commit being tagged, not from the
+# working tree: that is exactly what a consumer sees at `go get <module>@<tag>`,
+# and it is immune to go.mod files that are untracked, ignored, vendored, or
+# sitting in a nested git worktree checked out under the repo (e.g. .claude/).
 MODULES=(".")
 while IFS= read -r gomod; do
     dir="${gomod%/go.mod}"
-    dir="${dir#./}"
-    [[ "$dir" == "tools" ]] && continue
+    [[ "$dir" == "go.mod" || "$dir" == "tools" ]] && continue
     MODULES+=("$dir")
-done < <(find "$REPO_ROOT" -name go.mod -not -path '*/vendor/*' -not -path "$REPO_ROOT/go.mod" | sed "s|$REPO_ROOT/||" | sort)
+done < <(git -C "$REPO_ROOT" ls-tree -r --name-only "$HEAD" | grep -E '(^|/)go\.mod$' | sort)
 
 # Build the list of tags to create
 declare -a TAGS
@@ -60,9 +65,6 @@ if [[ ${#CONFLICTS[@]} -gt 0 ]]; then
     done
     exit 1
 fi
-
-# Create all tags at HEAD
-HEAD="$(git -C "$REPO_ROOT" rev-parse HEAD)"
 
 if $DRY; then
     echo "Dry run — would create ${#TAGS[@]} tag(s) at $HEAD:"


### PR DESCRIPTION
Some of our helper scripts (i.e., release tagging) do not work nicely when there are git worktrees in the some subdirectory. This commit improves this.

Closes #1687 