### PR TITLE
test(fabric): cover channel configuration updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,7 @@ INTEGRATION_TARGETS += fsc-signedpingpong
 ## fabric section
 INTEGRATION_TARGETS += fabric-atsa
 INTEGRATION_TARGETS += fabric-atsachaincode
+INTEGRATION_TARGETS += fabric-configupdate
 INTEGRATION_TARGETS += fabric-events
 INTEGRATION_TARGETS += fabric-iou
 INTEGRATION_TARGETS += fabric-runtimeconfig

--- a/integration/fabric/configupdate/configupdate.go
+++ b/integration/fabric/configupdate/configupdate.go
@@ -1,0 +1,135 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package configupdate drives Fabric channel configuration changes against a running
+// network, so that a test can observe how FSC nodes react to a CONFIG block that arrives
+// while they are up.
+//
+// The FSC-side path under test lives in platform/fabric/core/generic/committer: a CONFIG
+// block reaches Committer.HandleConfig, which commits it to the vault, hands the envelope
+// to MembershipService.Update, and then calls applyConfigUpdates to re-read the channel's
+// orderer configuration and reconfigure the ordering service. Until this suite existed
+// that path only ever ran for a channel's genesis block, during start-up catch-up, and
+// nothing asserted on it.
+package configupdate
+
+import (
+	"time"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	protosorderer "github.com/hyperledger/fabric-protos-go-apiv2/orderer"
+	"github.com/onsi/gomega"
+
+	"github.com/hyperledger-labs/fabric-smart-client/integration"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/network"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/topology"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/protoutil"
+)
+
+// batchTimeoutKey is the key of the BatchTimeout value in the channel config's Orderer group.
+const batchTimeoutKey = "BatchTimeout"
+
+// ordererGroupKey is the key of the Orderer group in the channel config.
+const ordererGroupKey = "Orderer"
+
+// channelHandles are the nwo handles needed to submit a configuration update: the network,
+// the channel to update, an orderer to submit through, and a Fabric peer whose local
+// configuration the peer CLI is invoked with.
+type channelHandles struct {
+	Network *network.Network
+	Channel string
+	Orderer *topology.Orderer
+	Peer    *topology.Peer
+}
+
+// handles locates the single Fabric platform in the running infrastructure and derives the
+// channel, orderer and submitting peer from its topology.
+func handles(ii *integration.Infrastructure) *channelHandles {
+	platforms := ii.NWOCtx.PlatformsByType("fabric")
+	gomega.Expect(platforms).To(gomega.HaveLen(1), "expected exactly one fabric platform")
+
+	p, ok := platforms[0].(*fabric.Platform)
+	gomega.Expect(ok).To(gomega.BeTrue(), "expected the fabric platform to be a *fabric.Platform")
+
+	n := p.Network
+	gomega.Expect(n.Channels).NotTo(gomega.BeEmpty(), "the fabric topology declares no channel")
+	gomega.Expect(n.Orderers).NotTo(gomega.BeEmpty(), "the fabric topology declares no orderer")
+
+	channel := n.Channels[0].Name
+	// PeersWithChannel returns only peers of type FabricPeer, never FSC nodes, and sorts
+	// them deterministically.
+	peers := n.PeersWithChannel(channel)
+	gomega.Expect(peers).NotTo(gomega.BeEmpty(), "no fabric peer has joined channel [%s]", channel)
+
+	return &channelHandles{
+		Network: n,
+		Channel: channel,
+		Orderer: n.Orderers[0],
+		Peer:    peers[0],
+	}
+}
+
+// ConfigBlockNumber returns the block number of the channel's current configuration block,
+// as reported by the ordering service. It increases by one for every configuration update
+// that is committed.
+func ConfigBlockNumber(ii *integration.Infrastructure) uint64 {
+	h := handles(ii)
+	return network.CurrentConfigBlockNumber(h.Network, h.Peer, h.Orderer, h.Channel)
+}
+
+// BatchTimeout returns the channel's current orderer BatchTimeout.
+func BatchTimeout(ii *integration.Infrastructure) time.Duration {
+	h := handles(ii)
+	config := network.GetConfig(h.Network, h.Peer, h.Orderer, h.Channel)
+	return batchTimeoutOf(config)
+}
+
+// SetBatchTimeout computes, signs and submits an orderer-signed channel configuration
+// update that sets the orderer's BatchTimeout to the given value, and returns once the
+// resulting configuration block has been committed.
+//
+// BatchTimeout is chosen deliberately: it lives in the Orderer group, which is exactly
+// what committer.applyConfigUpdates re-reads through MembershipService.OrdererConfig
+// before reconfiguring the ordering service, and changing it cannot partition the network
+// or invalidate any identity, so a failure of the following flow points at FSC rather
+// than at the fixture.
+func SetBatchTimeout(ii *integration.Infrastructure, timeout time.Duration) {
+	h := handles(ii)
+
+	config := network.GetConfig(h.Network, h.Peer, h.Orderer, h.Channel)
+	gomega.Expect(batchTimeoutOf(config)).NotTo(gomega.Equal(timeout),
+		"BatchTimeout is already [%s]; an update that changes nothing cannot be computed", timeout)
+
+	updated, ok := proto.Clone(config).(*common.Config)
+	gomega.Expect(ok).To(gomega.BeTrue(), "expected the cloned config to be a *common.Config")
+
+	updated.ChannelGroup.Groups[ordererGroupKey].Values[batchTimeoutKey] = &common.ConfigValue{
+		ModPolicy: "Admins",
+		Value:     protoutil.MarshalOrPanic(&protosorderer.BatchTimeout{Timeout: timeout.String()}),
+	}
+
+	// The Orderer group's Admins policy is what gates this update, so the orderer signs it.
+	network.UpdateOrdererConfig(h.Network, h.Orderer, h.Channel, config, updated, h.Peer, h.Orderer)
+}
+
+// batchTimeoutOf extracts the BatchTimeout from a channel configuration.
+func batchTimeoutOf(config *common.Config) time.Duration {
+	group, ok := config.ChannelGroup.Groups[ordererGroupKey]
+	gomega.Expect(ok).To(gomega.BeTrue(), "channel config has no [%s] group", ordererGroupKey)
+
+	value, ok := group.Values[batchTimeoutKey]
+	gomega.Expect(ok).To(gomega.BeTrue(), "[%s] group has no [%s] value", ordererGroupKey, batchTimeoutKey)
+
+	batchTimeout := &protosorderer.BatchTimeout{}
+	gomega.Expect(proto.Unmarshal(value.Value, batchTimeout)).NotTo(gomega.HaveOccurred())
+
+	timeout, err := time.ParseDuration(batchTimeout.Timeout)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "cannot parse BatchTimeout [%s]", batchTimeout.Timeout)
+
+	return timeout
+}

--- a/integration/fabric/configupdate/configupdate.go
+++ b/integration/fabric/configupdate/configupdate.go
@@ -24,6 +24,7 @@ import (
 	"github.com/onsi/gomega"
 
 	"github.com/hyperledger-labs/fabric-smart-client/integration"
+	nwocommon "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/network"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/topology"
@@ -74,14 +75,6 @@ func handles(ii *integration.Infrastructure) *channelHandles {
 	}
 }
 
