### PR TITLE
fix(state): reject state:"hash" on fields that cannot be hashed

### DIFF
--- a/platform/fabric/services/state/namespace.go
+++ b/platform/fabric/services/state/namespace.go
@@ -312,6 +312,9 @@ func (n *Namespace) GetInputAt(index int, state any) error {
 		}
 		k = k2
 		raw = v
+		// TODO: certified inputs and hash hiding do not compose. flag=false returns a
+		// nil mapping without consulting the RWSet, so the `_root_` preimage is never
+		// recovered, raw stays the digest, and the Unmarshal below fails.
 		flag = false
 	}
 

--- a/platform/fabric/services/state/namespace_errors_test.go
+++ b/platform/fabric/services/state/namespace_errors_test.go
@@ -1,0 +1,541 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package state
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cdriver "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+)
+
+const errNS = "assetns"
+
+// seedOutput writes a state through the namespace so the RWSet has a write entry
+// to read back, and returns the id it was stored under.
+func seedOutput(tb testing.TB, tx *Transaction, h *House) string {
+	tb.Helper()
+	require.NoError(tb, tx.AddOutput(h))
+	return h.LinearID
+}
+
+// requirePanicsContaining asserts f panics and that the panic value mentions want.
+//
+// It matches a substring rather than the whole value on purpose: several of these
+// messages carry a long-standing "filed"/"failed" typo, and an exact match would
+// turn a spelling fix into a test failure. Prefer the injected cause as want, since
+// that is the part a behaviour change would actually drop.
+func requirePanicsContaining(tb testing.TB, want string, f func()) {
+	tb.Helper()
+	defer func() {
+		r := recover()
+		require.NotNil(tb, r, "expected a panic")
+		require.Contains(tb, fmt.Sprint(r), want)
+	}()
+	f()
+}
+
+// seedRead registers a read entry for key with the given raw value.
+func seedRead(tb testing.TB, rwset *testRWSet, key string, raw []byte) {
+	tb.Helper()
+	require.NoError(tb, rwset.SetState(errNS, cdriver.PKey(key), raw))
+	rwset.writes[errNS] = nil // keep the write list clean; we only want a read
+	require.NoError(tb, rwset.AddReadAt(errNS, key, nil))
+}
+
+// TestNamespaceIndexOutOfRange checks that an index the RWSet cannot serve is
+// reported rather than panicking.
+//
+// The three indices below all take the same `i < 0 || i >= len(...)` branch in the
+// RWSet, so this is one path, not three. They are kept as a table because the
+// interesting property is that GetInputAt and GetOutputAt both surface the failure
+// for a negative index, one past the end, and far past the end -- a regression that
+// silently clamped instead of erroring would still be caught.
+func TestNamespaceIndexOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	for _, index := range []int{-1, 1, 99} {
+		t.Run(fmt.Sprintf("get output at %d", index), func(t *testing.T) {
+			t.Parallel()
+			tx, _, _ := newTestStateTransaction(errNS)
+			seedOutput(t, tx, &House{Address: "one", LinearID: "id-1"})
+
+			err := tx.GetOutputAt(index, &House{})
+			require.Error(t, err)
+			require.ErrorContains(t, err, "failed getting state")
+		})
+
+		t.Run(fmt.Sprintf("get input at %d", index), func(t *testing.T) {
+			t.Parallel()
+			tx, rwset, _ := newTestStateTransaction(errNS)
+			raw, err := json.Marshal(&House{Address: "one", LinearID: "id-1"})
+			require.NoError(t, err)
+			seedRead(t, rwset, "id-1", raw)
+
+			err = tx.GetInputAt(index, &House{})
+			require.Error(t, err)
+			require.ErrorContains(t, err, "failed getting state")
+		})
+	}
+}
+
+// TestNamespaceGetOutputAtLastValidIndex is the boundary companion to the
+// out-of-range cases: count-1 must succeed.
+func TestNamespaceGetOutputAtLastValidIndex(t *testing.T) {
+	t.Parallel()
+
+	tx, _, _ := newTestStateTransaction(errNS)
+	seedOutput(t, tx, &House{Address: "first", LinearID: "id-1"})
+	seedOutput(t, tx, &House{Address: "second", LinearID: "id-2"})
+	require.Equal(t, 2, tx.NumOutputs())
+
+	var got House
+	require.NoError(t, tx.GetOutputAt(1, &got))
+	require.Equal(t, "second", got.Address)
+}
+
+func TestNamespaceGetOutputAtUnmarshalMismatch(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(errNS)
+	require.NoError(t, rwset.SetState(errNS, "id-1", []byte("{not-json")))
+
+	err := tx.GetOutputAt(0, &House{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed unmarshalling state")
+}
+
+func TestNamespaceGetOutputAtMappingError(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(errNS)
+	seedOutput(t, tx, &House{Address: "one", LinearID: "id-1"})
+	rwset.getStateMetadataErr = errors.New("metadata failed")
+
+	err := tx.GetOutputAt(0, &House{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed getting mapping")
+}
+
+func TestNamespaceGetInputAtUnmarshalMismatch(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(errNS)
+	seedRead(t, rwset, "id-1", []byte("{not-json"))
+
+	err := tx.GetInputAt(0, &House{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed unmarshalling state")
+}
+
+// TestNamespaceGetInputAtFallsBackToCertifiedInput covers the recovery path: when
+// GetReadAt fails but the key is present in certifiedInputs, the value is served
+// from there instead of surfacing the error.
+func TestNamespaceGetInputAtFallsBackToCertifiedInput(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(errNS)
+	raw, err := json.Marshal(&House{Address: "certified", LinearID: "id-1"})
+	require.NoError(t, err)
+
+	// A read key exists, but reading its value fails.
+	require.NoError(t, rwset.AddReadAt(errNS, "id-1", nil))
+	rwset.getReadAtErr = errors.New("read value unavailable")
+	tx.certifiedInputs["id-1"] = raw
+
+	var got House
+	require.NoError(t, tx.GetInputAt(0, &got))
+	require.Equal(t, "certified", got.Address)
+}
+
+// TestNamespaceGetInputAtCertifiedInputMissing is the same path when the key is
+// absent from certifiedInputs: the original read error is returned.
+func TestNamespaceGetInputAtCertifiedInputMissing(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(errNS)
+	require.NoError(t, rwset.AddReadAt(errNS, "id-1", nil))
+	rwset.getReadAtErr = errors.New("read value unavailable")
+
+	err := tx.GetInputAt(0, &House{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed getting state")
+}
+
+// TestNamespaceGetInputAtBothLookupsFail exercises the joined-error branch, where
+// GetReadAt and GetReadKeyAt both fail and both causes are reported.
+func TestNamespaceGetInputAtBothLookupsFail(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(errNS)
+	rwset.getReadAtErr = errors.New("read value unavailable")
+	rwset.getReadKeyAtErr = errors.New("read key unavailable")
+
+	err := tx.GetInputAt(0, &House{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "read value unavailable")
+	require.ErrorContains(t, err, "read key unavailable")
+}
+
+func TestNamespaceAddInputByLinearIDGetStateError(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(errNS)
+	rwset.getStateErr = errors.New("get state failed")
+
+	err := tx.AddInputByLinearID("id-1", &House{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed getting state")
+}
+
+func TestNamespaceAddInputByLinearIDMappingError(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(errNS)
+	rwset.getStateMetadataErr = errors.New("metadata failed")
+
+	err := tx.AddInputByLinearID("id-1", &House{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed getting mapping")
+}
+
+func TestNamespaceAddInputByLinearIDUnmarshalMismatch(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(errNS)
+	require.NoError(t, rwset.SetState(errNS, "id-1", []byte("{not-json")))
+
+	err := tx.AddInputByLinearID("id-1", &House{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed unmarshalling state")
+}
+
+// TestNamespaceAddInputByLinearIDOptionError checks an option that fails aborts
+// before the input is registered.
+func TestNamespaceAddInputByLinearIDOptionError(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(errNS)
+	raw, err := json.Marshal(&House{Address: "one", LinearID: "id-1"})
+	require.NoError(t, err)
+	require.NoError(t, rwset.SetState(errNS, "id-1", raw))
+
+	optErr := errors.New("bad option")
+	err = tx.AddInputByLinearID("id-1", &House{}, func(*addInputOptions) error { return optErr })
+	require.ErrorIs(t, err, optErr)
+	require.ErrorContains(t, err, "failed parsing opts")
+}
+
+func TestNamespaceAddOutputSetStateError(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(errNS)
+	rwset.setStateErr = errors.New("write rejected")
+
+	err := tx.AddOutput(&House{Address: "one", LinearID: "id-1"})
+	require.ErrorIs(t, err, rwset.setStateErr)
+}
+
+// TestNamespaceAddOutputHashHidingSetStateError covers the hash-hiding branch's
+// own write, which is a separate call site from the default branch.
+func TestNamespaceAddOutputHashHidingSetStateError(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(errNS)
+	rwset.setStateErr = errors.New("write rejected")
+
+	err := tx.AddOutput(&House{Address: "one", LinearID: "id-1"}, WithHashHiding())
+	require.ErrorIs(t, err, rwset.setStateErr)
+}
+
+// TestNamespaceAddOutputHashHidingStoresHashAndPreimage asserts the visible state
+// is the digest while the preimage is kept in the field mapping.
+func TestNamespaceAddOutputHashHidingStoresHashAndPreimage(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(errNS)
+	h := &House{Address: "secret", LinearID: "id-1"}
+	require.NoError(t, tx.AddOutput(h, WithHashHiding()))
+
+	stored, err := rwset.GetState(errNS, "id-1")
+	require.NoError(t, err)
+
+	// NotEmpty first: without it, a missing key would also satisfy NotContains and
+	// the test would pass for the wrong reason.
+	require.NotEmpty(t, stored, "the key must hold the digest")
+	require.Len(t, stored, sha256.Size, "the stored value is a sha256 digest")
+	require.NotContains(t, string(stored), "secret", "the raw state must not be written in the clear")
+
+	var got House
+	require.NoError(t, tx.GetOutputAt(0, &got))
+	require.Equal(t, "secret", got.Address, "the preimage is recovered from the mapping")
+}
+
+func TestNamespaceAddOutputOptionError(t *testing.T) {
+	t.Parallel()
+
+	tx, _, _ := newTestStateTransaction(errNS)
+	optErr := errors.New("bad option")
+
+	err := tx.AddOutput(&House{LinearID: "id-1"}, func(*addOutputOptions) error { return optErr })
+	require.ErrorIs(t, err, optErr)
+	require.ErrorContains(t, err, "failed parsing opts")
+}
+
+// TestNamespaceAddOutputMetaHandlerError covers the setMeta step of AddOutput: a
+// failing meta handler aborts the call after the state has been written.
+func TestNamespaceAddOutputMetaHandlerError(t *testing.T) {
+	t.Parallel()
+
+	tx, _, _ := newTestStateTransaction(errNS)
+	tx.metaHandlers = []MetaHandler{&testMetaHandler{err: errors.New("meta failed")}}
+
+	err := tx.AddOutput(&House{Address: "one", LinearID: "id-1"})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed setting metadata")
+}
+
+func TestNamespaceDeleteSetStateError(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(errNS)
+	rwset.setStateErr = errors.New("delete rejected")
+
+	err := tx.Delete(&House{LinearID: "id-1"})
+	require.ErrorIs(t, err, rwset.setStateErr)
+}
+
+// TestNamespaceDeleteWritesNilValue records that a delete is modelled as a write
+// of a nil value, which is what Outputs() reads back as a delete marker.
+func TestNamespaceDeleteWritesNilValue(t *testing.T) {
+	t.Parallel()
+
+	tx, _, _ := newTestStateTransaction(errNS)
+	require.NoError(t, tx.Delete(&House{LinearID: "id-1"}))
+	require.Equal(t, 1, tx.NumOutputs())
+
+	outputs := tx.Outputs()
+	require.Equal(t, 1, outputs.Count())
+	require.True(t, outputs.At(0).IsDelete(), "a deleted key is reported as a delete")
+}
+
+func TestNamespaceDeleteAbsentKeyIsAccepted(t *testing.T) {
+	t.Parallel()
+
+	tx, _, _ := newTestStateTransaction(errNS)
+	require.NoError(t, tx.Delete(&House{LinearID: "never-written"}),
+		"deleting a key that was never written is not an error")
+}
+
+// TestNamespaceInterleavedAddDeleteRead walks a mixed sequence and checks the
+// input/output counts stay consistent throughout.
+//
+// Each key is written exactly once, deliberately. The real vault.WriteSet
+// de-duplicates by key -- only a key's first write extends OrderedWrites (see
+// WriteSet.Add in platform/common/core/generic/vault/rwset.go) -- whereas testRWSet
+// appends every call. A sequence that re-wrote a key would assert counts that hold
+// for the fake and not for the framework, so this walks distinct keys and the
+// overwrite case is left unasserted rather than asserted wrongly.
+func TestNamespaceInterleavedAddDeleteRead(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(errNS)
+	require.Zero(t, tx.NumOutputs())
+	require.Zero(t, tx.NumInputs())
+
+	seedOutput(t, tx, &House{Address: "first", LinearID: "id-1"})
+	require.Equal(t, 1, tx.NumOutputs())
+
+	require.NoError(t, tx.Delete(&House{LinearID: "id-2"}))
+	require.Equal(t, 2, tx.NumOutputs(), "deleting a fresh key is one more write")
+
+	seedOutput(t, tx, &House{Address: "third", LinearID: "id-3"})
+	require.Equal(t, 3, tx.NumOutputs())
+
+	require.NoError(t, rwset.AddReadAt(errNS, "id-3", nil))
+	require.Equal(t, 1, tx.NumInputs())
+
+	var got House
+	require.NoError(t, tx.GetOutputAt(2, &got))
+	require.Equal(t, "third", got.Address)
+
+	outputs := tx.Outputs()
+	require.Equal(t, 3, outputs.Count())
+	require.True(t, outputs.At(1).IsDelete(), "the deleted key is reported as a delete")
+}
+
+func TestNamespaceNumInputsAndOutputsPanicOnRWSetError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("num inputs", func(t *testing.T) {
+		t.Parallel()
+		tx, _, driverTx := newTestStateTransaction(errNS)
+		driverTx.getRWSetErr = errors.New("rwset failed")
+		requirePanicsContaining(t, "rwset failed", func() { _ = tx.NumInputs() })
+	})
+
+	t.Run("num outputs", func(t *testing.T) {
+		t.Parallel()
+		tx, _, driverTx := newTestStateTransaction(errNS)
+		driverTx.getRWSetErr = errors.New("rwset failed")
+		requirePanicsContaining(t, "rwset failed", func() { _ = tx.NumOutputs() })
+	})
+}
+
+func TestNamespaceStreamsPanicOnRWSetError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("outputs", func(t *testing.T) {
+		t.Parallel()
+		tx, _, driverTx := newTestStateTransaction(errNS)
+		driverTx.getRWSetErr = errors.New("rwset failed")
+		require.Panics(t, func() { _ = tx.Outputs() })
+	})
+
+	t.Run("inputs", func(t *testing.T) {
+		t.Parallel()
+		tx, _, driverTx := newTestStateTransaction(errNS)
+		driverTx.getRWSetErr = errors.New("rwset failed")
+		require.Panics(t, func() { _ = tx.Inputs() })
+	})
+}
+
+// TestNamespaceOutputsPanicOnWriteLookupError covers the panic inside the loop,
+// which is a different call site from the RWSet lookup above.
+func TestNamespaceOutputsPanicOnWriteLookupError(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(errNS)
+	seedOutput(t, tx, &House{Address: "one", LinearID: "id-1"})
+	rwset.getWriteAtErr = errors.New("write lookup failed")
+
+	require.Panics(t, func() { _ = tx.Outputs() })
+}
+
+func TestNamespaceInputsPanicOnReadKeyLookupError(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(errNS)
+	require.NoError(t, rwset.AddReadAt(errNS, "id-1", nil))
+	rwset.getReadKeyAtErr = errors.New("read key lookup failed")
+
+	require.Panics(t, func() { _ = tx.Inputs() })
+}
+
+func TestNamespaceCommandsEmptyAndPopulated(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no parameters", func(t *testing.T) {
+		t.Parallel()
+		tx, _, _ := newTestStateTransaction(errNS)
+		require.Zero(t, tx.Commands().Count())
+	})
+
+	t.Run("appends to existing header", func(t *testing.T) {
+		t.Parallel()
+		tx, _, _ := newTestStateTransaction(errNS)
+		require.NoError(t, tx.AddCommand("create"))
+		require.NoError(t, tx.AddCommand("transfer"))
+
+		commands := tx.Commands()
+		require.Equal(t, 2, commands.Count())
+		require.Equal(t, "create", commands.At(0).Name)
+		require.Equal(t, "transfer", commands.At(1).Name)
+	})
+}
+
+// failingLinearState is an AutoLinearState whose id cannot be derived, so
+// AddOutput and Delete fail before touching the RWSet.
+type failingLinearState struct {
+	err error
+}
+
+func (f *failingLinearState) GetLinearID() (string, error) { return "", f.err }
+
+func TestNamespaceStateIDError(t *testing.T) {
+	t.Parallel()
+
+	idErr := errors.New("cannot derive id")
+
+	t.Run("add output", func(t *testing.T) {
+		t.Parallel()
+		tx, rwset, _ := newTestStateTransaction(errNS)
+		err := tx.AddOutput(&failingLinearState{err: idErr})
+		require.ErrorIs(t, err, idErr)
+		require.Zero(t, rwset.NumWrites(errNS), "nothing is written when the id cannot be derived")
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		t.Parallel()
+		tx, rwset, _ := newTestStateTransaction(errNS)
+		err := tx.Delete(&failingLinearState{err: idErr})
+		require.ErrorIs(t, err, idErr)
+		require.Zero(t, rwset.NumWrites(errNS))
+	})
+}
+
+// TestNamespaceAddOutputEmbeddingStateDerivesInnerID covers the EmbeddingState
+// branch of getStateID, which recurses into the wrapped state.
+func TestNamespaceAddOutputEmbeddingStateDerivesInnerID(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(errNS)
+	inner := &House{Address: "wrapped", Valuation: 11, LinearID: "inner-id"}
+	require.NoError(t, tx.AddOutput(&embeddingHouse{Inner: inner}))
+
+	// The write is keyed by the embedded state's linear id, and holds the encoded
+	// wrapper, so assert the exact bytes rather than merely that something landed.
+	stored, err := rwset.GetState(errNS, "inner-id")
+	require.NoError(t, err)
+
+	var got embeddingHouse
+	require.NoError(t, json.Unmarshal(stored, &got))
+	require.Equal(t, inner, got.Inner)
+
+	// Nothing is written under the wrapper's own generated id.
+	require.Equal(t, 1, tx.NumOutputs())
+	key, _, err := rwset.GetWriteAt(errNS, 0)
+	require.NoError(t, err)
+	require.Equal(t, "inner-id", string(key))
+}
+
+type embeddingHouse struct {
+	Inner *House
+}
+
+func (e *embeddingHouse) GetState() any { return e.Inner }
+
+// TestNamespaceAddInputByLinearIDReadsHashHiddenPreimage exercises the `_root_`
+// mapping branch on the input path: the stored value is a digest, and the real
+// state has to come from the mapping.
+func TestNamespaceAddInputByLinearIDReadsHashHiddenPreimage(t *testing.T) {
+	t.Parallel()
+
+	tx, _, _ := newTestStateTransaction(errNS)
+	original := &House{Address: "hidden", Valuation: 7, LinearID: "id-1"}
+	require.NoError(t, tx.AddOutput(original, WithHashHiding()))
+
+	var got House
+	require.NoError(t, tx.AddInputByLinearID("id-1", &got))
+	require.Equal(t, "hidden", got.Address)
+	require.Equal(t, uint64(7), got.Valuation)
+}
+
+func TestNamespacePresentReflectsWrites(t *testing.T) {
+	t.Parallel()
+
+	tx, _, _ := newTestStateTransaction(errNS)
+	require.False(t, tx.Present(), "an untouched namespace is not present")
+
+	seedOutput(t, tx, &House{Address: "one", LinearID: "id-1"})
+	require.True(t, tx.Present())
+}

--- a/platform/fabric/services/state/namespace_test.go
+++ b/platform/fabric/services/state/namespace_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/stretchr/testify/require"
 
 	cdriver "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
@@ -306,14 +305,8 @@ func TestNamespaceErrorBranches(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("add input by linear id get state error", func(t *testing.T) {
-		t.Parallel()
-		tx, rwset, _ := newTestStateTransaction("assetns")
-		require.NoError(t, rwset.SetState("assetns", "k1", []byte("v1")))
-		rwset.getStateErr = errors.New("state failed")
-		err := tx.AddInputByLinearID("k1", &House{})
-		require.Error(t, err)
-	})
+	// AddInputByLinearID's GetState error is covered by
+	// TestNamespaceAddInputByLinearIDGetStateError, which also asserts the message.
 }
 
 func TestNamespaceStateIDAndNamespaceResolution(t *testing.T) {
@@ -385,20 +378,11 @@ func TestContractAndSBEHandlers(t *testing.T) {
 		require.Equal(t, []byte("my-contract"), meta["contract"])
 	})
 
-	t.Run("sbe policy path", func(t *testing.T) {
-		t.Parallel()
-		tx, rwset, _ := newTestStateTransaction("assetns")
-		require.NoError(t, rwset.SetState("assetns", "k1", []byte("v1")))
+	// sbeMetaHandler's happy path is covered by
+	// TestSBEMetaHandlerWritesValidationParameter in sbe_test.go.
 
-		owner := &House{Owner: view.Identity("owner1")}
-		h := &sbeMetaHandler{forceSBE: true}
-		require.NoError(t, h.StoreMeta(tx.Namespace, owner, "assetns", "k1", &addOutputOptions{}))
-
-		meta, err := rwset.GetStateMetadata("assetns", "k1", cdriver.FromIntermediate)
-		require.NoError(t, err)
-		require.NotEmpty(t, meta[peer.MetaDataKeys_VALIDATION_PARAMETER.String()])
-	})
-
+	// This stays here because it is the only assertion that identities do *not*
+	// survive a policy round-trip; sbe_test.go covers the rest of stateEP.
 	t.Run("state ep helpers", func(t *testing.T) {
 		t.Parallel()
 		ep, err := newStateEP(nil)

--- a/platform/fabric/services/state/opts.go
+++ b/platform/fabric/services/state/opts.go
@@ -12,8 +12,12 @@ type addOutputOptions struct {
 	sbe        bool
 }
 
+// AddOutputOption configures a single call to [Namespace.AddOutput]. An option that
+// returns an error aborts the call before anything is written.
 type AddOutputOption func(*addOutputOptions) error
 
+// WithContract records contract as the name of the contract governing the output,
+// under the "contract" key of the output's state metadata.
 func WithContract(contract string) AddOutputOption {
 	return func(o *addOutputOptions) error {
 		o.contract = contract
@@ -21,6 +25,14 @@ func WithContract(contract string) AddOutputOption {
 	}
 }
 
+// WithHashHiding stores the SHA-256 digest of the encoded state on the ledger in
+// place of the state itself, and keeps the preimage in the transaction's transient
+// data. Recovering the state requires that transient data; the ledger alone yields
+// only the digest.
+//
+// This hides the whole state. A single []byte field is hidden the same way by tagging
+// it state:"hash", independently of this option; [Namespace.AddOutput] returns an
+// error if that tag appears on a field of any other type.
 func WithHashHiding() AddOutputOption {
 	return func(o *addOutputOptions) error {
 		o.hashHiding = true
@@ -28,6 +40,11 @@ func WithHashHiding() AddOutputOption {
 	}
 }
 
+// WithStateBasedEndorsement sets the output's validation parameter to a state-based
+// endorsement policy requiring every owner of the state to endorse, replacing any
+// policy already stored there.
+//
+// The state must implement [Ownable]; for any other state the option has no effect.
 func WithStateBasedEndorsement() AddOutputOption {
 	return func(o *addOutputOptions) error {
 		o.sbe = true
@@ -39,8 +56,14 @@ type addInputOptions struct {
 	certification bool
 }
 
+// AddInputOption configures a single call to [Namespace.AddInputByLinearID]. An option
+// that returns an error aborts the call.
 type AddInputOption func(*addInputOptions) error
 
+// WithCertification certifies the input, so the other parties can check that the value
+// read is the committed one. The certification is produced before the call returns, by
+// the [Certifier] registered as a service or by [ChaincodeCertifier] if there is none,
+// and a failure to produce it fails the call.
 func WithCertification() AddInputOption {
 	return func(o *addInputOptions) error {
 		o.certification = true

--- a/platform/fabric/services/state/sbe_test.go
+++ b/platform/fabric/services/state/sbe_test.go
@@ -1,0 +1,305 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-protos-go-apiv2/msp"
+	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
+
+// mspRolePolicy builds a serialized SignaturePolicyEnvelope containing one ROLE
+// principal per mspid, which is the shape newStateEP knows how to read back.
+func mspRolePolicy(tb testing.TB, mspids ...string) []byte {
+	tb.Helper()
+
+	principals := make([]*msp.MSPPrincipal, 0, len(mspids))
+	for _, id := range mspids {
+		raw, err := proto.Marshal(&msp.MSPRole{Role: msp.MSPRole_MEMBER, MspIdentifier: id})
+		require.NoError(tb, err)
+		principals = append(principals, &msp.MSPPrincipal{
+			PrincipalClassification: msp.MSPPrincipal_ROLE,
+			Principal:               raw,
+		})
+	}
+
+	raw, err := proto.Marshal(&common.SignaturePolicyEnvelope{Identities: principals})
+	require.NoError(tb, err)
+	return raw
+}
+
+func TestNewStateEPEmptyPolicy(t *testing.T) {
+	t.Parallel()
+
+	ep, err := newStateEP(nil)
+	require.NoError(t, err)
+	require.Empty(t, ep.listOrgs())
+	require.Empty(t, ep.identities)
+}
+
+func TestNewStateEPFromPolicy(t *testing.T) {
+	t.Parallel()
+
+	ep, err := newStateEP(mspRolePolicy(t, "Org2MSP", "Org1MSP"))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"Org1MSP", "Org2MSP"}, ep.listOrgs())
+}
+
+func TestNewStateEPMalformedPolicy(t *testing.T) {
+	t.Parallel()
+
+	_, err := newStateEP([]byte("not-a-proto"))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "error unmarshaling to SignaturePolicy")
+}
+
+// TestNewStateEPMalformedPrincipal covers the inner unmarshal in setMSPIDsFromSP:
+// the envelope parses, but a ROLE principal's payload does not.
+func TestNewStateEPMalformedPrincipal(t *testing.T) {
+	t.Parallel()
+
+	raw, err := proto.Marshal(&common.SignaturePolicyEnvelope{
+		Identities: []*msp.MSPPrincipal{{
+			PrincipalClassification: msp.MSPPrincipal_ROLE,
+			Principal:               []byte("not-an-msp-role"),
+		}},
+	})
+	require.NoError(t, err)
+
+	_, err = newStateEP(raw)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "error unmarshaling msp principal")
+}
+
+// TestNewStateEPIgnoresNonRolePrincipals records that only ROLE principals are
+// read back; an IDENTITY principal is skipped rather than rejected.
+func TestNewStateEPIgnoresNonRolePrincipals(t *testing.T) {
+	t.Parallel()
+
+	raw, err := proto.Marshal(&common.SignaturePolicyEnvelope{
+		Identities: []*msp.MSPPrincipal{{
+			PrincipalClassification: msp.MSPPrincipal_IDENTITY,
+			Principal:               []byte("some-identity"),
+		}},
+	})
+	require.NoError(t, err)
+
+	ep, err := newStateEP(raw)
+	require.NoError(t, err)
+	require.Empty(t, ep.listOrgs(), "IDENTITY principals do not contribute orgs")
+}
+
+func TestStateEPPolicyRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ep, err := newStateEP(mspRolePolicy(t, "Org1MSP", "Org2MSP"))
+	require.NoError(t, err)
+
+	policy, err := ep.Policy()
+	require.NoError(t, err)
+	require.NotEmpty(t, policy)
+
+	back, err := newStateEP(policy)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"Org1MSP", "Org2MSP"}, back.listOrgs())
+}
+
+// TestStateEPPolicyOrgsAreSorted pins the deterministic ordering, which matters
+// because the policy bytes are compared across peers.
+func TestStateEPPolicyOrgsAreSorted(t *testing.T) {
+	t.Parallel()
+
+	first, err := newStateEP(mspRolePolicy(t, "OrgB", "OrgA", "OrgC"))
+	require.NoError(t, err)
+	firstBytes, err := first.Policy()
+	require.NoError(t, err)
+
+	second, err := newStateEP(mspRolePolicy(t, "OrgC", "OrgA", "OrgB"))
+	require.NoError(t, err)
+	secondBytes, err := second.Policy()
+	require.NoError(t, err)
+
+	require.Equal(t, firstBytes, secondBytes,
+		"the same org set must serialize identically regardless of input order")
+}
+
+func TestStateEPPolicyWithIdentities(t *testing.T) {
+	t.Parallel()
+
+	ep, err := newStateEP(nil)
+	require.NoError(t, err)
+	ep.addOwner(view.Identity("alice"))
+	ep.addOwner(view.Identity("bob"))
+
+	policy, err := ep.Policy()
+	require.NoError(t, err)
+
+	spe := &common.SignaturePolicyEnvelope{}
+	require.NoError(t, proto.Unmarshal(policy, spe))
+	require.Len(t, spe.Identities, 2)
+	require.Equal(t, int32(2), spe.Rule.GetNOutOf().N,
+		"every principal must sign")
+}
+
+// TestStateEPPolicyMixesOrgsAndIdentities checks both principal kinds end up in
+// one envelope, orgs first.
+func TestStateEPPolicyMixesOrgsAndIdentities(t *testing.T) {
+	t.Parallel()
+
+	ep, err := newStateEP(mspRolePolicy(t, "Org1MSP"))
+	require.NoError(t, err)
+	ep.addOwner(view.Identity("alice"))
+
+	policy, err := ep.Policy()
+	require.NoError(t, err)
+
+	spe := &common.SignaturePolicyEnvelope{}
+	require.NoError(t, proto.Unmarshal(policy, spe))
+	require.Len(t, spe.Identities, 2)
+	require.Equal(t, msp.MSPPrincipal_ROLE, spe.Identities[0].PrincipalClassification)
+	require.Equal(t, msp.MSPPrincipal_IDENTITY, spe.Identities[1].PrincipalClassification)
+}
+
+func TestStateEPPolicyEmpty(t *testing.T) {
+	t.Parallel()
+
+	ep, err := newStateEP(nil)
+	require.NoError(t, err)
+
+	policy, err := ep.Policy()
+	require.NoError(t, err)
+
+	spe := &common.SignaturePolicyEnvelope{}
+	require.NoError(t, proto.Unmarshal(policy, spe))
+	require.Empty(t, spe.Identities)
+	require.Equal(t, int32(0), spe.Rule.GetNOutOf().N)
+}
+
+// --- sbeMetaHandler -------------------------------------------------------
+
+func TestSBEMetaHandlerSkippedWhenNotRequested(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction("sbens")
+	handler := &sbeMetaHandler{forceSBE: false}
+
+	require.NoError(t, handler.StoreMeta(tx.Namespace, &House{Owner: view.Identity("o")}, "sbens", "k1",
+		&addOutputOptions{sbe: false}))
+
+	meta, err := rwset.GetStateMetadata("sbens", "k1")
+	require.NoError(t, err)
+	require.Empty(t, meta, "no policy is written when SBE is not requested")
+}
+
+func TestSBEMetaHandlerSkippedForNonOwnableState(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction("sbens")
+	handler := &sbeMetaHandler{forceSBE: true}
+
+	// Asset does not implement Ownable.
+	require.NoError(t, handler.StoreMeta(tx.Namespace, &Asset{ID: "a1"}, "sbens", "k1", &addOutputOptions{}))
+
+	meta, err := rwset.GetStateMetadata("sbens", "k1")
+	require.NoError(t, err)
+	require.Empty(t, meta, "a state without owners gets no endorsement policy")
+}
+
+func TestSBEMetaHandlerWritesValidationParameter(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction("sbens")
+	handler := &sbeMetaHandler{forceSBE: true}
+
+	require.NoError(t, handler.StoreMeta(tx.Namespace,
+		&House{Owner: view.Identity("owner-1")}, "sbens", "k1", &addOutputOptions{}))
+
+	meta, err := rwset.GetStateMetadata("sbens", "k1")
+	require.NoError(t, err)
+	require.Contains(t, meta, peer.MetaDataKeys_VALIDATION_PARAMETER.String())
+	require.NotEmpty(t, meta[peer.MetaDataKeys_VALIDATION_PARAMETER.String()])
+}
+
+// TestSBEMetaHandlerPreservesExistingMetadata checks the policy is merged into
+// existing metadata rather than replacing the whole map.
+func TestSBEMetaHandlerPreservesExistingMetadata(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction("sbens")
+	require.NoError(t, rwset.SetStateMetadata("sbens", "k1", map[string][]byte{"keep": []byte("me")}))
+
+	handler := &sbeMetaHandler{forceSBE: true}
+	require.NoError(t, handler.StoreMeta(tx.Namespace,
+		&House{Owner: view.Identity("owner-1")}, "sbens", "k1", &addOutputOptions{}))
+
+	meta, err := rwset.GetStateMetadata("sbens", "k1")
+	require.NoError(t, err)
+	require.Equal(t, []byte("me"), meta["keep"], "unrelated metadata survives")
+	require.Contains(t, meta, peer.MetaDataKeys_VALIDATION_PARAMETER.String())
+}
+
+// TestSBEMetaHandlerOptionEnablesSBE covers the per-output opt-in, as distinct
+// from the handler-wide forceSBE flag.
+func TestSBEMetaHandlerOptionEnablesSBE(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction("sbens")
+	handler := &sbeMetaHandler{forceSBE: false}
+
+	require.NoError(t, handler.StoreMeta(tx.Namespace,
+		&House{Owner: view.Identity("owner-1")}, "sbens", "k1", &addOutputOptions{sbe: true}))
+
+	meta, err := rwset.GetStateMetadata("sbens", "k1")
+	require.NoError(t, err)
+	require.Contains(t, meta, peer.MetaDataKeys_VALIDATION_PARAMETER.String())
+}
+
+func TestSBEMetaHandlerRWSetError(t *testing.T) {
+	t.Parallel()
+
+	tx, _, driverTx := newTestStateTransaction("sbens")
+	driverTx.getRWSetErr = errors.New("rwset failed")
+	handler := &sbeMetaHandler{forceSBE: true}
+
+	err := handler.StoreMeta(tx.Namespace, &House{Owner: view.Identity("o")}, "sbens", "k1",
+		&addOutputOptions{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "getting rw set")
+}
+
+func TestSBEMetaHandlerGetMetadataError(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction("sbens")
+	rwset.getStateMetadataErr = errors.New("read metadata failed")
+	handler := &sbeMetaHandler{forceSBE: true}
+
+	err := handler.StoreMeta(tx.Namespace, &House{Owner: view.Identity("o")}, "sbens", "k1",
+		&addOutputOptions{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "getting metadata")
+}
+
+func TestSBEMetaHandlerSetMetadataError(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction("sbens")
+	rwset.setStateMetadataErr = errors.New("write metadata failed")
+	handler := &sbeMetaHandler{forceSBE: true}
+
+	err := handler.StoreMeta(tx.Namespace, &House{Owner: view.Identity("o")}, "sbens", "k1",
+		&addOutputOptions{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed setting metadata")
+}

--- a/platform/fabric/services/state/tags.go
+++ b/platform/fabric/services/state/tags.go
@@ -19,6 +19,12 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/rwset"
 )
 
+// byteSliceType is []byte. Assignability to it is the precondition for hashing a
+// field: reflect.Value.Bytes needs element kind uint8 and reflect.Value.Set needs
+// assignability, and only assignability implies both. Checking the element kind alone
+// admits []MyByte, which reads fine and then panics in Set.
+var byteSliceType = reflect.TypeFor[[]byte]()
+
 func (n *Namespace) setFieldMapping(namespace, key string, mapping map[string][]byte) error {
 	logger.Debugf("setting field mapping for [%s:%s]", namespace, key)
 	if len(mapping) == 0 {
@@ -124,6 +130,10 @@ func (n *Namespace) marshalTags(set *fabric.RWSet, source any) (any, map[string]
 					// unverifiable hash. Use a []byte field for hash-hiding.
 					return nil, nil, errors.Errorf("state:\"hash\" is not supported for string field [%s]; use []byte", t.Field(i).Name)
 				case reflect.Slice:
+					// See byteSliceType: anything else panics in Bytes or in Set below.
+					if !byteSliceType.AssignableTo(field.Type()) {
+						return nil, nil, errors.Errorf("state:\"hash\" is not supported for field [%s] of type [%s]; use []byte", t.Field(i).Name, field.Type())
+					}
 					mapping[t.Field(i).Name] = field.Bytes()
 
 					hash := sha256.New()
@@ -132,6 +142,10 @@ func (n *Namespace) marshalTags(set *fabric.RWSet, source any) (any, map[string]
 					logger.Debugf("computing hash [%s] in place of [%s:%s]",
 						base64.StdEncoding.EncodeToString(h), t.Field(i).Name, string(field.Bytes()))
 					field.Set(reflect.ValueOf(h))
+				default:
+					// Anything else would be silently left unhashed, emitting the value
+					// in the clear while the caller believes it is hidden. Fail closed.
+					return nil, nil, errors.Errorf("state:\"hash\" is not supported for field [%s] of kind [%s]; use []byte", t.Field(i).Name, field.Kind())
 				}
 			}
 		}
@@ -156,6 +170,12 @@ func (n *Namespace) unmarshalTags(set *fabric.RWSet, source any, mapping map[str
 					// unverified. Use a []byte field for hash-hiding.
 					return errors.Errorf("state:\"hash\" is not supported for string field [%s]; use []byte", t.Field(i).Name)
 				case reflect.Slice:
+					// Mirror marshalTags. Rejecting outright is safe here: marshalTags
+					// panicked on these before writing anything, so no committed state can
+					// hold one.
+					if !byteSliceType.AssignableTo(field.Type()) {
+						return errors.Errorf("state:\"hash\" is not supported for field [%s] of type [%s]; use []byte", t.Field(i).Name, field.Type())
+					}
 					original, ok := mapping[t.Field(i).Name]
 					if !ok {
 						return errors.Errorf("mapping not found for [%s]", t.Field(i).Name)
@@ -178,6 +198,15 @@ func (n *Namespace) unmarshalTags(set *fabric.RWSet, source any, mapping map[str
 					}
 
 					field.Set(reflect.ValueOf(original))
+				default:
+					// A preimage means the field was hashed but cannot be verified here, so
+					// fail closed. Without one it was written in the clear by a release that
+					// skipped this kind silently: pass it through, because rejecting it would
+					// make that committed state permanently unreadable. New occurrences are
+					// stopped by the matching default in marshalTags.
+					if _, hashed := mapping[t.Field(i).Name]; hashed {
+						return errors.Errorf("state:\"hash\" is not supported for field [%s] of kind [%s]; use []byte", t.Field(i).Name, field.Kind())
+					}
 				}
 			}
 		}

--- a/platform/fabric/services/state/tags_errors_test.go
+++ b/platform/fabric/services/state/tags_errors_test.go
@@ -1,0 +1,430 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package state
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cdriver "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+)
+
+const tagNS = "tagns"
+
+func TestGetFieldMappingInvalidKey(t *testing.T) {
+	t.Parallel()
+
+	tx, _, _ := newTestStateTransaction(tagNS)
+
+	// A NUL byte is rejected by the composite-key encoding, so the mapping key
+	// cannot be built. An empty key is not rejected -- see
+	// TestFieldMappingKeyAcceptsEmptyKey.
+	_, err := tx.getFieldMapping(tagNS, "\x00", true)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "creating mapping key")
+}
+
+// TestGetFieldMappingNotInTransientAndNotAllowedToLookUp covers the flag=false
+// short circuit: the RWSet is never consulted and a nil mapping is returned.
+//
+// The nil here is recorded as current behaviour, not as desirable behaviour, and it
+// is asymmetric with the flag=true case (see
+// TestGetFieldMappingAbsentEverywhereReturnsEmpty, which yields a non-nil empty map).
+// TODO: GetInputAt passes flag=false on exactly the certifiedInputs fallback path, so
+// a hash-hidden state served from there never recovers its `_root_` preimage and the
+// read fails. See the TODO in namespace.go's GetInputAt.
+func TestGetFieldMappingNotInTransientAndNotAllowedToLookUp(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(tagNS)
+	rwset.getStateMetadataErr = errors.New("must not be called")
+
+	mapping, err := tx.getFieldMapping(tagNS, "id-1", false)
+	require.NoError(t, err)
+	require.Nil(t, mapping)
+}
+
+func TestGetFieldMappingRWSetError(t *testing.T) {
+	t.Parallel()
+
+	tx, _, driverTx := newTestStateTransaction(tagNS)
+	driverTx.getRWSetErr = errors.New("rwset failed")
+
+	_, err := tx.getFieldMapping(tagNS, "id-1", true)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "getting rw set")
+}
+
+func TestGetFieldMappingMetadataError(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(tagNS)
+	rwset.getStateMetadataErr = errors.New("metadata failed")
+
+	_, err := tx.getFieldMapping(tagNS, "id-1", true)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "getting metadata")
+}
+
+// TestGetFieldMappingAbsentEverywhereReturnsEmpty distinguishes "no mapping" from
+// an error: an absent mapping yields an empty map, not nil and not a failure.
+func TestGetFieldMappingAbsentEverywhereReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	tx, _, _ := newTestStateTransaction(tagNS)
+
+	mapping, err := tx.getFieldMapping(tagNS, "id-1", true)
+	require.NoError(t, err)
+	require.NotNil(t, mapping)
+	require.Empty(t, mapping)
+}
+
+// TestGetFieldMappingReadsFromStateMetadata covers the RWSet fallback: the mapping
+// is absent from the transient store but present in the committed metadata.
+func TestGetFieldMappingReadsFromStateMetadata(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(tagNS)
+	mappingKey, err := fieldMappingKey(tagNS, "id-1")
+	require.NoError(t, err)
+
+	raw, err := json.Marshal(map[string][]byte{"_root_": []byte("preimage")})
+	require.NoError(t, err)
+	require.NoError(t, rwset.SetStateMetadata(tagNS, "id-1", cdriver.Metadata{mappingKey: raw}))
+
+	mapping, err := tx.getFieldMapping(tagNS, "id-1", true)
+	require.NoError(t, err)
+	require.Equal(t, []byte("preimage"), mapping["_root_"])
+}
+
+func TestGetFieldMappingCorruptPayload(t *testing.T) {
+	t.Parallel()
+
+	tx, _, _ := newTestStateTransaction(tagNS)
+	mappingKey, err := fieldMappingKey(tagNS, "id-1")
+	require.NoError(t, err)
+	require.NoError(t, tx.SetTransient(mappingKey, []byte("{bad-json")))
+
+	_, err = tx.getFieldMapping(tagNS, "id-1", true)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unmarshalling mapping")
+}
+
+// TestSetFieldMappingEmptyIsNoOp records that an empty mapping is skipped rather
+// than written, so no transient entry is created.
+func TestSetFieldMappingEmptyIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	tx, _, _ := newTestStateTransaction(tagNS)
+	require.NoError(t, tx.setFieldMapping(tagNS, "id-1", map[string][]byte{}))
+
+	mappingKey, err := fieldMappingKey(tagNS, "id-1")
+	require.NoError(t, err)
+	require.Empty(t, tx.GetTransient(mappingKey))
+}
+
+func TestSetFieldMappingRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tx, _, _ := newTestStateTransaction(tagNS)
+	want := map[string][]byte{"_root_": []byte("value"), "other": []byte("x")}
+	require.NoError(t, tx.setFieldMapping(tagNS, "id-1", want))
+
+	got, err := tx.getFieldMapping(tagNS, "id-1", true)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestFieldMappingKeyRejectsNUL(t *testing.T) {
+	t.Parallel()
+
+	_, err := fieldMappingKey(tagNS, "\x00")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "U+0000")
+}
+
+// TestFieldMappingKeyAcceptsEmptyKey records that an empty key is not an error:
+// the composite-key encoding only rejects U+0000 and U+10FFFF, so an empty
+// attribute produces a valid -- if degenerate -- key.
+func TestFieldMappingKeyAcceptsEmptyKey(t *testing.T) {
+	t.Parallel()
+
+	key, err := fieldMappingKey(tagNS, "")
+	require.NoError(t, err)
+	require.NotEmpty(t, key)
+}
+
+// TestMarshalTagsHashOnStringFailsClosed pins a deliberate refusal: hash-hiding a
+// string field would emit a hash whose preimage is never retained, so it could be
+// neither recovered nor verified. Both directions reject it rather than emitting
+// an unverifiable value.
+func TestMarshalTagsHashOnStringFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	type stringTagged struct {
+		Secret string `state:"hash"`
+	}
+
+	n := &Namespace{}
+	_, _, err := n.marshalTags(nil, &stringTagged{Secret: "s"})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "not supported for string field")
+
+	err = n.unmarshalTags(nil, &stringTagged{Secret: "s"}, map[string][]byte{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "not supported for string field")
+}
+
+// TestTagsHashRejectsUnsupportedKinds checks that state:"hash" on a field that
+// cannot be hashed is rejected.
+//
+// Previously an unhandled kind fell through the switch silently, so the value was
+// written in the clear while the caller believed it was hidden, and a non-byte slice
+// panicked inside reflect.Value.Bytes.
+//
+// marshalTags now refuses all of them. unmarshalTags refuses the slice kinds
+// unconditionally -- marshalTags panicked on those before it could write anything, so
+// no committed state can hold one -- but for the remaining kinds it refuses only when
+// a preimage is present, because a release that skipped the kind silently left
+// readable state behind. See TestUnmarshalTagsPassesThroughUnhashedUnsupportedKind.
+func TestTagsHashRejectsUnsupportedKinds(t *testing.T) {
+	t.Parallel()
+
+	type intTagged struct {
+		Count int `state:"hash"`
+	}
+	type stringSliceTagged struct {
+		Names []string `state:"hash"`
+	}
+	type intSliceTagged struct {
+		Sizes []int `state:"hash"`
+	}
+	type mapTagged struct {
+		Attrs map[string]string `state:"hash"`
+	}
+
+	for _, tc := range []struct {
+		name  string
+		field string
+		state any
+		// readRejectsWithoutPreimage marks the kinds handled by the slice guard, which
+		// cannot have produced legacy data and so fails closed either way.
+		readRejectsWithoutPreimage bool
+	}{
+		{name: "int", field: "Count", state: &intTagged{Count: 7}},
+		{name: "map", field: "Attrs", state: &mapTagged{Attrs: map[string]string{"k": "v"}}},
+		{
+			name: "string slice", field: "Names",
+			state:                      &stringSliceTagged{Names: []string{"a", "b"}},
+			readRejectsWithoutPreimage: true,
+		},
+		{
+			name: "int slice", field: "Sizes",
+			state:                      &intSliceTagged{Sizes: []int{1, 2}},
+			readRejectsWithoutPreimage: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			n := &Namespace{}
+			_, _, err := n.marshalTags(nil, tc.state)
+			require.Error(t, err, "marshalTags must refuse a field it cannot hash")
+			require.ErrorContains(t, err, "is not supported for field")
+
+			// A preimage means something hashed the field and this code cannot verify
+			// it, so the read side always refuses.
+			err = n.unmarshalTags(nil, tc.state, map[string][]byte{tc.field: []byte("preimage")})
+			require.Error(t, err, "unmarshalTags must refuse a hashed field it cannot verify")
+			require.ErrorContains(t, err, "is not supported for field")
+
+			err = n.unmarshalTags(nil, tc.state, map[string][]byte{})
+			if tc.readRejectsWithoutPreimage {
+				require.Error(t, err, "a slice of this shape could never have been committed")
+				require.ErrorContains(t, err, "is not supported for field")
+			} else {
+				require.NoError(t, err, "an unhashed legacy field must stay readable")
+			}
+		})
+	}
+}
+
+// TestUnmarshalTagsPassesThroughUnhashedUnsupportedKind covers the upgrade path: a
+// release that silently skipped an unsupported kind wrote the value in the clear and
+// recorded no preimage, so reading that state back has to keep working -- otherwise
+// upgrading strands already-committed data with no way to migrate it. A fixed-size
+// byte array is the realistic shape.
+func TestUnmarshalTagsPassesThroughUnhashedUnsupportedKind(t *testing.T) {
+	t.Parallel()
+
+	type arrayTagged struct {
+		Fingerprint [4]byte `state:"hash"`
+	}
+
+	n := &Namespace{}
+	state := &arrayTagged{Fingerprint: [4]byte{1, 2, 3, 4}}
+
+	// The write side refuses, so no new state of this shape can be produced.
+	_, _, err := n.marshalTags(nil, state)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "of kind [array]")
+
+	// The read side leaves the legacy value alone.
+	require.NoError(t, n.unmarshalTags(nil, state, map[string][]byte{}))
+	require.Equal(t, [4]byte{1, 2, 3, 4}, state.Fingerprint, "the committed value is untouched")
+
+	// A preimage, though, means it was hashed and cannot be verified here.
+	err = n.unmarshalTags(nil, state, map[string][]byte{"Fingerprint": []byte("preimage")})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "is not supported for field")
+}
+
+// TestTagsHashRejectsNamedByteElementSlice guards the hole an element-kind check
+// leaves open: []MyByte has element Kind Uint8, so `Elem().Kind() != reflect.Uint8`
+// admits it, reflect.Value.Bytes then succeeds, and writing the digest back panics in
+// reflect.Value.Set because []byte is not assignable to []MyByte. Assignability is
+// the check that actually closes it.
+func TestTagsHashRejectsNamedByteElementSlice(t *testing.T) {
+	t.Parallel()
+
+	type namedByte byte
+	type namedElemTagged struct {
+		Data []namedByte `state:"hash"`
+	}
+
+	n := &Namespace{}
+	state := &namedElemTagged{Data: []namedByte{1, 2, 3}}
+
+	require.NotPanics(t, func() {
+		_, _, err := n.marshalTags(nil, state)
+		require.Error(t, err, "marshalTags must refuse a slice it cannot write back")
+		require.ErrorContains(t, err, "is not supported for field")
+	})
+
+	// A matching digest, so the hash check would pass and reach the field.Set that
+	// used to panic.
+	sum := sha256.Sum256([]byte{1, 2, 3})
+	hashed := make([]namedByte, len(sum))
+	for i, b := range sum {
+		hashed[i] = namedByte(b)
+	}
+	require.NotPanics(t, func() {
+		err := n.unmarshalTags(nil, &namedElemTagged{Data: hashed},
+			map[string][]byte{"Data": {1, 2, 3}})
+		require.Error(t, err, "unmarshalTags must refuse it too")
+		require.ErrorContains(t, err, "is not supported for field")
+	})
+}
+
+// TestTagsHashAcceptsNamedByteSliceType is the counterpart: a named slice type whose
+// underlying type is []byte *is* assignable from []byte, so the tighter check must not
+// start rejecting it.
+func TestTagsHashAcceptsNamedByteSliceType(t *testing.T) {
+	t.Parallel()
+
+	type hashDigest []byte
+	type namedSliceTagged struct {
+		Data hashDigest `state:"hash"`
+	}
+
+	n := &Namespace{}
+	hashed, mapping, err := n.marshalTags(nil, &namedSliceTagged{Data: hashDigest("secret")})
+	require.NoError(t, err, "a named []byte type must still be hashable")
+	require.Equal(t, []byte("secret"), mapping["Data"], "the preimage is retained")
+
+	digest := sha256.Sum256([]byte("secret"))
+	require.Equal(t, hashDigest(digest[:]), hashed.(*namedSliceTagged).Data,
+		"the field holds the digest")
+
+	require.NoError(t, n.unmarshalTags(nil, hashed, mapping))
+	require.Equal(t, hashDigest("secret"), hashed.(*namedSliceTagged).Data,
+		"the preimage is restored")
+}
+
+// TestTagsHashOnNonByteSliceDoesNotPanic is the regression guard for the panic
+// this used to cause: reflect.Value.Bytes panics on a slice whose elements are not
+// bytes, so the kind check has to run before it.
+func TestTagsHashOnNonByteSliceDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	type stringSliceTagged struct {
+		Names []string `state:"hash"`
+	}
+
+	n := &Namespace{}
+	require.NotPanics(t, func() {
+		_, _, _ = n.marshalTags(nil, &stringSliceTagged{Names: []string{"a"}})
+	})
+	require.NotPanics(t, func() {
+		_ = n.unmarshalTags(nil, &stringSliceTagged{Names: []string{"a"}}, map[string][]byte{})
+	})
+}
+
+// TestMarshalTagsIgnoresUnknownTagValue records that an unrecognised state tag is
+// ignored, so adding one is not a compile- or run-time error.
+func TestMarshalTagsIgnoresUnknownTagValue(t *testing.T) {
+	t.Parallel()
+
+	type oddlyTagged struct {
+		Data []byte `state:"encrypt"`
+	}
+
+	n := &Namespace{}
+	dest, mapping, err := n.marshalTags(nil, &oddlyTagged{Data: []byte("x")})
+	require.NoError(t, err)
+	require.Empty(t, mapping)
+	require.Equal(t, []byte("x"), dest.(*oddlyTagged).Data)
+}
+
+// TestUnmarshalTagsMissingMappingEntry checks a hash-tagged field with no preimage
+// is rejected: without it the hash cannot be verified, so it fails closed.
+func TestUnmarshalTagsMissingMappingEntry(t *testing.T) {
+	t.Parallel()
+
+	n := &Namespace{}
+	hashed, mapping, err := n.marshalTags(nil, &Asset{ID: "a1", PrivateProperties: []byte("private")})
+	require.NoError(t, err)
+	require.NotEmpty(t, mapping)
+
+	err = n.unmarshalTags(nil, hashed, map[string][]byte{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "mapping not found")
+}
+
+// TestUnmarshalTagsHashMismatch covers the integrity check: a preimage that does
+// not hash to the stored digest is rejected.
+func TestUnmarshalTagsHashMismatch(t *testing.T) {
+	t.Parallel()
+
+	n := &Namespace{}
+	hashed, _, err := n.marshalTags(nil, &Asset{ID: "a1", PrivateProperties: []byte("private")})
+	require.NoError(t, err)
+
+	err = n.unmarshalTags(nil, hashed, map[string][]byte{"PrivateProperties": []byte("tampered")})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed checking hash")
+}
+
+// TestMarshalUnmarshalTagsRoundTrip is the success counterpart: a matching
+// preimage restores the original value.
+func TestMarshalUnmarshalTagsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	n := &Namespace{}
+	original := &Asset{ID: "a1", PrivateProperties: []byte("private")}
+	hashed, mapping, err := n.marshalTags(nil, original)
+	require.NoError(t, err)
+	require.NotEqual(t, original.PrivateProperties, hashed.(*Asset).PrivateProperties,
+		"the field is replaced by its digest")
+
+	require.NoError(t, n.unmarshalTags(nil, hashed, mapping))
+	require.Equal(t, []byte("private"), hashed.(*Asset).PrivateProperties)
+}

--- a/platform/fabric/services/state/trustedread_test.go
+++ b/platform/fabric/services/state/trustedread_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const trustedNS = "trustedns"
+
+// TestTrustedReadCertifierCertifyInputIsNoOp pins the documented behaviour: every
+// node self-reads the committed value through GetReadAt, so no per-input proof is
+// produced and certifiedInputs stays empty.
+func TestTrustedReadCertifierCertifyInputIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	tx, _, _ := newTestStateTransaction(trustedNS)
+	certifier := &TrustedReadCertifier{}
+
+	require.NoError(t, certifier.CertifyInput(tx.Namespace, "id-1"))
+	require.Empty(t, tx.certifiedInputs,
+		"the trusted-read certifier produces no certification to store")
+}
+
+func TestTrustedReadCertifierVerifyRWSetError(t *testing.T) {
+	t.Parallel()
+
+	tx, _, driverTx := newTestStateTransaction(trustedNS)
+	injected := errors.New("rwset failed")
+	driverTx.getRWSetErr = injected
+
+	err := (&TrustedReadCertifier{}).VerifyInputCertificationAt(tx.Namespace, 0, "id-1")
+	require.ErrorIs(t, err, injected, "the underlying cause must be preserved")
+	require.ErrorContains(t, err, "failed getting rw set")
+}
+
+func TestTrustedReadCertifierVerifyReadError(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(trustedNS)
+	injected := errors.New("read failed")
+	rwset.getReadAtErr = injected
+
+	err := (&TrustedReadCertifier{}).VerifyInputCertificationAt(tx.Namespace, 0, "id-1")
+	require.ErrorIs(t, err, injected, "the underlying cause must be preserved")
+	require.ErrorContains(t, err, "failed reading committed state")
+}
+
+func TestTrustedReadCertifierVerifyFieldMappingError(t *testing.T) {
+	t.Parallel()
+
+	tx, rwset, _ := newTestStateTransaction(trustedNS)
+	require.NoError(t, rwset.SetState(trustedNS, "id-1", []byte("committed")))
+	require.NoError(t, rwset.AddReadAt(trustedNS, "id-1", nil))
+	injected := errors.New("metadata failed")
+	rwset.getStateMetadataErr = injected
+
+	err := (&TrustedReadCertifier{}).VerifyInputCertificationAt(tx.Namespace, 0, "id-1")
+	require.ErrorIs(t, err, injected, "the underlying cause must be preserved")
+	require.ErrorContains(t, err, "failed getting field mapping")
+}


### PR DESCRIPTION
`fabric/services/state` was at 80.8%. The integration suites drive the happy paths end to end, so what was left uncovered was mostly error branches and boundary conditions that only a unit test can reach. Writing those tests turned up a bug, which this PR also fixes.

## The bug

`state:"hash"` on a field the tag handler cannot process failed unsafely in two different ways:

- a non-byte slice (`[]string`, `[]int`) panicked inside `reflect.Value.Bytes`;
- any other unhandled kind fell through the switch silently, so the value was written to the ledger **in the clear** while the caller believed it was hidden.

Both now return an error at write time. The check is whether a `[]byte` is assignable to the field, which is the precondition for both reflect calls in play (`Bytes` needs element kind uint8, `Set` needs assignability, and only assignability implies both). An element-kind check looks equivalent but still admits `[]MyByte`, which reads fine and then panics in `Set`.

`[]byte` and named types whose underlying type is `[]byte` remain supported. The only `state:"hash"` uses in this repo are `[]byte`, so nothing here changes behaviour.

### Compatibility

The read side is deliberately **not** a mirror of the write side. `unmarshalTags` runs on every read path, so refusing outright would make states already committed by an older release — value in the clear, no preimage recorded — permanently unreadable, with no migration path. It refuses only when a preimage is present, which means the field was hashed and cannot be verified here. New occurrences are prevented by the write-side check.

Slices are refused unconditionally: those panicked before anything was written, so no ledger can hold one.

Downstream code with `state:"hash"` on a non-`[]byte` field will now get an error from `AddOutput` where it previously got silent, unhidden data.


## Coverage

| | before | after |
|---|---|---|
| package | 80.8% | **86.9%** |
| `namespace.go` | 79.3% | 92.9% |
| `sbe.go` | 65.2% | 93.4% |
| `tags.go` | — | 94.2% |

New: `namespace_errors_test.go`, `tags_errors_test.go`, `sbe_test.go`, `trustedread_test.go`. All reuse the existing `common_test.go` fakes; no new test infrastructure.

## Also in here

- Godoc for the exported options in `opts.go`, which had none.
- A `TODO` recording that certified inputs and hash hiding do not compose: `GetInputAt` serves a certified input without consulting the field mapping, so a hash-hidden state read that way never recovers its preimage and the unmarshal fails. Pre-existing, and relevant to the ATSA hash-hiding work.
- Two subtests removed from `namespace_test.go` that the new files subsume.
- `TestNamespaceInterleavedAddDeleteRead` no longer asserts that re-writing a key appends another write entry. That holds for `testRWSet`, which appends on every `SetState`, but not for `vault.WriteSet`, which de-duplicates by key — so the test was pinning fake-only behaviour.

## Testing

`go test -race -cover ./platform/fabric/services/state/` passes at 86.9%.
`golangci-lint run ./platform/fabric/services/state/...` reports 0 issues. Root and `integration` modules both build.

Closes #1701