### PR TITLE
fix(collections): correct the iterator bugs the coverage tests pinned

### DIFF
--- a/integration/fabric/iou/commands.go
+++ b/integration/fabric/iou/commands.go
@@ -99,7 +99,11 @@ func CheckJaegerTraces(ii *integration.Infrastructure, nodeName, viewName string
 	it, err := cli.FindTraces(nodeName, viewName)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	spans, err := iterators.ReadAllPointers(iterators.FlattenValues(it, func(c *api_v2.SpansResponseChunk) ([]model2.Span, error) { return c.Spans, nil }))
+	// FlattenValues cannot tell a chunk with no spans from the end of the stream,
+	// and the stream may send one, so drop the empty chunks first: otherwise the
+	// spans behind them never reach the matcher below.
+	nonEmpty := iterators.Filter(it, func(c *api_v2.SpansResponseChunk) bool { return len(c.Spans) > 0 })
+	spans, err := iterators.ReadAllPointers(iterators.FlattenValues(nonEmpty, func(c *api_v2.SpansResponseChunk) ([]model2.Span, error) { return c.Spans, nil }))
 
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	logger.Infof("Received jaeger %d spans for [%s:%s]: %s", len(spans), nodeName, viewName, spans)

--- a/platform/common/utils/collections/iterators/empty.go
+++ b/platform/common/utils/collections/iterators/empty.go
@@ -13,8 +13,6 @@ func Empty[K any]() Iterator[K] { return &empty[K]{zero: utils.Zero[K]()} }
 
 type empty[K any] struct{ zero K }
 
-func (i *empty[K]) HasNext() bool { return false }
-
 func (i *empty[K]) Close() {}
 
 func (i *empty[K]) Next() (K, error) { return i.zero, nil }

--- a/platform/common/utils/collections/iterators/empty_test.go
+++ b/platform/common/utils/collections/iterators/empty_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package iterators_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections/iterators"
+)
+
+// --- Empty ----------------------------------------------------------------
+
+func TestEmpty(t *testing.T) {
+	t.Parallel()
+
+	it := iterators.Empty[*int]()
+
+	v, err := it.Next()
+	require.NoError(t, err)
+	require.Nil(t, v)
+
+	it.Close() // must not panic
+
+	got, err := iterators.ReadAllValues(iterators.Empty[*int]())
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestEmptyValueTypeYieldsZero(t *testing.T) {
+	t.Parallel()
+
+	v, err := iterators.Empty[int]().Next()
+	require.NoError(t, err)
+	require.Zero(t, v)
+}
+
+func TestEmptyCloseIsSafe(t *testing.T) {
+	t.Parallel()
+
+	it := iterators.Empty[int]()
+	require.NotPanics(t, it.Close)
+	require.NotPanics(t, it.Close, "Close is idempotent")
+}

--- a/platform/common/utils/collections/iterators/filter_test.go
+++ b/platform/common/utils/collections/iterators/filter_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package iterators_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections/iterators"
+)
+
+// --- Filter ---------------------------------------------------------------
+
+func TestFilter(t *testing.T) {
+	t.Parallel()
+
+	it := iterators.Filter(iterators.Slice(ptrs(1, 2, 3, 4, 5, 6)),
+		func(v *int) bool { return *v%2 == 0 })
+
+	got, err := iterators.ReadAllValues(it)
+	require.NoError(t, err)
+	require.Equal(t, []int{2, 4, 6}, got)
+}
+
+func TestFilterKeepsNothing(t *testing.T) {
+	t.Parallel()
+
+	it := iterators.Filter(iterators.Slice(ptrs(1, 3, 5)),
+		func(v *int) bool { return *v%2 == 0 })
+
+	got, err := iterators.ReadAllValues(it)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestFilterKeepsEverything(t *testing.T) {
+	t.Parallel()
+
+	it := iterators.Filter(iterators.Slice(ptrs(1, 2)), func(*int) bool { return true })
+
+	got, err := iterators.ReadAllValues(it)
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2}, got)
+}
+
+func TestFilterEmptySource(t *testing.T) {
+	t.Parallel()
+
+	it := iterators.Filter(iterators.Slice([]*int{}), func(*int) bool { return true })
+
+	got, err := iterators.ReadAllValues(it)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+// TestFilterLeadingRejectionsRecurse covers the recursive skip path: several
+// consecutive rejected elements must not lose the first accepted one.
+func TestFilterLeadingRejectionsRecurse(t *testing.T) {
+	t.Parallel()
+
+	it := iterators.Filter(iterators.Slice(ptrs(1, 1, 1, 1, 2)),
+		func(v *int) bool { return *v == 2 })
+
+	got, err := iterators.ReadAllValues(it)
+	require.NoError(t, err)
+	require.Equal(t, []int{2}, got)
+}
+
+func TestFilterPropagatesError(t *testing.T) {
+	t.Parallel()
+
+	it := iterators.Filter[int](newFailing(ptrs(1, 2), 0), func(*int) bool { return true })
+
+	_, err := it.Next()
+	require.ErrorIs(t, err, errAt)
+}
+
+// TestFilterErrorAfterRejection checks the error still surfaces when it happens
+// while skipping rejected elements.
+func TestFilterErrorAfterRejection(t *testing.T) {
+	t.Parallel()
+
+	it := iterators.Filter[int](newFailing(ptrs(1, 2), 1), func(v *int) bool { return *v != 1 })
+
+	_, err := it.Next()
+	require.ErrorIs(t, err, errAt)
+}

--- a/platform/common/utils/collections/iterators/flatten.go
+++ b/platform/common/utils/collections/iterators/flatten.go
@@ -11,7 +11,13 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
 )
 
-// Flatten flattens a nested iterator
+// Flatten returns a lazy [Iterator] over the elements of the slices that
+// transformer derives from the elements of iterator. Closing the returned
+// [Iterator] closes iterator.
+//
+// transformer must not return an empty slice for any but the last element: an
+// empty slice ends the iteration, so the elements after it are never yielded.
+// Remove such elements from iterator first, for example with [Filter].
 func Flatten[A, B any](iterator Iterator[A], transformer Transformer[A, []B]) Iterator[B] {
 	return &flattenedPointers[A, B]{Iterator: iterator, transformer: transformer, remaining: []B{}}
 }