-// ConfigBlockNumber returns the block number of the channel's current configuration block,
-// as reported by the ordering service. It increases by one for every configuration update
-// that is committed.
-func ConfigBlockNumber(ii *integration.Infrastructure) uint64 {
-	h := handles(ii)
-	return network.CurrentConfigBlockNumber(h.Network, h.Peer, h.Orderer, h.Channel)
-}
-
 // BatchTimeout returns the channel's current orderer BatchTimeout.
 func BatchTimeout(ii *integration.Infrastructure) time.Duration {
 	h := handles(ii)
@@ -115,6 +108,21 @@ func SetBatchTimeout(ii *integration.Infrastructure, timeout time.Duration) {
 
 	// The Orderer group's Admins policy is what gates this update, so the orderer signs it.
 	network.UpdateOrdererConfig(h.Network, h.Orderer, h.Channel, config, updated, h.Peer, h.Orderer)
+}
+
+// ConfigSequenceOn returns the sequence number of the channel configuration the
+// named FSC node currently holds, as the node itself reports it.
+//
+// A configuration update returns as soon as the *ordering service* has
+// committed it, which is strictly earlier than any FSC node observing it over
+// delivery. Callers must therefore poll this with gomega.Eventually rather than
+// asserting on it once. g asserts through the Gomega passed to the
+// gomega.Eventually poll function, so a transient view-call failure is a
+// retryable failure of that poll rather than an abort of the whole spec.
+func ConfigSequenceOn(g gomega.Gomega, ii *integration.Infrastructure, node string) int {
+	res, err := ii.Client(node).CallView("configseq", nil)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	return nwocommon.JSONUnmarshalInt(res)
 }
 
 // batchTimeoutOf extracts the BatchTimeout from a channel configuration.

--- a/integration/fabric/configupdate/configupdate_suite_test.go
+++ b/integration/fabric/configupdate/configupdate_suite_test.go
@@ -1,0 +1,25 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package configupdate_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/hyperledger-labs/fabric-smart-client/integration"
+)
+
+func TestEndToEnd(t *testing.T) { //nolint:paralleltest
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Channel Config Update Suite")
+}
+
+func StartPort() int {
+	return integration.FabricConfigUpdatePort.StartPortForNode()
+}

--- a/integration/fabric/configupdate/configupdate_test.go
+++ b/integration/fabric/configupdate/configupdate_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package configupdate_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"github.com/hyperledger-labs/fabric-smart-client/integration"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/fabric/configupdate"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/fabric/iou"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
+)
+
+var _ = Describe("EndToEnd", func() {
+	Describe("Channel Config Update With Websockets", Label("T1"), func() {
+		s := NewTestSuite(fsc.WebSocket, integration.NoReplication, true)
+		BeforeEach(s.Setup)
+		AfterEach(s.TearDown)
+		It("succeeded", s.TestSucceeded)
+	})
+})
+
+type TestSuite struct {
+	*integration.TestSuite
+}
+
+func NewTestSuite(commType fsc.P2PCommunicationType, nodeOpts *integration.ReplicationOptions, tlsEnabled bool) *TestSuite {
+	return &TestSuite{TestSuite: integration.NewTestSuite(func() (*integration.Infrastructure, error) {
+		return integration.Generate(StartPort(), integration.WithRaceDetection, configupdate.Topology(&configupdate.Opts{
+			CommType:        commType,
+			ReplicationOpts: nodeOpts,
+			TLSEnabled:      tlsEnabled,
+		})...)
+	})}
+}
+
+// TestSucceeded drives the IOU flow across two channel configuration changes and a node
+// restart. Each IOU transaction after a change is the assertion: it needs the FSC nodes to
+// still hold a usable view of the channel — its MSPs, for endorsement and validation, and
+// its ordering endpoints, for broadcast — which is precisely the state that
+// committer.HandleConfig rebuilds when a CONFIG block arrives.
+func (s *TestSuite) TestSucceeded() {
+	iou.InitApprover(s.II, "approver1")
+	iou.InitApprover(s.II, "approver2")
+
+	By("transacting on the channel's initial configuration")
+	gomega.Expect(configupdate.BatchTimeout(s.II)).To(gomega.Equal(time.Second),
+		"the fixture is expected to start from the configtx default")
+	iouState := iou.CreateIOU(s.II, "", 10, "approver1")
+	iou.CheckState(s.II, "borrower", iouState, 10)
+	iou.CheckState(s.II, "lender", iouState, 10)
+
+	By("changing the channel configuration while the FSC nodes are running")
+	before := configupdate.ConfigBlockNumber(s.II)
+	configupdate.SetBatchTimeout(s.II, 2*time.Second)
+	gomega.Expect(configupdate.ConfigBlockNumber(s.II)).To(gomega.BeNumerically(">", before),
+		"the configuration update did not produce a new configuration block")
+	gomega.Expect(configupdate.BatchTimeout(s.II)).To(gomega.Equal(2 * time.Second))
+
+	By("transacting again, which requires the nodes to have followed the change")
+	iou.UpdateIOU(s.II, iouState, 5, "approver2")
+	iou.CheckState(s.II, "borrower", iouState, 5)
+	iou.CheckState(s.II, "lender", iouState, 5)
+
+	By("changing the configuration a second time, so more than one update is on the ledger")
+	configupdate.SetBatchTimeout(s.II, 500*time.Millisecond)
+	gomega.Expect(configupdate.BatchTimeout(s.II)).To(gomega.Equal(500 * time.Millisecond))
+
+	iou.UpdateIOU(s.II, iouState, 3, "approver1")
+	iou.CheckState(s.II, "borrower", iouState, 3)
+	iou.CheckState(s.II, "lender", iouState, 3)
+
+	By("restarting a node, so it replays the stored configuration transactions")
+	// On start-up a channel calls Committer.ReloadConfigTransactions, which walks the
+	// configtx_<n> entries in the node's vault and re-applies each one. With two updates
+	// committed above, this is the first time in the suite that the loop runs over a
+	// sequence longer than the genesis block alone.
+	s.II.StopFSCNode("borrower")
+	time.Sleep(3 * time.Second)
+	s.II.StartFSCNode("borrower")
+	time.Sleep(3 * time.Second)
+
+	By("transacting once more through the restarted node")
+	iou.UpdateIOU(s.II, iouState, 1, "approver2")
+	iou.CheckState(s.II, "borrower", iouState, 1)
+	iou.CheckState(s.II, "lender", iouState, 1)
+}

--- a/integration/fabric/configupdate/configupdate_test.go
+++ b/integration/fabric/configupdate/configupdate_test.go
@@ -41,6 +41,22 @@ func NewTestSuite(commType fsc.P2PCommunicationType, nodeOpts *integration.Repli
 	})}
 }
 
+// allNodes are the FSC nodes in this topology. Every one of them commits the
+// CONFIG block independently, so every one of them is asserted on.
+var allNodes = []string{"borrower", "lender", "approver1", "approver2"}
+
+// expectConfigSequence waits for every named node to report the given channel
+// configuration sequence. A CONFIG block reaches a node asynchronously over
+// delivery, so this polls rather than asserting once.
+func expectConfigSequence(s *TestSuite, expected int, nodes ...string) {
+	for _, node := range nodes {
+		gomega.Eventually(func(g gomega.Gomega) int {
+			return configupdate.ConfigSequenceOn(g, s.II, node)
+		}, 60*time.Second, time.Second).Should(gomega.Equal(expected),
+			"node [%s] never reported channel configuration sequence [%d]", node, expected)
+	}
+}
+
 // TestSucceeded drives the IOU flow across two channel configuration changes and a node
 // restart. Each IOU transaction after a change is the assertion: it needs the FSC nodes to
 // still hold a usable view of the channel — its MSPs, for endorsement and validation, and
