### PR TITLE
test(fabricx): cover channel configuration updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,7 @@ INTEGRATION_TARGETS += fabricx-atsa
 INTEGRATION_TARGETS += fabricx-simple
 INTEGRATION_TARGETS += fabricx-deployment
 INTEGRATION_TARGETS += fabricx-multiendorsement
+INTEGRATION_TARGETS += fabricx-configupdate
 
 .PHONE: list-integration-tests
 list-integration-tests: ## List all integration tests

--- a/integration/fabric/configupdate/configupdate.go
+++ b/integration/fabric/configupdate/configupdate.go
@@ -32,11 +32,11 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/protoutil"
 )
 
-// batchTimeoutKey is the key of the BatchTimeout value in the channel config's Orderer group.
-const batchTimeoutKey = "BatchTimeout"
+// BatchTimeoutKey is the key of the BatchTimeout value in the channel config's Orderer group.
+const BatchTimeoutKey = "BatchTimeout"
 
-// ordererGroupKey is the key of the Orderer group in the channel config.
-const ordererGroupKey = "Orderer"
+// OrdererGroupKey is the key of the Orderer group in the channel config.
+const OrdererGroupKey = "Orderer"
 
 // channelHandles are the nwo handles needed to submit a configuration update: the network,
 // the channel to update, an orderer to submit through, and a Fabric peer whose local
@@ -79,7 +79,7 @@ func handles(ii *integration.Infrastructure) *channelHandles {
 func BatchTimeout(ii *integration.Infrastructure) time.Duration {
 	h := handles(ii)
 	config := network.GetConfig(h.Network, h.Peer, h.Orderer, h.Channel)
-	return batchTimeoutOf(config)
+	return BatchTimeoutOf(config)
 }
 
 // SetBatchTimeout computes, signs and submits an orderer-signed channel configuration
@@ -95,13 +95,13 @@ func SetBatchTimeout(ii *integration.Infrastructure, timeout time.Duration) {
 	h := handles(ii)
 
 	config := network.GetConfig(h.Network, h.Peer, h.Orderer, h.Channel)
-	gomega.Expect(batchTimeoutOf(config)).NotTo(gomega.Equal(timeout),
+	gomega.Expect(BatchTimeoutOf(config)).NotTo(gomega.Equal(timeout),
 		"BatchTimeout is already [%s]; an update that changes nothing cannot be computed", timeout)
 
 	updated, ok := proto.Clone(config).(*common.Config)
 	gomega.Expect(ok).To(gomega.BeTrue(), "expected the cloned config to be a *common.Config")
 
-	updated.ChannelGroup.Groups[ordererGroupKey].Values[batchTimeoutKey] = &common.ConfigValue{
+	updated.ChannelGroup.Groups[OrdererGroupKey].Values[BatchTimeoutKey] = &common.ConfigValue{
 		ModPolicy: "Admins",
 		Value:     protoutil.MarshalOrPanic(&protosorderer.BatchTimeout{Timeout: timeout.String()}),
 	}
@@ -125,13 +125,16 @@ func ConfigSequenceOn(g gomega.Gomega, ii *integration.Infrastructure, node stri
 	return nwocommon.JSONUnmarshalInt(res)
 }
 
-// batchTimeoutOf extracts the BatchTimeout from a channel configuration.
-func batchTimeoutOf(config *common.Config) time.Duration {
-	group, ok := config.ChannelGroup.Groups[ordererGroupKey]
-	gomega.Expect(ok).To(gomega.BeTrue(), "channel config has no [%s] group", ordererGroupKey)
+// BatchTimeoutOf extracts the BatchTimeout from a channel configuration. It aborts the
+// running spec through Gomega if the configuration does not carry one.
+//
+// The fabricx sibling suite shares it: the value is read the same way on both platforms.
+func BatchTimeoutOf(config *common.Config) time.Duration {
+	group, ok := config.ChannelGroup.Groups[OrdererGroupKey]
+	gomega.Expect(ok).To(gomega.BeTrue(), "channel config has no [%s] group", OrdererGroupKey)
 
-	value, ok := group.Values[batchTimeoutKey]
-	gomega.Expect(ok).To(gomega.BeTrue(), "[%s] group has no [%s] value", ordererGroupKey, batchTimeoutKey)
+	value, ok := group.Values[BatchTimeoutKey]
+	gomega.Expect(ok).To(gomega.BeTrue(), "[%s] group has no [%s] value", OrdererGroupKey, BatchTimeoutKey)
 
 	batchTimeout := &protosorderer.BatchTimeout{}
 	gomega.Expect(proto.Unmarshal(value.Value, batchTimeout)).NotTo(gomega.HaveOccurred())

--- a/integration/fabricx/configupdate/commands_test.go
+++ b/integration/fabricx/configupdate/commands_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package configupdate_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/gomega"
+
+	"github.com/hyperledger-labs/fabric-smart-client/integration"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/fabric/iou/views"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common"
+)
+
+// defaultViewTimeout bounds every view call these specs make.
+//
+// The shared integration/fabric/iou helpers call CallView with no context, so a view that
+// never answers blocks the spec for as long as Ginkgo lets it -- two runs during
+// development hung for over twenty minutes. Bounding each call turns that into a failure
+// that names the call which hung and arrives in two minutes, which is why the sibling
+// fabricx suites define their own helpers rather than reusing the shared ones (see
+// integration/fabricx/iou/commands_test.go). Do not replace these with the
+// integration/fabric/iou equivalents.
+const defaultViewTimeout = 2 * time.Minute
+
+// InitApprover runs the named approver's init view, which is what registers the iou
+// namespace's endorsement policy with that node.
+func InitApprover(ii *integration.Infrastructure, approver string) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultViewTimeout)
+	defer cancel()
+
+	_, err := ii.Client(approver).CallViewWithContext(ctx, "init", nil)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "the [%s] init view failed", approver)
+}
+
+// CreateIOU has the borrower create an IOU for the given amount, endorsed by the named
+// approver, and returns the linear ID of the state it wrote.
+func CreateIOU(ii *integration.Infrastructure, amount uint, approver string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultViewTimeout)
+	defer cancel()
+
+	res, err := ii.Client("borrower").CallViewWithContext(ctx, "create",
+		common.JSONMarshall(&views.Create{
+			Amount:   amount,
+			Lender:   ii.Identity("lender"),
+			Approver: ii.Identity(approver),
+		}),
+	)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "the create view failed for amount [%d]", amount)
+	gomega.Expect(res).NotTo(gomega.BeNil())
+
+	return common.JSONUnmarshalString(res)
+}
+
+// CheckState asserts that the named party's own query view reports the given IOU at the
+// expected amount.
+//
+// It queries the node's view service rather than its command line, which is what
+// integration/fabric/iou does: the CLI client ignores the context it is handed and bounds
+// itself at ten minutes instead, and nothing in these specs is about the CLI.
+func CheckState(ii *integration.Infrastructure, party, iouStateID string, expected int) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultViewTimeout)
+	defer cancel()
+
+	res, err := ii.Client(party).CallViewWithContext(ctx, "query",
+		common.JSONMarshall(&views.Query{LinearID: iouStateID}))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "the [%s] query view failed", party)
+	gomega.Expect(common.JSONUnmarshalInt(res)).To(gomega.BeEquivalentTo(expected))
+}