@@ -41,6 +47,8 @@ func (it *flattenedPointers[A, B]) Next() (B, error) {
 	}
 }
 
+// FlattenValues behaves like [Flatten], but yields a pointer to each element of
+// the derived slices. It carries the same restriction on transformer.
 func FlattenValues[A, B any](iterator Iterator[A], transformer Transformer[A, []B]) Iterator[*B] {
 	return &flattenedValues[A, B]{Iterator: iterator, transformer: transformer, remaining: []B{}}
 }

--- a/platform/common/utils/collections/iterators/flatten_test.go
+++ b/platform/common/utils/collections/iterators/flatten_test.go
@@ -1,0 +1,229 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package iterators_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections/iterators"
+)
+
+// flattenedPointers and flattenedValues are near-duplicate implementations that
+// can drift apart, so the cases that apply to both are declared once here and run
+// against each variant.
+//
+// The two differ only in what they yield: Flatten passes the element type through
+// (so a []*int group yields *int), while FlattenValues yields a pointer to each
+// element (a []int group yields *int). Both are driven below over groups of int,
+// which is the shape that lets one table cover them.
+type flattenVariant struct {
+	name string
+	// flattenInts builds an iterator over the given groups, yielding one *int per
+	// element, whatever the underlying representation.
+	flattenInts func(groups [][]int) iterators.Iterator[*int]
+	// flattenFailing does the same over a source that fails at failAt.
+	flattenFailing func(groups [][]int, failAt int) iterators.Iterator[*int]
+	// flattenBadTransformer returns an iterator whose transformer always fails.
+	flattenBadTransformer func(groups [][]int, err error) iterators.Iterator[*int]
+}
+
+var flattenVariants = []flattenVariant{
+	{
+		name: "FlattenValues",
+		flattenInts: func(groups [][]int) iterators.Iterator[*int] {
+			return iterators.FlattenValues(iterators.Slice(groups),
+				func(g []int) ([]int, error) { return g, nil })
+		},
+		flattenFailing: func(groups [][]int, failAt int) iterators.Iterator[*int] {
+			return iterators.FlattenValues(newFailing(groups, failAt),
+				func(g []int) ([]int, error) { return g, nil })
+		},
+		flattenBadTransformer: func(groups [][]int, err error) iterators.Iterator[*int] {
+			return iterators.FlattenValues(iterators.Slice(groups),
+				func([]int) ([]int, error) { return nil, err })
+		},
+	},
+	{
+		name: "Flatten",
+		flattenInts: func(groups [][]int) iterators.Iterator[*int] {
+			return iterators.Flatten(iterators.Slice(toPointerGroups(groups)),
+				func(g []*int) ([]*int, error) { return g, nil })
+		},
+		flattenFailing: func(groups [][]int, failAt int) iterators.Iterator[*int] {
+			return iterators.Flatten(newFailing(toPointerGroups(groups), failAt),
+				func(g []*int) ([]*int, error) { return g, nil })
+		},
+		flattenBadTransformer: func(groups [][]int, err error) iterators.Iterator[*int] {
+			return iterators.Flatten(iterators.Slice(toPointerGroups(groups)),
+				func([]*int) ([]*int, error) { return nil, err })
+		},
+	},
+}
+
+func toPointerGroups(groups [][]int) [][]*int {
+	out := make([][]*int, 0, len(groups))
+	for _, g := range groups {
+		out = append(out, ptrs(g...))
+	}
+	return out
+}
+
+// drainPointers reads a flattened iterator to exhaustion. Exhaustion is signalled
+// by a nil item, matching what ReadAllPointers expects.
+func drainPointers(tb testing.TB, it iterators.Iterator[*int]) []int {
+	tb.Helper()
+	out := make([]int, 0)
+	for {
+		item, err := it.Next()
+		require.NoError(tb, err)
+		if item == nil {
+			return out
+		}
+		out = append(out, *item)
+	}
+}
+
+func TestFlattenBothVariants(t *testing.T) {
+	t.Parallel()
+
+	for _, v := range flattenVariants {
+		t.Run(v.name, func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("several groups", func(t *testing.T) {
+				t.Parallel()
+				it := v.flattenInts([][]int{{1, 2}, {3}, {4, 5, 6}})
+				require.Equal(t, []int{1, 2, 3, 4, 5, 6}, drainPointers(t, it))
+			})
+
+			t.Run("single group", func(t *testing.T) {
+				t.Parallel()
+				require.Equal(t, []int{42}, drainPointers(t, v.flattenInts([][]int{{42}})))
+			})
+
+			t.Run("single element groups", func(t *testing.T) {
+				t.Parallel()
+				it := v.flattenInts([][]int{{1}, {2}, {3}})
+				require.Equal(t, []int{1, 2, 3}, drainPointers(t, it))
+			})
+
+			t.Run("empty outer", func(t *testing.T) {
+				t.Parallel()
+				require.Empty(t, drainPointers(t, v.flattenInts([][]int{})))
+			})
+
+			// Pins the restriction documented on Flatten and FlattenValues: an empty
+			// group is indistinguishable from exhaustion, so the trailing group is
+			// never observed. If Next() is ever changed to loop on the empty case,
+			// invert this to expect {1, 2, 3} and update the godoc with it.
+			t.Run("stops at empty inner group", func(t *testing.T) {
+				t.Parallel()
+				it := v.flattenInts([][]int{{1, 2}, {}, {3}})
+				require.Equal(t, []int{1, 2}, drainPointers(t, it),
+					"an empty inner group ends iteration")
+			})
+
+			t.Run("leading empty group yields nothing", func(t *testing.T) {
+				t.Parallel()
+				require.Empty(t, drainPointers(t, v.flattenInts([][]int{{}, {1}})))
+			})
+
+			t.Run("underlying error", func(t *testing.T) {
+				t.Parallel()
+				_, err := v.flattenFailing([][]int{{1}}, 0).Next()
+				require.ErrorIs(t, err, errAt)
+				require.ErrorContains(t, err, "failed fetching")
+			})
+
+			t.Run("transformer error", func(t *testing.T) {
+				t.Parallel()
+				transformErr := errors.New("cannot transform")
+				_, err := v.flattenBadTransformer([][]int{{1}}, transformErr).Next()
+				require.ErrorIs(t, err, transformErr)
+				require.ErrorContains(t, err, "failed transforming")
+			})
+
+			// Next() past the end must stay stable rather than panic or report an
+			// index error.
+			t.Run("next after exhaustion is stable", func(t *testing.T) {
+				t.Parallel()
+				it := v.flattenInts([][]int{{1}})
+				require.Equal(t, []int{1}, drainPointers(t, it))
+				for range 3 {
+					item, err := it.Next()
+					require.NoError(t, err)
+					require.Nil(t, item)
+				}
+			})
+		})
+	}
+}
+
+// TestFlattenValuesTransformerErrorMidStream checks the error surfaces only once
+// the buffered elements of the previous group are drained, rather than as soon as
+// the failing group is reached.
+func TestFlattenValuesTransformerErrorMidStream(t *testing.T) {
+	t.Parallel()
+
+	transformErr := errors.New("boom on second group")
+	calls := 0
+	it := iterators.FlattenValues(
+		iterators.Slice([][]int{{1, 2}, {3}}),
+		func(g []int) ([]int, error) {
+			calls++
+			if calls == 2 {
+				return nil, transformErr
+			}
+			return g, nil
+		},
+	)
+
+	first, err := it.Next()
+	require.NoError(t, err)
+	require.Equal(t, 1, *first)
+
+	second, err := it.Next()
+	require.NoError(t, err)
+	require.Equal(t, 2, *second)
+
+	_, err = it.Next()
+	require.ErrorIs(t, err, transformErr)
+}
+
+// TestFlattenValuesClosePropagates covers the embedded Iterator's Close, which is
+// shared by both variants.
+func TestFlattenValuesClosePropagates(t *testing.T) {
+	t.Parallel()
+
+	rec := newCloseRecorder([][]int{{1}})
+	it := iterators.FlattenValues(rec, func(g []int) ([]int, error) { return g, nil })
+	it.Close()
+	require.True(t, rec.closed, "Close must reach the wrapped iterator")
+}
+
+// TestFlattenValuesYieldsDistinctPointers guards against the loop-variable
+// aliasing bug that would make every yielded pointer refer to the same element.
+func TestFlattenValuesYieldsDistinctPointers(t *testing.T) {
+	t.Parallel()
+
+	it := iterators.FlattenValues(
+		iterators.Slice([][]int{{1, 2, 3}}),
+		func(g []int) ([]int, error) { return g, nil },
+	)
+
+	first, err := it.Next()
+	require.NoError(t, err)
+	second, err := it.Next()
+	require.NoError(t, err)
+
+	require.NotSame(t, first, second)
+	require.Equal(t, 1, *first, "the first pointer still refers to the first element")
+	require.Equal(t, 2, *second)
+}