@@ -57,12 +73,17 @@ func (s *TestSuite) TestSucceeded() {
 	iou.CheckState(s.II, "borrower", iouState, 10)
 	iou.CheckState(s.II, "lender", iouState, 10)
 
+	// after the initial IOU flow, before any configuration change
+	By("checking every node starts from the genesis configuration")
+	expectConfigSequence(s, 0, allNodes...)
+
 	By("changing the channel configuration while the FSC nodes are running")
-	before := configupdate.ConfigBlockNumber(s.II)
 	configupdate.SetBatchTimeout(s.II, 2*time.Second)
-	gomega.Expect(configupdate.ConfigBlockNumber(s.II)).To(gomega.BeNumerically(">", before),
-		"the configuration update did not produce a new configuration block")
 	gomega.Expect(configupdate.BatchTimeout(s.II)).To(gomega.Equal(2 * time.Second))
+
+	// after SetBatchTimeout(2 * time.Second)
+	By("checking every node applied the first configuration update")
+	expectConfigSequence(s, 1, allNodes...)
 
 	By("transacting again, which requires the nodes to have followed the change")
 	iou.UpdateIOU(s.II, iouState, 5, "approver2")
@@ -73,19 +94,28 @@ func (s *TestSuite) TestSucceeded() {
 	configupdate.SetBatchTimeout(s.II, 500*time.Millisecond)
 	gomega.Expect(configupdate.BatchTimeout(s.II)).To(gomega.Equal(500 * time.Millisecond))
 
+	// after SetBatchTimeout(500 * time.Millisecond)
+	By("checking every node applied the second configuration update")
+	expectConfigSequence(s, 2, allNodes...)
+
 	iou.UpdateIOU(s.II, iouState, 3, "approver1")
 	iou.CheckState(s.II, "borrower", iouState, 3)
 	iou.CheckState(s.II, "lender", iouState, 3)
 
 	By("restarting a node, so it replays the stored configuration transactions")
-	// On start-up a channel calls Committer.ReloadConfigTransactions, which walks the
-	// configtx_<n> entries in the node's vault and re-applies each one. With two updates
-	// committed above, this is the first time in the suite that the loop runs over a
-	// sequence longer than the genesis block alone.
+	// On start-up a channel calls Committer.ReloadConfigTransactions, which
+	// walks the configtx_<n> entries in the node's vault and re-applies each
+	// one. With two updates committed above, the borrower's vault holds
+	// configtx_0, configtx_1 and configtx_2, so this is the first time in the
+	// test suite that the loop runs over more than the genesis entry.
 	s.II.StopFSCNode("borrower")
 	time.Sleep(3 * time.Second)
 	s.II.StartFSCNode("borrower")
 	time.Sleep(3 * time.Second)
+
+	// after the borrower has been stopped and started again
+	By("checking the restarted node replayed both stored configuration transactions")
+	expectConfigSequence(s, 2, "borrower")
 
 	By("transacting once more through the restarted node")
 	iou.UpdateIOU(s.II, iouState, 1, "approver2")

--- a/integration/fabric/configupdate/topology.go
+++ b/integration/fabric/configupdate/topology.go
@@ -1,0 +1,83 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package configupdate
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/integration"
+	cviews "github.com/hyperledger-labs/fabric-smart-client/integration/fabric/common/views"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/fabric/iou"
+	iouviews "github.com/hyperledger-labs/fabric-smart-client/integration/fabric/iou/views"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/topology"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
+)
+
+type Opts struct {
+	CommType        fsc.P2PCommunicationType
+	ReplicationOpts *integration.ReplicationOptions
+	TLSEnabled      bool
+}
+
+// Topology is the IOU topology, reduced to what a channel-configuration test needs.
+//
+// It reuses the IOU views and SDK verbatim: the flow itself is not what is under test,
+// it is the load-bearing assertion. If the FSC nodes mishandle the CONFIG block that
+// arrives mid-test — losing their view of the channel's MSPs, or dropping the ordering
+// endpoints that platform/fabric/core/generic/committer.applyConfigUpdates re-reads —
+// the next IOU transaction cannot be endorsed, ordered or finalised, and fails.
+//
+// Monitoring and tracing are deliberately left out: they add container startup cost and
+// nothing here asserts on them.
+func Topology(opts *Opts) []api.Topology {
+	// A Fabric topology with three organizations and a namespace endorsed by Org1,
+	// as in the IOU test. The channel starts with the configtx defaults, notably a
+	// BatchTimeout of 1s, which the test then changes at runtime.
+	fabricTopology := fabric.NewDefaultTopology()
+	fabricTopology.AddOrganizationsByName("Org1", "Org2", "Org3")
+	fabricTopology.SetNamespaceApproverOrgs("Org1")
+	fabricTopology.AddNamespace("iou", topology.Unanimity("Org1"))
+	fabricTopology.TLSEnabled = opts.TLSEnabled
+
+	fscTopology := fsc.NewTopology()
+	fscTopology.P2PCommunicationType = opts.CommType
+
+	// Two approvers, both in Org1, so that the flow before and after a config update can
+	// be driven through different endorsers.
+	for _, approver := range []string{"approver1", "approver2"} {
+		fscTopology.AddNodeByName(approver).
+			AddOptions(fabric.WithOrganization("Org1")).
+			AddOptions(opts.ReplicationOpts.For(approver)...).
+			RegisterResponder(&iouviews.ApproverView{}, &iouviews.CreateIOUView{}).
+			RegisterResponder(&iouviews.ApproverView{}, &iouviews.UpdateIOUView{}).
+			RegisterViewFactory("init", &iouviews.ApproverInitViewFactory{}).
+			RegisterViewFactory("finality", &cviews.FinalityViewFactory{})
+	}
+
+	fscTopology.AddNodeByName("borrower").
+		AddOptions(fabric.WithOrganization("Org2")).
+		AddOptions(opts.ReplicationOpts.For("borrower")...).
+		RegisterViewFactory("create", &iouviews.CreateIOUViewFactory{}).
+		RegisterViewFactory("update", &iouviews.UpdateIOUViewFactory{}).
+		RegisterViewFactory("query", &iouviews.QueryViewFactory{}).
+		RegisterViewFactory("finality", &cviews.FinalityViewFactory{})
+
+	fscTopology.AddNodeByName("lender").
+		AddOptions(fabric.WithOrganization("Org3")).
+		AddOptions(opts.ReplicationOpts.For("lender")...).
+		RegisterResponder(&iouviews.CreateIOUResponderView{}, &iouviews.CreateIOUView{}).
+		RegisterResponder(&iouviews.UpdateIOUResponderView{}, &iouviews.UpdateIOUView{}).
+		RegisterViewFactory("query", &iouviews.QueryViewFactory{}).
+		RegisterViewFactory("finality", &cviews.FinalityViewFactory{})
+
+	fscTopology.AddSDKForCommType(&iou.SDK{}, opts.CommType)
+
+	return []api.Topology{
+		fabricTopology,
+		fscTopology,
+	}
+}

--- a/integration/fabric/configupdate/topology.go
+++ b/integration/fabric/configupdate/topology.go
@@ -9,6 +9,7 @@ package configupdate
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration"
 	cviews "github.com/hyperledger-labs/fabric-smart-client/integration/fabric/common/views"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/fabric/configupdate/views"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/fabric/iou"
 	iouviews "github.com/hyperledger-labs/fabric-smart-client/integration/fabric/iou/views"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api"
@@ -55,7 +56,8 @@ func Topology(opts *Opts) []api.Topology {
 			RegisterResponder(&iouviews.ApproverView{}, &iouviews.CreateIOUView{}).
 			RegisterResponder(&iouviews.ApproverView{}, &iouviews.UpdateIOUView{}).
 			RegisterViewFactory("init", &iouviews.ApproverInitViewFactory{}).
-			RegisterViewFactory("finality", &cviews.FinalityViewFactory{})
+			RegisterViewFactory("finality", &cviews.FinalityViewFactory{}).
+			RegisterViewFactory("configseq", &views.ConfigSequenceViewFactory{})
 	}
 
 	fscTopology.AddNodeByName("borrower").
@@ -64,7 +66,8 @@ func Topology(opts *Opts) []api.Topology {
 		RegisterViewFactory("create", &iouviews.CreateIOUViewFactory{}).
 		RegisterViewFactory("update", &iouviews.UpdateIOUViewFactory{}).
 		RegisterViewFactory("query", &iouviews.QueryViewFactory{}).
-		RegisterViewFactory("finality", &cviews.FinalityViewFactory{})
+		RegisterViewFactory("finality", &cviews.FinalityViewFactory{}).
+		RegisterViewFactory("configseq", &views.ConfigSequenceViewFactory{})
 
 	fscTopology.AddNodeByName("lender").
 		AddOptions(fabric.WithOrganization("Org3")).
@@ -72,7 +75,8 @@ func Topology(opts *Opts) []api.Topology {
 		RegisterResponder(&iouviews.CreateIOUResponderView{}, &iouviews.CreateIOUView{}).
 		RegisterResponder(&iouviews.UpdateIOUResponderView{}, &iouviews.UpdateIOUView{}).
 		RegisterViewFactory("query", &iouviews.QueryViewFactory{}).
-		RegisterViewFactory("finality", &cviews.FinalityViewFactory{})
+		RegisterViewFactory("finality", &cviews.FinalityViewFactory{}).
+		RegisterViewFactory("configseq", &views.ConfigSequenceViewFactory{})
 
 	fscTopology.AddSDKForCommType(&iou.SDK{}, opts.CommType)
 

--- a/integration/fabric/configupdate/views/configseq.go
+++ b/integration/fabric/configupdate/views/configseq.go
@@ -1,0 +1,38 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package views
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/assert"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
+
+// ConfigSequenceView reports the sequence number of the channel configuration
+// the FSC node running it currently holds.
+//
+// This is the suite's window onto the committer's CONFIG-block path: the
+// sequence advances only if a configuration block reached the node and was
+// applied, so a node that silently drops one keeps reporting the sequence it
+// started from.
+type ConfigSequenceView struct{}
+
+func (v *ConfigSequenceView) Call(viewCtx view.Context) (any, error) {
+	_, ch, err := fabric.GetDefaultChannel(viewCtx)
+	assert.NoError(err, "failed getting the default channel")
+
+	sequence, err := ch.ConfigSequence()
+	assert.NoError(err, "failed getting the channel configuration sequence")
+
+	return sequence, nil
+}
+
+type ConfigSequenceViewFactory struct{}
+
+func (f *ConfigSequenceViewFactory) NewView([]byte) (view.View, error) {
+	return &ConfigSequenceView{}, nil
+}

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -37,6 +37,7 @@ const (
 	FabricStopRestart
 	RuntimeConfigPort
 	FabricXAssetTransferPort
+	FabricConfigUpdatePort
 )
 
 // StartPortForNode On linux, the default ephemeral port range is 32768-60999 and can be

--- a/platform/fabric/channel.go
+++ b/platform/fabric/channel.go
@@ -42,6 +42,16 @@ func (c *Channel) MSPManager() *MSPManager {
 	return &MSPManager{ch: c.ch.ChannelMembership()}
 }
 
+// ConfigSequence returns the sequence number of the channel configuration this
+// node currently holds. It is 0 for the channel's genesis configuration and
+// increases by one for every configuration update the node has applied, so a
+// caller can tell whether a configuration change has reached this node yet. A
+// channel with no configuration in force reports driver.ErrNotInitialized or
+// driver.ErrConfigRejected instead.
+func (c *Channel) ConfigSequence() (uint64, error) {
+	return c.ch.ChannelMembership().ConfigSequence()
+}
+
 // ACLProvider returns the ACLProvider of the channel
 func (c *Channel) ACLProvider() *ACLProvider {
 	return NewACLProvider(c.ch.ChannelMembership())

--- a/platform/fabric/core/generic/committer/config.go
+++ b/platform/fabric/core/generic/committer/config.go
@@ -23,7 +23,7 @@ const ConfigTXPrefix = "configtx_"
 
 func (c *Committer) HandleConfig(ctx context.Context, _ *common.BlockMetadata, tx CommitTx) (*FinalityEvent, error) {
 	logger.Debugf("[%s] Config transaction received: %s", c.ChannelConfig.ID(), tx.TxID)
-	if err := c.CommitConfig(ctx, tx.BlkNum, tx.TxNum, tx.Raw, tx.Envelope); err != nil {
+	if err := c.CommitConfig(ctx, tx.BlkNum, tx.Raw, tx.Envelope); err != nil {
 		return nil, errors.Wrapf(err, "cannot commit config envelope for channel [%s]", c.ChannelConfig.ID())
 	}
 	return &FinalityEvent{Ctx: ctx}, nil
@@ -111,8 +111,35 @@ func (c *Committer) ReloadConfigTransactions() error {
 	return nil
 }
 
+// configSequenceOf returns the sequence number carried by a channel
+// configuration transaction.
+//
+// This is the channel's own counter: 0 for the genesis configuration,
+// incremented by one by the ordering service for every accepted configuration
+// update. It is what the vault entry must be keyed on. The transaction's index
+// within its block cannot serve: a configuration block holds exactly one
+// transaction, so that index is always 0 and every configuration block would
+// collide with the genesis entry.
+func configSequenceOf(env *common.Envelope) (uint64, error) {
+	payload, err := protoutil.UnmarshalPayload(env.Payload)
+	if err != nil {
+		return 0, errors.Wrapf(err, "cannot get payload from config transaction")
+	}
+
+	cenv, err := protoutil.UnmarshalConfigEnvelope(payload.Data)
+	if err != nil {
+		return 0, errors.Wrapf(err, "cannot get config envelope from config transaction")
+	}
+
+	if cenv.Config == nil {
+		return 0, errors.New("config envelope carries no config")
+	}
+
+	return cenv.Config.Sequence, nil
+}
+
 // CommitConfig is used to validate and apply configuration transactions for a Channel.
-func (c *Committer) CommitConfig(ctx context.Context, blockNumber driver.BlockNum, txNum driver.TxNum, raw []byte, env *common.Envelope) error {
+func (c *Committer) CommitConfig(ctx context.Context, blockNumber driver.BlockNum, raw []byte, env *common.Envelope) error {
 	logger.DebugfContext(ctx, "Start commit config")
 	defer logger.DebugfContext(ctx, "End commit config")
 	commitConfigMutex.Lock()
@@ -122,8 +149,13 @@ func (c *Committer) CommitConfig(ctx context.Context, blockNumber driver.BlockNu
 		return errors.Errorf("envelope nil")
 	}
 
+	sequence, err := configSequenceOf(env)
+	if err != nil {
+		return errors.Wrapf(err, "cannot read the config sequence")
+	}
+
 	// first we check if config is already committed
-	txID := ConfigTXPrefix + strconv.FormatUint(txNum, 10)
+	txID := ConfigTXPrefix + strconv.FormatUint(sequence, 10)
 	vc, _, err := c.Vault.Status(ctx, txID)
 	if err != nil {
 		return errors.Wrapf(err, "failed getting tx's status [%s]", txID)
@@ -140,7 +172,7 @@ func (c *Committer) CommitConfig(ctx context.Context, blockNumber driver.BlockNu
 	}
 
 	// when validation passes, we can commit the config transaction
-	if err := c.commitConfig(ctx, txID, blockNumber, txNum, raw); err != nil {
+	if err := c.commitConfig(ctx, txID, blockNumber, sequence, raw); err != nil {
 		return errors.Wrapf(err, "failed committing configtx to the vault")
 	}
 

--- a/platform/fabric/core/generic/committer/config_test.go
+++ b/platform/fabric/core/generic/committer/config_test.go
@@ -18,9 +18,24 @@ import (
 
 	cdriver "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/committer/fake"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/protoutil"
 	fdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
 )
+
+// configEnvelope builds a channel configuration transaction carrying the given
+// sequence, which is what CommitConfig keys the vault entry on.
+func configEnvelope(sequence uint64) *common.Envelope {
+	payload := &common.Payload{
+		Data: protoutil.MarshalOrPanic(&common.ConfigEnvelope{
+			Config: &common.Config{
+				Sequence:     sequence,
+				ChannelGroup: &common.ConfigGroup{},
+			},
+		}),
+	}
+	return &common.Envelope{Payload: protoutil.MarshalOrPanic(payload)}
+}
 
 func TestHandleConfigWrapsCommitError(t *testing.T) {
 	t.Parallel()
@@ -86,7 +101,7 @@ func TestCommitConfig(t *testing.T) {
 		c := &Committer{
 			logger: logger,
 		}
-		err := c.CommitConfig(t.Context(), 1, 1, []byte("raw"), nil)
+		err := c.CommitConfig(t.Context(), 1, []byte("raw"), nil)
 		require.ErrorContains(t, err, "envelope nil")
 	})
 
@@ -100,7 +115,7 @@ func TestCommitConfig(t *testing.T) {
 				},
 			},
 		}
-		err := c.CommitConfig(t.Context(), 1, 2, []byte("raw"), &common.Envelope{})
+		err := c.CommitConfig(t.Context(), 1, []byte("raw"), configEnvelope(2))
 		require.ErrorContains(t, err, "failed getting tx's status")
 	})
 
@@ -114,7 +129,7 @@ func TestCommitConfig(t *testing.T) {
 				},
 			},
 		}
-		err := c.CommitConfig(t.Context(), 1, 3, []byte("raw"), &common.Envelope{})
+		err := c.CommitConfig(t.Context(), 1, []byte("raw"), configEnvelope(3))
 		require.NoError(t, err)
 	})
 
@@ -128,7 +143,7 @@ func TestCommitConfig(t *testing.T) {
 				},
 			},
 		}