--- a/integration/fabricx/configupdate/configupdate.go
+++ b/integration/fabricx/configupdate/configupdate.go
@@ -1,0 +1,182 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package configupdate drives Fabric-X channel configuration changes against a running
+// network, so that a test can observe how FSC nodes react to a configuration that changes
+// while they are up.
+//
+// The FSC-side path under test is platform/fabricx/core/channel/config: a
+// ChannelConfigMonitor polls the committer's query service for the latest configuration
+// transaction and, on seeing a new one, hands the envelope to membership.Service.Update
+// and reconfigures the ordering service from the new Orderer group. Until this suite
+// existed that loop only ever ran for a channel's genesis configuration.
+package configupdate
+
+import (
+	"context"
+	"time"
+
+	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+	protosorderer "github.com/hyperledger/fabric-protos-go-apiv2/orderer"
+	"github.com/hyperledger/fabric-x-common/common/channelconfig"
+	"github.com/hyperledger/fabric-x-common/protoutil"
+	"github.com/onsi/gomega"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/hyperledger-labs/fabric-smart-client/integration"
+	fabconfigupdate "github.com/hyperledger-labs/fabric-smart-client/integration/fabric/configupdate"
+	nwocommon "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common"
+	nwofabricx "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabricx"
+	fxnetwork "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabricx/network"
+)
+
+// AllNodes names the FSC nodes in [Topology]. Each runs its own channel config monitor and
+// applies a configuration independently, so specs assert on all of them.
+var AllNodes = []string{"borrower", "lender", "approver1", "approver2"}
+
+// NetworkOf returns the network of the fabricx platform in the running infrastructure.
+// It aborts the running spec unless the infrastructure holds exactly one.
+func NetworkOf(ii *integration.Infrastructure) *fxnetwork.Network {
+	platforms := ii.NWOCtx.PlatformsByType(nwofabricx.TopologyName)
+	gomega.Expect(platforms).To(gomega.HaveLen(1), "expected exactly one fabricx platform")
+
+	p, ok := platforms[0].(*nwofabricx.Platform)
+	gomega.Expect(ok).To(gomega.BeTrue(), "expected the fabricx platform to be a *fabricx.Platform")
+
+	return p.Network
+}
+
+// configSeqViewTimeout bounds a single configseq call. gomega.Eventually runs its poll
+// function synchronously, so an unanswered view would block the polling loop itself rather
+// than expire with it; a bound well inside the callers' polling window instead fails the
+// current poll and leaves the loop free to retry. A node that has just been restarted is
+// the case that needs the room.
+const configSeqViewTimeout = 15 * time.Second
+
+// ConfigSequenceOn returns the channel configuration sequence the named FSC node currently
+// holds, as the node itself reports it through the configseq view.
+//
+// A configuration reaches a node on its config monitor's next poll, strictly later than
+// the ordering service accepting it, so callers must poll this with gomega.Eventually
+// rather than asserting on it once. Pass that poll's Gomega as g: a transient view-call
+// failure then fails only the current poll, leaving the spec to retry, instead of
+// aborting it.
+func ConfigSequenceOn(g gomega.Gomega, ii *integration.Infrastructure, node string) int {
+	ctx, cancel := context.WithTimeout(context.Background(), configSeqViewTimeout)
+	defer cancel()
+
+	res, err := ii.Client(node).CallViewWithContext(ctx, "configseq", nil)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	return nwocommon.JSONUnmarshalInt(res)
+}
+
+// BatchTimeout returns the orderer BatchTimeout in the channel configuration the committer
+// currently holds. Like [fxnetwork.GetConfig], it queries the committer on every call.
+func BatchTimeout(n *fxnetwork.Network) time.Duration {
+	return fabconfigupdate.BatchTimeoutOf(fxnetwork.GetConfig(n))
+}
+
+// SetBatchTimeout submits a channel configuration update setting the orderer's
+// BatchTimeout to the given value, and returns once the committer serves the resulting
+// configuration, so a caller may read it back immediately.
+//
+// Passing the value the channel already holds aborts the running spec: an update that
+// changes nothing cannot be computed.
+//
+// BatchTimeout is the value these tests change because it sits in the Orderer group, which
+// is what the channel config monitor re-reads before reconfiguring the ordering service,
+// and because the mock orderer ignores the value itself -- so changing it exercises the
+// configuration path without disturbing the running network.
+func SetBatchTimeout(n *fxnetwork.Network, timeout time.Duration) {
+	current := fxnetwork.GetConfig(n)
+	gomega.Expect(fabconfigupdate.BatchTimeoutOf(current)).NotTo(gomega.Equal(timeout),
+		"BatchTimeout is already [%s]; an update that changes nothing cannot be computed", timeout)
+
+	updated := cloneConfig(current)
+	updated.ChannelGroup.Groups[fabconfigupdate.OrdererGroupKey].Values[fabconfigupdate.BatchTimeoutKey] = &cb.ConfigValue{
+		ModPolicy: "Admins",
+		Value:     protoutil.MarshalOrPanic(&protosorderer.BatchTimeout{Timeout: timeout.String()}),
+	}
+
+	submit(n, current, updated)
+}
+
+// submit sends an updated configuration through the topology's first orderer, co-signed by
+// the peer-org Admins named in orgs, and returns once the committer serves a configuration
+// newer than current.
+//
+// orgs is passed straight through to [fxnetwork.UpdateConfig]: pass none for an
+// Orderer-group change, which the orderer's own admin signature already authorizes, or
+// enough peer organizations to satisfy an Application- or Channel-group value's Admins
+// policy.
+//
+// [fxnetwork.UpdateConfig] returns as soon as the ordering service accepts the envelope,
+// which is roughly 15ms ahead of the committer applying it. Waiting here rather than at
+// each call site means no caller can read back the configuration it just replaced.
+func submit(n *fxnetwork.Network, current, updated *cb.Config, orgs ...string) {
+	gomega.Expect(n.Channels).NotTo(gomega.BeEmpty(), "the fabricx topology declares no channel")
+	gomega.Expect(n.Orderers).NotTo(gomega.BeEmpty(), "the fabricx topology declares no orderer")
+
+	fxnetwork.UpdateConfig(n, n.Orderers[0], n.Channels[0].Name, current, updated, orgs...)
+
+	gomega.Eventually(func() uint64 {
+		return fxnetwork.GetConfig(n).GetSequence()
+	}, 60*time.Second, time.Second).Should(gomega.BeNumerically(">", current.GetSequence()),
+		"the committer never served a configuration newer than sequence [%d]", current.GetSequence())
+}
+
+// unsupportedCapability is a capability name no fabric-x binary defines. Requiring it in
+// the Application group is refused by membership.capabilitiesSupported and accepted by the
+// committer, which never checks capability support -- the asymmetry TestRefused needs.
+const unsupportedCapability = "V99_0"
+
+// RequireUnsupportedCapability submits a channel configuration update that adds an
+// Application capability no node can support, and returns once the committer serves the
+// resulting configuration. It aborts the running spec through Gomega if the channel
+// configuration is not shaped the way this update assumes, or if the committer never
+// serves the update.
+//
+// The Application group's Admins policy is MAJORITY Admins over its three organizations
+// (Org1, Org2, Org3), so the update is co-signed by Org1 and Org2's peer Admins -- two of
+// three -- alongside the orderer admin [submit] always signs with.
+func RequireUnsupportedCapability(n *fxnetwork.Network) {
+	current := fxnetwork.GetConfig(n)
+	updated := cloneConfig(current)
+
+	group, ok := updated.ChannelGroup.Groups[channelconfig.ApplicationGroupKey]
+	gomega.Expect(ok).To(gomega.BeTrue(), "channel config has no [%s] group", channelconfig.ApplicationGroupKey)
+
+	value, ok := group.Values[channelconfig.CapabilitiesKey]
+	gomega.Expect(ok).To(gomega.BeTrue(), "[%s] group has no [%s] value",
+		channelconfig.ApplicationGroupKey, channelconfig.CapabilitiesKey)
+
+	capabilities := &cb.Capabilities{}
+	gomega.Expect(proto.Unmarshal(value.Value, capabilities)).NotTo(gomega.HaveOccurred())
+	gomega.Expect(capabilities.Capabilities).NotTo(gomega.HaveKey(unsupportedCapability),
+		"the channel configuration already requires [%s], so adding it would change nothing",
+		unsupportedCapability)
+
+	if capabilities.Capabilities == nil {
+		capabilities.Capabilities = map[string]*cb.Capability{}
+	}
+	capabilities.Capabilities[unsupportedCapability] = &cb.Capability{}
+
+	group.Values[channelconfig.CapabilitiesKey] = &cb.ConfigValue{
+		ModPolicy: value.ModPolicy,
+		Value:     protoutil.MarshalOrPanic(capabilities),
+	}
+
+	submit(n, current, updated, "Org1", "Org2")
+}
+
+// cloneConfig returns a deep copy of a channel configuration, so that the original stays
+// available as the "current" side of the update being computed.
+func cloneConfig(config *cb.Config) *cb.Config {
+	clone, ok := proto.Clone(config).(*cb.Config)
+	gomega.Expect(ok).To(gomega.BeTrue(), "expected the cloned config to be a *common.Config")
+
+	return clone
+}

