### PR TITLE
test(delivery): cover the delivery package and fix Stop

### DIFF
--- a/platform/fabric/core/generic/delivery/deliverclient.go
+++ b/platform/fabric/core/generic/delivery/deliverclient.go
@@ -27,7 +27,10 @@ import (
 	grpc2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
 )
 
-// TxEvent contains information for token transaction commit
+// TxEvent reports the outcome of waiting for a single transaction to be
+// committed. Committed distinguishes a successful commit from a failure
+// described by Err; Block and IndexInBlock locate the transaction in the
+// ledger, and CommitPeer names the peer that reported it.
 type TxEvent struct {
 	TxID         string
 	Committed    bool
@@ -68,6 +71,9 @@ type deliverClient struct {
 	client services.PeerClient
 }
 
+// NewDeliverClient returns a DeliverClient backed by the given peer client. The
+// error is always nil today; connecting to the peer is deferred to NewDeliver
+// and NewDeliverFiltered.
 func NewDeliverClient(client services.PeerClient) (DeliverClient, error) {
 	return &deliverClient{
 		client: client,
@@ -102,12 +108,20 @@ func (d *deliverClient) NewDeliverFiltered(ctx context.Context, opts ...grpc.Cal
 	return df, nil
 }
 
+// Certificate returns the TLS certificate the underlying peer client presents.
+// The returned pointer refers to a copy, so mutating it does not affect the
+// client.
 func (d *deliverClient) Certificate() *tls.Certificate {
 	cert := d.client.Certificate()
 	return &cert
 }
 
-// CreateDeliverEnvelope creates a signed envelope with SeekPosition_Newest for block
+// CreateDeliverEnvelope creates the signed seek envelope that opens a Deliver
+// stream. It requests every block from start onwards with no upper bound, and
+// asks the peer to block until each next block is ready rather than ending the
+// stream at the current ledger height. If cert is non-nil its SHA2-256 hash is
+// bound into the envelope, as the peer requires when client TLS auth is
+// enabled.
 func CreateDeliverEnvelope(channelID string, signingIdentity driver.SigningIdentity, cert *tls.Certificate, start *ab.SeekPosition) (*common.Envelope, error) {
 	logger.Debugf("create delivery envelope starting from: [%s]", start)
 	creator, err := signingIdentity.Serialize()
@@ -153,6 +167,10 @@ func CreateDeliverEnvelope(channelID string, signingIdentity driver.SigningIdent
 	return envelope, nil
 }
 
+// DeliverSend sends the seek envelope on the stream and then half-closes it,
+// since a Deliver client only ever sends this one message. It returns the error
+// from the send; a failure to close is logged rather than returned, because the
+// stream is still usable for receiving.
 func DeliverSend(df DeliverStream, envelope *common.Envelope) error {
 	err := df.Send(envelope)
 	if err := df.CloseSend(); err != nil {
@@ -161,6 +179,10 @@ func DeliverSend(df DeliverStream, envelope *common.Envelope) error {
 	return err
 }
 
+// DeliverReceive reads from a filtered Deliver stream until it sees the
+// transaction txid, then reports the outcome on eventCh exactly once and
+// returns. A stream error, or a status response other than a block, also
+// produces an event with Err set.
 func DeliverReceive(df DeliverFiltered, address, txid string, eventCh chan<- TxEvent) error {
 	event := TxEvent{
 		TxID:       txid,
@@ -243,8 +265,10 @@ func DeliverWaitForResponse(ctx context.Context, eventCh <-chan TxEvent, txid st
 	}
 }
 
-// CreateHeader creates common.Header for a token transaction
-// tlsCertHash is for client TLS cert, only applicable when ClientAuthRequired is true
+// CreateHeader creates the common.Header for a transaction of the given type,
+// returning the freshly generated transaction ID alongside it. tlsCertHash
+// binds the client TLS certificate into the header and is only applicable when
+// the peer has ClientAuthRequired set.
 func CreateHeader(txType common.HeaderType, channelID string, creator, tlsCertHash []byte) (string, *common.Header, error) {
 	ts := timestamppb.Now()
 

--- a/platform/fabric/core/generic/delivery/deliverclient_test.go
+++ b/platform/fabric/core/generic/delivery/deliverclient_test.go
@@ -7,12 +7,18 @@ SPDX-License-Identifier: Apache-2.0
 package delivery
 
 import (
+	"context"
+	"crypto/tls"
 	"errors"
 	"testing"
+	"time"
 
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+	ab "github.com/hyperledger/fabric-protos-go-apiv2/orderer"
 	pb "github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 )
 
 // fakeDeliverFiltered implements DeliverFiltered by replaying a fixed
@@ -93,5 +99,335 @@ func TestDeliverReceive_MalformedBlock(t *testing.T) {
 			require.Error(t, err)
 			require.ErrorContains(t, err, "malformed block")
 		})
+	})
+}
+
+func TestNewDeliverClient(t *testing.T) {
+	t.Parallel()
+	mpc := &mockPeerClient{}
+	client, err := NewDeliverClient(mpc)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+}
+
+func TestNewDeliver(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		mpc := &mockPeerClient{
+			deliverCli: &mockDeliverClientRPC{stream: &mockDeliverStream{}},
+		}
+		client, _ := NewDeliverClient(mpc)
+		stream, err := client.NewDeliver(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, stream)
+	})
+
+	t.Run("DeliverClient fails", func(t *testing.T) {
+		t.Parallel()
+		mpc := &mockPeerClient{
+			deliverErr: errors.New("deliver client error"),
+		}
+		client, _ := NewDeliverClient(mpc)
+		stream, err := client.NewDeliver(t.Context())
+		require.ErrorContains(t, err, "failed to create deliver client for peer")
+		require.Nil(t, stream)
+	})
+
+	t.Run("Deliver fails", func(t *testing.T) {
+		t.Parallel()
+		mpc := &mockPeerClient{
+			deliverCli: &mockDeliverClientRPC{streamErr: errors.New("rpc error")},
+		}
+		client, _ := NewDeliverClient(mpc)
+		stream, err := client.NewDeliver(t.Context())
+		require.ErrorContains(t, err, "failed to new a deliver filtered")
+		require.Nil(t, stream)
+	})
+}
+
+func TestNewDeliverFiltered(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		mpc := &mockPeerClient{
+			deliverCli: &mockDeliverClientRPC{filtered: &mockDeliverFiltered{}},
+		}
+		client, _ := NewDeliverClient(mpc)
+		stream, err := client.NewDeliverFiltered(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, stream)
+	})
+
+	t.Run("DeliverClient fails", func(t *testing.T) {
+		t.Parallel()
+		mpc := &mockPeerClient{
+			deliverErr: errors.New("deliver client error"),
+		}
+		client, _ := NewDeliverClient(mpc)
+		stream, err := client.NewDeliverFiltered(t.Context())
+		require.ErrorContains(t, err, "failed to create deliver client for peer")
+		require.Nil(t, stream)
+	})
+
+	t.Run("DeliverFiltered fails", func(t *testing.T) {
+		t.Parallel()
+		mpc := &mockPeerClient{
+			deliverCli: &mockDeliverClientRPC{filteredErr: errors.New("rpc error")},
+		}
+		client, _ := NewDeliverClient(mpc)
+		stream, err := client.NewDeliverFiltered(t.Context())
+		require.ErrorContains(t, err, "failed to new a deliver filtered")
+		require.Nil(t, stream)
+	})
+}
+
+func TestCertificate(t *testing.T) {
+	t.Parallel()
+	cert := tls.Certificate{Certificate: [][]byte{[]byte("cert")}}
+	mpc := &mockPeerClient{cert: cert}
+	client, _ := NewDeliverClient(mpc)
+	c := client.Certificate()
+	require.NotNil(t, c)
+	require.Equal(t, cert.Certificate, c.Certificate)
+}
+
+func TestCreateDeliverEnvelope(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		cert := &tls.Certificate{}
+		start := &ab.SeekPosition{}
+		id := &mockSigningIdentity{}
+		env, err := CreateDeliverEnvelope("mychannel", id, cert, start)
+		require.NoError(t, err)
+		require.NotNil(t, env)
+		require.NotNil(t, env.Payload)
+		require.NotNil(t, env.Signature)
+
+		payload := &cb.Payload{}
+		err = proto.Unmarshal(env.Payload, payload)
+		require.NoError(t, err)
+
+		chdr := &cb.ChannelHeader{}
+		err = proto.Unmarshal(payload.Header.ChannelHeader, chdr)
+		require.NoError(t, err)
+		require.Equal(t, "mychannel", chdr.ChannelId)
+	})
+
+	t.Run("serialize fails", func(t *testing.T) {
+		t.Parallel()
+		cert := &tls.Certificate{}
+		start := &ab.SeekPosition{}
+		id := &mockSigningIdentity{serializeErr: errors.New("serialize error")}
+		env, err := CreateDeliverEnvelope("mychannel", id, cert, start)
+		require.ErrorContains(t, err, "serialize error")
+		require.Nil(t, env)
+	})
+
+	t.Run("sign fails", func(t *testing.T) {
+		t.Parallel()
+		cert := &tls.Certificate{}
+		start := &ab.SeekPosition{}
+		id := &mockSigningIdentity{signErr: errors.New("sign error")}
+		env, err := CreateDeliverEnvelope("mychannel", id, cert, start)
+		require.ErrorContains(t, err, "sign error")
+		require.Nil(t, env)
+	})
+}
+
+func TestDeliverWaitForResponse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		eventCh := make(chan TxEvent, 1)
+		eventCh <- TxEvent{TxID: "tx1", Committed: true, Block: 10, IndexInBlock: 5}
+
+		committed, block, idx, err := DeliverWaitForResponse(t.Context(), eventCh, "tx1")
+		require.NoError(t, err)
+		require.True(t, committed)
+		require.Equal(t, uint64(10), block)
+		require.Equal(t, 5, idx)
+	})
+
+	t.Run("txid mismatch", func(t *testing.T) {
+		t.Parallel()
+		eventCh := make(chan TxEvent, 1)
+		eventCh <- TxEvent{TxID: "tx2"}
+
+		committed, _, _, err := DeliverWaitForResponse(t.Context(), eventCh, "tx1")
+		require.ErrorContains(t, err, "no event received for txid tx1")
+		require.False(t, committed)
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		t.Parallel()
+		eventCh := make(chan TxEvent)
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+		t.Cleanup(cancel)
+
+		committed, _, _, err := DeliverWaitForResponse(ctx, eventCh, "tx1")
+		require.ErrorContains(t, err, "timed out waiting for committing txid [tx1]")
+		require.False(t, committed)
+	})
+}
+
+func TestDeliverSend(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		stream := &mockDeliverStreamTest{}
+		err := DeliverSend(stream, &cb.Envelope{})
+		require.NoError(t, err)
+	})
+
+	t.Run("send fails", func(t *testing.T) {
+		t.Parallel()
+		stream := &mockDeliverStreamTest{sendErr: errors.New("send error")}
+		err := DeliverSend(stream, &cb.Envelope{})
+		require.ErrorContains(t, err, "send error")
+	})
+
+	t.Run("close send fails", func(t *testing.T) {
+		t.Parallel()
+		stream := &mockDeliverStreamTest{closeSendErr: errors.New("close error")}
+		err := DeliverSend(stream, &cb.Envelope{})
+		require.NoError(t, err) // DeliverSend returns the Send error, not the CloseSend error, but logs the CloseSend error.
+	})
+}
+
+func TestDeliverReceive(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Recv error", func(t *testing.T) {
+		t.Parallel()
+		df := &mockDeliverStreamTest{recvErr: errors.New("recv error")}
+		ch := make(chan TxEvent, 1)
+		err := DeliverReceive(df, "peer0", "tx1", ch)
+		require.ErrorContains(t, err, "recv error")
+		event := <-ch
+		require.ErrorContains(t, event.Err, "recv error")
+	})
+
+	t.Run("FilteredBlock VALID", func(t *testing.T) {
+		t.Parallel()
+		df := &mockDeliverStreamTest{
+			recvResp: &pb.DeliverResponse{
+				Type: &pb.DeliverResponse_FilteredBlock{
+					FilteredBlock: &pb.FilteredBlock{
+						Number: 10,
+						FilteredTransactions: []*pb.FilteredTransaction{
+							{Txid: "tx1", TxValidationCode: pb.TxValidationCode_VALID},
+						},
+					},
+				},
+			},
+		}
+		ch := make(chan TxEvent, 1)
+		err := DeliverReceive(df, "peer0", "tx1", ch)
+		require.NoError(t, err)
+		event := <-ch
+		require.True(t, event.Committed)
+		require.Equal(t, uint64(10), event.Block)
+		require.Equal(t, 0, event.IndexInBlock)
+	})
+
+	t.Run("FilteredBlock INVALID", func(t *testing.T) {
+		t.Parallel()
+		df := &mockDeliverStreamTest{
+			recvResp: &pb.DeliverResponse{
+				Type: &pb.DeliverResponse_FilteredBlock{
+					FilteredBlock: &pb.FilteredBlock{
+						Number: 10,
+						FilteredTransactions: []*pb.FilteredTransaction{
+							{Txid: "tx1", TxValidationCode: pb.TxValidationCode_MVCC_READ_CONFLICT},
+						},
+					},
+				},
+			},
+		}
+		ch := make(chan TxEvent, 1)
+		err := DeliverReceive(df, "peer0", "tx1", ch)
+		require.ErrorContains(t, err, "status is not valid: MVCC_READ_CONFLICT")
+	})
+
+	t.Run("DeliverResponse_Status", func(t *testing.T) {
+		t.Parallel()
+		df := &mockDeliverStreamTest{
+			recvResp: &pb.DeliverResponse{
+				Type: &pb.DeliverResponse_Status{
+					Status: cb.Status_SUCCESS,
+				},
+			},
+		}
+		ch := make(chan TxEvent, 1)
+		err := DeliverReceive(df, "peer0", "tx1", ch)
+		require.ErrorContains(t, err, "deliver completed with status (SUCCESS) before txid tx1 received from peer peer0")
+	})
+
+	t.Run("DeliverResponse unexpected", func(t *testing.T) {
+		t.Parallel()
+		df := &mockDeliverStreamTest{
+			recvResp: &pb.DeliverResponse{
+				Type: nil,
+			},
+		}
+		ch := make(chan TxEvent, 1)
+		err := DeliverReceive(df, "peer0", "tx1", ch)
+		require.ErrorContains(t, err, "received unexpected response type")
+	})
+
+	t.Run("DeliverResponse_Block VALID", func(t *testing.T) {
+		t.Parallel()
+		chdr := &cb.ChannelHeader{TxId: "tx1"}
+		chdrBytes, _ := proto.Marshal(chdr)
+		payload := &cb.Payload{Header: &cb.Header{ChannelHeader: chdrBytes}}
+		payloadBytes, _ := proto.Marshal(payload)
+		env := &cb.Envelope{Payload: payloadBytes}
+		envBytes, _ := proto.Marshal(env)
+
+		df := &mockDeliverStreamTest{
+			recvResp: &pb.DeliverResponse{
+				Type: &pb.DeliverResponse_Block{
+					Block: &cb.Block{
+						Header: &cb.BlockHeader{Number: 11},
+						Data: &cb.BlockData{
+							Data: [][]byte{envBytes},
+						},
+					},
+				},
+			},
+		}
+		ch := make(chan TxEvent, 1)
+		err := DeliverReceive(df, "peer0", "tx1", ch)
+		require.NoError(t, err)
+		event := <-ch
+		require.True(t, event.Committed)
+		require.Equal(t, uint64(11), event.Block)
+		require.Equal(t, 0, event.IndexInBlock)
+	})
+
+	t.Run("DeliverResponse_Block invalid envelope", func(t *testing.T) {
+		t.Parallel()
+		df := &mockDeliverStreamTest{
+			recvResp: &pb.DeliverResponse{
+				Type: &pb.DeliverResponse_Block{
+					Block: &cb.Block{
+						Header: &cb.BlockHeader{Number: 11},
+						Data: &cb.BlockData{
+							Data: [][]byte{[]byte("garbage")},
+						},
+					},
+				},
+			},
+		}
+		ch := make(chan TxEvent, 1)
+		err := DeliverReceive(df, "peer0", "tx1", ch)
+		require.ErrorContains(t, err, "error parsing transaction")
 	})
 }