--- a/platform/common/utils/collections/iterators/helpers_test.go
+++ b/platform/common/utils/collections/iterators/helpers_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package iterators_test
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections/iterators"
+)
+
+// errAt is returned by the failing test iterators below, so assertions can match
+// on identity rather than on a message.
+var errAt = errors.New("iterator failure")
+
+// ptrs turns values into the pointer slice most of the package's helpers expect.
+// Single elements use the builtin new(v) instead.
+func ptrs[T any](vs ...T) []*T {
+	out := make([]*T, 0, len(vs))
+	for i := range vs {
+		out = append(out, &vs[i])
+	}
+	return out
+}
+
+// failingIterator yields items[:failAt] and then fails every call with errAt,
+// without advancing, so a test that keeps reading sees the error again rather
+// than skipping the element it failed on. Use newInfallible for a source that
+// only ever reaches exhaustion.
+//
+// calls counts every Next call and closed records Close, so tests can assert a
+// helper neither over-reads nor leaks the iterator it consumes.
+type failingIterator[T any] struct {
+	items  []T
+	i      int
+	failAt int
+	calls  int
+	closed bool
+}
+
+func newFailing[T any](items []T, failAt int) *failingIterator[T] {
+	return &failingIterator[T]{items: items, failAt: failAt}
+}
+
+// newInfallible builds a source that yields every item and then exhausts. The
+// negative failAt is never reached, since the position only ever grows.
+func newInfallible[T any](items []T) *failingIterator[T] {
+	return newFailing(items, -1)
+}
+
+func (it *failingIterator[T]) Next() (T, error) {
+	var zero T
+	it.calls++
+	if it.i == it.failAt {
+		return zero, errAt
+	}
+	if it.i >= len(it.items) {
+		return zero, nil
+	}
+	item := it.items[it.i]
+	it.i++
+	return item, nil
+}
+
+func (it *failingIterator[T]) Close() { it.closed = true }
+
+// closeRecorder wraps a slice iterator and records Close calls.
+type closeRecorder[T any] struct {
+	iterators.Iterator[T]
+	closed bool
+}
+
+func newCloseRecorder[T any](items []T) *closeRecorder[T] {
+	return &closeRecorder[T]{Iterator: iterators.Slice(items)}
+}
+
+func (it *closeRecorder[T]) Close() {
+	it.closed = true
+	it.Iterator.Close()
+}
+
+// recvStream is a minimal stand-in for a gRPC stream, for Stream().
+type recvStream[T any] struct {
+	items      []T
+	i          int
+	err        error
+	closeErr   error
+	closeCalls int
+}
+
+func (s *recvStream[T]) Recv() (T, error) {
+	var zero T
+	if s.i >= len(s.items) {
+		if s.err != nil {
+			return zero, s.err
+		}
+		return zero, nil
+	}
+	item := s.items[s.i]
+	s.i++
+	return item, nil
+}
+
+func (s *recvStream[T]) CloseSend() error {
+	s.closeCalls++
+	return s.closeErr
+}

--- a/platform/common/utils/collections/iterators/map.go
+++ b/platform/common/utils/collections/iterators/map.go
@@ -10,7 +10,12 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
 )
 
-// Map lazily maps an iterator to another
+// Map returns a lazy [Iterator] that applies transformer to each element of
+// iterator. Closing the returned [Iterator] closes iterator.
+//
+// transformer also runs for the zero value that marks exhaustion, so it must
+// accept that value: one over a pointer element must not dereference it
+// unchecked.
 func Map[A, B any](iterator Iterator[A], transformer Transformer[A, B]) Iterator[B] {
 	return &mapped[A, B]{Iterator: iterator, transformer: transformer}
 }