--- a/integration/fabricx/configupdate/configupdate_suite_test.go
+++ b/integration/fabricx/configupdate/configupdate_suite_test.go
@@ -1,0 +1,19 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package configupdate_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndToEnd(t *testing.T) { //nolint:paralleltest
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "FabricX Config Update Suite")
+}

--- a/integration/fabricx/configupdate/configupdate_test.go
+++ b/integration/fabricx/configupdate/configupdate_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package configupdate_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	"github.com/hyperledger-labs/fabric-smart-client/integration"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/fabricx/configupdate"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/fabricx/iou"
+	nwofabricx "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabricx"
+	fxnetwork "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabricx/network"
+	nwofsc "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
+)
+
+var _ = Describe("EndToEnd", func() {
+	Describe("Channel Config Update", Label("T1"), func() {
+		s := NewTestSuite(nwofsc.WebSocket, integration.NoReplication)
+		BeforeEach(s.Setup)
+		AfterEach(s.TearDown)
+		It("succeeded", s.TestSucceeded)
+	})
+
+	Describe("Refused configuration", Label("T2"), func() {
+		s := NewTestSuite(nwofsc.WebSocket, integration.NoReplication)
+		BeforeEach(s.Setup)
+		AfterEach(s.TearDown)
+		It("keeps the configuration in force", s.TestRefused)
+	})
+})
+
+type TestSuite struct {
+	*integration.TestSuite
+}
+
+func NewTestSuite(commType nwofsc.P2PCommunicationType, nodeOpts *integration.ReplicationOptions) *TestSuite {
+	return &TestSuite{TestSuite: integration.NewTestSuite(func() (*integration.Infrastructure, error) {
+		ii, err := integration.New(
+			integration.FabricXConfigUpdatePort.StartPortForNode(), "",
+			configupdate.Topology(&iou.SDK{}, commType, nodeOpts)...,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		ii.RegisterPlatformFactory(nwofabricx.NewPlatformFactory())
+		ii.Generate()
+
+		return ii, nil
+	})}
+}
+
+// expectConfigSequence waits for every named node to report the given channel
+// configuration sequence. A configuration reaches a node asynchronously, through the
+// config monitor's next poll, so this polls rather than asserting once.
+func expectConfigSequence(s *TestSuite, expected int, nodes ...string) {
+	for _, node := range nodes {
+		gomega.Eventually(func(g gomega.Gomega) int {
+			return configupdate.ConfigSequenceOn(g, s.II, node)
+		}, 60*time.Second, time.Second).Should(gomega.Equal(expected),
+			"node [%s] never reported channel configuration sequence [%d]", node, expected)
+	}
+}
+
+// TestSucceeded drives the IOU flow across three channel configuration changes, one of
+// which lands while a node is down.
+//
+// Every IOU call goes through approver1: the fabricx namespace endorsement policy is
+// Unanimity("Org1") and only approver1 is in Org1. approver2 is here to be asserted on,
+// not to endorse.
+func (s *TestSuite) TestSucceeded() {
+	n := configupdate.NetworkOf(s.II)
+
+	InitApprover(s.II, "approver1")
+	InitApprover(s.II, "approver2")
+
+	By("transacting on the channel's initial configuration")
+	gomega.Expect(fxnetwork.GetConfig(n).GetSequence()).To(gomega.BeNumerically("==", 0))
+	iouState := CreateIOU(s.II, 10, "approver1")
+	CheckState(s.II, "borrower", iouState, 10)
+	CheckState(s.II, "lender", iouState, 10)
+
+	By("checking every node starts from the genesis configuration")
+	expectConfigSequence(s, 0, configupdate.AllNodes...)
+
+	By("changing the channel configuration while the FSC nodes are running")
+	configupdate.SetBatchTimeout(n, 2*time.Second)
+	gomega.Expect(configupdate.BatchTimeout(n)).To(gomega.Equal(2 * time.Second))
+
+	By("checking every node applied the first configuration update")
+	expectConfigSequence(s, 1, configupdate.AllNodes...)
+
+	By("transacting again, which requires the nodes to have followed the change")
+	second := CreateIOU(s.II, 20, "approver1")
+	CheckState(s.II, "borrower", second, 20)
+	CheckState(s.II, "lender", second, 20)
+
+	By("changing the configuration a second time, so more than one update is on the ledger")
+	configupdate.SetBatchTimeout(n, 500*time.Millisecond)
+	gomega.Expect(configupdate.BatchTimeout(n)).To(gomega.Equal(500 * time.Millisecond))
+
+	By("checking every node applied the second configuration update")
+	expectConfigSequence(s, 2, configupdate.AllNodes...)
+
+	third := CreateIOU(s.II, 30, "approver1")
+	CheckState(s.II, "borrower", third, 30)
+	CheckState(s.II, "lender", third, 30)
+
+	By("changing the configuration a third time, while one node is down")
+	// The fabric platform replays stored configuration transactions from the node's vault
+	// on start-up. Fabricx has no such replay: the config monitor's first poll fetches
+	// only the latest configuration. What is worth testing here is therefore not that a
+	// restarted node re-applies what it already had, but that a node absent for an update
+	// converges on the configuration it missed.
+	s.II.StopFSCNode("borrower")
+	configupdate.SetBatchTimeout(n, 3*time.Second)
+	gomega.Expect(configupdate.BatchTimeout(n)).To(gomega.Equal(3 * time.Second))
+	s.II.StartFSCNode("borrower")
+
+	By("checking the node that was down caught up on the configuration it missed")
+	expectConfigSequence(s, 3, configupdate.AllNodes...)
+
+	By("transacting once more through the node that was down")
+	fourth := CreateIOU(s.II, 40, "approver1")
+	CheckState(s.II, "borrower", fourth, 40)
+	CheckState(s.II, "lender", fourth, 40)
+}
+
+// TestRefused submits a configuration the FSC nodes cannot support and checks that they go
+// on serving the one they already hold.
+//
+// It first applies an ordinary configuration update and waits for every node to adopt it.
+// That step is not redundant with Spec 1: it is what makes the later "nodes stay put"
+// assertion mean "the nodes refused the configuration" rather than "the nodes never saw
+// it". Without it, a stalled or dead config monitor would leave every node at sequence 0
+// regardless of the poisoned update, and the spec would pass for the wrong reason. Proving
+// the monitor live on this same network, moments before the poisoned update, closes that
+// gap -- do not remove it as apparent duplication of Spec 1.
+//
+// This spec runs on its own network because the refused configuration cannot be recovered
+// from in place: every update is computed against whatever the committer currently serves,
+// so a later update would inherit the unsupported capability and be refused too. The good
+// update above must come first for the same reason: computed after the poisoned one, it
+// would inherit V99_0 and be refused too.
+//
+// It is also expected to produce a noisy log. On a failed apply the monitor returns before
+// updating lastVersion and lastSequence (monitor.go:236), so it re-fetches and re-refuses
+// the same configuration for as long as the network runs. checkAndUpdate wraps the fetch
+// and apply in retryWithBackoff, so one round refuses the configuration six times, sleeping
+// 1+2+4+8+16 seconds between attempts -- about half a minute -- and because the poll loop
+// calls it synchronously on a one-second ticker, the next round starts as soon as the
+// previous one gives up. That is current behaviour, not a fault in this test.
+func (s *TestSuite) TestRefused() {
+	n := configupdate.NetworkOf(s.II)
+
+	InitApprover(s.II, "approver1")
+
+	By("transacting on the channel's initial configuration")
+	iouState := CreateIOU(s.II, 10, "approver1")
+	CheckState(s.II, "borrower", iouState, 10)
+	expectConfigSequence(s, 0, configupdate.AllNodes...)
+
+	By("applying a configuration the nodes accept, so a stalled monitor fails here")
+	configupdate.SetBatchTimeout(n, 2*time.Second)
+	expectConfigSequence(s, 1, configupdate.AllNodes...)
+
+	By("submitting a configuration requiring a capability no node supports")
+	configupdate.RequireUnsupportedCapability(n)
+
+	// Asserting that the committer accepted it is what stops this spec from passing for
+	// the wrong reason: were the committer to start refusing the capability itself, every
+	// node would stay at sequence 1 and the spec would still be green.
+	By("checking the committer accepted the configuration")
+	gomega.Eventually(func() uint64 {
+		return fxnetwork.GetConfig(n).GetSequence()
+	}, 60*time.Second, time.Second).Should(gomega.BeNumerically("==", 2))
+
+	By("checking no node adopts it")
+	for _, node := range configupdate.AllNodes {
+		gomega.Consistently(func(g gomega.Gomega) int {
+			return configupdate.ConfigSequenceOn(g, s.II, node)
+		}, 10*time.Second, time.Second).Should(gomega.Equal(1),
+			"node [%s] adopted a configuration it cannot support", node)
+	}
+
+	By("checking the nodes still transact on the configuration they kept")
+	second := CreateIOU(s.II, 20, "approver1")
+	CheckState(s.II, "borrower", second, 20)
+	CheckState(s.II, "lender", second, 20)
+}

--- a/integration/fabricx/configupdate/topology.go
+++ b/integration/fabricx/configupdate/topology.go
@@ -1,0 +1,39 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package configupdate
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/integration"
+	configviews "github.com/hyperledger-labs/fabric-smart-client/integration/fabric/configupdate/views"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/fabricx/iou"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/api"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/node"
+)
+
+// Topology returns the fabricx IOU topology, in which every FSC node can additionally
+// report the sequence of the channel configuration it holds, through the configseq view.
+//
+// Nothing else about that topology needs changing for these specs, so it is taken as it
+// is: the iou namespace requires unanimous endorsement by Org1, and approver1 is its only
+// member, so every IOU call in a spec must go through approver1. approver2 belongs to Org2
+// and exists to be asserted on, not to endorse.
+func Topology(sdk node.SDK, commType fsc.P2PCommunicationType, replicationOpts *integration.ReplicationOptions) []api.Topology {
+	topologies := iou.Topology(sdk, commType, replicationOpts)
+
+	for _, t := range topologies {
+		fscTopology, ok := t.(*fsc.Topology)
+		if !ok {
+			continue
+		}
+		for _, n := range fscTopology.Nodes {
+			n.RegisterViewFactory("configseq", &configviews.ConfigSequenceViewFactory{})
+		}
+	}
+
+	return topologies
+}

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/hyperledger/fabric-contract-api-go/v2 v2.2.1
 	github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208
 	github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7