-		err := c.CommitConfig(t.Context(), 1, 4, []byte("raw"), &common.Envelope{})
+		err := c.CommitConfig(t.Context(), 1, []byte("raw"), configEnvelope(4))
 		require.ErrorContains(t, err, "invalid configtx's")
 	})
 
@@ -174,11 +189,116 @@ func TestCommitConfig(t *testing.T) {
 			},
 		}
 		require.NotPanics(t, func() {
-			err := c.CommitConfig(t.Context(), 1, 5, []byte("raw"), &common.Envelope{})
+			err := c.CommitConfig(t.Context(), 1, []byte("raw"), configEnvelope(5))
 			require.ErrorContains(t, err, "failed updating membership service for configtx")
 			require.ErrorContains(t, err, "membership-update-failed")
 		})
 	})
+}
+
+// TestCommitConfigKeysOnTheConfigSequence is the regression test for config
+// blocks being dropped after the first one.
+//
+// CommitConfig used to key the vault entry on the transaction's index within
+// its block. A configuration block holds exactly one transaction, so that index
+// is always 0 and every configuration block mapped to configtx_0. The channel's
+// genesis block committed that key during start-up catch-up, so every later
+// configuration block hit the "already committed" guard and returned before
+// MembershipService.Update and applyConfigUpdates ever ran.
+func TestCommitConfigKeysOnTheConfigSequence(t *testing.T) {
+	t.Parallel()
+
+	var committedTxID string
+	updated := false
+	// configtx_0 is already Valid, as it is on any node that has caught up with
+	// the channel's genesis block. For configtx_1 the status is consulted
+	// twice: CommitConfig's own "already committed" guard must see Unknown to
+	// proceed, then commitConfig -> Committer.CommitTX consults it again and
+	// must see Busy, because Unknown there routes to commitUnknown() instead of
+	// the commit() path that calls CommitTxFn. The existing "membership update
+	// failure" sub-test documents the same mechanics.
+	var seqOneStatusCalls int
+	c := &Committer{
+		logger:        logger,
+		ChannelConfig: &fake.ChannelConfig{IDValue: "ch-seq"},
+		Vault: &fake.Vault{
+			StatusFn: func(_ context.Context, txID cdriver.TxID) (fdriver.ValidationCode, string, error) {
+				if txID == ConfigTXPrefix+"0" {
+					return fdriver.Valid, "", nil
+				}
+				seqOneStatusCalls++
+				if seqOneStatusCalls == 1 {
+					return fdriver.Unknown, "", nil
+				}
+				return fdriver.Busy, "", nil
+			},
+			NewRWSetFn: func(context.Context, cdriver.TxID) (fdriver.RWSet, error) {
+				return &fake.RWSet{}, nil
+			},
+			CommitTxFn: func(_ context.Context, txID cdriver.TxID, _ cdriver.BlockNum, _ cdriver.TxNum) error {
+				committedTxID = txID
+				return nil
+			},
+		},
+		ProcessorManager: &fake.ProcessorManager{
+			ProcessByIDFn: func(context.Context, string, cdriver.TxID) error { return nil },
+		},
+		MembershipService: &fake.MembershipService{
+			UpdateFn: func(*common.Envelope) error {
+				updated = true
+				return nil
+			},
+		},
+		ConfigService:   &fake.ConfigService{NetworkNameValue: "net1"},
+		OrderingService: &fake.OrderingService{},
+	}
+
+	require.NoError(t, c.CommitConfig(t.Context(), 12, []byte("raw"), configEnvelope(1)))
+	require.Equal(t, ConfigTXPrefix+"1", committedTxID,
+		"a config block at sequence 1 must not be keyed on the genesis entry")
+	require.True(t, updated,
+		"the membership service must be updated for a config block that has not been seen")
+}
+
+// TestCommitConfigSkipsAConfigItAlreadyHas asserts the guard still works for a
+// genuine replay: the same sequence arriving twice is committed once.
+func TestCommitConfigSkipsAConfigItAlreadyHas(t *testing.T) {
+	t.Parallel()
+
+	updated := false
+	c := &Committer{
+		logger:        logger,
+		ChannelConfig: &fake.ChannelConfig{IDValue: "ch-replay"},
+		Vault: &fake.Vault{
+			StatusFn: func(context.Context, cdriver.TxID) (fdriver.ValidationCode, string, error) {
+				return fdriver.Valid, "", nil
+			},
+		},
+		MembershipService: &fake.MembershipService{
+			UpdateFn: func(*common.Envelope) error {
+				updated = true
+				return nil
+			},
+		},
+	}
+
+	require.NoError(t, c.CommitConfig(t.Context(), 12, []byte("raw"), configEnvelope(4)))
+	require.False(t, updated, "a config block already in the vault must not be reapplied")
+}
+
+// TestCommitConfigRejectsAnEnvelopeWithoutASequence covers an envelope whose
+// sequence cannot be read. Keying on a guessed value would silently collide
+// with a real entry, so this must fail rather than fall back to 0.
+func TestCommitConfigRejectsAnEnvelopeWithoutASequence(t *testing.T) {
+	t.Parallel()
+
+	c := &Committer{
+		logger:        logger,
+		ChannelConfig: &fake.ChannelConfig{IDValue: "ch-bad"},
+	}
+
+	err := c.CommitConfig(t.Context(), 1, []byte("raw"), &common.Envelope{})
+	require.ErrorContains(t, err, "cannot read the config sequence")
 }
 
 func TestApplyConfigUpdates(t *testing.T) {

--- a/platform/fabric/core/generic/membership/membership.go
+++ b/platform/fabric/core/generic/membership/membership.go
@@ -20,6 +20,15 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
+// configuration is the channel configuration in force together with the
+// sequence number of the configuration it came from. The two are held as a
+// single value so that a reader can never observe a new configuration paired
+// with the sequence of the one it replaced.
+type configuration struct {
+	channelConfig *channelconfig.ChannelConfig
+	sequence      uint64
+}
+
 // Service answers membership questions about a channel from its current
 // configuration. The configuration is not available when the service is built;
 // it arrives with the first configuration block, via Update. Until one is in
@@ -29,14 +38,14 @@ type Service struct {
 	// config holds the channel configuration once it has been loaded. Reading
 	// it goes through deferred.Holder.Get, which cannot hand out a
 	// configuration that is not there.
-	config *deferred.Holder[*channelconfig.ChannelConfig]
+	config *deferred.Holder[*configuration]
 
 	channelName string
 }
 
 func NewService(channelName string) *Service {
 	return &Service{
-		config:      deferred.NewHolder[*channelconfig.ChannelConfig]("channel [" + channelName + "] configuration"),
+		config:      deferred.NewHolder[*configuration]("channel [" + channelName + "] configuration"),
 		channelName: channelName,
 	}
 }
@@ -44,12 +53,12 @@ func NewService(channelName string) *Service {
 // Update installs the channel configuration carried by env. The previously held
 // configuration is kept if env cannot be parsed.
 func (c *Service) Update(env *cb.Envelope) error {
-	return c.config.Update(func(*channelconfig.ChannelConfig, bool) (*channelconfig.ChannelConfig, error) {
+	return c.config.Update(func(*configuration, bool) (*configuration, error) {
 		return parseConfig(env)
 	})
 }
 
-func parseConfig(env *cb.Envelope) (*channelconfig.ChannelConfig, error) {
+func parseConfig(env *cb.Envelope) (*configuration, error) {
 	payload, err := protoutil.UnmarshalPayload(env.Payload)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot get payload from config transaction")
@@ -60,7 +69,31 @@ func parseConfig(env *cb.Envelope) (*channelconfig.ChannelConfig, error) {
 		return nil, errors.Wrapf(err, "error unmarshalling config which passed initial validity checks")
 	}
 
-	return channelconfig.NewChannelConfig(cenv.Config.ChannelGroup, factory.GetDefault())
+	if cenv.Config == nil {
+		return nil, errors.New("config envelope carries no config")
+	}
+
+	cc, err := channelconfig.NewChannelConfig(cenv.Config.ChannelGroup, factory.GetDefault())
+	if err != nil {
+		return nil, err
+	}
+
+	return &configuration{channelConfig: cc, sequence: cenv.Config.Sequence}, nil
+}
+
+// ConfigSequence returns the sequence number of the channel configuration
+// currently in force. It is 0 for a channel's genesis configuration and
+// increases by one for every configuration update this node has applied, so a
+// caller can tell whether a configuration change has reached this node yet. A
+// channel with no configuration in force reports driver.ErrNotInitialized or
+// driver.ErrConfigRejected instead.
+func (c *Service) ConfigSequence() (uint64, error) {
+	res, err := c.config.Get()
+	if err != nil {
+		return 0, err
+	}
+
+	return res.sequence, nil
 }
 
 func (c *Service) IsValid(identity view.Identity) error {
@@ -69,7 +102,7 @@ func (c *Service) IsValid(identity view.Identity) error {
 		return err
 	}
 
-	id, err := res.MSPManager().DeserializeIdentity(identity)
+	id, err := res.channelConfig.MSPManager().DeserializeIdentity(identity)
 	if err != nil {
 		return errors.Wrapf(err, "failed deserializing identity [%s]", identity.String())
 	}
@@ -83,7 +116,7 @@ func (c *Service) GetVerifier(identity view.Identity) (driver.Verifier, error) {
 		return nil, err
 	}
 
-	id, err := res.MSPManager().DeserializeIdentity(identity)
+	id, err := res.channelConfig.MSPManager().DeserializeIdentity(identity)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed deserializing identity [%s]", identity.String())
 	}
@@ -102,7 +135,7 @@ func (c *Service) GetMSPIDs() ([]string, error) {
 	}
 
 	var mspIDs []string
-	if ac := res.ApplicationConfig(); ac != nil {
+	if ac := res.channelConfig.ApplicationConfig(); ac != nil {
 		for _, org := range ac.Organizations() {
 			mspIDs = append(mspIDs, org.MSPID())
 		}
@@ -122,7 +155,7 @@ func (c *Service) IsIdemixMSP(mspID string) (bool, error) {
 		return false, err
 	}
 
-	ac := res.ApplicationConfig()
+	ac := res.channelConfig.ApplicationConfig()
 	if ac == nil {
 		return false, nil
 	}
@@ -142,7 +175,7 @@ func (c *Service) OrdererConfig(cs driver.ConfigService) (string, []*grpc.Connec
 		return "", nil, err
 	}
 
-	oc := res.OrdererConfig()
+	oc := res.channelConfig.OrdererConfig()
 	if oc == nil {
 		return "", nil, errors.Errorf("orderer config does not exist for channel [%s]", c.channelName)
 	}
@@ -196,7 +229,7 @@ func (c *Service) CheckACL(signedProp driver.SignedProposal) error {
 }
 
 type mspManager struct {
-	config *deferred.Holder[*channelconfig.ChannelConfig]
+	config *deferred.Holder[*configuration]
 }
 
 func (m *mspManager) DeserializeIdentity(serializedIdentity []byte) (driver.MSPIdentity, error) {
@@ -205,5 +238,5 @@ func (m *mspManager) DeserializeIdentity(serializedIdentity []byte) (driver.MSPI
 		return nil, err
 	}
 
-	return res.MSPManager().DeserializeIdentity(serializedIdentity)
+	return res.channelConfig.MSPManager().DeserializeIdentity(serializedIdentity)
 }

--- a/platform/fabric/core/generic/membership/membership_test.go
+++ b/platform/fabric/core/generic/membership/membership_test.go
@@ -15,18 +15,19 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/membership/channelconfig"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/protoutil"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
 var _ driver.MembershipService = (*Service)(nil)
 
-// seed installs cfg as the service's channel configuration, standing in for the
-// first successful Update.
-func seed(t *testing.T, s *Service, cfg *channelconfig.ChannelConfig) {
+// seed installs cfg as the service's channel configuration at the given
+// sequence, standing in for the first successful Update.
+func seed(t *testing.T, s *Service, cfg *channelconfig.ChannelConfig, sequence uint64) {
 	t.Helper()
-	require.NoError(t, s.config.Update(func(*channelconfig.ChannelConfig, bool) (*channelconfig.ChannelConfig, error) {
-		return cfg, nil
+	require.NoError(t, s.config.Update(func(*configuration, bool) (*configuration, error) {
+		return &configuration{channelConfig: cfg, sequence: sequence}, nil
 	}))
 }
 
@@ -69,6 +70,11 @@ func TestAccessorsBeforeFirstUpdate(t *testing.T) {
 		{"MSPManager.DeserializeIdentity", func(s *Service) error {
 			id, err := s.MSPManager().DeserializeIdentity(identity)
 			require.Nil(t, id)
+			return err
+		}},
+		{"ConfigSequence", func(s *Service) error {
+			seq, err := s.ConfigSequence()
+			require.Zero(t, seq)
 			return err
 		}},
 	} {
@@ -124,7 +130,7 @@ func TestServiceRecoversFromARejectedConfig(t *testing.T) {
 	s := NewService("mychannel")
 
 	require.Error(t, s.Update(&cb.Envelope{Payload: []byte("not-a-proto")}))
-	seed(t, s, &channelconfig.ChannelConfig{})
+	seed(t, s, &channelconfig.ChannelConfig{}, 0)
 
 	_, err := s.GetMSPIDs()
 	require.NoError(t, err, "an accepted configuration must clear an earlier refusal")
@@ -139,7 +145,7 @@ func TestLoadedConfigIsDistinguishableFromMissingConfig(t *testing.T) {
 	t.Run("GetMSPIDs on a config with no application section", func(t *testing.T) {
 		t.Parallel()
 		s := NewService("mychannel")
-		seed(t, s, &channelconfig.ChannelConfig{})
+		seed(t, s, &channelconfig.ChannelConfig{}, 0)
 
 		ids, err := s.GetMSPIDs()
 		require.NoError(t, err, "a loaded configuration must not report ErrNotInitialized")
@@ -149,7 +155,7 @@ func TestLoadedConfigIsDistinguishableFromMissingConfig(t *testing.T) {
 	t.Run("IsIdemixMSP on a config with no application section", func(t *testing.T) {
 		t.Parallel()
 		s := NewService("mychannel")
-		seed(t, s, &channelconfig.ChannelConfig{})
+		seed(t, s, &channelconfig.ChannelConfig{}, 0)
 
 		isIdemix, err := s.IsIdemixMSP("Org1MSP")
 		require.NoError(t, err, "a loaded configuration must not report ErrNotInitialized")
@@ -159,7 +165,7 @@ func TestLoadedConfigIsDistinguishableFromMissingConfig(t *testing.T) {
 	t.Run("OrdererConfig on a config with no orderer section", func(t *testing.T) {
 		t.Parallel()
 		s := NewService("mychannel")
-		seed(t, s, &channelconfig.ChannelConfig{})
+		seed(t, s, &channelconfig.ChannelConfig{}, 0)
 
 		_, _, err := s.OrdererConfig(nil)
 		require.Error(t, err)
@@ -172,4 +178,54 @@ func TestLoadedConfigIsDistinguishableFromMissingConfig(t *testing.T) {
 func TestCheckACLIsNotImplemented(t *testing.T) {
 	t.Parallel()
 	require.ErrorIs(t, NewService("mychannel").CheckACL(nil), driver.ErrNotImplemented)
+}
+
+// TestConfigSequenceReportsTheSequenceInForce asserts that the sequence a
+// reader sees is the one belonging to the configuration currently held, which
+// is what lets a caller tell whether a configuration update has reached this
+// node yet.
+func TestConfigSequenceReportsTheSequenceInForce(t *testing.T) {
+	t.Parallel()
+	s := NewService("mychannel")
+
+	seed(t, s, &channelconfig.ChannelConfig{}, 0)
+	seq, err := s.ConfigSequence()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), seq)
+
+	seed(t, s, &channelconfig.ChannelConfig{}, 7)
+	seq, err = s.ConfigSequence()
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), seq)
+}
+
+// TestConfigSequenceSurvivesARejectedUpdate asserts that a refused update
+// leaves both halves of the held value alone: reporting the new sequence
+// beside the old configuration would tell a caller the node had applied a
+// configuration it had in fact rejected.
+func TestConfigSequenceSurvivesARejectedUpdate(t *testing.T) {
+	t.Parallel()
+	s := NewService("mychannel")
+	seed(t, s, &channelconfig.ChannelConfig{}, 3)
+
+	require.Error(t, s.Update(&cb.Envelope{Payload: []byte("not-a-proto")}))
+
+	seq, err := s.ConfigSequence()
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), seq, "a rejected update must not advance the sequence")
+}
+
+// TestUpdateWithoutAConfigIsRejected covers a config envelope that unmarshals
+// but carries no Config. Before the sequence was read this dereferenced
+// cenv.Config blindly and would panic.
+func TestUpdateWithoutAConfigIsRejected(t *testing.T) {
+	t.Parallel()
+	s := NewService("mychannel")
+
+	payload := &cb.Payload{Data: protoutil.MarshalOrPanic(&cb.ConfigEnvelope{})}
+	env := &cb.Envelope{Payload: protoutil.MarshalOrPanic(payload)}
+
+	var err error
+	require.NotPanics(t, func() { err = s.Update(env) })
+	require.ErrorContains(t, err, "config envelope carries no config")
 }

--- a/platform/fabric/core/generic/transaction/mock/channel_membership.go
+++ b/platform/fabric/core/generic/transaction/mock/channel_membership.go
@@ -20,6 +20,18 @@ type ChannelMembership struct {
 	checkACLReturnsOnCall map[int]struct {
 		result1 error
 	}
+	ConfigSequenceStub        func() (uint64, error)
+	configSequenceMutex       sync.RWMutex
+	configSequenceArgsForCall []struct {
+	}
+	configSequenceReturns struct {
+		result1 uint64
+		result2 error
+	}
+	configSequenceReturnsOnCall map[int]struct {
+		result1 uint64
+		result2 error
+	}
 	GetMSPIDsStub        func() ([]string, error)
 	getMSPIDsMutex       sync.RWMutex
 	getMSPIDsArgsForCall []struct {
@@ -142,6 +154,62 @@ func (fake *ChannelMembership) CheckACLReturnsOnCall(i int, result1 error) {
 	fake.checkACLReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *ChannelMembership) ConfigSequence() (uint64, error) {
+	fake.configSequenceMutex.Lock()
+	ret, specificReturn := fake.configSequenceReturnsOnCall[len(fake.configSequenceArgsForCall)]
+	fake.configSequenceArgsForCall = append(fake.configSequenceArgsForCall, struct {
+	}{})
+	stub := fake.ConfigSequenceStub
+	fakeReturns := fake.configSequenceReturns
+	fake.recordInvocation("ConfigSequence", []interface{}{})
+	fake.configSequenceMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *ChannelMembership) ConfigSequenceCallCount() int {
+	fake.configSequenceMutex.RLock()
+	defer fake.configSequenceMutex.RUnlock()
+	return len(fake.configSequenceArgsForCall)
+}
+
+func (fake *ChannelMembership) ConfigSequenceCalls(stub func() (uint64, error)) {
+	fake.configSequenceMutex.Lock()
+	defer fake.configSequenceMutex.Unlock()
+	fake.ConfigSequenceStub = stub
+}
+
+func (fake *ChannelMembership) ConfigSequenceReturns(result1 uint64, result2 error) {
+	fake.configSequenceMutex.Lock()
+	defer fake.configSequenceMutex.Unlock()
+	fake.ConfigSequenceStub = nil
+	fake.configSequenceReturns = struct {
+		result1 uint64
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ChannelMembership) ConfigSequenceReturnsOnCall(i int, result1 uint64, result2 error) {
+	fake.configSequenceMutex.Lock()
+	defer fake.configSequenceMutex.Unlock()
+	fake.ConfigSequenceStub = nil
+	if fake.configSequenceReturnsOnCall == nil {
+		fake.configSequenceReturnsOnCall = make(map[int]struct {
+			result1 uint64
+			result2 error
+		})
+	}
+	fake.configSequenceReturnsOnCall[i] = struct {
+		result1 uint64
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *ChannelMembership) GetMSPIDs() ([]string, error) {

--- a/platform/fabric/driver/membership.go
+++ b/platform/fabric/driver/membership.go
@@ -112,6 +112,13 @@ type ChannelMembership interface {
 	// instead, so callers choosing an identity encoding from this cannot
 	// mistake an absent configuration for a real answer.
 	IsIdemixMSP(mspID string) (bool, error)
+	// ConfigSequence returns the sequence number of the channel configuration
+	// currently in force. It is 0 for a channel's genesis configuration and
+	// increases by one for every configuration update the node has applied, so
+	// a caller can tell whether a configuration change has reached this node
+	// yet. A channel with no configuration in force reports one of the errors
+	// above instead.
+	ConfigSequence() (uint64, error)
 }
 
 // MembershipService is the driver-side view of a channel's membership: a

--- a/platform/fabric/services/endorser/mock/channel_membership.go
+++ b/platform/fabric/services/endorser/mock/channel_membership.go
@@ -20,6 +20,18 @@ type ChannelMembership struct {
 	checkACLReturnsOnCall map[int]struct {
 		result1 error
 	}
+	ConfigSequenceStub        func() (uint64, error)
+	configSequenceMutex       sync.RWMutex
+	configSequenceArgsForCall []struct {
+	}
+	configSequenceReturns struct {
+		result1 uint64
+		result2 error
+	}
+	configSequenceReturnsOnCall map[int]struct {
+		result1 uint64
+		result2 error
+	}
 	GetMSPIDsStub        func() ([]string, error)
 	getMSPIDsMutex       sync.RWMutex
 	getMSPIDsArgsForCall []struct {
@@ -142,6 +154,62 @@ func (fake *ChannelMembership) CheckACLReturnsOnCall(i int, result1 error) {
 	fake.checkACLReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *ChannelMembership) ConfigSequence() (uint64, error) {
+	fake.configSequenceMutex.Lock()
+	ret, specificReturn := fake.configSequenceReturnsOnCall[len(fake.configSequenceArgsForCall)]
+	fake.configSequenceArgsForCall = append(fake.configSequenceArgsForCall, struct {
+	}{})
+	stub := fake.ConfigSequenceStub
+	fakeReturns := fake.configSequenceReturns
+	fake.recordInvocation("ConfigSequence", []interface{}{})
+	fake.configSequenceMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *ChannelMembership) ConfigSequenceCallCount() int {
+	fake.configSequenceMutex.RLock()
+	defer fake.configSequenceMutex.RUnlock()
+	return len(fake.configSequenceArgsForCall)
+}
+
+func (fake *ChannelMembership) ConfigSequenceCalls(stub func() (uint64, error)) {
+	fake.configSequenceMutex.Lock()
+	defer fake.configSequenceMutex.Unlock()
+	fake.ConfigSequenceStub = stub
+}
+
+func (fake *ChannelMembership) ConfigSequenceReturns(result1 uint64, result2 error) {
+	fake.configSequenceMutex.Lock()
+	defer fake.configSequenceMutex.Unlock()
+	fake.ConfigSequenceStub = nil
+	fake.configSequenceReturns = struct {
+		result1 uint64
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ChannelMembership) ConfigSequenceReturnsOnCall(i int, result1 uint64, result2 error) {
+	fake.configSequenceMutex.Lock()
+	defer fake.configSequenceMutex.Unlock()
+	fake.ConfigSequenceStub = nil
+	if fake.configSequenceReturnsOnCall == nil {
+		fake.configSequenceReturnsOnCall = make(map[int]struct {
+			result1 uint64
+			result2 error
+		})
+	}
+	fake.configSequenceReturnsOnCall[i] = struct {
+		result1 uint64
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *ChannelMembership) GetMSPIDs() ([]string, error) {

--- a/platform/fabricx/core/membership/membership.go
+++ b/platform/fabricx/core/membership/membership.go
@@ -329,6 +329,20 @@ func (s *Service) IsIdemixMSP(mspID string) (bool, error) {
 	return false, nil
 }
 
+// ConfigSequence returns the sequence number of the channel configuration
+// currently in force. It reflects the sequence of the configuration bundle
+// built by the config monitor and increases by one for every configuration
+// update this node has applied. A channel with no configuration in force
+// reports driver.ErrNotInitialized or driver.ErrConfigRejected instead.
+func (s *Service) ConfigSequence() (uint64, error) {
+	res, err := s.config.Get()
+	if err != nil {
+		return 0, err
+	}
+
+	return res.ConfigtxValidator().Sequence(), nil
+}
+
 // CheckACL checks the ACL for the resource for the Channel using the
 // SignedProposal from which an id can be extracted for testing against a policy
 func (s *Service) CheckACL(signedProp driver.SignedProposal) error {

--- a/platform/fabricx/core/transaction/mock/channel_membership.go
+++ b/platform/fabricx/core/transaction/mock/channel_membership.go
@@ -20,6 +20,18 @@ type ChannelMembership struct {
 	checkACLReturnsOnCall map[int]struct {
 		result1 error
 	}
+	ConfigSequenceStub        func() (uint64, error)
+	configSequenceMutex       sync.RWMutex
+	configSequenceArgsForCall []struct {
+	}
+	configSequenceReturns struct {
+		result1 uint64
+		result2 error
+	}
+	configSequenceReturnsOnCall map[int]struct {
+		result1 uint64
+		result2 error
+	}
 	GetMSPIDsStub        func() ([]string, error)
 	getMSPIDsMutex       sync.RWMutex
 	getMSPIDsArgsForCall []struct {
@@ -142,6 +154,62 @@ func (fake *ChannelMembership) CheckACLReturnsOnCall(i int, result1 error) {
 	fake.checkACLReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *ChannelMembership) ConfigSequence() (uint64, error) {
+	fake.configSequenceMutex.Lock()
+	ret, specificReturn := fake.configSequenceReturnsOnCall[len(fake.configSequenceArgsForCall)]
+	fake.configSequenceArgsForCall = append(fake.configSequenceArgsForCall, struct {
+	}{})
+	stub := fake.ConfigSequenceStub
+	fakeReturns := fake.configSequenceReturns
+	fake.recordInvocation("ConfigSequence", []interface{}{})
+	fake.configSequenceMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *ChannelMembership) ConfigSequenceCallCount() int {
+	fake.configSequenceMutex.RLock()
+	defer fake.configSequenceMutex.RUnlock()
+	return len(fake.configSequenceArgsForCall)
+}
+
+func (fake *ChannelMembership) ConfigSequenceCalls(stub func() (uint64, error)) {
+	fake.configSequenceMutex.Lock()
+	defer fake.configSequenceMutex.Unlock()
+	fake.ConfigSequenceStub = stub
+}
+
+func (fake *ChannelMembership) ConfigSequenceReturns(result1 uint64, result2 error) {
+	fake.configSequenceMutex.Lock()
+	defer fake.configSequenceMutex.Unlock()
+	fake.ConfigSequenceStub = nil
+	fake.configSequenceReturns = struct {
+		result1 uint64
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ChannelMembership) ConfigSequenceReturnsOnCall(i int, result1 uint64, result2 error) {
+	fake.configSequenceMutex.Lock()
+	defer fake.configSequenceMutex.Unlock()
+	fake.ConfigSequenceStub = nil
+	if fake.configSequenceReturnsOnCall == nil {
+		fake.configSequenceReturnsOnCall = make(map[int]struct {
+			result1 uint64
+			result2 error
+		})
+	}
+	fake.configSequenceReturnsOnCall[i] = struct {
+		result1 uint64
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *ChannelMembership) GetMSPIDs() ([]string, error) {


### PR DESCRIPTION
Adds `integration/fabric/configupdate`, closing the gap in #1695

The suite runs the IOU flow, then changes the channel's orderer `BatchTimeout` (1s → 2s → 500ms) via orderer-signed config updates while the FSC nodes are running, re-running the flow after each change and again after restarting a node. Each transaction after a change is the assertion: it needs the nodes to still hold a usable view of the channel — its MSPs, to endorse and validate, and its ordering endpoints, to broadcast — which is exactly what `committer.HandleConfig` rebuilds. The restart additionally drives `ReloadConfigTransactions` over a sequence longer than the genesis block alone, for the first time in the test suite.

`BatchTimeout` is deliberate: it lives in the Orderer group that `applyConfigUpdates` re-reads, and changing it cannot partition the network or invalidate an identity, so a downstream failure points at FSC rather than the fixture.

The topology is IOU's, reusing its views and SDK verbatim, minus monitoring and tracing (nothing here asserts on them, and they cost container start-up).

**Side effect:** this gives the previously unused nwo config-block helpers their first caller — all of `network/update.go` (240 LOC) and 8 of the 12 functions in `network/configblock.go`. Still unreached: `UpdateConfig`, `UpdateOrdererConfigSession`, `UpdateConsensusMetadata`, `UpdateOrdererMSP`, and all of `network/orderer_client.go`.

**Known limitation:** this proves the nodes survive and keep transacting across a CONFIG block, not that they adopt *new* orderer endpoints — `applyConfigUpdates` returns early on an empty endpoint list (`committer/config.go:157-160`), so a silent no-op there would still pass. Catching that needs a multi-orderer Raft topology where the endpoint set actually changes; worth a follow-up.