### PR TITLE
test(integration): run libp2p in four targets instead of nine

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Set up monitoring
         # we only need this for a subset of integration tests
-        if: contains(fromJSON('["fabric-iou", "fabric-runtimeconfig", "fsc-stoprestart"]'), matrix.tests)
+        if: contains(fromJSON('["fabric-iou", "fabric-iou-libp2p", "fabric-runtimeconfig", "fsc-stoprestart"]'), matrix.tests)
         run: |
           make -j4 pull-images-monitoring
 

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,10 @@ include $(TOP)/checks.mk
 # we use a multi-module repo structure here and therefore need to carefully collect packages for unit tests
 GO_PACKAGES = $$(go list ./...)
 NWO_PACKAGES = ./nwo/...
+# The libp2p comm host is its own module, so the root `go list ./...` cannot see
+# it. Named here so `unit-tests` can step into it explicitly -- without this its
+# host-conformance tests (shared with the websocket host) never run.
+LIBP2P_HOST_MODULE = platform/view/services/comm/host/libp2p
 GO_PACKAGES_SDK = $$(go list ./... | grep '/sdk/dig$$')
 GO_TEST_PARAMS ?= -race -cover
 TEST_PKGS ?= $(GO_PACKAGES)
@@ -167,6 +171,7 @@ unit-tests: ## Run unit tests
 	rc=0; \
 	go test $(GO_TEST_PARAMS) $(GO_COVERPKG) --skip '(Postgres)' $(TEST_PKGS) || rc=1; \
 	go test -C integration $(GO_TEST_PARAMS) --skip '(Postgres)' $(NWO_PACKAGES) || rc=1; \
+	go test -C $(LIBP2P_HOST_MODULE) $(GO_TEST_PARAMS) ./... || rc=1; \
 	exit $$rc
 
 .PHONY: unit-tests-postgres
@@ -196,6 +201,9 @@ INTEGRATION_TARGETS += fabric-atsachaincode
 INTEGRATION_TARGETS += fabric-configupdate
 INTEGRATION_TARGETS += fabric-events
 INTEGRATION_TARGETS += fabric-iou
+# fabric/iou runs both comm types. They are split into two targets so CI runs
+# them as parallel matrix entries rather than serially in one job.
+INTEGRATION_TARGETS += fabric-iou-libp2p
 INTEGRATION_TARGETS += fabric-runtimeconfig
 INTEGRATION_TARGETS += fabric-stoprestart
 INTEGRATION_TARGETS += fabric-twonets
@@ -211,6 +219,21 @@ INTEGRATION_TARGETS += fabricx-deployment
 INTEGRATION_TARGETS += fabricx-multiendorsement
 INTEGRATION_TARGETS += fabricx-configupdate
 
+# Targets are normally named <platform>-<suite> and map onto
+# ./integration/<platform>/<suite>. Targets that run one suite under a
+# different name need an explicit directory.
+INTEGRATION_DIR_fabric-iou-libp2p = fabric/iou
+
+# Per-target ginkgo flags. A suite that declares more than one p2p comm type is
+# split into one target per type. The websocket target uses a negative filter
+# so a spec added later without a comm-type label still runs there, rather
+# than silently running in neither job.
+INTEGRATION_FLAGS_fabric-iou        = --label-filter='!libp2p'
+INTEGRATION_FLAGS_fabric-iou-libp2p = --label-filter=libp2p
+
+integration_default_dir = $(firstword $(subst -, ,$(1)))/$(subst $(firstword $(subst -, ,$(1)))-,,$(1))
+integration_dir = $(or $(INTEGRATION_DIR_$(1)),$(call integration_default_dir,$(1)))
+
 .PHONE: list-integration-tests
 list-integration-tests: ## List all integration tests
 	@$(foreach t,$(INTEGRATION_TARGETS) $(HSM_INTEGRATION_TARGETS),echo "$(t)";)