+	github.com/hyperledger/fabric-x-common v0.2.8
 	github.com/jaegertracing/jaeger-idl v0.9.0
 	github.com/knadh/koanf/parsers/yaml v1.1.1
 	github.com/knadh/koanf/providers/file v1.2.1
@@ -99,7 +100,6 @@ require (
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
 	github.com/hyperledger/fabric-amcl v0.0.0-20230602173724-9e02669dceb2 // indirect
-	github.com/hyperledger/fabric-x-common v0.2.8 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/boxo v0.41.0 // indirect
 	github.com/ipfs/go-cid v0.6.2 // indirect

--- a/integration/nwo/fabricx/network/configupdate.go
+++ b/integration/nwo/fabricx/network/configupdate.go
@@ -1,0 +1,281 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package network
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+
+	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
+	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+	protosorderer "github.com/hyperledger/fabric-protos-go-apiv2/orderer"
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/hyperledger/fabric-x-common/cmd/common/signer"
+	"github.com/hyperledger/fabric-x-common/common/channelconfig"
+	"github.com/hyperledger/fabric-x-common/protoutil"
+	"github.com/hyperledger/fabric-x-common/tools/configtxlator/update"
+	"github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	fabric_network "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/network"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/topology"
+)
+
+// configRequestTimeout bounds every gRPC call the configuration helpers make.
+const configRequestTimeout = 30 * time.Second
+
+// clientCredentials returns the transport credentials needed to reach the committer's
+// query service and the ordering service. Both require mTLS, and accept any identity
+// signed by a fabric organization CA, so the credentials of the first FSC peer are
+// borrowed -- the same thing extensions/scv2/ext.go does when it generates node
+// configuration.
+func clientCredentials(n *Network) credentials.TransportCredentials {
+	var fscPeer *topology.Peer
+	for _, p := range n.Peers {
+		if p.Type == topology.FSCPeer {
+			fscPeer = p
+			break
+		}
+	}
+	gomega.Expect(fscPeer).NotTo(gomega.BeNil(), "the topology has no FSC peer to borrow TLS credentials from")
+
+	tlsDir := n.PeerLocalTLSDir(fscPeer)
+	cert, err := tls.LoadX509KeyPair(filepath.Join(tlsDir, "server.crt"), filepath.Join(tlsDir, "server.key"))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "cannot load the client TLS key pair")
+
+	bundle, err := os.ReadFile(n.CACertsBundlePath())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "cannot read the CA certificate bundle")
+
+	pool := x509.NewCertPool()
+	gomega.Expect(pool.AppendCertsFromPEM(bundle)).To(gomega.BeTrue(), "the CA certificate bundle holds no certificate")
+
+	return credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      pool,
+		MinVersion:   tls.VersionTLS12,
+	})
+}
+
+// GetConfig returns the channel configuration the committer currently holds, whose
+// [common.Config.GetSequence] advances by one for every update the channel has applied.
+//
+// Every call queries the committer over the network, bounded by configRequestTimeout, and
+// no result is cached, so a caller waiting for a configuration change can poll this. An
+// unreachable query service, or a reply carrying no configuration, aborts the running spec
+// through Gomega.
+//
+// It takes no channel argument because a committer test node serves exactly one channel,
+// fixed when its container starts.
+func GetConfig(n *Network) *cb.Config {
+	committer := n.Peer(n.CommitterOrg, n.CommitterName)
+	gomega.Expect(committer).NotTo(gomega.BeNil(),
+		"no committer peer [%s.%s] in the topology", n.CommitterOrg, n.CommitterName)
+
+	addr := fmt.Sprintf("127.0.0.1:%d", n.PeerPort(committer, QueryServicePortName))
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(clientCredentials(n)))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "cannot reach the query service at [%s]", addr)
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), configRequestTimeout)
+	defer cancel()
+
+	res, err := committerpb.NewQueryServiceClient(conn).GetConfigTransaction(ctx, &emptypb.Empty{})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "the query service reported no config transaction")
+
+	env := &cb.Envelope{}
+	gomega.Expect(proto.Unmarshal(res.GetEnvelope(), env)).NotTo(gomega.HaveOccurred())
+
+	payload, err := protoutil.UnmarshalPayload(env.Payload)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	cenv, err := protoutil.UnmarshalConfigEnvelope(payload.Data)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(cenv.GetConfig()).NotTo(gomega.BeNil(), "the config envelope carries no configuration")
+
+	return cenv.GetConfig()
+}
+
+// UpdateConfig computes the difference between two channel configurations, signs it as the
+// orderer organization's admin plus, for each organization named in orgs, that
+// organization's peer Admin, and broadcasts the resulting CONFIG envelope to the ordering
+// service.
+//
+// The orderer admin alone satisfies an Orderer-group value's Admins policy (ImplicitMeta
+// MAJORITY Admins over the Orderer group's own, single organization) -- the only kind of
+// change callers needed until this parameter existed. An Application- or Channel-group
+// value is instead gated by a MAJORITY Admins policy over the Application group's peer
+// organizations, which no orderer identity can satisfy; name enough of those organizations
+// in orgs to reach that majority. The orderer admin remains the envelope's creator and
+// outer signer either way -- orgs only adds the additional ConfigSignatures a
+// peer-org-gated value's ModPolicy requires.
+//
+// It returns once the ordering service has accepted the envelope, which is earlier than
+// the committer having applied it: a caller that reads the configuration back immediately
+// may still observe the one it replaced. To wait for the new configuration to be in force,
+// poll [GetConfig] for a higher sequence.
+//
+// The envelope is derived through the current configuration's own configtx validator, the
+// same check FSC's membership service re-runs on receipt, so an envelope accepted here is
+// one the nodes under test should accept as well. An update the current configuration
+// rejects, or a broadcast the ordering service refuses, aborts the running spec through
+// Gomega.
+//
+// Fabric-X has no component that does this on a client's behalf, which is why it lives
+// here: the mock orderer in the committer test node only batches what is broadcast to it.
+func UpdateConfig(n *Network, o *topology.Orderer, channel string, current, updated *cb.Config, orgs ...string) {
+	// The Orderer group's Admins policy gates an Orderer-group change, so the orderer's
+	// admin signs it.
+	admin := adminSigner(n, o)
+
+	configUpdate, err := update.Compute(current, updated)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "cannot compute the configuration update")
+	configUpdate.ChannelId = channel
+
+	updateEnvelope := &cb.ConfigUpdateEnvelope{ConfigUpdate: protoutil.MarshalOrPanic(configUpdate)}
+	updateEnvelope.Signatures = []*cb.ConfigSignature{signConfigUpdate(admin, updateEnvelope.ConfigUpdate)}
+	for _, org := range orgs {
+		updateEnvelope.Signatures = append(updateEnvelope.Signatures,
+			signConfigUpdate(peerAdminSigner(n, org), updateEnvelope.ConfigUpdate))
+	}
+
+	signedUpdate, err := protoutil.CreateSignedEnvelope(cb.HeaderType_CONFIG_UPDATE, channel, admin, updateEnvelope, 0, 0)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "cannot sign the configuration update")
+
+	bundle, err := channelconfig.NewBundle(channel, current, factory.GetDefault())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "cannot build a bundle from the current configuration")
+
+	// ProposeConfigUpdate authorizes the update against the current configuration's mod
+	// policies and returns the configuration that results from applying it, with its
+	// sequence advanced by one.
+	configEnvelope, err := bundle.ConfigtxValidator().ProposeConfigUpdate(signedUpdate)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "the current configuration rejected the update")
+
+	broadcast(n, o, signedConfigTx(admin, channel, configEnvelope))
+}
+
+// signedConfigTx wraps a ConfigEnvelope into the CONFIG envelope broadcast to the ordering
+// service.
+//
+// The envelope is assembled by hand rather than through protoutil.CreateSignedEnvelope
+// because that helper leaves the channel header's TxId empty, and the committer's sidecar
+// checks for a transaction ID (service/sidecar/mapping.go:119) before it dispatches on
+// header type (:125). A CONFIG envelope without one is excluded as
+// MALFORMED_MISSING_TX_ID, the config block commits carrying zero transactions, nothing is
+// logged at INFO level, and the configuration simply never changes.
+func signedConfigTx(admin *signer.Signer, channel string, configEnvelope *cb.ConfigEnvelope) *cb.Envelope {
+	creator, err := admin.Serialize()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "cannot serialize the signing identity")
+
+	nonce, err := protoutil.CreateNonce()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "cannot create a nonce")
+
+	signatureHeader := &cb.SignatureHeader{Creator: creator, Nonce: nonce}
+	channelHeader := protoutil.MakeChannelHeader(cb.HeaderType_CONFIG, 0, channel, 0)
+	protoutil.SetTxID(channelHeader, signatureHeader)
+
+	payload := protoutil.MarshalOrPanic(&cb.Payload{
+		Header: protoutil.MakePayloadHeader(channelHeader, signatureHeader),
+		Data:   protoutil.MarshalOrPanic(configEnvelope),
+	})
+
+	signature, err := admin.Sign(payload)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "cannot sign the configuration transaction")
+
+	return &cb.Envelope{Payload: payload, Signature: signature}
+}
+
+// adminSigner is the given orderer organization's Admin identity.
+func adminSigner(n *Network, o *topology.Orderer) *signer.Signer {
+	org := n.Organization(o.Organization)
+	gomega.Expect(org).NotTo(gomega.BeNil(), "orderer [%s] belongs to no known organization", o.Name)
+
+	s, err := signer.NewSigner(signer.Config{
+		MSPID:        org.MSPID,
+		IdentityPath: n.OrdererUserCert(o, "Admin"),
+		KeyPath:      n.OrdererUserKey(o, "Admin"),
+	})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "cannot load the orderer admin signing identity")
+
+	return s
+}
+
+// peerAdminSigner is the given organization's peer Admin identity.
+//
+// It mirrors adminSigner, but resolves credentials through the organization's first peer
+// rather than an orderer: Fabric-X strips Fabric peers from the running network, yet keeps
+// their crypto material and topology.Peer registration, which is the same pattern
+// createNSCommon already relies on (via PeersInOrg and PeerUserMSPDir) to reach a peer
+// organization's Admin identity for namespace deployment. It aborts the running spec
+// through Gomega if the organization has no peers or no known identity.
+func peerAdminSigner(n *Network, org string) *signer.Signer {
+	peers := n.PeersInOrg(org)
+	gomega.Expect(peers).NotTo(gomega.BeEmpty(), "organization [%s] has no peers to sign as its Admin", org)
+
+	organization := n.Organization(org)
+	gomega.Expect(organization).NotTo(gomega.BeNil(), "no known organization [%s]", org)
+
+	s, err := signer.NewSigner(signer.Config{
+		MSPID:        organization.MSPID,
+		IdentityPath: n.PeerUserCert(peers[0], "Admin"),
+		KeyPath:      n.PeerUserKey(peers[0], "Admin"),
+	})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "cannot load the [%s] admin signing identity", org)
+
+	return s
+}
+
+// signConfigUpdate produces one admin signature over a marshalled ConfigUpdate.
+//
+// The signing input is the concatenation of the signature header and the ConfigUpdate, in
+// that order, which is what Fabric's configtx validator reconstructs to verify the
+// signature. slices.Concat rather than append: appending to the marshalled header would
+// write into its backing array if it ever had spare capacity, corrupting the header this
+// same signature covers.
+func signConfigUpdate(admin *signer.Signer, configUpdate []byte) *cb.ConfigSignature {
+	header, err := protoutil.NewSignatureHeader(admin)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "cannot build a signature header")
+
+	signature := &cb.ConfigSignature{SignatureHeader: protoutil.MarshalOrPanic(header)}
+	signature.Signature, err = admin.Sign(slices.Concat(signature.SignatureHeader, configUpdate))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "cannot sign the configuration update")
+
+	return signature
+}
+
+// broadcast submits an envelope to the ordering service and waits for its status.
+//
+// It dials the orderer itself rather than through fabric_network.Broadcast: that helper
+// dials with RequireClientCert false, and the fabricx topology sets ClientAuthRequired,
+// so the orderer closes the connection with "tls: certificate required".
+func broadcast(n *Network, o *topology.Orderer, env *cb.Envelope) {
+	addr := n.OrdererAddress(o, fabric_network.ListenPort)
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(clientCredentials(n)))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "cannot reach the ordering service at [%s]", addr)
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), configRequestTimeout)
+	defer cancel()
+
+	stream, err := protosorderer.NewAtomicBroadcastClient(conn).Broadcast(ctx)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "cannot open a broadcast stream")
+
+	gomega.Expect(stream.Send(env)).NotTo(gomega.HaveOccurred(), "cannot send the configuration transaction")
+
+	res, err := stream.Recv()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "the ordering service returned no status")
+	gomega.Expect(res.GetStatus()).To(gomega.Equal(cb.Status_SUCCESS),
+		"the ordering service rejected the configuration transaction: [%s]", res.GetInfo())
+}

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -38,6 +38,7 @@ const (
 	RuntimeConfigPort
 	FabricXAssetTransferPort
 	FabricConfigUpdatePort
+	FabricXConfigUpdatePort
 )
 
 // StartPortForNode On linux, the default ephemeral port range is 32768-60999 and can be


