### PR TITLE
test(nwo): wait for an FSC node to exit instead of sleeping

### DIFF
--- a/integration/fabric/configupdate/configupdate_test.go
+++ b/integration/fabric/configupdate/configupdate_test.go
@@ -109,9 +109,7 @@ func (s *TestSuite) TestSucceeded() {
 	// configtx_0, configtx_1 and configtx_2, so this is the first time in the
 	// test suite that the loop runs over more than the genesis entry.
 	s.II.StopFSCNode("borrower")
-	time.Sleep(3 * time.Second)
 	s.II.StartFSCNode("borrower")
-	time.Sleep(3 * time.Second)
 
 	// after the borrower has been stopped and started again
 	By("checking the restarted node replayed both stored configuration transactions")

--- a/integration/fabric/stoprestart/stoprestart_test.go
+++ b/integration/fabric/stoprestart/stoprestart_test.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package stoprestart_test
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -74,9 +72,7 @@ func (s *TestSuite) TestSucceeded() {
 	Expect(common.JSONUnmarshalString(res)).To(BeEquivalentTo("OK"))
 
 	s.II.StopFSCNode("bob")
-	time.Sleep(3 * time.Second)
 	s.II.StartFSCNode("bob")
-	time.Sleep(3 * time.Second)
 
 	res, err = s.II.Client("alice").CallView("init", nil)
 	Expect(err).NotTo(HaveOccurred())
@@ -97,9 +93,7 @@ func (s *TestSuite) TestSucceededWithReplicas() {
 	Expect(common.JSONUnmarshalString(res)).To(BeEquivalentTo("OK"))
 
 	s.II.StopFSCNode("bob")
-	time.Sleep(3 * time.Second)
 	s.II.StartFSCNode("bob")
-	time.Sleep(3 * time.Second)
 
 	res, err = s.II.Client("fsc.alice.0").CallView("init", nil)
 	Expect(err).NotTo(HaveOccurred())

--- a/integration/fsc/stoprestart/stoprestart_test.go
+++ b/integration/fsc/stoprestart/stoprestart_test.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package stoprestart_test
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -74,9 +72,7 @@ func (s *TestSuite) TestSucceeded() {
 	Expect(common.JSONUnmarshalString(res)).To(BeEquivalentTo("OK"))
 
 	s.II.StopFSCNode("bob")
-	time.Sleep(3 * time.Second)
 	s.II.StartFSCNode("bob")
-	time.Sleep(3 * time.Second)
 
 	res, err = s.II.Client("alice").CallView("init", nil)
 	Expect(err).NotTo(HaveOccurred())
@@ -104,9 +100,7 @@ func (s *TestSuite) TestSucceededWithReplicas() {
 	Expect(common.JSONUnmarshalString(res)).To(BeEquivalentTo("OK"))
 
 	s.II.StopFSCNode("bob")
-	time.Sleep(3 * time.Second)
 	s.II.StartFSCNode("bob")
-	time.Sleep(3 * time.Second)
 
 	res, err = s.II.Client("fsc.alice.0").CallView("init", nil)
 	Expect(err).NotTo(HaveOccurred())

--- a/integration/nwo/common/runner/runner.go
+++ b/integration/nwo/common/runner/runner.go
@@ -191,16 +191,17 @@ func (r *Runner) Run(sigChan <-chan os.Signal, ready chan<- struct{}) error {
 }
 
 func (r *Runner) monitorForExit(exited chan<- struct{}) {
-	err := r.Command.Wait()
+	if err := r.Command.Wait(); err != nil {
+		logger.Debugf("process [%s] exited with error: %s", r.Name, err)
+	}
 	status := r.Command.ProcessState.Sys().(syscall.WaitStatus)
 	if status.Signaled() {
 		r.exitCode.Store(int32(128 + int(status.Signal())))
 	} else {
 		exitStatus := status.ExitStatus()
-		// An exit status of -1 is how the OS reports "no status", and it is the
-		// same value this type uses for "still running": storing it would leave
-		// a dead process looking alive forever to anyone waiting on it.
-		if exitStatus == notExited && err != nil {
+		// Wait has returned, so the process is gone. ExitStatus reports -1 for
+		// anything but a normal exit, and -1 means "still running" here.
+		if exitStatus == notExited {
 			exitStatus = gexec.INVALID_EXIT_CODE
 		}
 		r.exitCode.Store(int32(exitStatus))

--- a/integration/nwo/common/runner/runner.go
+++ b/integration/nwo/common/runner/runner.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -33,6 +34,12 @@ import (
 )
 
 var logger = logging.MustGetLogger()
+
+// notExited is what ExitCode reports while the process is still alive. It is
+// the value gexec.Exit() treats as "not exited yet", so a Runner must hold it
+// from construction until its process is actually gone — a zero-valued
+// exitCode would read as a clean exit that never happened.
+const notExited = -1
 
 // Config defines a Runner.
 type Config struct {
@@ -54,13 +61,17 @@ type Runner struct {
 	StartCheckTimeout time.Duration
 	Cleanup           func()
 	stop              chan os.Signal
-	exitCode          int
+	// exitCode is -1 while the process is alive and its real exit code once it
+	// is not. It is written by monitorForExit's goroutine and read by callers
+	// waiting for the process to go away — nwo.StopFSCNode polls it through
+	// gexec.Exit() — so it is atomic rather than a plain int.
+	exitCode atomic.Int32
 }
 
 // New creates a Runner from a config object. Runners must be created
 // with New to properly initialize their internal state.
 func New(config Config) *Runner {
-	return &Runner{
+	r := &Runner{
 		config:            config,
 		Name:              config.Name,
 		Command:           config.Command,
@@ -69,8 +80,10 @@ func New(config Config) *Runner {
 		StartCheckTimeout: config.StartCheckTimeout,
 		Cleanup:           config.Cleanup,
 		stop:              make(chan os.Signal),
-		exitCode:          -1,
 	}
+	r.exitCode.Store(notExited)
+
+	return r
 }
 
 func (r *Runner) Run(sigChan <-chan os.Signal, ready chan<- struct{}) error {
@@ -160,11 +173,11 @@ func (r *Runner) Run(sigChan <-chan os.Signal, ready chan<- struct{}) error {
 				r.Cleanup()
 			}
 
-			if r.exitCode == 0 {
-				return nil
+			if code := r.exitCode.Load(); code != 0 {
+				return errors.Errorf("exit status %d", code)
 			}
 
-			return errors.Errorf("exit status %d", r.exitCode)
+			return nil
 		case signal := <-r.stop:
 			logger.Infof("dispatch signal [%d] to process [%s]", signal, r.Name)
 			if signal != nil {
@@ -181,13 +194,16 @@ func (r *Runner) monitorForExit(exited chan<- struct{}) {
 	err := r.Command.Wait()
 	status := r.Command.ProcessState.Sys().(syscall.WaitStatus)
 	if status.Signaled() {
-		r.exitCode = 128 + int(status.Signal())
+		r.exitCode.Store(int32(128 + int(status.Signal())))
 	} else {
 		exitStatus := status.ExitStatus()
-		if exitStatus == -1 && err != nil {
-			r.exitCode = gexec.INVALID_EXIT_CODE
+		// An exit status of -1 is how the OS reports "no status", and it is the
+		// same value this type uses for "still running": storing it would leave
+		// a dead process looking alive forever to anyone waiting on it.
+		if exitStatus == notExited && err != nil {
+			exitStatus = gexec.INVALID_EXIT_CODE
 		}
-		r.exitCode = exitStatus
+		r.exitCode.Store(int32(exitStatus))
 	}
 
 	close(exited)
@@ -207,7 +223,7 @@ func (r *Runner) Clone() *Runner {
 	c.Args = r.config.Command.Args
 	c.Env = r.config.Command.Env
 	c.Dir = r.config.Command.Dir
-	return &Runner{
+	clone := &Runner{
 		config:            r.config,
 		Name:              r.config.Name,
 		Command:           c,
@@ -216,10 +232,12 @@ func (r *Runner) Clone() *Runner {
 		StartCheckTimeout: r.config.StartCheckTimeout,
 		Cleanup:           r.config.Cleanup,
 		stop:              make(chan os.Signal),
-		exitCode:          -1,
 	}
+	clone.exitCode.Store(notExited)
+
+	return clone
 }
 
 func (r *Runner) ExitCode() int {
-	return r.exitCode
+	return int(r.exitCode.Load())
 }

--- a/integration/nwo/common/runner/runner_test.go
+++ b/integration/nwo/common/runner/runner_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package runner_test
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+	"github.com/tedsuo/ifrit"
+
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common/runner"
+)
+
+// TestStopBringsTheProcessDown pins the contract nwo.StopFSCNode relies on: a
+// caller that has sent Stop can wait for the process to be gone by polling
+// ExitCode, rather than sleeping for a guessed interval and hoping.
+//
+// ExitCode must therefore mean exactly one thing at each moment — -1 while the
+// process is alive, and the real code once it is not — and must be safe to read
+// from the caller's goroutine while the runner's own monitor writes it.
+func TestStopBringsTheProcessDown(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	r := runner.New(runner.Config{
+		Name:    "sleeper",
+		Command: exec.Command("sleep", "60"),
+	})
+	g.Expect(r.ExitCode()).To(gomega.Equal(-1), "a runner that has not started must not look exited")
+
+	process := ifrit.Invoke(r)
+	g.Eventually(process.Ready(), 10*time.Second).Should(gomega.BeClosed())
+	g.Consistently(r.ExitCode, 200*time.Millisecond).Should(gomega.Equal(-1),
+		"a running process must not look exited")
+
+	r.Stop()
+
+	g.Eventually(r, 30*time.Second).Should(gexec.Exit(), "Stop must bring the process down")
+	g.Expect(r.ExitCode()).To(gomega.Equal(128+int(syscall.SIGTERM)),
+		"a process killed by a signal reports 128+signal")
+}
+
+// TestCloneStartsUnexited guards the trap in Clone: a Runner reports "still
+// running" with a sentinel rather than a zero value, so a clone that forgot to
+// set it would claim to have exited cleanly before it had ever run. nwo restarts
+// a node by cloning its runner, so anything waiting on that clone's exit would
+// return immediately.
+func TestCloneStartsUnexited(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	r := runner.New(runner.Config{
+		Name:    "sleeper",
+		Command: exec.Command("sleep", "60"),
+	})
+
+	g.Expect(r.Clone().ExitCode()).To(gomega.Equal(-1), "a fresh clone must not look exited")
+}

--- a/integration/nwo/nwo.go
+++ b/integration/nwo/nwo.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
 	"github.com/tedsuo/ifrit"
 	"github.com/tedsuo/ifrit/grouper"
 
@@ -202,12 +203,23 @@ func (n *NWO) Stop() {
 	logger.Infof("Stopping...done!")
 }
 
+// StopFSCNode stops the named FSC node and returns once its process is gone.
+//
+// Waiting matters because the node holds resources a replacement cannot share:
+// its listening ports and its vault. Returning as soon as the signal was sent
+// would leave a caller that restarts the node racing the old process for them,
+// which is why callers used to follow this with a sleep long enough to hope the
+// exit had happened. StartFSCNode already waits for readiness; this is its
+// counterpart.
 func (n *NWO) StopFSCNode(id string) {
 	logger.Infof("Search FSC node [%s]...", id)
 	for _, member := range n.ViewMembers {
 		if strings.HasPrefix(member.Name, fmt.Sprintf("fsc.%s.", id)) {
 			logger.Infof("FSC node [%s] found. Stopping...", id)
-			member.Runner.(*runner.Runner).Stop()
+			r := member.Runner.(*runner.Runner)
+			r.Stop()
+			gomega.Eventually(r, n.StopEventuallyTimeout).Should(gexec.Exit(),
+				"FSC node [%s] did not exit after SIGTERM", id)
 			logger.Infof("FSC node [%s:%s] stopped", member.Name, id)
 			return
 		}


### PR DESCRIPTION
While working on #1696 we discussed that we should not use sleeps in integration tests to wait until a FSC node shutdown as completed as this might be flaky. This PR addresses this issue.

StopFSCNode sent SIGTERM and returned, so a caller that restarted the node raced the dying process for its ports and its vault. Callers papered over this with time.Sleep(3s) on either side of the restart: one to hope the node had gone, one to hope its replacement had come up. The second was already redundant -- StartFSCNode waits for the node to log its start check -- and the first was a guess.

Wait for the process to be gone, the way every other stop path in nwo already does with StopEventuallyTimeout, and drop both sleeps from the stoprestart suites.

Waiting means reading Runner.exitCode from the caller's goroutine while the runner's monitor writes it, which the race detector flags, so make it atomic. Two latent bugs fall out of pinning that value down: a cloned Runner never initialised it, so a restarted node's runner reported a clean exit before it had run, and a process whose OS exit status was -1 stored that as its exit code -- indistinguishable from "still running", which would have hung the new wait until it timed out.