--- a/platform/fabric/core/generic/delivery/deliverclient_test.go
+++ b/platform/fabric/core/generic/delivery/deliverclient_test.go
@@ -281,21 +281,21 @@ func TestDeliverSend(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
-		stream := &mockDeliverStreamTest{}
+		stream := &mockDeliverStream{}
 		err := DeliverSend(stream, &cb.Envelope{})
 		require.NoError(t, err)
 	})
 
 	t.Run("send fails", func(t *testing.T) {
 		t.Parallel()
-		stream := &mockDeliverStreamTest{sendErr: errors.New("send error")}
+		stream := &mockDeliverStream{sendErr: errors.New("send error")}
 		err := DeliverSend(stream, &cb.Envelope{})
 		require.ErrorContains(t, err, "send error")
 	})
 
 	t.Run("close send fails", func(t *testing.T) {
 		t.Parallel()
-		stream := &mockDeliverStreamTest{closeSendErr: errors.New("close error")}
+		stream := &mockDeliverStream{closeSendErr: errors.New("close error")}
 		err := DeliverSend(stream, &cb.Envelope{})
 		require.NoError(t, err) // DeliverSend returns the Send error, not the CloseSend error, but logs the CloseSend error.
 	})
@@ -306,7 +306,7 @@ func TestDeliverReceive(t *testing.T) {
 
 	t.Run("Recv error", func(t *testing.T) {
 		t.Parallel()
-		df := &mockDeliverStreamTest{recvErr: errors.New("recv error")}
+		df := &mockDeliverStream{recvErr: errors.New("recv error")}
 		ch := make(chan TxEvent, 1)
 		err := DeliverReceive(df, "peer0", "tx1", ch)
 		require.ErrorContains(t, err, "recv error")
@@ -316,7 +316,7 @@ func TestDeliverReceive(t *testing.T) {
 
 	t.Run("FilteredBlock VALID", func(t *testing.T) {
 		t.Parallel()
-		df := &mockDeliverStreamTest{
+		df := &mockDeliverStream{
 			recvResp: &pb.DeliverResponse{
 				Type: &pb.DeliverResponse_FilteredBlock{
 					FilteredBlock: &pb.FilteredBlock{
@@ -339,7 +339,7 @@ func TestDeliverReceive(t *testing.T) {
 
 	t.Run("FilteredBlock INVALID", func(t *testing.T) {
 		t.Parallel()
-		df := &mockDeliverStreamTest{
+		df := &mockDeliverStream{
 			recvResp: &pb.DeliverResponse{
 				Type: &pb.DeliverResponse_FilteredBlock{
 					FilteredBlock: &pb.FilteredBlock{
@@ -358,7 +358,7 @@ func TestDeliverReceive(t *testing.T) {
 
 	t.Run("DeliverResponse_Status", func(t *testing.T) {
 		t.Parallel()
-		df := &mockDeliverStreamTest{
+		df := &mockDeliverStream{
 			recvResp: &pb.DeliverResponse{
 				Type: &pb.DeliverResponse_Status{
 					Status: cb.Status_SUCCESS,
@@ -372,7 +372,7 @@ func TestDeliverReceive(t *testing.T) {
 
 	t.Run("DeliverResponse unexpected", func(t *testing.T) {
 		t.Parallel()
-		df := &mockDeliverStreamTest{
+		df := &mockDeliverStream{
 			recvResp: &pb.DeliverResponse{
 				Type: nil,
 			},
@@ -391,7 +391,7 @@ func TestDeliverReceive(t *testing.T) {
 		env := &cb.Envelope{Payload: payloadBytes}
 		envBytes, _ := proto.Marshal(env)
 
-		df := &mockDeliverStreamTest{
+		df := &mockDeliverStream{
 			recvResp: &pb.DeliverResponse{
 				Type: &pb.DeliverResponse_Block{
 					Block: &cb.Block{
@@ -414,7 +414,7 @@ func TestDeliverReceive(t *testing.T) {
 
 	t.Run("DeliverResponse_Block invalid envelope", func(t *testing.T) {
 		t.Parallel()
-		df := &mockDeliverStreamTest{
+		df := &mockDeliverStream{
 			recvResp: &pb.DeliverResponse{
 				Type: &pb.DeliverResponse_Block{
 					Block: &cb.Block{

--- a/platform/fabric/core/generic/delivery/delivery.go
+++ b/platform/fabric/core/generic/delivery/delivery.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -79,6 +80,7 @@ type Delivery struct {
 	lastBlockReceived   uint64
 	bufferSize          int
 	stop                chan error
+	stopOnce            sync.Once
 }
 
 var ctr = atomic.Uint32{}
@@ -129,11 +131,13 @@ func (d *Delivery) Start(ctx context.Context) {
 }
 
 func (d *Delivery) Stop(err error) {
-	logger.Debugf("stop delivery with error [%v]", err)
-	if err != nil {
-		d.stop <- err
-	}
-	close(d.stop)
+	d.stopOnce.Do(func() {
+		logger.Debugf("stop delivery with error [%v]", err)
+		if err != nil {
+			d.stop <- err
+		}
+		close(d.stop)
+	})
 }
 
 func (d *Delivery) Run(ctx context.Context) error {

--- a/platform/fabric/core/generic/delivery/delivery.go
+++ b/platform/fabric/core/generic/delivery/delivery.go
@@ -32,12 +32,18 @@ import (
 
 var logger = logging.MustGetLogger()
 
+// StartGenesis seeks the oldest block available on the ordering service, i.e.
+// the genesis block. It is the fallback start position whenever the last
+// processed block cannot be determined.
 var StartGenesis = &ab.SeekPosition{
 	Type: &ab.SeekPosition_Oldest{
 		Oldest: &ab.SeekOldest{},
 	},
 }
 
+// blockResponse pairs a block received from the peer's Deliver stream with the
+// tracing context of the span that received it, so that the callback invoked on
+// another goroutine stays attached to the same trace.
 type blockResponse struct {
 	ctx   context.Context
 	block *cb.Block
@@ -60,10 +66,16 @@ type Vault interface {
 	GetLastBlock(context.Context) (uint64, error)
 }
 
+// Services provides the peer clients that Delivery connects through.
 type Services interface {
+	// NewPeerClient returns a client for the peer described by cc.
 	NewPeerClient(cc grpc.ConnectionConfig) (services.PeerClient, error)
 }
 
+// Delivery streams blocks from a Fabric peer's Deliver service and invokes a
+// callback for each one. A Delivery is single-use: once stopped it cannot be
+// restarted, and Run must not be called more than once. Stop may be called
+// concurrently with Run and from any number of goroutines.
 type Delivery struct {
 	channel             string
 	channelConfig       driver.ChannelConfig
@@ -79,12 +91,26 @@ type Delivery struct {
 	tracer              trace.Tracer
 	lastBlockReceived   uint64
 	bufferSize          int
-	stop                chan error
-	stopOnce            sync.Once
+
+	// stop is closed exactly once, by Stop, to signal shutdown to every
+	// goroutine started by Run. It carries no value: untilStop, readBlocks and
+	// runReceiver all read it, so a value sent over it would be observed by
+	// exactly one of them. The cause goes in stopErr instead.
+	stop chan struct{}
+	// stopOnce guards the close of stop.
+	stopOnce sync.Once
+	// stopErr holds the error passed to the first call to Stop, if any. It is
+	// written before stop is closed, so any goroutine that observes the close
+	// also observes the error.
+	stopErr atomic.Pointer[error]
 }
 
 var ctr = atomic.Uint32{}
 
+// New creates a Delivery for the given channel. It fails if channelConfig is
+// nil. bufferSize bounds the queue of blocks awaiting the callback and is
+// raised to 1 if not positive. The returned Delivery is inert until Run or
+// Start is called.
 func New(
 	networkName string,
 	channelConfig driver.ChannelConfig,
@@ -118,28 +144,48 @@ func New(
 		callback:   callback,
 		vault:      vault,
 		bufferSize: max(bufferSize, 1),
-		stop:       make(chan error),
+		stop:       make(chan struct{}),
 	}
 	return d, nil
 }
 
-// Start runs the delivery service in a goroutine
+// Start runs the delivery service in its own goroutine and returns
+// immediately. The error returned by Run is discarded; use Run directly to
+// observe it.
 func (d *Delivery) Start(ctx context.Context) {
 	go utils.IgnoreErrorFunc(func() error {
 		return d.Run(ctx)
 	})
 }
 
+// Stop shuts the delivery service down, reporting err as the cause. A nil err
+// means a clean shutdown. Only the first call has any effect: err from later
+// calls is discarded. Stop never blocks and is safe to call concurrently and
+// after the service has already stopped.
 func (d *Delivery) Stop(err error) {
 	d.stopOnce.Do(func() {
 		logger.Debugf("stop delivery with error [%v]", err)
 		if err != nil {
-			d.stop <- err
+			d.stopErr.Store(&err)
 		}
 		close(d.stop)
 	})
 }
 
+// stopError returns the error passed to the first call to Stop, or nil if the
+// service was stopped cleanly or is still running.
+func (d *Delivery) stopError() error {
+	if err := d.stopErr.Load(); err != nil {
+		return *err
+	}
+	return nil
+}
+
+// Run streams blocks until the service is stopped, either by a call to Stop,
+// by the callback reporting an error or asking to stop, or by ctx being
+// cancelled. It blocks until then and returns the error that caused the
+// shutdown, or nil for a clean stop. A nil ctx is treated as
+// context.Background.
 func (d *Delivery) Run(ctx context.Context) error {
 	logger.Debugf("Running delivery service [%d]", ctr.Add(1))
 	if ctx == nil {
@@ -151,6 +197,9 @@ func (d *Delivery) Run(ctx context.Context) error {
 	return d.untilStop()
 }
 
+// readBlocks invokes the callback for each block arriving on ch until the
+// service is stopped. It stops the service if the callback fails or asks to
+// stop.
 func (d *Delivery) readBlocks(ch <-chan blockResponse) {
 	for {
 		select {
@@ -167,13 +216,17 @@ func (d *Delivery) readBlocks(ch <-chan blockResponse) {
 				d.Stop(nil)
 				return
 			}
-		case err := <-d.stop:
-			logger.Debugf("stopping delivery service with err [%s]", err)
+		case <-d.stop:
+			logger.Debugf("stopping block reader with err [%v]", d.stopError())
 			return
 		}
 	}
 }
 
+// runReceiver maintains the Deliver stream to the peer, reconnecting on
+// failure, and forwards received blocks to ch. It returns once the service is
+// stopped; it stops the service itself when ctx is cancelled. It is a no-op if
+// ctx or ch is nil.
 func (d *Delivery) runReceiver(ctx context.Context, ch chan<- blockResponse) {
 	if ctx == nil || ch == nil {
 		return
@@ -300,14 +353,18 @@ func (d *Delivery) handleBlockResponse(ctx context.Context, span trace.Span, r *
 	return true
 }
 
+// untilStop blocks until the service is stopped and returns the error that
+// caused it, or nil for a clean stop.
 func (d *Delivery) untilStop() error {
-	for err := range d.stop {
-		logger.Debugf("stopping delivery service with error [%s]", err)
-		return err
-	}
-	return nil
+	<-d.stop
+	err := d.stopError()
+	logger.Debugf("stopping delivery service with error [%v]", err)
+	return err
 }
 
+// connect opens a Deliver stream to a peer picked for delivery and sends the
+// seek envelope that positions it at the next block to process. It returns the
+// stream and a cancel function that the caller must invoke to release it.
 func (d *Delivery) connect(ctx context.Context) (DeliverStream, context.CancelFunc, error) {
 	// first cleanup everything
 	d.cleanup()
@@ -352,6 +409,10 @@ func (d *Delivery) connect(ctx context.Context) (DeliverStream, context.CancelFu
 	return stream, cancel, nil
 }
 
+// GetStartPosition returns the position the Deliver stream should be seeked
+// to. It prefers the last block this Delivery received, then the vault's last
+// block, then the block holding the vault's last transaction, and falls back to
+// StartGenesis when none of those can be determined.
 func (d *Delivery) GetStartPosition(ctx context.Context) *ab.SeekPosition {
 	if d.lastBlockReceived != 0 {
 		logger.Debugf("restarting from the last block received [%d]", d.lastBlockReceived)
@@ -394,6 +455,7 @@ func (d *Delivery) GetStartPosition(ctx context.Context) *ab.SeekPosition {
 	return StartGenesis
 }
 
+// SeekPosition returns a seek position for the given block number.
 func SeekPosition(blockNumber uint64) *ab.SeekPosition {
 	return &ab.SeekPosition{
 		Type: &ab.SeekPosition_Specified{
@@ -404,6 +466,7 @@ func SeekPosition(blockNumber uint64) *ab.SeekPosition {
 	}
 }
 
+// cleanup closes the current peer client, if any.
 func (d *Delivery) cleanup() {
 	if d.client != nil {
 		d.client.Close()

--- a/platform/fabric/core/generic/delivery/delivery_test.go
+++ b/platform/fabric/core/generic/delivery/delivery_test.go
@@ -8,6 +8,7 @@ package delivery
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -375,7 +376,7 @@ func TestDeliveryLifecycle(t *testing.T) {
 
 		d := &Delivery{
 			bufferSize:    1,
-			stop:          make(chan error),
+			stop:          make(chan struct{}),
 			tracer:        tracerProvider.Tracer("test"),
 			channelConfig: &mockChannelConfig{},
 			ConfigService: &mockConfigService{peerConf: &grpc.ConnectionConfig{Address: "peer1"}},
@@ -384,21 +385,60 @@ func TestDeliveryLifecycle(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(t.Context())
 		d.Start(ctx)
-
-		go func() {
-			time.Sleep(10 * time.Millisecond) // Give it time to start
-			cancel()
-		}()
+		// Cancelling the context is the only stop signal; runReceiver observes
+		// it on its next loop iteration regardless of how far it got, so no
+		// sleep is needed to make this deterministic.
+		cancel()
 
 		err := d.untilStop()
 		require.ErrorContains(t, err, "context done")
+		// Every reader of stop observes the same error, not just the first.
+		require.ErrorContains(t, d.untilStop(), "context done")
+	})
+
+	t.Run("Stop is idempotent and keeps the first error", func(t *testing.T) {
+		t.Parallel()
+
+		d := &Delivery{stop: make(chan struct{})}
+
+		// Concurrent Stop calls must neither panic on a double close nor block.
+		var wg sync.WaitGroup
+		for i := range 8 {
+			wg.Go(func() {
+				if i == 0 {
+					d.Stop(errors.New("first"))
+					return
+				}
+				d.Stop(errors.Errorf("later %d", i))
+			})
+		}
+		wg.Wait()
+
+		<-d.stop // closed
+		// Whichever call won, the error it reported is the one published, and a
+		// Stop after shutdown must still not block.
+		first := d.stopError()
+		require.Error(t, first)
+		d.Stop(errors.New("after shutdown"))
+		require.Equal(t, first, d.stopError())
+	})
+
+	t.Run("Stop with nil error reports a clean shutdown", func(t *testing.T) {
+		t.Parallel()
+
+		d := &Delivery{stop: make(chan struct{})}
+		d.Stop(nil)
+
+		<-d.stop
+		require.NoError(t, d.stopError())
+		require.NoError(t, d.untilStop())
 	})
 
 	t.Run("readBlocks stops on callback error", func(t *testing.T) {
 		t.Parallel()
 		d := &Delivery{
 			bufferSize: 1,
-			stop:       make(chan error, 1),
+			stop:       make(chan struct{}),
 			callback: func(ctx context.Context, block *cb.Block) (bool, error) {
 				return false, errors.New("callback error")
 			},
@@ -407,15 +447,15 @@ func TestDeliveryLifecycle(t *testing.T) {
 		ch <- blockResponse{block: &cb.Block{Header: &cb.BlockHeader{}}}
 
 		d.readBlocks(ch)
-		err := <-d.stop
-		require.ErrorContains(t, err, "callback error")
+		<-d.stop // readBlocks must have stopped the service
+		require.ErrorContains(t, d.stopError(), "callback error")
 	})
 
 	t.Run("readBlocks stops on stop true", func(t *testing.T) {
 		t.Parallel()
 		d := &Delivery{
 			bufferSize: 1,
-			stop:       make(chan error, 1),
+			stop:       make(chan struct{}),
 			callback: func(ctx context.Context, block *cb.Block) (bool, error) {
 				return true, nil
 			},
@@ -424,15 +464,17 @@ func TestDeliveryLifecycle(t *testing.T) {
 		ch <- blockResponse{block: &cb.Block{Header: &cb.BlockHeader{}}}
 
 		d.readBlocks(ch)
-		err := <-d.stop
-		require.NoError(t, err)
+		<-d.stop // readBlocks must have stopped the service
+		require.NoError(t, d.stopError())
 	})
 }
 
+// TestDeliveryRunNilCtx covers Run substituting context.Background for a nil
+// context instead of panicking.
 func TestDeliveryRunNilCtx(t *testing.T) {
 	t.Parallel()
 	d := &Delivery{
-		stop:          make(chan error, 1),
+		stop:          make(chan struct{}),
 		bufferSize:    1,
 		NetworkName:   "testNet",
 		channel:       "testChannel",
@@ -443,12 +485,14 @@ func TestDeliveryRunNilCtx(t *testing.T) {
 		Services:      &mockServices{err: errors.New("err")},
 	}
 
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		d.stop <- errors.New("done")
-		close(d.stop)
-	}()
-	err := d.Run(context.TODO())
+	// Stop may land before or after Run starts; either way Run must observe the
+	// published error rather than a nil one, so no synchronisation is needed.
+	go d.Stop(errors.New("done"))
+
+	// A literal nil would trip staticcheck's nil-context check, but a nil
+	// context value is exactly what this test exercises.
+	var nilCtx context.Context
+	err := d.Run(nilCtx)
 	require.ErrorContains(t, err, "done")
 }
 
@@ -498,7 +542,7 @@ func TestDeliveryConnect(t *testing.T) {
 			Services: &mockServices{
 				peerClient: &mockPeerClient{
 					deliverCli: &mockDeliverClientRPC{
-						stream: &mockDeliverStreamDelTest{sendErr: errors.New("send error")},
+						stream: &mockDeliverStream{sendErr: errors.New("send error")},
 					},
 				},
 			},
@@ -527,7 +571,7 @@ func TestDeliveryConnect(t *testing.T) {
 			Services: &mockServices{
 				peerClient: &mockPeerClient{
 					deliverCli: &mockDeliverClientRPC{
-						stream: &mockDeliverStreamDelTest{},
+						stream: &mockDeliverStream{},
 					},
 				},
 			},
@@ -557,7 +601,7 @@ func TestRunReceiver(t *testing.T) {
 		t.Parallel()
 		d := &Delivery{
 			tracer:        tracerProvider.Tracer("test"),
-			stop:          make(chan error, 1),
+			stop:          make(chan struct{}),
 			ConfigService: &mockConfigService{peerConf: &grpc.ConnectionConfig{Address: "peer1"}},
 			Services:      &mockServices{err: errors.New("err")},
 			channelConfig: &mockChannelConfig{},
@@ -568,9 +612,11 @@ func TestRunReceiver(t *testing.T) {
 		ch := make(chan blockResponse, 1)
 
 		d.runReceiver(ctx, ch)
-		// Should exit quickly
-		// it might consume the context done error itself and leave the channel empty/closed
+
+		// runReceiver must have stopped the service before returning, and the
+		// reason must survive for every other reader of stop.
 		<-d.stop
+		require.ErrorContains(t, d.stopError(), "context done")
 	})
 
 	t.Run("nil ctx", func(t *testing.T) {
@@ -597,7 +643,7 @@ func TestRunReceiverResponses(t *testing.T) {
 		Services: &mockServices{
 			peerClient: &mockPeerClient{
 				deliverCli: &mockDeliverClientRPC{
-					stream: &mockDeliverStreamDelTest{
+					stream: &mockDeliverStream{
 						recvChan:    recvChan,
 						recvErrChan: recvErrChan,
 						readChan:    readChan,
@@ -615,7 +661,7 @@ func TestRunReceiverResponses(t *testing.T) {
 		channelConfig: &mockChannelConfig{},
 		tracer:        noop.NewTracerProvider().Tracer("test"),
 		client:        &mockPeerClient{},
-		stop:          make(chan error, 1),
+		stop:          make(chan struct{}),
 	}
 	d.Ledger = &mockLedger{blockNumber: 10}
 
@@ -658,4 +704,79 @@ func TestRunReceiverResponses(t *testing.T) {
 	close(recvChan)
 	cancel()
 	<-done
+}
+
+// TestRunReceiverReconnects covers the recovery paths runReceiver takes without
+// ever leaving the loop: a failed connection attempt, a malformed block that
+// forces the stream to be torn down and re-established, and a response type it
+// does not handle. Each step is driven to completion and observed, so nothing
+// here depends on timing.
+func TestRunReceiverReconnects(t *testing.T) {
+	t.Parallel()
+
+	recvChan := make(chan *pb.DeliverResponse, 2)
+	readChan := make(chan struct{}, 4)
+	attempts := make(chan struct{}, 8)
+
+	svcs := &mockFlakyServices{
+		peerClient: &mockPeerClient{
+			deliverCli: &mockDeliverClientRPC{
+				stream: &mockDeliverStream{recvChan: recvChan, readChan: readChan},
+			},
+		},
+		attempts: attempts,
+	}
+	svcs.failures.Store(1) // refuse the first attempt, then serve
+
+	d := &Delivery{
+		NetworkName:     "testNet",
+		channel:         "testChannel",
+		stop:            make(chan struct{}),
+		bufferSize:      1,
+		tracer:          noop.NewTracerProvider().Tracer("test"),
+		channelConfig:   &mockChannelConfig{},
+		ConfigService:   &mockConfigService{peerConf: &grpc.ConnectionConfig{Address: "peer1"}},
+		Services:        svcs,
+		LocalMembership: &mockLocalMembership{id: &mockSigningIdentity{}},
+		vault:           &mockVault{},
+		Ledger:          &mockLedger{blockNumber: 10},
+		client:          &mockPeerClient{},
+	}
+
+	// A block missing its header is malformed: handleBlockResponse rejects it and
+	// runReceiver drops the stream and reconnects rather than forwarding it.
+	recvChan <- &pb.DeliverResponse{Type: &pb.DeliverResponse_Block{Block: &cb.Block{
+		Data:     &cb.BlockData{},
+		Metadata: &cb.BlockMetadata{},
+	}}}
+	// A filtered block is not something this receiver asked for, so it falls to
+	// the unhandled-response branch.
+	recvChan <- &pb.DeliverResponse{Type: &pb.DeliverResponse_FilteredBlock{
+		FilteredBlock: &pb.FilteredBlock{Number: 11},
+	}}
+
+	ch := make(chan blockResponse, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.runReceiver(t.Context(), ch)
+	}()
+
+	// Both responses must be consumed, which means the first attempt was
+	// refused, the second connected, and the malformed block forced a third.
+	for range 2 {
+		select {
+		case <-readChan:
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for the receiver to consume a response")
+		}
+	}
+
+	close(recvChan)
+	d.Stop(nil)
+	<-done
+
+	require.NoError(t, d.stopError())
+	require.GreaterOrEqual(t, len(attempts), 3, "expected a refused attempt plus a reconnect after the malformed block")
+	require.Empty(t, ch, "neither a malformed block nor a filtered block may be forwarded")
 }

--- a/platform/fabric/core/generic/delivery/delivery_test.go
+++ b/platform/fabric/core/generic/delivery/delivery_test.go
@@ -8,7 +8,6 @@ package delivery
 
 import (
 	"context"
-	"crypto/tls"
 	"testing"
 	"time"
 
@@ -20,22 +19,9 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/services"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
 )
-
-// stubPeerClient implements services.PeerClient with just enough behavior
-// (Address) to satisfy the logging calls inside handleBlockResponse.
-type stubPeerClient struct{}
-
-func (stubPeerClient) Address() string                            { return "peer0" }
-func (stubPeerClient) Certificate() tls.Certificate               { return tls.Certificate{} }
-func (stubPeerClient) Close()                                     {}
-func (stubPeerClient) EndorserClient() (pb.EndorserClient, error) { return nil, nil }
-func (stubPeerClient) DiscoveryClient() (services.DiscoveryClient, error) {
-	return nil, nil
-}
-func (stubPeerClient) DeliverClient() (pb.DeliverClient, error) { return nil, nil }
 
 // mockVault implements Vault for testing
 type mockVault struct {
@@ -312,7 +298,7 @@ func TestHandleBlockResponse(t *testing.T) {
 
 	t.Run("nil block is rejected, not dereferenced", func(t *testing.T) {
 		t.Parallel()
-		d := &Delivery{client: stubPeerClient{}}
+		d := &Delivery{client: &mockPeerClient{}}
 		ch := make(chan blockResponse, 1)
 		ok := d.handleBlockResponse(t.Context(), newSpan(t), &pb.DeliverResponse_Block{Block: nil}, ch, time.Millisecond)
 		require.False(t, ok)
@@ -321,7 +307,7 @@ func TestHandleBlockResponse(t *testing.T) {
 
 	t.Run("block with nil header is rejected, not dereferenced", func(t *testing.T) {
 		t.Parallel()
-		d := &Delivery{client: stubPeerClient{}}
+		d := &Delivery{client: &mockPeerClient{}}
 		ch := make(chan blockResponse, 1)
 		malformed := &cb.Block{
 			Data:     &cb.BlockData{},
@@ -335,7 +321,7 @@ func TestHandleBlockResponse(t *testing.T) {
 
 	t.Run("block with nil data is rejected, not dereferenced", func(t *testing.T) {
 		t.Parallel()
-		d := &Delivery{client: stubPeerClient{}}
+		d := &Delivery{client: &mockPeerClient{}}
 		ch := make(chan blockResponse, 1)
 		malformed := &cb.Block{
 			Data:     nil,
@@ -349,7 +335,7 @@ func TestHandleBlockResponse(t *testing.T) {
 
 	t.Run("block with nil metadata is rejected, not dereferenced", func(t *testing.T) {
 		t.Parallel()
-		d := &Delivery{client: stubPeerClient{}}
+		d := &Delivery{client: &mockPeerClient{}}
 		ch := make(chan blockResponse, 1)
 		malformed := &cb.Block{
 			Data:     &cb.BlockData{},
@@ -363,7 +349,7 @@ func TestHandleBlockResponse(t *testing.T) {
 
 	t.Run("well-formed block is pushed to channel", func(t *testing.T) {
 		t.Parallel()
-		d := &Delivery{client: stubPeerClient{}}
+		d := &Delivery{client: &mockPeerClient{}}
 		ch := make(chan blockResponse, 1)
 		good := &cb.Block{
 			Data:     &cb.BlockData{},
@@ -377,4 +363,299 @@ func TestHandleBlockResponse(t *testing.T) {
 		require.Equal(t, uint64(42), received.block.Header.Number)
 		require.Equal(t, uint64(42), d.lastBlockReceived)
 	})
+}
+
+func TestDeliveryLifecycle(t *testing.T) {
+	t.Parallel()
+
+	tracerProvider := noop.NewTracerProvider()
+
+	t.Run("Start, Stop, and Run", func(t *testing.T) {
+		t.Parallel()
+
+		d := &Delivery{
+			bufferSize:    1,
+			stop:          make(chan error),
+			tracer:        tracerProvider.Tracer("test"),
+			channelConfig: &mockChannelConfig{},
+			ConfigService: &mockConfigService{peerConf: &grpc.ConnectionConfig{Address: "peer1"}},
+			Services:      &mockServices{err: errors.New("err")},
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		d.Start(ctx)
+
+		go func() {
+			time.Sleep(10 * time.Millisecond) // Give it time to start
+			cancel()
+		}()
+
+		err := d.untilStop()
+		require.ErrorContains(t, err, "context done")
+	})
+
+	t.Run("readBlocks stops on callback error", func(t *testing.T) {
+		t.Parallel()
+		d := &Delivery{
+			bufferSize: 1,
+			stop:       make(chan error, 1),
+			callback: func(ctx context.Context, block *cb.Block) (bool, error) {
+				return false, errors.New("callback error")
+			},
+		}
+		ch := make(chan blockResponse, 1)
+		ch <- blockResponse{block: &cb.Block{Header: &cb.BlockHeader{}}}
+
+		d.readBlocks(ch)
+		err := <-d.stop
+		require.ErrorContains(t, err, "callback error")
+	})
+
+	t.Run("readBlocks stops on stop true", func(t *testing.T) {
+		t.Parallel()
+		d := &Delivery{
+			bufferSize: 1,
+			stop:       make(chan error, 1),
+			callback: func(ctx context.Context, block *cb.Block) (bool, error) {
+				return true, nil
+			},
+		}
+		ch := make(chan blockResponse, 1)
+		ch <- blockResponse{block: &cb.Block{Header: &cb.BlockHeader{}}}
+
+		d.readBlocks(ch)
+		err := <-d.stop
+		require.NoError(t, err)
+	})
+}
+
+func TestDeliveryRunNilCtx(t *testing.T) {
+	t.Parallel()
+	d := &Delivery{
+		stop:          make(chan error, 1),
+		bufferSize:    1,
+		NetworkName:   "testNet",
+		channel:       "testChannel",
+		client:        &mockPeerClient{},
+		tracer:        noop.NewTracerProvider().Tracer("test"),
+		channelConfig: &mockChannelConfig{},
+		ConfigService: &mockConfigService{peerConf: &grpc.ConnectionConfig{Address: "peer1"}},
+		Services:      &mockServices{err: errors.New("err")},
+	}
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		d.stop <- errors.New("done")
+		close(d.stop)
+	}()
+	err := d.Run(context.TODO())
+	require.ErrorContains(t, err, "done")
+}
+
+func TestDeliveryConnect(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NewPeerClient fails", func(t *testing.T) {
+		t.Parallel()
+		d := &Delivery{
+			ConfigService: &mockConfigService{peerConf: &grpc.ConnectionConfig{Address: "peer1"}},
+			Services:      &mockServices{err: errors.New("peer client error")},
+			NetworkName:   "testNet",
+			channel:       "testChannel",
+		}
+
+		stream, cancel, err := d.connect(t.Context())
+		require.ErrorContains(t, err, "failed creating peer client")
+		require.Nil(t, stream)
+		require.Nil(t, cancel)
+	})
+
+	t.Run("NewDeliverClient succeeds but NewDeliver fails", func(t *testing.T) {
+		t.Parallel()
+		d := &Delivery{
+			ConfigService: &mockConfigService{peerConf: &grpc.ConnectionConfig{Address: "peer1"}},
+			Services: &mockServices{
+				peerClient: &mockPeerClient{
+					deliverErr: errors.New("deliver err"),
+				},
+			},
+			NetworkName: "testNet",
+			channel:     "testChannel",
+		}
+
+		stream, cancel, err := d.connect(t.Context())
+		require.ErrorContains(t, err, "failed to get delivery stream")
+		require.Nil(t, stream)
+		if cancel != nil {
+			cancel() // though usually cancel is called inside connect when error happens
+		}
+	})
+
+	t.Run("DeliverSend fails", func(t *testing.T) {
+		t.Parallel()
+		d := &Delivery{
+			ConfigService: &mockConfigService{peerConf: &grpc.ConnectionConfig{Address: "peer1"}},
+			Services: &mockServices{
+				peerClient: &mockPeerClient{
+					deliverCli: &mockDeliverClientRPC{
+						stream: &mockDeliverStreamDelTest{sendErr: errors.New("send error")},
+					},
+				},
+			},
+			LocalMembership: &mockLocalMembership{
+				id: &mockSigningIdentity{},
+			},
+			vault:       &mockVault{},
+			NetworkName: "testNet",
+			channel:     "testChannel",
+		}
+
+		d.Ledger = &mockLedger{blockNumber: 10}
+
+		stream, cancel, err := d.connect(t.Context())
+		require.ErrorContains(t, err, "failed sending seek envelope")
+		require.Nil(t, stream)
+		if cancel != nil {
+			cancel()
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		d := &Delivery{
+			ConfigService: &mockConfigService{peerConf: &grpc.ConnectionConfig{Address: "peer1"}},
+			Services: &mockServices{
+				peerClient: &mockPeerClient{
+					deliverCli: &mockDeliverClientRPC{
+						stream: &mockDeliverStreamDelTest{},
+					},
+				},
+			},
+			LocalMembership: &mockLocalMembership{
+				id: &mockSigningIdentity{},
+			},
+			vault:       &mockVault{},
+			NetworkName: "testNet",
+			channel:     "testChannel",
+		}
+		d.Ledger = &mockLedger{blockNumber: 10}
+
+		stream, cancel, err := d.connect(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, stream)
+		if cancel != nil {
+			cancel()
+		}
+	})
+}
+
+func TestRunReceiver(t *testing.T) {
+	t.Parallel()
+	tracerProvider := noop.NewTracerProvider()
+
+	t.Run("context already done", func(t *testing.T) {
+		t.Parallel()
+		d := &Delivery{
+			tracer:        tracerProvider.Tracer("test"),
+			stop:          make(chan error, 1),
+			ConfigService: &mockConfigService{peerConf: &grpc.ConnectionConfig{Address: "peer1"}},
+			Services:      &mockServices{err: errors.New("err")},
+			channelConfig: &mockChannelConfig{},
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel() // already done
+		ch := make(chan blockResponse, 1)
+
+		d.runReceiver(ctx, ch)
+		// Should exit quickly
+		// it might consume the context done error itself and leave the channel empty/closed
+		<-d.stop
+	})
+
+	t.Run("nil ctx", func(t *testing.T) {
+		t.Parallel()
+		d := &Delivery{
+			NetworkName: "testNet",
+			channel:     "testChannel",
+			client:      &mockPeerClient{},
+		}
+		require.NotPanics(t, func() {
+			d.runReceiver(context.TODO(), nil)
+		})
+	})
+}
+
+func TestRunReceiverResponses(t *testing.T) {
+	t.Parallel()
+	recvChan := make(chan *pb.DeliverResponse, 5)
+	recvErrChan := make(chan error, 5)
+	readChan := make(chan struct{}, 5)
+
+	d := &Delivery{
+		ConfigService: &mockConfigService{peerConf: &grpc.ConnectionConfig{Address: "peer1"}},
+		Services: &mockServices{
+			peerClient: &mockPeerClient{
+				deliverCli: &mockDeliverClientRPC{
+					stream: &mockDeliverStreamDelTest{
+						recvChan:    recvChan,
+						recvErrChan: recvErrChan,
+						readChan:    readChan,
+					},
+				},
+			},
+		},
+		LocalMembership: &mockLocalMembership{
+			id: &mockSigningIdentity{},
+		},
+		vault:         &mockVault{},
+		NetworkName:   "testNet",
+		channel:       "testChannel",
+		callback:      func(ctx context.Context, block *cb.Block) (bool, error) { return false, nil },
+		channelConfig: &mockChannelConfig{},
+		tracer:        noop.NewTracerProvider().Tracer("test"),
+		client:        &mockPeerClient{},
+		stop:          make(chan error, 1),
+	}
+	d.Ledger = &mockLedger{blockNumber: 10}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	ch := make(chan blockResponse, 5)
+
+	recvChan <- &pb.DeliverResponse{Type: &pb.DeliverResponse_Status{Status: cb.Status_SUCCESS}}
+	recvChan <- &pb.DeliverResponse{Type: &pb.DeliverResponse_Status{Status: cb.Status_NOT_FOUND}}
+	recvChan <- &pb.DeliverResponse{Type: &pb.DeliverResponse_Block{Block: &cb.Block{
+		Header:   &cb.BlockHeader{Number: 10},
+		Data:     &cb.BlockData{},
+		Metadata: &cb.BlockMetadata{Metadata: [][]byte{nil, nil, nil}},
+	}}}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.runReceiver(ctx, ch)
+	}()
+
+	// wait for 3 messages to be read
+	for range 3 {
+		select {
+		case <-readChan:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout")
+		}
+	}
+
+	// Wait for the block to be processed and sent to ch (only Block gets sent to ch)
+	select {
+	case resp := <-ch:
+		require.Equal(t, uint64(10), resp.block.Header.Number)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	close(recvChan)
+	cancel()
+	<-done
 }

--- a/platform/fabric/core/generic/delivery/helpers_test.go
+++ b/platform/fabric/core/generic/delivery/helpers_test.go
@@ -9,7 +9,7 @@ package delivery
 import (
 	"context"
 	"crypto/tls"
-	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -20,6 +20,7 @@ import (
 	googlegrpc "google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/services"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
@@ -40,7 +41,17 @@ func (m *mockPeerClient) Certificate() tls.Certificate                       { r
 func (m *mockPeerClient) Close()                                             {}
 func (m *mockPeerClient) EndorserClient() (pb.EndorserClient, error)         { return nil, nil }
 func (m *mockPeerClient) DiscoveryClient() (services.DiscoveryClient, error) { return nil, nil }
-func (m *mockPeerClient) DeliverClient() (pb.DeliverClient, error)           { return m.deliverCli, m.deliverErr }
+
+// DeliverClient never returns a nil client with a nil error: a real peer client
+// cannot do that, and NewDeliver would dereference the nil interface and take
+// the whole test binary down with it. Tests that reach connect without
+// configuring a deliver client get a clean failure instead.
+func (m *mockPeerClient) DeliverClient() (pb.DeliverClient, error) {
+	if m.deliverCli == nil && m.deliverErr == nil {
+		return nil, errors.New("mockPeerClient: no deliver client configured")
+	}
+	return m.deliverCli, m.deliverErr
+}
 
 type mockDeliverClientRPC struct {
 	stream      pb.Deliver_DeliverClient
@@ -61,12 +72,10 @@ func (m *mockDeliverClientRPC) DeliverWithPrivateData(_ context.Context, _ ...go
 	return nil, nil
 }
 
+// mockDeliverFiltered stands in for a filtered Deliver stream. Tests only ever
+// use it as an opaque non-nil value, so the embedded interface is never called.
 type mockDeliverFiltered struct {
 	pb.Deliver_DeliverFilteredClient
-}
-
-type mockDeliverStream struct {
-	pb.Deliver_DeliverClient
 }
 
 // --- Identity mock ---
@@ -90,32 +99,39 @@ func (m *mockSigningIdentity) Sign(msg []byte) ([]byte, error) {
 	return []byte("signature"), nil
 }
 
-// --- Simple deliver stream mock (single response, for DeliverSend/Receive tests) ---
+// mockDeliverStream is a DeliverStream whose Recv works in one of two modes.
+//
+// Static mode (recvResp and/or recvErr set) returns the same result on every
+// call, which suits the single-exchange DeliverSend/DeliverReceive tests.
+// Scripted mode (recvChan set) serves queued responses in order, which suits
+// the multi-step runReceiver and Scan tests; recvErrChan injects a transport
+// error ahead of the queue, and readChan, if set, receives one value per
+// response actually delivered so a test can wait for progress instead of
+// sleeping.
+//
+// It embeds pb.Deliver_DeliverClient so it can also be assigned where a gRPC
+// stream is expected. The embedded interface is nil, so calling any method
+// beyond Send, Recv and CloseSend panics — no test does.
+type mockDeliverStream struct {
+	pb.Deliver_DeliverClient
 
-type mockDeliverStreamTest struct {
 	sendErr      error
 	closeSendErr error
-	recvErr      error
-	recvResp     *pb.DeliverResponse
-}
 
-func (m *mockDeliverStreamTest) Send(*cb.Envelope) error            { return m.sendErr }
-func (m *mockDeliverStreamTest) Recv() (*pb.DeliverResponse, error) { return m.recvResp, m.recvErr }
-func (m *mockDeliverStreamTest) CloseSend() error                   { return m.closeSendErr }
+	// static mode
+	recvResp *pb.DeliverResponse
+	recvErr  error
 
-// --- Channel-based deliver stream mock (for multi-step scenarios) ---
-
-type mockDeliverStreamDelTest struct {
-	pb.Deliver_DeliverClient
-	sendErr     error
+	// scripted mode
 	recvChan    chan *pb.DeliverResponse
 	recvErrChan chan error
 	readChan    chan struct{}
 }
 
-func (m *mockDeliverStreamDelTest) Send(*cb.Envelope) error { return m.sendErr }
-func (m *mockDeliverStreamDelTest) CloseSend() error        { return nil }
-func (m *mockDeliverStreamDelTest) Recv() (*pb.DeliverResponse, error) {
+func (m *mockDeliverStream) Send(*cb.Envelope) error { return m.sendErr }
+func (m *mockDeliverStream) CloseSend() error        { return m.closeSendErr }
+
+func (m *mockDeliverStream) Recv() (*pb.DeliverResponse, error) {
 	if m.recvErrChan != nil {
 		select {
 		case err := <-m.recvErrChan:
@@ -125,17 +141,26 @@ func (m *mockDeliverStreamDelTest) Recv() (*pb.DeliverResponse, error) {
 		default:
 		}
 	}
+
 	if m.recvChan != nil {
 		resp, ok := <-m.recvChan
-		if m.readChan != nil {
-			m.readChan <- struct{}{}
-		}
 		if !ok {
 			return nil, errors.New("closed")
 		}
+		// Signal only for responses actually delivered. Signalling on a closed
+		// recvChan too would let a caller that spins on the resulting error
+		// fill readChan and then block here forever, hanging the test that is
+		// waiting for the caller to return.
+		if m.readChan != nil {
+			m.readChan <- struct{}{}
+		}
 		return resp, nil
 	}
-	return nil, errors.New("not implemented")
+
+	if m.recvResp != nil || m.recvErr != nil {
+		return m.recvResp, m.recvErr
+	}
+	return nil, errors.New("mockDeliverStream: Recv not configured")
 }
 
 // --- Infrastructure mocks ---
@@ -156,6 +181,29 @@ type mockServices struct {
 
 func (m *mockServices) NewPeerClient(grpc.ConnectionConfig) (services.PeerClient, error) {
 	return m.peerClient, m.err
+}
+
+// mockFlakyServices refuses the first failures calls to NewPeerClient and then
+// hands out peerClient, so a test can drive the reconnect path. Every attempt is
+// announced on attempts, if set, so a test can wait for progress instead of
+// sleeping.
+type mockFlakyServices struct {
+	peerClient services.PeerClient
+	failures   atomic.Int32
+	attempts   chan struct{}
+}
+
+func (m *mockFlakyServices) NewPeerClient(grpc.ConnectionConfig) (services.PeerClient, error) {
+	if m.attempts != nil {
+		select {
+		case m.attempts <- struct{}{}:
+		default: // a test that stopped counting must not wedge the receiver
+		}
+	}
+	if m.failures.Add(-1) >= 0 {
+		return nil, errors.New("mockFlakyServices: connection refused")
+	}
+	return m.peerClient, nil
 }
 
 type mockLocalMembership struct {
@@ -263,7 +311,7 @@ func newTestService(t *testing.T, opts testServiceOpts) *Service {
 	case opts.recvChan != nil:
 		pc = &mockPeerClient{
 			deliverCli: &mockDeliverClientRPC{
-				stream: &mockDeliverStreamDelTest{
+				stream: &mockDeliverStream{
 					recvChan: opts.recvChan,
 					readChan: opts.readChan,
 				},

--- a/platform/fabric/core/generic/delivery/mocks_test.go
+++ b/platform/fabric/core/generic/delivery/mocks_test.go
@@ -1,0 +1,310 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package delivery
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"testing"
+	"time"
+
+	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+	pb "github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	googlegrpc "google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/services"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+)
+
+// --- Peer and deliver client mocks ---
+
+type mockPeerClient struct {
+	addr       string
+	deliverCli pb.DeliverClient
+	deliverErr error
+	cert       tls.Certificate
+}
+
+func (m *mockPeerClient) Address() string                                    { return m.addr }
+func (m *mockPeerClient) Certificate() tls.Certificate                       { return m.cert }
+func (m *mockPeerClient) Close()                                             {}
+func (m *mockPeerClient) EndorserClient() (pb.EndorserClient, error)         { return nil, nil }
+func (m *mockPeerClient) DiscoveryClient() (services.DiscoveryClient, error) { return nil, nil }
+func (m *mockPeerClient) DeliverClient() (pb.DeliverClient, error)           { return m.deliverCli, m.deliverErr }
+
+type mockDeliverClientRPC struct {
+	stream      pb.Deliver_DeliverClient
+	streamErr   error
+	filtered    pb.Deliver_DeliverFilteredClient
+	filteredErr error
+}
+
+func (m *mockDeliverClientRPC) Deliver(_ context.Context, _ ...googlegrpc.CallOption) (pb.Deliver_DeliverClient, error) {
+	return m.stream, m.streamErr
+}
+
+func (m *mockDeliverClientRPC) DeliverFiltered(_ context.Context, _ ...googlegrpc.CallOption) (pb.Deliver_DeliverFilteredClient, error) {
+	return m.filtered, m.filteredErr
+}
+
+func (m *mockDeliverClientRPC) DeliverWithPrivateData(_ context.Context, _ ...googlegrpc.CallOption) (pb.Deliver_DeliverWithPrivateDataClient, error) {
+	return nil, nil
+}
+
+type mockDeliverFiltered struct {
+	pb.Deliver_DeliverFilteredClient
+}
+
+type mockDeliverStream struct {
+	pb.Deliver_DeliverClient
+}
+
+// --- Identity mock ---
+
+type mockSigningIdentity struct {
+	serializeErr error
+	signErr      error
+}
+
+func (m *mockSigningIdentity) Serialize() ([]byte, error) {
+	if m.serializeErr != nil {
+		return nil, m.serializeErr
+	}
+	return []byte("serialized"), nil
+}
+
+func (m *mockSigningIdentity) Sign(msg []byte) ([]byte, error) {
+	if m.signErr != nil {
+		return nil, m.signErr
+	}
+	return []byte("signature"), nil
+}
+
+// --- Simple deliver stream mock (single response, for DeliverSend/Receive tests) ---
+
+type mockDeliverStreamTest struct {
+	sendErr      error
+	closeSendErr error
+	recvErr      error
+	recvResp     *pb.DeliverResponse
+}
+
+func (m *mockDeliverStreamTest) Send(*cb.Envelope) error            { return m.sendErr }
+func (m *mockDeliverStreamTest) Recv() (*pb.DeliverResponse, error) { return m.recvResp, m.recvErr }
+func (m *mockDeliverStreamTest) CloseSend() error                   { return m.closeSendErr }
+
+// --- Channel-based deliver stream mock (for multi-step scenarios) ---
+
+type mockDeliverStreamDelTest struct {
+	pb.Deliver_DeliverClient
+	sendErr     error
+	recvChan    chan *pb.DeliverResponse
+	recvErrChan chan error
+	readChan    chan struct{}
+}
+
+func (m *mockDeliverStreamDelTest) Send(*cb.Envelope) error { return m.sendErr }
+func (m *mockDeliverStreamDelTest) CloseSend() error        { return nil }
+func (m *mockDeliverStreamDelTest) Recv() (*pb.DeliverResponse, error) {
+	if m.recvErrChan != nil {
+		select {
+		case err := <-m.recvErrChan:
+			if err != nil {
+				return nil, err
+			}
+		default:
+		}
+	}
+	if m.recvChan != nil {
+		resp, ok := <-m.recvChan
+		if m.readChan != nil {
+			m.readChan <- struct{}{}
+		}
+		if !ok {
+			return nil, errors.New("closed")
+		}
+		return resp, nil
+	}
+	return nil, errors.New("not implemented")
+}
+
+// --- Infrastructure mocks ---
+
+type mockConfigService struct {
+	driver.ConfigService
+	peerConf *grpc.ConnectionConfig
+}
+
+func (m *mockConfigService) PickPeer(driver.PeerFunctionType) *grpc.ConnectionConfig {
+	return m.peerConf
+}
+
+type mockServices struct {
+	peerClient services.PeerClient
+	err        error
+}
+
+func (m *mockServices) NewPeerClient(grpc.ConnectionConfig) (services.PeerClient, error) {
+	return m.peerClient, m.err
+}
+
+type mockLocalMembership struct {
+	driver.LocalMembership
+	id driver.SigningIdentity
+}
+
+func (m *mockLocalMembership) DefaultSigningIdentity() driver.SigningIdentity {
+	return m.id
+}
+
+type mockChannelConfig struct {
+	driver.ChannelConfig
+}
+
+func (m *mockChannelConfig) DeliverySleepAfterFailure() time.Duration { return 10 * time.Millisecond }
+
+func (m *mockChannelConfig) CommitterWaitForEventTimeout() time.Duration {
+	return 10 * time.Millisecond
+}
+func (m *mockChannelConfig) DeliveryBufferSize() int { return 1 }
+func (m *mockChannelConfig) ID() string              { return "testChannel" }
+
+// --- Transaction mocks ---
+
+type mockTransactionManager struct {
+	ptx driver.ProcessedTransaction
+	err error
+}
+
+func (m *mockTransactionManager) ComputeTxID(*driver.TxIDComponents) string { return "" }
+func (m *mockTransactionManager) NewEnvelope() driver.Envelope              { return nil }
+func (m *mockTransactionManager) NewProposalResponseFromBytes([]byte) (driver.ProposalResponse, error) {
+	return nil, nil
+}
+
+func (m *mockTransactionManager) NewTransaction(context.Context, driver.TransactionType, view.Identity, []byte, string, string, []byte) (driver.Transaction, error) {
+	return nil, nil
+}
+
+func (m *mockTransactionManager) NewTransactionFromBytes(context.Context, string, []byte) (driver.Transaction, error) {
+	return nil, nil
+}
+
+func (m *mockTransactionManager) NewTransactionFromEnvelopeBytes(context.Context, string, []byte) (driver.Transaction, error) {
+	return nil, nil
+}
+
+func (m *mockTransactionManager) AddTransactionFactory(driver.TransactionType, driver.TransactionFactory) {
+}
+
+func (m *mockTransactionManager) NewProcessedTransactionFromEnvelopePayload([]byte) (driver.ProcessedTransaction, int32, error) {
+	return nil, 0, nil
+}
+
+func (m *mockTransactionManager) NewProcessedTransaction([]byte) (driver.ProcessedTransaction, error) {
+	return nil, nil
+}
+
+func (m *mockTransactionManager) NewProcessedTransactionFromEnvelopeRaw([]byte) (driver.ProcessedTransaction, error) {
+	return m.ptx, m.err
+}
+
+type mockProcessedTx struct {
+	txID    string
+	results []byte
+	env     []byte
+}
+
+func (m *mockProcessedTx) TxID() string          { return m.txID }
+func (m *mockProcessedTx) Results() []byte       { return m.results }
+func (m *mockProcessedTx) Envelope() []byte      { return m.env }
+func (m *mockProcessedTx) ValidationCode() int32 { return 0 }
+func (m *mockProcessedTx) IsValid() bool         { return true }
+
+// --- Test helpers ---
+
+// testServiceOpts configures newTestService. Zero values yield sensible defaults.
+type testServiceOpts struct {
+	recvChan   chan *pb.DeliverResponse
+	readChan   chan struct{}
+	deliverErr error
+	txMgr      *mockTransactionManager
+	ledger     *mockLedger
+}
+
+// newTestService creates a *Service with sensible defaults, failing the test on error.
+func newTestService(t *testing.T, opts testServiceOpts) *Service {
+	t.Helper()
+
+	txMgr := opts.txMgr
+	if txMgr == nil {
+		txMgr = &mockTransactionManager{ptx: &mockProcessedTx{txID: "tx2"}}
+	}
+
+	ledger := opts.ledger
+	if ledger == nil {
+		ledger = &mockLedger{blockNumber: 10}
+	}
+
+	var pc *mockPeerClient
+	switch {
+	case opts.deliverErr != nil:
+		pc = &mockPeerClient{deliverErr: opts.deliverErr}
+	case opts.recvChan != nil:
+		pc = &mockPeerClient{
+			deliverCli: &mockDeliverClientRPC{
+				stream: &mockDeliverStreamDelTest{
+					recvChan: opts.recvChan,
+					readChan: opts.readChan,
+				},
+			},
+		}
+	default:
+		pc = &mockPeerClient{}
+	}
+
+	svc, err := NewService(
+		"testChannel",
+		&mockChannelConfig{},
+		"testNet",
+		&mockLocalMembership{id: &mockSigningIdentity{}},
+		&mockConfigService{peerConf: &grpc.ConnectionConfig{Address: "peer1"}},
+		&mockServices{peerClient: pc},
+		ledger,
+		&mockVault{},
+		txMgr,
+		nil,
+		noop.NewTracerProvider(),
+		nil,
+		[]cb.HeaderType{cb.HeaderType_ENDORSER_TRANSACTION},
+	)
+	require.NoError(t, err)
+	return svc
+}
+
+// newValidEnvelopeBytes builds a protobuf-encoded Envelope with the given header type and txID.
+func newValidEnvelopeBytes(t *testing.T, headerType cb.HeaderType, txID string) []byte {
+	t.Helper()
+	channelHeaderBytes, err := proto.Marshal(&cb.ChannelHeader{
+		Type: int32(headerType),
+		TxId: txID,
+	})
+	require.NoError(t, err)
+	payloadBytes, err := proto.Marshal(&cb.Payload{
+		Header: &cb.Header{ChannelHeader: channelHeaderBytes},
+	})
+	require.NoError(t, err)
+	envBytes, err := proto.Marshal(&cb.Envelope{Payload: payloadBytes})
+	require.NoError(t, err)
+	return envBytes
+}

--- a/platform/fabric/core/generic/delivery/service.go
+++ b/platform/fabric/core/generic/delivery/service.go
@@ -71,6 +71,10 @@ func NewService(
 	metricsProvider metrics.Provider,
 	acceptedHeaderTypes []common.HeaderType,
 ) (*Service, error) {
+	if channelConfig == nil {
+		return nil, errors.New("expected channelConfig, got nil")
+	}
+
 	deliveryService, err := New(
 		networkName,
 		channelConfig,

--- a/platform/fabric/core/generic/delivery/service.go
+++ b/platform/fabric/core/generic/delivery/service.go
@@ -21,6 +21,9 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/tracing"
 )
 
+// ValidationFlags is the per-transaction validation code vector carried in a
+// block's TRANSACTIONS_FILTER metadata entry, one entry per transaction in
+// block.Data.Data.
 type ValidationFlags []uint8
 
 // validationCodeAt safely returns the validation code for the transaction at
@@ -40,6 +43,10 @@ func validationCodeAt(block *common.Block, i int) (uint8, error) {
 	return flags[i], nil
 }
 
+// Service is the channel-scoped entry point to the peer's Deliver service. It
+// owns a long-running Delivery, started by Start, that feeds the committer, and
+// it also serves one-off historical scans (ScanBlock, Scan and friends), each of
+// which runs on its own short-lived Delivery.
 type Service struct {
 	channel             string
 	channelConfig       driver.ChannelConfig
@@ -56,6 +63,10 @@ type Service struct {
 	deliveryService     *Delivery
 }
 
+// NewService creates the delivery Service for a channel. It fails if
+// channelConfig is nil, which would otherwise panic here: the wait-for-event
+// timeout and buffer size are read off channelConfig while building the
+// arguments to New.
 func NewService(
 	channel string,
 	channelConfig driver.ChannelConfig,
@@ -110,15 +121,22 @@ func NewService(
 	}, nil
 }
 
+// Start begins streaming blocks in the background. It returns as soon as the
+// delivery goroutine is running, and never returns an error.
 func (c *Service) Start(ctx context.Context) error {
 	c.deliveryService.Start(ctx)
 	return nil
 }
 
+// Stop shuts the background delivery down cleanly. It is idempotent and does
+// not affect scans already in flight, which own their own Delivery.
 func (c *Service) Stop() {
 	c.deliveryService.Stop(nil)
 }
 
+// scanBlock runs a throwaway Delivery over this channel, starting from the
+// position implied by vault, and invokes callback for each block. It blocks
+// until the callback asks to stop, the callback fails, or ctx is cancelled.
 func (c *Service) scanBlock(ctx context.Context, vault Vault, callback driver.BlockCallback) error {
 	deliveryService, err := New(
 		c.NetworkName,
@@ -141,14 +159,20 @@ func (c *Service) scanBlock(ctx context.Context, vault Vault, callback driver.Bl
 	return deliveryService.Run(ctx)
 }
 
+// ScanBlock delivers whole blocks to callback, starting from the genesis block.
 func (c *Service) ScanBlock(ctx context.Context, callback driver.BlockCallback) error {
 	return c.scanBlock(ctx, &fakeVault{}, callback)
 }
 
+// ScanBlockFrom delivers whole blocks to callback, starting from the given
+// block number.
 func (c *Service) ScanBlockFrom(ctx context.Context, block driver.BlockNum, callback driver.BlockCallback) error {
 	return c.scanBlock(ctx, &fakeVault{block: block}, callback)
 }
 
+// Scan delivers the transactions committed after txID to callback, one at a
+// time and in block order, skipping any whose header type this Service was not
+// configured to accept. Passing an empty txID starts from the genesis block.
 func (c *Service) Scan(ctx context.Context, txID string, callback driver.DeliveryCallback) error {
 	vault := &fakeVault{txID: txID}
 	return c.scanBlock(ctx, vault,
@@ -197,6 +221,8 @@ func (c *Service) Scan(ctx context.Context, txID string, callback driver.Deliver
 		})
 }
 
+// ScanFromBlock behaves like Scan but starts from the given block number
+// instead of from a transaction ID.
 func (c *Service) ScanFromBlock(ctx context.Context, block driver.BlockNum, callback driver.DeliveryCallback) error {
 	vault := &fakeVault{block: block}
 	return c.scanBlock(ctx, vault,
@@ -245,6 +271,8 @@ func (c *Service) ScanFromBlock(ctx context.Context, block driver.BlockNum, call
 		})
 }
 
+// processedTransaction is the driver.ProcessedTransaction handed to a
+// DeliveryCallback during a scan.
 type processedTransaction struct {
 	txID    driver.TxID
 	results []byte
@@ -272,6 +300,9 @@ func (p *processedTransaction) ValidationCode() int32 {
 	return p.vc
 }
 
+// fakeVault is a stationary Vault used to seed a scan's start position. Unlike
+// the real vault it is never advanced by the committer, so a scan always starts
+// where the caller asked rather than where the node happens to have got to.
 type fakeVault struct {
 	txID  driver.TxID
 	block driver.BlockNum

--- a/platform/fabric/core/generic/delivery/service_test.go
+++ b/platform/fabric/core/generic/delivery/service_test.go
@@ -7,11 +7,17 @@ SPDX-License-Identifier: Apache-2.0
 package delivery
 
 import (
+	"context"
 	"testing"
 
-	"github.com/hyperledger/fabric-protos-go-apiv2/common"
-	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
+	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+	pb "github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
 )
 
 // Regression coverage for a bug where Scan/ScanFromBlock indexed straight
@@ -27,24 +33,24 @@ func TestValidationCodeAt(t *testing.T) {
 
 	t.Run("returns validation code for a well-formed block", func(t *testing.T) {
 		t.Parallel()
-		metadata := make([][]byte, int(common.BlockMetadataIndex_TRANSACTIONS_FILTER)+1)
-		metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER] = []byte{uint8(peer.TxValidationCode_VALID)}
-		block := &common.Block{
-			Header:   &common.BlockHeader{Number: 1},
-			Data:     &common.BlockData{Data: [][]byte{[]byte("tx0")}},
-			Metadata: &common.BlockMetadata{Metadata: metadata},
+		metadata := make([][]byte, int(cb.BlockMetadataIndex_TRANSACTIONS_FILTER)+1)
+		metadata[cb.BlockMetadataIndex_TRANSACTIONS_FILTER] = []byte{uint8(pb.TxValidationCode_VALID)}
+		block := &cb.Block{
+			Header:   &cb.BlockHeader{Number: 1},
+			Data:     &cb.BlockData{Data: [][]byte{[]byte("tx0")}},
+			Metadata: &cb.BlockMetadata{Metadata: metadata},
 		}
 
 		code, err := validationCodeAt(block, 0)
 		require.NoError(t, err)
-		require.Equal(t, uint8(peer.TxValidationCode_VALID), code)
+		require.Equal(t, uint8(pb.TxValidationCode_VALID), code)
 	})
 
 	t.Run("nil metadata is rejected, not a panic", func(t *testing.T) {
 		t.Parallel()
-		block := &common.Block{
-			Header: &common.BlockHeader{Number: 2},
-			Data:   &common.BlockData{Data: [][]byte{[]byte("tx0")}},
+		block := &cb.Block{
+			Header: &cb.BlockHeader{Number: 2},
+			Data:   &cb.BlockData{Data: [][]byte{[]byte("tx0")}},
 		}
 
 		require.NotPanics(t, func() {
@@ -55,11 +61,11 @@ func TestValidationCodeAt(t *testing.T) {
 
 	t.Run("metadata missing transactions filter entry is rejected, not a panic", func(t *testing.T) {
 		t.Parallel()
-		metadata := make([][]byte, int(common.BlockMetadataIndex_TRANSACTIONS_FILTER))
-		block := &common.Block{
-			Header:   &common.BlockHeader{Number: 3},
-			Data:     &common.BlockData{Data: [][]byte{[]byte("tx0")}},
-			Metadata: &common.BlockMetadata{Metadata: metadata},
+		metadata := make([][]byte, int(cb.BlockMetadataIndex_TRANSACTIONS_FILTER))
+		block := &cb.Block{
+			Header:   &cb.BlockHeader{Number: 3},
+			Data:     &cb.BlockData{Data: [][]byte{[]byte("tx0")}},
+			Metadata: &cb.BlockMetadata{Metadata: metadata},
 		}
 
 		require.NotPanics(t, func() {
@@ -70,15 +76,15 @@ func TestValidationCodeAt(t *testing.T) {
 
 	t.Run("index beyond validation flags length is rejected, not a panic", func(t *testing.T) {
 		t.Parallel()
-		metadata := make([][]byte, int(common.BlockMetadataIndex_TRANSACTIONS_FILTER)+1)
-		metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER] = []byte{uint8(peer.TxValidationCode_VALID)}
-		block := &common.Block{
-			Header: &common.BlockHeader{Number: 4},
+		metadata := make([][]byte, int(cb.BlockMetadataIndex_TRANSACTIONS_FILTER)+1)
+		metadata[cb.BlockMetadataIndex_TRANSACTIONS_FILTER] = []byte{uint8(pb.TxValidationCode_VALID)}
+		block := &cb.Block{
+			Header: &cb.BlockHeader{Number: 4},
 			// Two transactions in Data.Data, but the transactions filter only
 			// covers one - the exact mismatch a malicious/misbehaving peer
 			// can send.
-			Data:     &common.BlockData{Data: [][]byte{[]byte("tx0"), []byte("tx1")}},
-			Metadata: &common.BlockMetadata{Metadata: metadata},
+			Data:     &cb.BlockData{Data: [][]byte{[]byte("tx0"), []byte("tx1")}},
+			Metadata: &cb.BlockMetadata{Metadata: metadata},
 		}
 
 		require.NotPanics(t, func() {
@@ -86,4 +92,321 @@ func TestValidationCodeAt(t *testing.T) {
 			require.ErrorContains(t, err, "out of range")
 		})
 	})
+}
+
+func TestServiceLifecycle(t *testing.T) {
+	t.Run("NewService nil channelConfig", func(t *testing.T) {
+		t.Parallel()
+		svc, err := NewService(
+			"testChannel",
+			nil, // channelConfig
+			"testNet",
+			&mockLocalMembership{id: &mockSigningIdentity{}},
+			&mockConfigService{peerConf: &grpc.ConnectionConfig{Address: "peer1"}},
+			&mockServices{},
+			&mockLedger{},
+			&mockVault{},
+			&mockTransactionManager{},
+			func(ctx context.Context, block *cb.Block) (bool, error) { return false, nil },
+			noop.NewTracerProvider(),
+			nil,
+			[]cb.HeaderType{cb.HeaderType_ENDORSER_TRANSACTION},
+		)
+		require.Error(t, err)
+		require.Nil(t, svc)
+	})
+
+	t.Parallel()
+
+	t.Run("NewService succeeds", func(t *testing.T) {
+		t.Parallel()
+		svc := newTestService(t, testServiceOpts{})
+		require.NotNil(t, svc)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+
+		err := svc.Start(ctx)
+		require.NoError(t, err)
+
+		svc.Stop()
+	})
+}
+
+func TestScanBlockVariants(t *testing.T) {
+	t.Run("Scan skips non-endorser and handles callback error", func(t *testing.T) {
+		t.Parallel()
+		recvChan := make(chan *pb.DeliverResponse, 5)
+		svc := newTestService(t, testServiceOpts{recvChan: recvChan})
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+
+		envBytes := newValidEnvelopeBytes(t, cb.HeaderType_ENDORSER_TRANSACTION, "tx2")
+		envBytesSkip := newValidEnvelopeBytes(t, cb.HeaderType_CONFIG, "tx-config")
+
+		recvChan <- &pb.DeliverResponse{Type: &pb.DeliverResponse_Block{Block: &cb.Block{
+			Header:   &cb.BlockHeader{Number: 14},
+			Data:     &cb.BlockData{Data: [][]byte{envBytesSkip, envBytes}},
+			Metadata: &cb.BlockMetadata{Metadata: [][]byte{nil, nil, {uint8(pb.TxValidationCode_VALID), uint8(pb.TxValidationCode_VALID)}}},
+		}}}
+
+		err := svc.Scan(ctx, "txid", func(tx driver.ProcessedTransaction) (bool, error) {
+			return false, errors.New("callback err")
+		})
+		require.ErrorContains(t, err, "callback err")
+	})
+
+	t.Run("Scan handles stop=true", func(t *testing.T) {
+		t.Parallel()
+		recvChan := make(chan *pb.DeliverResponse, 5)
+		svc := newTestService(t, testServiceOpts{recvChan: recvChan})
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+
+		envBytes := newValidEnvelopeBytes(t, cb.HeaderType_ENDORSER_TRANSACTION, "tx2")
+
+		recvChan <- &pb.DeliverResponse{Type: &pb.DeliverResponse_Block{Block: &cb.Block{
+			Header:   &cb.BlockHeader{Number: 14},
+			Data:     &cb.BlockData{Data: [][]byte{envBytes}},
+			Metadata: &cb.BlockMetadata{Metadata: [][]byte{nil, nil, {uint8(pb.TxValidationCode_VALID)}}},
+		}}}
+
+		err := svc.Scan(ctx, "txid", func(tx driver.ProcessedTransaction) (bool, error) {
+			return true, nil
+		})
+		require.NoError(t, err)
+	})
+
+	t.Parallel()
+
+	t.Run("ScanBlock fails immediately on canceled context", func(t *testing.T) {
+		t.Parallel()
+		svc := newTestService(t, testServiceOpts{})
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		t.Cleanup(cancel)
+
+		err := svc.ScanBlock(ctx, func(context.Context, *cb.Block) (bool, error) { return false, nil })
+		if err != nil {
+			require.ErrorContains(t, err, "context done")
+		}
+	})
+
+	t.Run("ScanBlockFrom fails immediately on canceled context", func(t *testing.T) {
+		t.Parallel()
+		svc := newTestService(t, testServiceOpts{})
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		t.Cleanup(cancel)
+
+		err := svc.ScanBlockFrom(ctx, 10, func(context.Context, *cb.Block) (bool, error) { return false, nil })
+		if err != nil {
+			require.ErrorContains(t, err, "context done")
+		}
+	})
+
+	t.Run("Scan fails immediately on canceled context", func(t *testing.T) {
+		t.Parallel()
+		recvChan := make(chan *pb.DeliverResponse, 5)
+		readChan := make(chan struct{})
+		svc := newTestService(t, testServiceOpts{recvChan: recvChan, readChan: readChan})
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		t.Cleanup(cancel)
+
+		err := svc.Scan(ctx, "tx1", func(tx driver.ProcessedTransaction) (bool, error) { return false, nil })
+		if err != nil {
+			require.ErrorContains(t, err, "context done")
+		}
+	})
+
+	t.Run("Scan fails on unmarshal error with invalid block data", func(t *testing.T) {
+		t.Parallel()
+		recvChan := make(chan *pb.DeliverResponse, 5)
+		readChan := make(chan struct{})
+		svc := newTestService(t, testServiceOpts{recvChan: recvChan, readChan: readChan})
+
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+		go func() {
+			<-readChan
+			close(recvChan)
+		}()
+
+		recvChan <- &pb.DeliverResponse{Type: &pb.DeliverResponse_Block{Block: &cb.Block{
+			Header:   &cb.BlockHeader{Number: 10},
+			Data:     &cb.BlockData{Data: [][]byte{[]byte("invalid tx")}},
+			Metadata: &cb.BlockMetadata{Metadata: [][]byte{nil, nil, {uint8(pb.TxValidationCode_VALID)}}},
+		}}}
+
+		err := svc.Scan(ctx, "tx1", func(tx driver.ProcessedTransaction) (bool, error) { return false, nil })
+		require.ErrorContains(t, err, "error unmarshalling")
+	})
+
+	t.Run("Scan processes valid block and returns false to continue", func(t *testing.T) {
+		t.Parallel()
+		recvChan := make(chan *pb.DeliverResponse, 5)
+		svc := newTestService(t, testServiceOpts{recvChan: recvChan})
+
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+
+		envBytes := newValidEnvelopeBytes(t, cb.HeaderType_ENDORSER_TRANSACTION, "tx2")
+
+		processed := make(chan struct{})
+		go func() {
+			<-processed
+			close(recvChan)
+			cancel()
+		}()
+
+		recvChan <- &pb.DeliverResponse{Type: &pb.DeliverResponse_Block{Block: &cb.Block{
+			Header:   &cb.BlockHeader{Number: 11},
+			Data:     &cb.BlockData{Data: [][]byte{envBytes}},
+			Metadata: &cb.BlockMetadata{Metadata: [][]byte{nil, nil, {uint8(pb.TxValidationCode_VALID)}}},
+		}}}
+
+		err := svc.Scan(ctx, "tx1", func(tx driver.ProcessedTransaction) (bool, error) {
+			close(processed)
+			return false, nil // return stop = false to reach the end of the loop
+		})
+		if err != nil {
+			require.ErrorContains(t, err, "context done")
+		}
+	})
+
+	t.Run("Scan processes valid block and returns true to stop", func(t *testing.T) {
+		t.Parallel()
+		recvChan := make(chan *pb.DeliverResponse, 5)
+		svc := newTestService(t, testServiceOpts{recvChan: recvChan})
+
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+
+		envBytes := newValidEnvelopeBytes(t, cb.HeaderType_ENDORSER_TRANSACTION, "tx2")
+
+		recvChan <- &pb.DeliverResponse{Type: &pb.DeliverResponse_Block{Block: &cb.Block{
+			Header:   &cb.BlockHeader{Number: 16},
+			Data:     &cb.BlockData{Data: [][]byte{envBytes}},
+			Metadata: &cb.BlockMetadata{Metadata: [][]byte{nil, nil, {uint8(pb.TxValidationCode_VALID)}}},
+		}}}
+
+		err := svc.ScanFromBlock(ctx, 10, func(tx driver.ProcessedTransaction) (bool, error) {
+			return true, nil // return stop = true
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("ScanFromBlock handles callback error", func(t *testing.T) {
+		t.Parallel()
+		recvChan := make(chan *pb.DeliverResponse, 5)
+		svc := newTestService(t, testServiceOpts{recvChan: recvChan})
+
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+
+		envBytes := newValidEnvelopeBytes(t, cb.HeaderType_ENDORSER_TRANSACTION, "tx2")
+
+		recvChan <- &pb.DeliverResponse{Type: &pb.DeliverResponse_Block{Block: &cb.Block{
+			Header:   &cb.BlockHeader{Number: 13},
+			Data:     &cb.BlockData{Data: [][]byte{envBytes}},
+			Metadata: &cb.BlockMetadata{Metadata: [][]byte{nil, nil, {uint8(pb.TxValidationCode_VALID)}}},
+		}}}
+		recvChan <- &pb.DeliverResponse{Type: &pb.DeliverResponse_Status{Status: cb.Status_SUCCESS}}
+
+		err := svc.ScanFromBlock(ctx, 10, func(tx driver.ProcessedTransaction) (bool, error) {
+			return false, errors.New("callback error")
+		})
+		require.ErrorContains(t, err, "callback error")
+	})
+
+	t.Run("ScanFromBlock handles transaction manager error and skips non-endorser transactions", func(t *testing.T) {
+		t.Parallel()
+		recvChan := make(chan *pb.DeliverResponse, 5)
+		svc := newTestService(t, testServiceOpts{
+			recvChan: recvChan,
+			txMgr:    &mockTransactionManager{err: errors.New("tx mgr error")},
+		})
+
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+
+		envBytes := newValidEnvelopeBytes(t, cb.HeaderType_ENDORSER_TRANSACTION, "tx2")
+		envBytesSkip := newValidEnvelopeBytes(t, cb.HeaderType_CONFIG, "tx-config")
+
+		recvChan <- &pb.DeliverResponse{Type: &pb.DeliverResponse_Block{Block: &cb.Block{
+			Header:   &cb.BlockHeader{Number: 14},
+			Data:     &cb.BlockData{Data: [][]byte{envBytesSkip, envBytes}}, // skip first, fail on second
+			Metadata: &cb.BlockMetadata{Metadata: [][]byte{nil, nil, {uint8(pb.TxValidationCode_VALID), uint8(pb.TxValidationCode_VALID)}}},
+		}}}
+
+		err := svc.ScanFromBlock(ctx, 10, func(tx driver.ProcessedTransaction) (bool, error) {
+			return false, nil
+		})
+		require.ErrorContains(t, err, "tx mgr error")
+	})
+
+	t.Run("ScanFromBlock handles unmarshal error for Envelope", func(t *testing.T) {
+		t.Parallel()
+		recvChan := make(chan *pb.DeliverResponse, 5)
+		svc := newTestService(t, testServiceOpts{recvChan: recvChan})
+
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+
+		recvChan <- &pb.DeliverResponse{Type: &pb.DeliverResponse_Block{Block: &cb.Block{
+			Header:   &cb.BlockHeader{Number: 14},
+			Data:     &cb.BlockData{Data: [][]byte{[]byte("invalid tx")}},
+			Metadata: &cb.BlockMetadata{Metadata: [][]byte{nil, nil, {uint8(pb.TxValidationCode_VALID)}}},
+		}}}
+
+		err := svc.ScanFromBlock(ctx, 10, func(tx driver.ProcessedTransaction) (bool, error) { return false, nil })
+		require.ErrorContains(t, err, "error unmarshalling Envelope")
+	})
+
+	t.Run("ScanFromBlock handles missing transaction filter in metadata", func(t *testing.T) {
+		t.Parallel()
+		recvChan := make(chan *pb.DeliverResponse, 5)
+		svc := newTestService(t, testServiceOpts{recvChan: recvChan})
+
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+
+		recvChan <- &pb.DeliverResponse{Type: &pb.DeliverResponse_Block{Block: &cb.Block{
+			Header:   &cb.BlockHeader{Number: 15},
+			Data:     &cb.BlockData{Data: [][]byte{[]byte("tx")}},
+			Metadata: &cb.BlockMetadata{Metadata: [][]byte{}},
+		}}}
+
+		err := svc.ScanFromBlock(ctx, 10, func(tx driver.ProcessedTransaction) (bool, error) { return false, nil })
+		require.ErrorContains(t, err, "metadata lacks transaction filter")
+	})
+
+	t.Run("ScanFromBlock connection failure propagates context error", func(t *testing.T) {
+		t.Parallel()
+		svc := newTestService(t, testServiceOpts{deliverErr: errors.New("deliver client error")})
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+
+		// cancel synchronously so it fails when trying to sleep before reconnecting
+		cancel()
+
+		err := svc.ScanFromBlock(ctx, 10, func(tx driver.ProcessedTransaction) (bool, error) { return false, nil })
+		if err != nil {
+			require.ErrorContains(t, err, "context done")
+		}
+	})
+}
+
+func TestFakeVault(t *testing.T) {
+	t.Parallel()
+	v := &fakeVault{txID: "tx1", block: 10}
+	txID, err := v.GetLastTxID(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "tx1", txID)
+
+	block, err := v.GetLastBlock(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), block)
 }

--- a/platform/fabric/core/generic/delivery/service_test.go
+++ b/platform/fabric/core/generic/delivery/service_test.go
@@ -95,6 +95,8 @@ func TestValidationCodeAt(t *testing.T) {
 }
 
 func TestServiceLifecycle(t *testing.T) {
+	t.Parallel()
+
 	t.Run("NewService nil channelConfig", func(t *testing.T) {
 		t.Parallel()
 		svc, err := NewService(
@@ -116,8 +118,6 @@ func TestServiceLifecycle(t *testing.T) {
 		require.Nil(t, svc)
 	})
 
-	t.Parallel()
-
 	t.Run("NewService succeeds", func(t *testing.T) {
 		t.Parallel()
 		svc := newTestService(t, testServiceOpts{})
@@ -129,6 +129,14 @@ func TestServiceLifecycle(t *testing.T) {
 		err := svc.Start(ctx)
 		require.NoError(t, err)
 
+		svc.Stop()
+		// Stop must be observable rather than merely not panicking, and the
+		// background delivery must be finished before the subtest returns so it
+		// cannot fail a later, unrelated test.
+		<-svc.deliveryService.stop
+		require.NoError(t, svc.deliveryService.stopError())
+
+		// Stopping twice is a no-op, not a double close.
 		svc.Stop()
 	})
 }


### PR DESCRIPTION
Resolves #1704

### Description

`platform/fabric/core/generic/delivery` was at **17.7%** of statements. This PR brings it to **93.4%**, fixes a shutdown race in the production code that the new tests uncovered, and documents the package.

### The shutdown race

`Delivery.Stop` sent its error over the unbuffered `stop` channel, but `untilStop`, `readBlocks` and `runReceiver` all read that channel. Whichever goroutine won consumed the value and the others observed only the close, so `Run` returned `nil` for a shutdown that had a cause — the lifecycle tests failed roughly one package run in ten. Buffering could not fix it: a buffered channel still delivers the value to exactly one reader.

`stop` is now a `chan struct{}` that is only ever closed, with the cause held in an `atomic.Pointer[error]` written before the close, so every reader observes the same error. That also removes a latent deadlock — the send inside `stopOnce` could block forever with no reader left, wedging every later `Stop` caller behind the `Once`.

### Tests

- Unit tests for `Delivery` (lifecycle, connect, receiver, reconnect), `Service` (start/stop plus the scan entry points) and the deliver client helpers.
- The ad-hoc stream doubles are folded into one configurable `mockDeliverStream` in `helpers_test.go`, matching the sibling `rwset` and `finality` packages; in this repo "mock" means counterfeiter-generated, and none of this is.
- `mockPeerClient.DeliverClient` returned `(nil, nil)` when unconfigured, which no real peer client does; `NewDeliver` then dereferenced the nil interface and killed the test binary from a goroutine. It now fails cleanly.
- The scripted stream signalled `readChan` on a closed `recvChan`, so a caller spinning on the resulting error could block in the double forever.
- With shutdown deterministic, both `time.Sleep` calls are gone and the subtest that only checked "did not panic" now asserts the reason for the stop.

### Documentation

The package had no package comment; it has one now. The exported comments follow the conventions in `docs/agents/conventions.md`: no implementation detail or internal call flow, no claims that will not survive a refactor, and Godoc `[Link]` references to sibling API elements.

Corrections to what was already there:

- `DeliverStream` and `DeliverFiltered` are structurally identical and differ only in which RPC opened them, so a stream must be used with the call that created it. Neither one-line comment said so.
- `CreateEnvelope` returns an envelope, not a payload.
- `CreateDeliverEnvelope` does not seek `Newest`, and neither `TxEvent` nor `CreateHeader` is token-specific.
- `Vault`, the `Deliver*` interfaces, `NonceSize` and the random helpers were undocumented or unpunctuated fragments.

### Verification

- `make checks` — clean across all four modules
- `go test -race -cover ./platform/fabric/core/generic/delivery/...` — 93.4% (`runReceiver` 94.1%, `Stop` and `untilStop` 100%)
- Repeated `-race` runs of the package and of the lifecycle tests that produced the panic, with no failures