### PR DESCRIPTION
Closes #1712.

Adds an integration suite covering channel configuration updates on the fabricx platform — the counterpart to #1696 for fabric. Until now the fabricx channel config monitor's update path only ever ran for a channel's genesis configuration.

## The specs

**T1 — the nodes follow the configuration.** Changes `BatchTimeout` on a running network three times, asserting each time that every FSC node reports the new sequence and that the IOU flow still works. The third change lands while `borrower` is stopped, so it also covers a node converging on a configuration it missed.

**T2 — the nodes refuse what they cannot support.** Submits a configuration requiring an Application capability no fabric-x binary defines. The committer accepts it, having no capability check of its own; the nodes must refuse it and go on serving what they hold.

T2 applies an ordinary update first and asserts adoption. Without that, a dead config monitor would leave every node at sequence 0 regardless of the poisoned update and the spec would pass for the wrong reason — fault injection confirms it, since raising `pollInterval` to 24h fails both specs, and before that step existed T2 passed under the fault.

## Harness

`integration/nwo/fabricx/network/configupdate.go` reads the committer's configuration and computes, signs and broadcasts an update; Fabric-X has no client-side component that does this. Two gotchas are documented in place: the envelope is assembled by hand because `protoutil.CreateSignedEnvelope` leaves the channel header's `TxId` empty, which the committer's sidecar silently drops as `MALFORMED_MISSING_TX_ID`, and `UpdateConfig` takes a variadic `orgs` because an Application-group value needs peer-org signatures no orderer identity can supply.

## Testing

`make integration-tests-fabricx-configupdate` — `Ran 2 of 2 Specs in 187.909 seconds`,
`2 Passed | 0 Failed`. `make checks` and `make lint` — 0 issues across all four modules.
`make tidy` — no diff.