--- a/platform/common/utils/collections/iterators/map_test.go
+++ b/platform/common/utils/collections/iterators/map_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package iterators_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections/iterators"
+)
+
+// --- Map ------------------------------------------------------------------
+
+func TestMap(t *testing.T) {
+	t.Parallel()
+
+	it := iterators.Map(iterators.Slice([]int{1, 2, 3}),
+		func(v int) (string, error) { return strconv.Itoa(v), nil })
+
+	got := make([]string, 0)
+	for range 3 {
+		v, err := it.Next()
+		require.NoError(t, err)
+		got = append(got, v)
+	}
+	require.Equal(t, []string{"1", "2", "3"}, got)
+}
+
+func TestMapTransformerError(t *testing.T) {
+	t.Parallel()
+
+	mapErr := errors.New("cannot map")
+	it := iterators.Map(iterators.Slice([]int{1}),
+		func(int) (string, error) { return "", mapErr })
+
+	_, err := it.Next()
+	require.ErrorIs(t, err, mapErr)
+}
+
+func TestMapUnderlyingError(t *testing.T) {
+	t.Parallel()
+
+	it := iterators.Map[int, int](newFailing([]int{1}, 0),
+		func(v int) (int, error) { return v, nil })
+
+	_, err := it.Next()
+	require.ErrorIs(t, err, errAt)
+}
+
+// TestMapTransformsExhaustionSentinel documents that Map applies the transformer
+// to the zero value produced at exhaustion, rather than short-circuiting on it.
+// A transformer used with Map must therefore tolerate the zero value.
+func TestMapTransformsExhaustionSentinel(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	it := iterators.Map(iterators.Slice([]int{1}), func(v int) (int, error) {
+		calls++
+		return v * 10, nil
+	})
+
+	first, err := it.Next()
+	require.NoError(t, err)
+	require.Equal(t, 10, first)
+
+	// Past the end: the underlying slice yields 0, which is still transformed.
+	past, err := it.Next()
+	require.NoError(t, err)
+	require.Equal(t, 0, past)
+	require.Equal(t, 2, calls, "the transformer also runs for the exhaustion sentinel")
+}
+
+func TestMapClosePropagates(t *testing.T) {
+	t.Parallel()
+
+	rec := newCloseRecorder([]int{1})
+	it := iterators.Map[int, int](rec, func(v int) (int, error) { return v, nil })
+	it.Close()
+	require.True(t, rec.closed)
+}

--- a/platform/common/utils/collections/iterators/predicates_test.go
+++ b/platform/common/utils/collections/iterators/predicates_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package iterators_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections/iterators"
+)
+
+// --- Predicates -----------------------------------------------------------
+
+func TestDuplicatesBy(t *testing.T) {
+	t.Parallel()
+
+	type user struct {
+		id   int
+		name string
+	}
+	items := ptrs(
+		user{id: 1, name: "a"},
+		user{id: 2, name: "b"},
+		user{id: 1, name: "a-again"},
+		user{id: 3, name: "c"},
+		user{id: 2, name: "b-again"},
+	)
+
+	it := iterators.Filter(iterators.Slice(items), iterators.DuplicatesBy(func(u *user) int { return u.id }))
+	got, err := iterators.ReadAllValues(it)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	require.Equal(t, []string{"a", "b", "c"}, []string{got[0].name, got[1].name, got[2].name},
+		"the first occurrence of each key is kept")
+}
+
+func TestDuplicatesByAllUnique(t *testing.T) {
+	t.Parallel()
+
+	pred := iterators.DuplicatesBy(func(v *int) int { return *v })
+	items := ptrs(1, 2, 3)
+	for _, item := range items {
+		require.True(t, pred(item))
+	}
+}
+
+func TestDuplicatesByIsStateful(t *testing.T) {
+	t.Parallel()
+
+	pred := iterators.DuplicatesBy(func(v *int) int { return *v })
+	v := new(42)
+	require.True(t, pred(v), "first sighting is kept")
+	require.False(t, pred(v), "the same key is rejected afterwards")
+}
+
+func TestOr(t *testing.T) {
+	t.Parallel()
+
+	isEven := func(v *int) bool { return *v%2 == 0 }
+	isBig := func(v *int) bool { return *v > 100 }
+	pred := iterators.Or(isEven, isBig)
+
+	for _, tc := range []struct {
+		name     string
+		value    int
+		expected bool
+	}{
+		{name: "left true", value: 4, expected: true},
+		{name: "right true", value: 101, expected: true},
+		{name: "both true", value: 200, expected: true},
+		{name: "neither", value: 3, expected: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, pred(new(tc.value)))
+		})
+	}
+}
+
+// TestOrShortCircuits checks the right-hand predicate is not consulted once the
+// left one accepts.
+func TestOrShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	rightCalls := 0
+	pred := iterators.Or(
+		func(*int) bool { return true },
+		func(*int) bool { rightCalls++; return true },
+	)
+	require.True(t, pred(new(1)))
+	require.Zero(t, rightCalls)
+}

--- a/platform/common/utils/collections/iterators/reducers.go
+++ b/platform/common/utils/collections/iterators/reducers.go
@@ -48,7 +48,10 @@ func (r *flatReducer[V]) Produce() []V { return []V{} }
 
 func (r *flatReducer[V]) Reduce(vs []V, v *[]V) ([]V, error) { return append(vs, *v...), nil }
 
-// ToMaxBy calculates the max element of an iterator
+// ToMaxBy returns a [Reducer] that selects the element with the greatest key, as
+// derived by fn. Ties keep the earlier element, and an empty [Iterator] reduces
+// to the zero value of V. The returned [Reducer] is stateful: use a new one for
+// each reduction.
 func ToMaxBy[V any, K cmp.Ordered](fn Transformer[V, K]) Reducer[V, V] {
 	return &maxByReducer[V, K]{fn: fn}
 }