@@ -220,13 +243,13 @@ integration-tests: $(addprefix integration-tests-,$(INTEGRATION_TARGETS) $(HSM_I
 
 $(addprefix integration-tests-,$(HSM_INTEGRATION_TARGETS)) : integration-tests-%:
 	export FAB_BINS=$(FAB_BINS); \
-		cd ./integration/$(firstword $(subst -, ,$*))/$(subst $(firstword $(subst -, ,$*))-,,$*); \
-		GOFLAGS="-tags=pkcs11" ginkgo $(GINKGO_TEST_OPTS) .
+		cd ./integration/$(call integration_dir,$*); \
+		GOFLAGS="-tags=pkcs11" ginkgo $(GINKGO_TEST_OPTS) $(INTEGRATION_FLAGS_$*) .
 
 $(addprefix integration-tests-,$(INTEGRATION_TARGETS)) : integration-tests-%:
 	export FAB_BINS=$(FAB_BINS); \
-		cd ./integration/$(firstword $(subst -, ,$*))/$(subst $(firstword $(subst -, ,$*))-,,$*); \
-		ginkgo $(GINKGO_TEST_OPTS) .
+		cd ./integration/$(call integration_dir,$*); \
+		ginkgo $(GINKGO_TEST_OPTS) $(INTEGRATION_FLAGS_$*) .
 
 #########################
 # Release

--- a/docs/agents/integration-tests.md
+++ b/docs/agents/integration-tests.md
@@ -15,7 +15,7 @@ Ginkgo v2 + Gomega.
 
 ```go
 opts := &integration.Opts{
-    CommType:   fsc.LibP2P, // or fsc.WebSocket
+    CommType:   fsc.WebSocket, // the default; use fsc.LibP2P only with a reason
     TLSEnabled: true,
     ReplicationOpts: &integration.ReplicationOptions{
         ReplicationFactors: map[string]int{"node": 3},
@@ -23,6 +23,24 @@ opts := &integration.Opts{
     },
 }
 ```
+
+### Choosing a p2p comm type
+
+New suites use `fsc.WebSocket`. Add a `fsc.LibP2P` variant only when the suite
+exercises something transport-specific that the host conformance tests in
+`platform/view/services/comm` cannot reach — every extra comm type costs a full
+network bootstrap per spec, because each `It` re-runs `Setup`/`TearDown`.
+
+Label each `Describe` with its comm type so a suite can be run one transport at
+a time (`ginkgo --label-filter=libp2p`) and split into parallel CI entries:
+
+    for _, c := range []fsc.P2PCommunicationType{fsc.WebSocket} {
+        Describe("My Life Cycle", Label(c), func() { /* ... */ })
+    }
+
+Label websocket-only variants (replication, no-TLS) with `Label(fsc.WebSocket)`
+too: `--label-filter` selects only labelled specs, so an unlabelled `Describe`
+is silently skipped when a filter is in play.
 
 ## Declaring a namespace
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,8 +91,11 @@ fsc:
 
   # ------------------- P2P Configuration -------------------------
   p2p:
-    # Type of p2p communication. Currently supported: libp2p (default), websocket
-    type: libp2p
+    # Type of p2p communication. Currently supported: websocket, libp2p.
+    # There is no default -- an unset or unrecognised type is rejected at
+    # startup. websocket is the primary implementation; libp2p is optional and
+    # lives in its own Go module.
+    type: websocket
     # listen address see https://github.com/libp2p/specs/blob/master/addressing/README.md
     # for information on the format
     listenAddress: /dns4/myhostname/tcp/20001

--- a/docs/platform/view/services/comm/libp2p.md
+++ b/docs/platform/view/services/comm/libp2p.md
@@ -1,6 +1,6 @@
 # Libp2p Transport
 
-The Libp2p transport is the default communication stack for the Fabric Smart Client. It leverages the industry-standard `libp2p` library to provide a decentralized, robust, and highly configurable P2P networking layer.
+The Libp2p transport is an optional communication stack for the Fabric Smart Client, distributed as its own Go module; the websocket transport is the primary implementation and lives in the root module. It leverages the industry-standard `libp2p` library to provide a decentralized, robust, and highly configurable P2P networking layer.
 
 ## Overview
 

--- a/docs/platform/view/services/comm/readme.md
+++ b/docs/platform/view/services/comm/readme.md
@@ -128,8 +128,9 @@ Configuration is managed via the FSC configuration file (usually `core.yaml`). F
 ```yaml
 fsc:
   p2p:
-    # Transport type: "libp2p" or "websocket"
-    type: libp2p
+    # Transport type: "websocket" or "libp2p". There is no default -- an unset
+    # or unrecognised type is rejected at startup.
+    type: websocket
     listenAddress: /ip4/0.0.0.0/tcp/11511
     # Buffer size for the incoming messages channel. Default: 1024
     # This controls how many messages can be queued before blocking message dispatch.

--- a/integration/fabric/atsa/atsa_test.go
+++ b/integration/fabric/atsa/atsa_test.go
@@ -21,21 +21,19 @@ import (
 type node = [2]string
 
 var _ = Describe("EndToEnd", func() {
-	Describe("Asset Transfer Secured Agreement (With Approvers) with LibP2P", func() {
-		s := NewTestSuite(nwofsc.LibP2P, integration.NoReplication)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("succeeded", s.TestSucceeded)
-	})
+	// websocket only: this suite's p2p usage goes through the same
+	// platform/fabric/services/state code path that fabric/iou exercises under
+	// libp2p, so a second transport here buys a Fabric bootstrap and no coverage.
+	for _, c := range []nwofsc.P2PCommunicationType{nwofsc.WebSocket} {
+		Describe("Asset Transfer Secured Agreement (With Approvers)", Label(c), func() {
+			s := NewTestSuite(c, integration.NoReplication)
+			BeforeEach(s.Setup)
+			AfterEach(s.TearDown)
+			It("succeeded", s.TestSucceeded)
+		})
+	}
 
-	Describe("Asset Transfer Secured Agreement (With Approvers) with Websockets", func() {
-		s := NewTestSuite(nwofsc.WebSocket, integration.NoReplication)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("succeeded", s.TestSucceeded)
-	})
-
-	Describe("Asset Transfer Secured Agreement (With Approvers) with Websockets with replicas", func() {
+	Describe("Asset Transfer Secured Agreement (With Approvers) with replicas", Label(nwofsc.WebSocket), func() {
 		s := NewTestSuite(
 			nwofsc.WebSocket,
 			&integration.ReplicationOptions{

--- a/integration/fabric/atsachaincode/atsa_test.go
+++ b/integration/fabric/atsachaincode/atsa_test.go
@@ -20,19 +20,17 @@ import (
 )
 
 var _ = Describe("EndToEnd", func() {
-	Describe("Asset Transfer Secured Agreement (With Chaincode) with LibP2P", func() {
-		s := NewTestSuite(fsc.LibP2P, integration.NoReplication)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("succeeded", s.TestSucceeded)
-	})
-
-	Describe("Asset Transfer Secured Agreement (With Chaincode) with WebSockets", func() {
-		s := NewTestSuite(fsc.WebSocket, integration.NoReplication)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("succeeded", s.TestSucceeded)
-	})
+	// websocket only: this suite registers no responders and never opens a
+	// session -- its views only invoke chaincode -- so no FSC-to-FSC traffic
+	// crosses the p2p layer and the transport is irrelevant to what it asserts.
+	for _, c := range []fsc.P2PCommunicationType{fsc.WebSocket} {
+		Describe("Asset Transfer Secured Agreement (With Chaincode)", Label(c), func() {
+			s := NewTestSuite(c, integration.NoReplication)
+			BeforeEach(s.Setup)
+			AfterEach(s.TearDown)
+			It("succeeded", s.TestSucceeded)
+		})
+	}
 })
 
 type TestSuite struct {

--- a/integration/fabric/iou/iou_test.go
+++ b/integration/fabric/iou/iou_test.go
@@ -17,28 +17,29 @@ import (
 )
 
 var _ = Describe("EndToEnd", func() {
-	Describe("IOU Life Cycle With LibP2P", Label("T1"), func() {
-		s := NewTestSuite(fsc.LibP2P, integration.NoReplication, true)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("succeeded", s.TestSucceeded)
-	})
+	// Both transports run the basic life cycle: this suite is the p2p-heavy
+	// end-to-end case (4 FSC nodes exchanging recipient identities and
+	// collecting endorsements), so it is where libp2p is worth its cost.
+	for _, c := range []fsc.P2PCommunicationType{fsc.WebSocket, fsc.LibP2P} {
+		Describe("IOU Life Cycle", Label(c), func() {
+			s := NewTestSuite(c, integration.NoReplication, true)
+			BeforeEach(s.Setup)
+			AfterEach(s.TearDown)
+			It("succeeded", s.TestSucceeded)
+		})
+	}
 
-	Describe("IOU Life Cycle With Websockets", Label("T2"), func() {
-		s := NewTestSuite(fsc.WebSocket, integration.NoReplication, true)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("succeeded", s.TestSucceeded)
-	})
-
-	Describe("IOU Life Cycle With Websockets and no TLS", Label("T3"), func() {
+	// The variants below vary TLS and replication, not the transport, so they
+	// run on websocket only. They still carry the label: a --label-filter
+	// selects only labelled specs, so an unlabelled Describe would be skipped.
+	Describe("IOU Life Cycle With Websockets and no TLS", Label(fsc.WebSocket), func() {
 		s := NewTestSuite(fsc.WebSocket, integration.NoReplication, false)
 		BeforeEach(s.Setup)
 		AfterEach(s.TearDown)
 		It("succeeded", s.TestSucceeded)
 	})
 
-	Describe("IOU Life Cycle With Websockets and replicas", Label("T4"), func() {
+	Describe("IOU Life Cycle With Websockets and replicas", Label(fsc.WebSocket), func() {
 		s := NewTestSuite(
 			fsc.WebSocket,
 			&integration.ReplicationOptions{

--- a/integration/fabric/iouhsm/iou_test.go
+++ b/integration/fabric/iouhsm/iou_test.go
@@ -19,21 +19,18 @@ import (
 )
 
 var _ = Describe("EndToEnd", func() {
-	Describe("IOU (With HSM) Life Cycle With LibP2P", func() {
-		s := NewTestSuite(fsc.LibP2P, integration.NoReplication)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("succeeded", s.TestSucceeded)
-	})
+	// websocket only: identical p2p path to fabric/iou, which keeps libp2p. The
+	// variable under test here is HSM signing, not the transport.
+	for _, c := range []fsc.P2PCommunicationType{fsc.WebSocket} {
+		Describe("IOU (With HSM) Life Cycle", Label(c), func() {
+			s := NewTestSuite(c, integration.NoReplication)
+			BeforeEach(s.Setup)
+			AfterEach(s.TearDown)
+			It("succeeded", s.TestSucceeded)
+		})
+	}
 
-	Describe("IOU (With HSM) Life Cycle With Websockets", func() {
-		s := NewTestSuite(fsc.WebSocket, integration.NoReplication)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("succeeded", s.TestSucceeded)
-	})
-
-	Describe("IOU (With HSM) Life Cycle With Websockets and replicas", func() {
+	Describe("IOU (With HSM) Life Cycle With Websockets and replicas", Label(fsc.WebSocket), func() {
 		s := NewTestSuite(fsc.WebSocket, &integration.ReplicationOptions{
 			ReplicationFactors: map[string]int{
 				"borrower": 3,

--- a/integration/fabric/stoprestart/stoprestart_test.go
+++ b/integration/fabric/stoprestart/stoprestart_test.go
@@ -17,21 +17,18 @@ import (
 )
 
 var _ = Describe("EndToEnd", func() {
-	Describe("Stop and Restart with Fabric With LibP2P", func() {
-		s := NewTestSuite(fsc.LibP2P, integration.NoReplication)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("stop and restart successfully", s.TestSucceeded)
-	})
+	// websocket only: fsc/stoprestart runs the same initiator/responder restart
+	// scenario under libp2p without paying for a Fabric network.
+	for _, c := range []fsc.P2PCommunicationType{fsc.WebSocket} {
+		Describe("Stop and Restart with Fabric", Label(c), func() {
+			s := NewTestSuite(c, integration.NoReplication)
+			BeforeEach(s.Setup)
+			AfterEach(s.TearDown)
+			It("stop and restart successfully", s.TestSucceeded)
+		})
+	}
 
-	Describe("Stop and Restart with Fabric With Websockets", func() {
-		s := NewTestSuite(fsc.WebSocket, integration.NoReplication)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("stop and restart successfully", s.TestSucceeded)
-	})
-
-	Describe("Stop and Restart with Fabric With Replicas many to one", func() {
+	Describe("Stop and Restart with Fabric With Replicas many to one", Label(fsc.WebSocket), func() {
 		s := NewTestSuite(fsc.WebSocket, &integration.ReplicationOptions{
 			ReplicationFactors: map[string]int{
 				"alice": 4,
@@ -43,7 +40,7 @@ var _ = Describe("EndToEnd", func() {
 		It("stop and restart successfully", s.TestSucceededWithReplicas)
 	})
 
-	Describe("Stop and Restart with Fabric With Replicas many to many", func() {
+	Describe("Stop and Restart with Fabric With Replicas many to many", Label(fsc.WebSocket), func() {
 		s := NewTestSuite(fsc.WebSocket, &integration.ReplicationOptions{
 			ReplicationFactors: map[string]int{
 				"alice": 4,

--- a/integration/fabric/twonets/twonets_test.go
+++ b/integration/fabric/twonets/twonets_test.go
@@ -17,19 +17,17 @@ import (
 )
 
 var _ = Describe("EndToEnd", func() {
-	Describe("Two Fabric Networks Life Cycle With LibP2P", func() {
-		s := NewTestSuite(fsc.LibP2P, integration.NoReplication)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("succeeded", s.TestSucceeded)
-	})
-
-	Describe("Two Fabric Networks Life Cycle With Websockets", func() {
-		s := NewTestSuite(fsc.WebSocket, integration.NoReplication)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("succeeded", s.TestSucceeded)
-	})
+	// websocket only: the p2p exchange here is a single ping/pong that
+	// fsc/pingpong covers without a Fabric network. This suite's subject is two
+	// Fabric networks, and it pays two bootstraps per spec.
+	for _, c := range []fsc.P2PCommunicationType{fsc.WebSocket} {
+		Describe("Two Fabric Networks Life Cycle", Label(c), func() {
+			s := NewTestSuite(c, integration.NoReplication)
+			BeforeEach(s.Setup)
+			AfterEach(s.TearDown)
+			It("succeeded", s.TestSucceeded)
+		})
+	}
 })
 
 type TestSuite struct {

--- a/integration/fsc/pingpong/pingpong_test.go
+++ b/integration/fsc/pingpong/pingpong_test.go
@@ -30,7 +30,13 @@ import (
 )
 
 var _ = Describe("EndToEnd", func() {
-	Describe("Node-based Ping pong", func() {
+	// libp2p, not websocket: these specs start in-process nodes straight from the
+	// committed testdata under ./testdata, whose config is libp2p. It cannot be
+	// switched to websocket by editing the config alone -- the websocket host
+	// derives its P2P TLS material from fsc.identity.cert.file, and this fixture's
+	// signing cert carries no IP SANs, so a handshake to 127.0.0.1 cannot verify.
+	// Making it websocket means regenerating the fixture's crypto.
+	Describe("Node-based Ping pong", Label(fsc.LibP2P), func() {
 		var (
 			initiator FSCNode
 			responder FSCNode
@@ -131,19 +137,24 @@ var _ = Describe("EndToEnd", func() {
 		})
 	})
 
-	Describe("Network-based Ping pong With LibP2P", func() {
+	// libp2p keeps only the specs that put bytes on the wire. The four dropped
+	// ones vary the client API (REST, web client, artifact generate-vs-load,
+	// stream-vs-call), which is transport-agnostic and fully covered by the
+	// websocket Describe below.
+	Describe("Network-based Ping pong With LibP2P", Label(fsc.LibP2P), func() {
 		s := NewTestSuite(fsc.LibP2P, false, integration.NoReplication)
 		BeforeEach(s.Setup)
 		AfterEach(s.TearDown)
-		It("generate artifacts & successful pingpong", func() { s.TestGenerateAndPingPong("initiator") })
 		It("load artifact & successful pingpong", func() { s.TestLoadAndPingPong("initiator") })
-		It("load artifact & successful pingpong with stream", func() { s.TestLoadAndPingPongStream("initiator") })
 		It("load artifact & successful stream", func() { s.TestLoadAndStream("initiator") })
-		It("load artifact & successful stream with websocket", func() { s.TestLoadAndStreamWebsocket("initiator") })
-		It("load artifact & init clients & successful pingpong", s.TestLoadInitPingPong)
 	})
 
-	Describe("Network-based Ping pong With Websockets", func() {
+	// The label describes this Describe's first spec only. Artifacts are generated
+	// on the first Setup and loaded from ./testdata thereafter (fsc.Platform.Load
+	// is a no-op, so core.yaml is never rewritten), and that committed fixture is
+	// libp2p -- see the node-based Describe above for why it cannot be websocket.
+	// So do not split this suite by label expecting a clean transport partition.
+	Describe("Network-based Ping pong With Websockets", Label(fsc.WebSocket), func() {
 		s := NewTestSuite(fsc.WebSocket, false, integration.NoReplication)
 		BeforeEach(s.Setup)
 		AfterEach(s.TearDown)
@@ -155,7 +166,7 @@ var _ = Describe("EndToEnd", func() {
 		It("load artifact & init clients & successful pingpong", s.TestLoadInitPingPong)
 	})
 
-	Describe("Network-based Ping pong With Websockets and replication", func() {
+	Describe("Network-based Ping pong With Websockets and replication", Label(fsc.WebSocket), func() {
 		s := NewTestSuite(fsc.WebSocket, true, &integration.ReplicationOptions{
 			ReplicationFactors: map[string]int{
 				"initiator": 3,
@@ -167,17 +178,17 @@ var _ = Describe("EndToEnd", func() {
 		It("generate artifacts & successful pingpong", func() { s.TestGenerateAndPingPong(initiatorReplicas...) })
 		It("load artifact & successful pingpong", func() { s.TestLoadAndPingPong(initiatorReplicas...) })
 		It("load artifact & successful pingpong with stream", func() { s.TestLoadAndPingPongStream(initiatorReplicas...) })
-		It("load artifact & successful stream", Label("T1"), func() { s.TestLoadAndStream(initiatorReplicas...) })
+		It("load artifact & successful stream", func() { s.TestLoadAndStream(initiatorReplicas...) })
 		It("load artifact & successful stream with websocket", func() { s.TestLoadAndStreamWebsocket(initiatorReplicas...) })
 	})
 
-	Describe("Network-based Mock Ping pong With LibP2P", func() {
+	Describe("Network-based Mock Ping pong With LibP2P", Label(fsc.LibP2P), func() {
 		s := NewTestSuite(fsc.LibP2P, false, integration.NoReplication)
 		BeforeEach(s.Setup)
 		AfterEach(s.TearDown)
 		It("generate artifacts & successful mock pingpong", s.TestGenerateAndMockPingPong)
 	})
-	Describe("Network-based Mock Ping pong With Websockets", func() {
+	Describe("Network-based Mock Ping pong With Websockets", Label(fsc.WebSocket), func() {
 		s := NewTestSuite(fsc.WebSocket, false, integration.NoReplication)
 		BeforeEach(s.Setup)
 		AfterEach(s.TearDown)
@@ -270,13 +281,20 @@ func (s *TestSuite) TestLoadAndStream(clients ...string) {
 }
 
 func (s *TestSuite) TestLoadAndStreamWebsocket(clients ...string) {
-	time.Sleep(7 * time.Second)
 	for _, clientName := range clients {
 		// Get a client for the fsc node labelled initiator
 		initiator := s.II.WebClient(clientName)
-		// Initiate a view and check the output
-		channel, err := initiator.StreamCallView("stream", nil)
-		Expect(err).NotTo(HaveOccurred())
+		// The node's web server may still be coming up. Poll the stream call
+		// itself rather than a separate endpoint: this suite enables only the web
+		// server (topology.WebEnabled), not Prometheus metrics, so there is no
+		// /metrics route to probe. An attempt that errors yields no usable
+		// stream, so retrying is safe.
+		var channel *client2.WSStream
+		Eventually(func() error {
+			var err error
+			channel, err = initiator.StreamCallView("stream", nil)
+			return err
+		}, 30*time.Second, 250*time.Millisecond).Should(Succeed())
 		var str string
 		Expect(channel.Recv(&str)).NotTo(HaveOccurred())
 		Expect(str).To(BeEquivalentTo("hello"))

--- a/integration/fsc/signedpingpong/signedpingpong_test.go
+++ b/integration/fsc/signedpingpong/signedpingpong_test.go
@@ -17,19 +17,16 @@ import (
 )
 
 var _ = Describe("EndToEnd", func() {
-	Describe("Network-based Signed Ping Pong With LibP2P", func() {
-		s := NewTestSuite(fsc.LibP2P, integration.NoReplication)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("signed exchange succeeds", func() { s.TestSignedExchange("alice") })
-	})
-
-	Describe("Network-based Signed Ping Pong With Websockets", func() {
-		s := NewTestSuite(fsc.WebSocket, integration.NoReplication)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("signed exchange succeeds", func() { s.TestSignedExchange("alice") })
-	})
+	// Both transports: a signed round-trip is cheap to run twice -- this suite
+	// starts no Fabric network.
+	for _, c := range []fsc.P2PCommunicationType{fsc.WebSocket, fsc.LibP2P} {
+		Describe("Network-based Signed Ping Pong", Label(c), func() {
+			s := NewTestSuite(c, integration.NoReplication)
+			BeforeEach(s.Setup)
+			AfterEach(s.TearDown)
+			It("signed exchange succeeds", func() { s.TestSignedExchange("alice") })
+		})
+	}
 })
 
 type TestSuite struct {

--- a/integration/fsc/stoprestart/stoprestart_test.go
+++ b/integration/fsc/stoprestart/stoprestart_test.go
@@ -17,21 +17,18 @@ import (
 )
 
 var _ = Describe("EndToEnd", func() {
-	Describe("Stop and Restart With LibP2P", func() {
-		s := NewTestSuite(fsc.LibP2P, integration.NoReplication)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("stop and restart successfully", s.TestSucceeded)
-	})
+	// Both transports: session and stream recovery after a peer restart is
+	// transport-sensitive, and this suite needs no Fabric network to check it.
+	for _, c := range []fsc.P2PCommunicationType{fsc.WebSocket, fsc.LibP2P} {
+		Describe("Stop and Restart", Label(c), func() {
+			s := NewTestSuite(c, integration.NoReplication)
+			BeforeEach(s.Setup)
+			AfterEach(s.TearDown)
+			It("stop and restart successfully", s.TestSucceeded)
+		})
+	}
 
-	Describe("Stop and Restart With Websockets", func() {
-		s := NewTestSuite(fsc.WebSocket, integration.NoReplication)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("stop and restart successfully", s.TestSucceeded)
-	})
-
-	Describe("Stop and Restart With Replicas many to one", func() {
+	Describe("Stop and Restart With Replicas many to one", Label(fsc.WebSocket), func() {
 		s := NewTestSuite(fsc.WebSocket, &integration.ReplicationOptions{
 			ReplicationFactors: map[string]int{
 				"alice": 4,
@@ -43,7 +40,7 @@ var _ = Describe("EndToEnd", func() {
 		It("stop and restart successfully", s.TestSucceededWithReplicas)
 	})
 
-	Describe("Stop and Restart With Replicas many to many", func() {
+	Describe("Stop and Restart With Replicas many to many", Label(fsc.WebSocket), func() {
 		s := NewTestSuite(fsc.WebSocket, &integration.ReplicationOptions{
 			ReplicationFactors: map[string]int{
 				"alice": 4,

--- a/integration/nwo/fsc/fsc.go
+++ b/integration/nwo/fsc/fsc.go
@@ -405,7 +405,7 @@ func (p *Platform) CheckTopology() {
 	}
 
 	for _, node := range p.Topology.Nodes {
-		if p.Topology.P2PCommunicationType != WebSocket && node.Options.ReplicationFactor() > 1 {
+		if p.P2PCommunicationType() != WebSocket && node.Options.ReplicationFactor() > 1 {
 			panic("replication only supported for websocket p2p communication")
 		}
 		for _, uniqueName := range node.ReplicaUniqueNames() {
@@ -503,7 +503,7 @@ func (p *Platform) P2PCommunicationType() P2PCommunicationType {
 	if typ := p.Topology.P2PCommunicationType; len(typ) > 0 {
 		return typ
 	}
-	return LibP2P
+	return WebSocket
 }
 
 func (p *Platform) RoutingConfigPath() string {

--- a/integration/nwo/fsc/topology.go
+++ b/integration/nwo/fsc/topology.go
@@ -71,7 +71,7 @@ func NewTopology() *Topology {
 			MetricsType: "none",
 			TLS:         true,
 		},
-		P2PCommunicationType: LibP2P,
+		P2PCommunicationType: WebSocket,
 	}
 }
 

--- a/integration/nwo/fsc/topology_test.go
+++ b/integration/nwo/fsc/topology_test.go
@@ -74,3 +74,30 @@ func TestTopology_SetLogging(t *testing.T) {
 		})
 	}
 }
+
+func TestNewTopology_DefaultsToWebSocket(t *testing.T) {
+	t.Parallel()
+	// websocket is the primary comm implementation, so a topology that does not
+	// state a transport must get websocket rather than the optional libp2p host.
+	assert.Equal(t, WebSocket, NewTopology().P2PCommunicationType)
+}
+
+func TestPlatform_P2PCommunicationType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		topology *Topology
+		want     P2PCommunicationType
+	}{
+		{name: "explicit libp2p is honoured", topology: &Topology{P2PCommunicationType: LibP2P}, want: LibP2P},
+		{name: "explicit websocket is honoured", topology: &Topology{P2PCommunicationType: WebSocket}, want: WebSocket},
+		{name: "unset falls back to websocket", topology: &Topology{}, want: WebSocket},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := &Platform{Topology: tt.topology}
+			assert.Equal(t, tt.want, p.P2PCommunicationType())
+		})
+	}
+}


### PR DESCRIPTION
Closes: #1715

## What

- Every `Describe` in the affected suites carries a comm-type label, so a suite can be run one transport at a time (`ginkgo --label-filter=libp2p`) and split into parallel CI entries.
- libp2p dropped from `fabric/atsa`, `fabric/atsachaincode`, `fabric/iouhsm`, `fabric/twonets`, `fabric/stoprestart`.
- `fsc/pingpong`'s libp2p sweep trimmed 6 → 2 specs; the other four vary the *client* API (REST, web client, artifact generate-vs-load, stream-vs-call), which is transport-agnostic and stays fully covered under websocket.
- `fabric-iou` split into `fabric-iou` (websocket) + `fabric-iou-libp2p`, so keeping both transports there doesn't set PR wall-clock. The websocket target uses `--label-filter='!libp2p'` so a spec added later without a label still runs somewhere.
- **`make unit-tests` now executes the libp2p host module** — the enabling change. `ok .../comm/host/libp2p`, 52.4% coverage.
- A fixed `time.Sleep(7 * time.Second)` in `TestLoadAndStreamWebsocket` replaced with a poll of the stream call it was waiting for.
- nwo harness defaults to websocket; four docs corrected (they claimed libp2p was "the default" — there is no default; `provider.NewHostProvider` rejects an unset `fsc.p2p.type`).

Net: 5 Fabric bootstraps and 4 nwo cycles removed. libp2p end-to-end goes from 9 targets to 4 (`fsc-pingpong`, `fsc-stoprestart`, `fsc-signedpingpong`, `fabric-iou-libp2p`).

## Why this is safe

Three of the five deletions are provably free: `atsachaincode` has no sessions at all; `iouhsm`'s HSM covers the *Fabric* identity while libp2p derives its peer key from `fsc.identity.key.file`; `fabric/stoprestart` duplicates `fsc/stoprestart`. `fabric/iou` retains the richest p2p flow — 4 nodes, recipient-identity exchange plus endorsement collection — under both transports.

Two residual gaps, both low risk: libp2p alongside two Fabric SDK graphs (`twonets`), and libp2p under `atsa`'s larger `services/state` payloads.

## Verified

pingpong 18/18 · iou 1/1 + 3/3 · signedpingpong 2/2 · stoprestart 4/4 · atsachaincode 1/1 · twonets 1/1 · `make unit-tests` green with libp2p executing · `make checks` (includes lint) 0 issues across all four modules · `make tidy` no `.mod`/`.sum` churn.

`fabric/atsa` and `fabric/iouhsm` are dry-run only — atsa fails locally on a pre-existing legacy-chaincode build issue unrelated to this branch, iouhsm needs SoftHSM. Both left to CI.

## Notes for review

- **`P2PCommunicationType` default flips to websocket.** Downstream consumers of `nwo` (Panurus) whose topologies omit the field will silently change transport.
- **`fsc/pingpong`'s committed testdata stays libp2p.** Moving it to websocket needs regenerated crypto: the fixture's signing cert has no IP SANs and the websocket host derives P2P TLS material from `fsc.identity.cert.file`. The node-based `Describe` is labelled `fsc.LibP2P` to match, with the reason recorded inline.
- Known follow-ups: gitignore `*.test` / `*.profile` / `pids.txt`; connection leak in `platform/view/services/web/client/client.go:131-141`; vestigial `Label("T1")` in `configupdate` / `runtimeconfig`; the seven one-element-loop simplifications flagged by the over-engineering review.