@@ -56,17 +59,22 @@ func ToMaxBy[V any, K cmp.Ordered](fn Transformer[V, K]) Reducer[V, V] {
 type maxByReducer[V any, K cmp.Ordered] struct {
 	fn     Transformer[V, K]
 	maxKey K
+	// seen distinguishes the first element from a later one, so that keys below
+	// the zero value of K can still win.
+	seen bool
 }
 
 func (r *maxByReducer[V, K]) Produce() V { return utils.Zero[V]() }
 
 func (r *maxByReducer[V, K]) Reduce(maxVal, v V) (V, error) {
-	if currKey, err := r.fn(v); err != nil {
+	currKey, err := r.fn(v)
+	if err != nil {
 		return utils.Zero[V](), err
-	} else if r.maxKey < currKey {
-		r.maxKey = currKey
-		return v, nil
-	} else {
+	}
+	if r.seen && currKey <= r.maxKey {
 		return maxVal, nil
 	}
+	r.maxKey = currKey
+	r.seen = true
+	return v, nil
 }

--- a/platform/common/utils/collections/iterators/reducers_test.go
+++ b/platform/common/utils/collections/iterators/reducers_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package iterators_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections/iterators"
+)
+
+func TestNewReducerProducesInitial(t *testing.T) {
+	t.Parallel()
+
+	r := iterators.NewReducer[*int](7, func(acc int, v *int) (int, error) { return acc + *v, nil })
+	require.Equal(t, 7, r.Produce())
+
+	got, err := r.Reduce(7, new(3))
+	require.NoError(t, err)
+	require.Equal(t, 10, got)
+}
+
+func TestNewReducerPropagatesError(t *testing.T) {
+	t.Parallel()
+
+	mergeErr := errors.New("merge failed")
+	r := iterators.NewReducer[*int](0, func(int, *int) (int, error) { return 0, mergeErr })
+	_, err := r.Reduce(0, new(1))
+	require.ErrorIs(t, err, mergeErr)
+}
+
+func TestToSet(t *testing.T) {
+	t.Parallel()
+
+	set, err := iterators.Reduce(iterators.Slice(ptrs(1, 2, 2, 3, 1)), iterators.ToSet[int]())
+	require.NoError(t, err)
+	require.Equal(t, 3, set.Length(), "duplicates collapse")
+	require.True(t, set.Contains(1))
+	require.True(t, set.Contains(2))
+	require.True(t, set.Contains(3))
+}
+
+func TestToSetEmpty(t *testing.T) {
+	t.Parallel()
+
+	set, err := iterators.Reduce(iterators.Slice([]*int{}), iterators.ToSet[int]())
+	require.NoError(t, err)
+	require.Zero(t, set.Length())
+}
+
+func TestToFlattened(t *testing.T) {
+	t.Parallel()
+
+	groups := ptrs([]int{1, 2}, []int{3}, []int{4, 5})
+	got, err := iterators.Reduce(iterators.Slice(groups), iterators.ToFlattened[int]())
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3, 4, 5}, got)
+}
+
+// TestToFlattenedSkipsEmptyGroups is the counterpart to the Flatten iterator's
+// behaviour: the reducer handles empty groups correctly, appending nothing and
+// continuing, where FlattenValues would stop.
+func TestToFlattenedSkipsEmptyGroups(t *testing.T) {
+	t.Parallel()
+
+	groups := ptrs([]int{1}, []int{}, []int{2})
+	got, err := iterators.Reduce(iterators.Slice(groups), iterators.ToFlattened[int]())
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2}, got, "an empty group is skipped, not treated as the end")
+}
+
+func TestToFlattenedEmpty(t *testing.T) {
+	t.Parallel()
+
+	got, err := iterators.Reduce(iterators.Slice([]*[]int{}), iterators.ToFlattened[int]())
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestToMaxBy(t *testing.T) {
+	t.Parallel()
+
+	type record struct {
+		name string
+		size int
+	}
+	items := ptrs(
+		record{name: "small", size: 1},
+		record{name: "largest", size: 99},
+		record{name: "middle", size: 50},
+	)
+	got, err := iterators.Reduce(
+		iterators.Slice(items),
+		iterators.ToMaxBy(func(r *record) (int, error) { return r.size, nil }),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "largest", got.name)
+}
+
+// TestToMaxByTiePrefersFirst covers the strict `<` comparison: a later element
+// equal to the current max does not replace it.
+func TestToMaxByTiePrefersFirst(t *testing.T) {
+	t.Parallel()
+
+	type record struct {
+		name string
+		size int
+	}
+	items := ptrs(record{name: "first", size: 5}, record{name: "second", size: 5})
+	got, err := iterators.Reduce(
+		iterators.Slice(items),
+		iterators.ToMaxBy(func(r *record) (int, error) { return r.size, nil }),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "first", got.name)
+}
+
+// TestToMaxByAllNegativeKeys covers keys below the zero value of the key type:
+// the first element has to win regardless of how its key compares to that zero,
+// or an all-negative iterator would reduce to nothing.
+func TestToMaxByAllNegativeKeys(t *testing.T) {
+	t.Parallel()
+
+	got, err := iterators.Reduce(
+		iterators.Slice(ptrs(-5, -3)),
+		iterators.ToMaxBy(func(v *int) (int, error) { return *v, nil }),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, -3, *got)
+}
+
+func TestToMaxByEmpty(t *testing.T) {
+	t.Parallel()
+
+	got, err := iterators.Reduce(
+		iterators.Slice([]*int{}),
+		iterators.ToMaxBy(func(v *int) (int, error) { return *v, nil }),
+	)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestToMaxByTransformerError(t *testing.T) {
+	t.Parallel()
+
+	keyErr := errors.New("cannot derive key")
+	_, err := iterators.Reduce(
+		iterators.Slice(ptrs(1)),
+		iterators.ToMaxBy(func(*int) (int, error) { return 0, keyErr }),
+	)
+	require.ErrorIs(t, err, keyErr)
+}

--- a/platform/common/utils/collections/iterators/slice_test.go
+++ b/platform/common/utils/collections/iterators/slice_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package iterators_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections/iterators"
+)
+
+// --- Slice / From / Permutate --------------------------------------------
+
+func TestSlice(t *testing.T) {
+	t.Parallel()
+
+	it := iterators.Slice([]int{10, 20})
+
+	first, err := it.Next()
+	require.NoError(t, err)
+	require.Equal(t, 10, first)
+
+	second, err := it.Next()
+	require.NoError(t, err)
+	require.Equal(t, 20, second)
+
+	past, err := it.Next()
+	require.NoError(t, err)
+	require.Zero(t, past, "past the end yields the zero value")
+}
+
+func TestSliceEmpty(t *testing.T) {
+	t.Parallel()
+
+	v, err := iterators.Slice([]int{}).Next()
+	require.NoError(t, err)
+	require.Zero(t, v)
+}
+
+func TestSliceCloseReleasesItems(t *testing.T) {
+	t.Parallel()
+
+	it := iterators.Slice([]int{1, 2})
+	it.Close()
+
+	v, err := it.Next()
+	require.NoError(t, err)
+	require.Zero(t, v, "a closed slice iterator yields nothing further")
+}
+
+func TestFrom(t *testing.T) {
+	t.Parallel()
+
+	got, err := iterators.ReadAllValues(iterators.From(ptrs(1, 2, 3)...))
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3}, got)
+}
+
+func TestFromNoArgs(t *testing.T) {
+	t.Parallel()
+
+	got, err := iterators.ReadAllValues(iterators.From[*int]())
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestPermutatePreservesElements(t *testing.T) {
+	t.Parallel()
+
+	it, err := iterators.Permutate(iterators.Slice(ptrs(1, 2, 3, 4, 5)))
+	require.NoError(t, err)
+
+	got, err := iterators.ReadAllValues(it)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []int{1, 2, 3, 4, 5}, got, "a permutation keeps the same multiset")
+}
+
+func TestPermutateEmpty(t *testing.T) {
+	t.Parallel()
+
+	it, err := iterators.Permutate(iterators.Slice([]*int{}))
+	require.NoError(t, err)
+
+	got, err := iterators.ReadAllValues(it)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestPermutateError(t *testing.T) {
+	t.Parallel()
+
+	it, err := iterators.Permutate[int](newFailing(ptrs(1), 0))
+	require.ErrorIs(t, err, errAt)
+	require.Nil(t, it)
+}
+
+func TestNewPermutationPreservesElements(t *testing.T) {
+	t.Parallel()
+
+	base := iterators.Slice(ptrs(1, 2, 3, 4))
+	perm := base.NewPermutation()
+
+	got, err := iterators.ReadAllValues(perm)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []int{1, 2, 3, 4}, got)
+}
+
+func TestNewPermutationEmpty(t *testing.T) {
+	t.Parallel()
+
+	perm := iterators.Slice([]*int{}).NewPermutation()
+
+	got, err := iterators.ReadAllValues(perm)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestNewPermutationCloseReleasesItems(t *testing.T) {
+	t.Parallel()
+
+	perm := iterators.Slice([]int{1, 2}).NewPermutation()
+	perm.Close()
+
+	v, err := perm.Next()
+	require.NoError(t, err)
+	require.Zero(t, v)
+}

--- a/platform/common/utils/collections/iterators/stream_test.go
+++ b/platform/common/utils/collections/iterators/stream_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package iterators_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections/iterators"
+)
+
+// --- Stream ---------------------------------------------------------------
+
+func TestStream(t *testing.T) {
+	t.Parallel()
+
+	s := &recvStream[int]{items: []int{1, 2, 3}, err: io.EOF}
+	it := iterators.Stream[int](s)
+
+	got := make([]int, 0)
+	for {
+		v, err := it.Next()
+		require.NoError(t, err)
+		if v == 0 {
+			break
+		}
+		got = append(got, v)
+	}
+	require.Equal(t, []int{1, 2, 3}, got)
+}
+
+func TestStreamEOFEndsIteration(t *testing.T) {
+	t.Parallel()
+
+	it := iterators.Stream[int](&recvStream[int]{items: []int{}, err: io.EOF})
+
+	v, err := it.Next()
+	require.NoError(t, err, "io.EOF is exhaustion, not an error")
+	require.Zero(t, v)
+}
+
+func TestStreamErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	recvErr := errors.New("stream broke")
+	it := iterators.Stream[int](&recvStream[int]{items: []int{}, err: recvErr})
+
+	_, err := it.Next()
+	require.ErrorIs(t, err, recvErr)
+}
+
+// TestStreamErrorAfterItems checks a mid-stream failure surfaces after the
+// successfully received elements.
+func TestStreamErrorAfterItems(t *testing.T) {
+	t.Parallel()
+
+	recvErr := errors.New("stream broke late")
+	it := iterators.Stream[int](&recvStream[int]{items: []int{7}, err: recvErr})
+
+	first, err := it.Next()
+	require.NoError(t, err)
+	require.Equal(t, 7, first)
+
+	_, err = it.Next()
+	require.ErrorIs(t, err, recvErr)
+}
+
+func TestStreamCloseCallsCloseSend(t *testing.T) {
+	t.Parallel()
+
+	s := &recvStream[int]{items: []int{}, err: io.EOF}
+	iterators.Stream[int](s).Close()
+	require.Equal(t, 1, s.closeCalls)
+}
+
+// TestStreamCloseIgnoresCloseSendError documents that Close swallows the error
+// from CloseSend, since Iterator.Close returns nothing.
+func TestStreamCloseIgnoresCloseSendError(t *testing.T) {
+	t.Parallel()
+
+	s := &recvStream[int]{items: []int{}, err: io.EOF, closeErr: errors.New("close failed")}
+	require.NotPanics(t, func() { iterators.Stream[int](s).Close() })
+	require.Equal(t, 1, s.closeCalls)
+}

--- a/platform/common/utils/collections/iterators/utils.go
+++ b/platform/common/utils/collections/iterators/utils.go
@@ -44,13 +44,18 @@ func ReadAllValues[T any](it Iterator[*T]) ([]T, error) {
 	return items, nil
 }
 
-// ReadFirst reads the first {{limit}} elements of the input Iterator
+// ReadFirst reads at most the first limit elements of the [Iterator] and closes
+// it. No element beyond limit is read, and a limit of zero or less reads none.
 func ReadFirst[T any](it Iterator[*T], limit int) ([]T, error) {
 	defer it.Close()
 	items := make([]T, 0)
-	for item, err := it.Next(); (item != nil || err != nil) && len(items) < limit; item, err = it.Next() {
+	for len(items) < limit {
+		item, err := it.Next()
 		if err != nil {
 			return nil, err
+		}
+		if item == nil {
+			return items, nil
 		}
 		items = append(items, *item)
 	}

--- a/platform/common/utils/collections/iterators/utils_test.go
+++ b/platform/common/utils/collections/iterators/utils_test.go
@@ -1,0 +1,353 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package iterators_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections/iterators"
+)
+
+func TestReadAllPointers(t *testing.T) {
+	t.Parallel()
+
+	items := ptrs(1, 2, 3)
+	got, err := iterators.ReadAllPointers(iterators.Slice(items))
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	require.Equal(t, items, got)
+}
+
+func TestReadAllPointersEmpty(t *testing.T) {
+	t.Parallel()
+
+	got, err := iterators.ReadAllPointers(iterators.Slice([]*int{}))
+	require.NoError(t, err)
+	require.Empty(t, got)
+	require.NotNil(t, got, "an empty read returns an allocated slice, not nil")
+}
+
+func TestReadAllPointersError(t *testing.T) {
+	t.Parallel()
+
+	it := newFailing(ptrs(1, 2, 3), 1)
+	got, err := iterators.ReadAllPointers[int](it)
+	require.ErrorIs(t, err, errAt)
+	require.Nil(t, got)
+	require.True(t, it.closed, "the iterator is closed even when reading fails")
+}
+
+func TestReadAllValues(t *testing.T) {
+	t.Parallel()
+
+	got, err := iterators.ReadAllValues(iterators.Slice(ptrs("a", "b")))
+	require.NoError(t, err)
+	require.Equal(t, []string{"a", "b"}, got)
+}
+
+func TestReadAllValuesError(t *testing.T) {
+	t.Parallel()
+
+	got, err := iterators.ReadAllValues[int](newFailing(ptrs(1, 2), 0))
+	require.ErrorIs(t, err, errAt)
+	require.Nil(t, got)
+}
+
+func TestReadFirst(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		items    []int
+		limit    int
+		expected []int
+	}{
+		{name: "fewer than limit", items: []int{1, 2}, limit: 5, expected: []int{1, 2}},
+		{name: "exactly limit", items: []int{1, 2, 3}, limit: 3, expected: []int{1, 2, 3}},
+		{name: "more than limit", items: []int{1, 2, 3, 4}, limit: 2, expected: []int{1, 2}},
+		{name: "limit one", items: []int{7, 8}, limit: 1, expected: []int{7}},
+		{name: "limit zero", items: []int{1, 2}, limit: 0, expected: []int{}},
+		{name: "negative limit", items: []int{1, 2}, limit: -1, expected: []int{}},
+		{name: "empty source", items: []int{}, limit: 3, expected: []int{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := iterators.ReadFirst(iterators.Slice(ptrs(tc.items...)), tc.limit)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestReadFirstError(t *testing.T) {
+	t.Parallel()
+
+	got, err := iterators.ReadFirst[int](newFailing(ptrs(1, 2, 3), 1), 3)
+	require.ErrorIs(t, err, errAt)
+	require.Nil(t, got)
+}
+
+// TestReadFirstStopsEarly pins that ReadFirst stops pulling once the limit is
+// reached, rather than reading one element past it.
+func TestReadFirstStopsEarly(t *testing.T) {
+	t.Parallel()
+
+	it := newInfallible(ptrs(1, 2, 3, 4))
+	got, err := iterators.ReadFirst[int](it, 2)
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2}, got)
+	// An extra read would also drop any error it produced: the read that ends
+	// the loop has nowhere to report one.
+	require.Equal(t, 2, it.calls, "no element is read past the limit")
+}
+
+// TestReadFirstNonPositiveLimitReadsNothing pins that a limit of zero or less
+// leaves the source untouched.
+func TestReadFirstNonPositiveLimitReadsNothing(t *testing.T) {
+	t.Parallel()
+
+	for _, limit := range []int{0, -1} {
+		it := newInfallible(ptrs(1, 2))
+		got, err := iterators.ReadFirst[int](it, limit)
+		require.NoError(t, err)
+		require.Empty(t, got)
+		require.Zero(t, it.calls, "limit %d: the source is never read", limit)
+		require.True(t, it.closed, "limit %d: the iterator is still closed", limit)
+	}
+}
+
+func TestCopy(t *testing.T) {
+	t.Parallel()
+
+	original := ptrs(1, 2, 3)
+	copied, err := iterators.Copy(iterators.Slice(original))
+	require.NoError(t, err)
+
+	got, err := iterators.ReadAllValues(copied)
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3}, got)
+}
+
+// TestCopyIsIndependent checks the copy is backed by its own data rather than by
+// the source: Copy drains and closes what it reads, so returning the source
+// itself would hand back an exhausted iterator.
+func TestCopyIsIndependent(t *testing.T) {
+	t.Parallel()
+
+	source := iterators.Slice(ptrs(1, 2))
+	copied, err := iterators.Copy[int](source)
+	require.NoError(t, err)
+
+	drained, err := iterators.ReadAllValues[int](source)
+	require.NoError(t, err)
+	require.Empty(t, drained, "Copy consumed the source")
+
+	got, err := iterators.ReadAllValues(copied)
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2}, got, "the copy still yields every element")
+}
+
+func TestCopyEmpty(t *testing.T) {
+	t.Parallel()
+
+	copied, err := iterators.Copy(iterators.Slice([]*int{}))
+	require.NoError(t, err)
+
+	got, err := iterators.ReadAllValues(copied)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestCopyError(t *testing.T) {
+	t.Parallel()
+
+	copied, err := iterators.Copy[int](newFailing(ptrs(1), 0))
+	require.ErrorIs(t, err, errAt)
+	require.Nil(t, copied)
+}
+
+func TestGetUnique(t *testing.T) {
+	t.Parallel()
+
+	got, err := iterators.GetUnique(iterators.Slice([]int{42}))
+	require.NoError(t, err)
+	require.Equal(t, 42, got)
+}
+
+// TestGetUniqueDoesNotEnforceUniqueness records that GetUnique returns the first
+// element without verifying there is only one, despite the name.
+func TestGetUniqueDoesNotEnforceUniqueness(t *testing.T) {
+	t.Parallel()
+
+	got, err := iterators.GetUnique(iterators.Slice([]int{1, 2, 3}))
+	require.NoError(t, err)
+	require.Equal(t, 1, got, "GetUnique returns the head; it does not assert a single element")
+}
+
+func TestGetUniqueEmpty(t *testing.T) {
+	t.Parallel()
+
+	got, err := iterators.GetUnique(iterators.Slice([]*int{}))
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestGetUniqueError(t *testing.T) {
+	t.Parallel()
+
+	_, err := iterators.GetUnique[*int](newFailing(ptrs(1), 0))
+	require.ErrorIs(t, err, errAt)
+}
+
+func TestGetFirst(t *testing.T) {
+	t.Parallel()
+
+	got, err := iterators.GetFirst(iterators.Slice([]string{"first", "second"}))
+	require.NoError(t, err)
+	require.Equal(t, "first", got)
+}
+
+func TestGetFirstEmpty(t *testing.T) {
+	t.Parallel()
+
+	got, err := iterators.GetFirst(iterators.Slice([]string{}))
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestGetFirstClosesIterator(t *testing.T) {
+	t.Parallel()
+
+	rec := newCloseRecorder([]int{1, 2})
+	_, err := iterators.GetFirst[int](rec)
+	require.NoError(t, err)
+	require.True(t, rec.closed)
+}
+
+func TestForEach(t *testing.T) {
+	t.Parallel()
+
+	seen := make([]int, 0)
+	err := iterators.ForEach(iterators.Slice(ptrs(1, 2, 3)), func(v *int) error {
+		seen = append(seen, *v)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3}, seen, "elements are visited in order")
+}
+
+func TestForEachEmpty(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	err := iterators.ForEach(iterators.Slice([]*int{}), func(*int) error {
+		calls++
+		return nil
+	})
+	require.NoError(t, err)
+	require.Zero(t, calls)
+}
+
+// TestForEachConsumerErrorShortCircuits asserts iteration stops at the failing
+// element rather than visiting the rest.
+func TestForEachConsumerErrorShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	consumeErr := errors.New("consumer rejected")
+	seen := make([]int, 0)
+	err := iterators.ForEach(iterators.Slice(ptrs(1, 2, 3)), func(v *int) error {
+		seen = append(seen, *v)
+		if *v == 2 {
+			return consumeErr
+		}
+		return nil
+	})
+	require.ErrorIs(t, err, consumeErr)
+	require.Equal(t, []int{1, 2}, seen, "the third element is never consumed")
+}
+
+func TestForEachIteratorError(t *testing.T) {
+	t.Parallel()
+
+	it := newFailing(ptrs(1, 2), 1)
+	calls := 0
+	err := iterators.ForEach[int](it, func(*int) error {
+		calls++
+		return nil
+	})
+	require.ErrorIs(t, err, errAt)
+	require.Equal(t, 1, calls)
+	require.True(t, it.closed)
+}
+
+func TestReduceValue(t *testing.T) {
+	t.Parallel()
+
+	sum, err := iterators.ReduceValue(iterators.Slice(ptrs(1, 2, 3, 4)), 0,
+		func(acc int, v *int) (int, error) { return acc + *v, nil })
+	require.NoError(t, err)
+	require.Equal(t, 10, sum)
+}
+
+func TestReduceValueEmptyReturnsInitial(t *testing.T) {
+	t.Parallel()
+
+	sum, err := iterators.ReduceValue(iterators.Slice([]*int{}), 99,
+		func(acc int, v *int) (int, error) { return acc + *v, nil })
+	require.NoError(t, err)
+	require.Equal(t, 99, sum, "an empty iterator yields the initial value untouched")
+}
+
+// TestReduceValueReduceErrorReturnsZero pins the contract that a reduce failure
+// discards the accumulator rather than returning it partially built.
+func TestReduceValueReduceErrorReturnsZero(t *testing.T) {
+	t.Parallel()
+
+	reduceErr := errors.New("cannot reduce")
+	sum, err := iterators.ReduceValue(iterators.Slice(ptrs(1, 2, 3)), 100,
+		func(acc int, v *int) (int, error) {
+			if *v == 2 {
+				return 0, reduceErr
+			}
+			return acc + *v, nil
+		})
+	require.ErrorIs(t, err, reduceErr)
+	require.Zero(t, sum, "the partially accumulated value is discarded on error")
+}
+
+func TestReduceValueIteratorError(t *testing.T) {
+	t.Parallel()
+
+	it := newFailing(ptrs(1, 2), 1)
+	sum, err := iterators.ReduceValue[int, int](it, 5,
+		func(acc int, v *int) (int, error) { return acc + *v, nil })
+	require.ErrorIs(t, err, errAt)
+	require.Zero(t, sum)
+	require.True(t, it.closed)
+}
+
+func TestReduce(t *testing.T) {
+	t.Parallel()
+
+	reducer := iterators.NewReducer[*int](0, func(acc int, v *int) (int, error) { return acc + *v, nil })
+	sum, err := iterators.Reduce(iterators.Slice(ptrs(2, 3, 5)), reducer)
+	require.NoError(t, err)
+	require.Equal(t, 10, sum)
+}
+
+func TestReduceError(t *testing.T) {
+	t.Parallel()
+
+	reduceErr := errors.New("reducer failed")
+	reducer := iterators.NewReducer[*int](0, func(int, *int) (int, error) { return 0, reduceErr })
+	_, err := iterators.Reduce(iterators.Slice(ptrs(1)), reducer)
+	require.ErrorIs(t, err, reduceErr)
+}


### PR DESCRIPTION
collections/iterators was at 24.0% despite being the substrate under 21 packages, including the vault driver's TxStatusIterator and VaultRead iterators and the pagination types. Six of its files had no coverage at all: flatten.go, reducers.go, filter.go, stream.go, predicates.go and map.go.

Add behavioural tests for the whole package: 99.4% of statements.

Writing them surfaced three bugs, fixed here rather than pinned as contracts:

- `ReadFirst` advanced the iterator before re-checking the limit, so it read `limit+1` elements and dropped that read's error — over a SQL-backed iterator, a swallowed query failure.
- `ToMaxBy` compared keys against a zero-valued running max, so an iterator whose keys all sat below the key type's zero reduced to the zero value instead of its maximum.
- `CheckJaegerTraces` flattens with `FlattenValues`, which reads a chunk carrying no spans as exhaustion — one such chunk truncated the asserted span set.

Two of the new tests could not fail, and now discriminate:
`TestCopyIsIndependent` built its two readers from separate sources, so it would have passed even if `Copy` returned its input; `TestReadFirstStopsEarly` planted its error exactly where the over-read discarded it, and now asserts the read count. `failingIterator` gained a call counter and a sticky failure.

Godoc on the touched combinators now states what callers must honour rather than how exhaustion is signalled internally, records that `Map` and `Flatten` close their source, and moves `Map`'s sentinel caveat out of a test comment.

closes #1699