### PR TITLE
fix(node): fix two profiling bugs found while covering error paths

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 package node
 
 import (
-	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -79,39 +79,56 @@ func TestCallback(t *testing.T) {
 	require.NotNil(t, ch)
 }
 
+// runListen runs listen in a goroutine, feeds err on the callback channel and
+// returns whatever listen panicked with (nil if it returned normally).
+func runListen(t *testing.T, n *Node, err error) any {
+	t.Helper()
+	got := make(chan any, 1)
+	go func() {
+		defer func() { got <- recover() }()
+		n.listen()
+	}()
+	n.callbackChannel <- err
+	select {
+	case r := <-got:
+		return r
+	case <-time.After(time.Second):
+		t.Fatal("listen did not finish")
+		return nil
+	}
+}
+
 func TestListen_NilError_NoCallback(t *testing.T) {
 	t.Parallel()
 	n := newWithFSCNode(&mockFSCNode{})
-	done := make(chan struct{})
-	go func() {
-		n.listen()
-		close(done)
-	}()
-	n.callbackChannel <- nil
-	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
-	t.Cleanup(cancel)
-	select {
-	case <-done:
-	case <-ctx.Done():
-		t.Fatal("listen did not return after nil error with no callback set")
-	}
+	require.Nil(t, runListen(t, n, nil), "listen should return without panicking")
 }
 
 func TestListen_NilError_WithCallback(t *testing.T) {
 	t.Parallel()
 	n := newWithFSCNode(&mockFSCNode{})
-	called := make(chan struct{})
+	called := false
 	n.executeCallbackFunc = func() error {
-		close(called)
+		called = true
 		return nil
 	}
-	go n.listen()
-	n.callbackChannel <- nil
-	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
-	t.Cleanup(cancel)
-	select {
-	case <-called:
-	case <-ctx.Done():
-		t.Fatal("executeCallbackFunc was not called")
-	}
+	require.Nil(t, runListen(t, n, nil), "listen should return without panicking")
+	require.True(t, called, "executeCallbackFunc was not called")
+}
+
+func TestListen_ChannelErrorPanics(t *testing.T) {
+	t.Parallel()
+	n := newWithFSCNode(&mockFSCNode{})
+	err, ok := runListen(t, n, errors.New("boom")).(error)
+	require.True(t, ok, "listen should panic with the channel error")
+	require.EqualError(t, err, "boom")
+}
+
+func TestListen_CallbackErrorPanics(t *testing.T) {
+	t.Parallel()
+	n := newWithFSCNode(&mockFSCNode{})
+	n.executeCallbackFunc = func() error { return errors.New("callback boom") }
+	err, ok := runListen(t, n, nil).(error)
+	require.True(t, ok, "listen should panic with the callback error")
+	require.EqualError(t, err, "callback boom")
 }

--- a/node/start/profile/profile.go
+++ b/node/start/profile/profile.go
@@ -132,6 +132,7 @@ func (p *Profile) startCPUProfile() error {
 		return errors.Wrap(err, "failed to create cpu profile file")
 	}
 	if err := pprof.StartCPUProfile(f); err != nil {
+		_ = f.Close()
 		return errors.Wrap(err, "failed to start cpu profile")
 	}
 	p.appendCloser(func() {
@@ -157,8 +158,14 @@ func (p *Profile) startMemProfile(memProfileType string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create memory profile file")
 	}
-	old := runtime.MemProfileRate
-	runtime.MemProfileRate = p.memProfileRate
+	if runtime.MemProfileRate != p.memProfileRate {
+		// Only the profile that actually changes the rate restores it. Otherwise
+		// the second memory profile would capture the rate the first one set and
+		// Stop would leave the process on that value.
+		old := runtime.MemProfileRate
+		runtime.MemProfileRate = p.memProfileRate
+		p.appendCloser(func() { runtime.MemProfileRate = old })
+	}
 	p.appendCloser(func() {
 		logger.Infof("Stopping memory profile")
 		defer func() {
@@ -177,7 +184,6 @@ func (p *Profile) startMemProfile(memProfileType string) error {
 		if err := f.Sync(); err != nil {
 			logger.Errorf("failed to flush memory profile data to disk: %s", err)
 		}
-		runtime.MemProfileRate = old
 	})
 
 	return nil

--- a/node/start/profile/profile_test.go
+++ b/node/start/profile/profile_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/pprof"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -113,6 +114,71 @@ func TestLifecycle(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, entries)
 	})
+}
+
+func TestNew_OptionError(t *testing.T) {
+	t.Parallel()
+	p, err := New(WithPath(""))
+	require.ErrorContains(t, err, "path is required")
+	require.Nil(t, p)
+}
+
+// TestStart_CreateFailure plants a *directory* where each profile file would go,
+// so os.Create fails. This covers the create-error return inside every
+// start*Profile as well as its propagation out of Start.
+func TestStart_CreateFailure(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		file    string
+		wantErr string
+		enable  func(*Profile)
+	}{
+		{"cpu", "cpu.pprof", "failed to create cpu profile file", func(p *Profile) { p.cpu = true }},
+		{"memoryHeap", "mem-heap.pprof", "failed to create memory profile file", func(p *Profile) { p.memoryHeap = true }},
+		{"memoryAllocs", "mem-allocs.pprof", "failed to create memory profile file", func(p *Profile) { p.memoryAllocs = true }},
+		{"mutex", "mutex.pprof", "failed to create mutex profile file", func(p *Profile) { p.mutex = true }},
+		{"blocker", "block.pprof", "failed to create block profile file", func(p *Profile) { p.blocker = true }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			require.NoError(t, os.Mkdir(filepath.Join(dir, tc.file), 0o755))
+			p := &Profile{path: dir}
+			tc.enable(p)
+			require.ErrorContains(t, p.Start(), tc.wantErr)
+		})
+	}
+}
+
+//nolint:paralleltest // manipulates the process-wide CPU profiler
+func TestStartCPUProfile_AlreadyRunning(t *testing.T) {
+	dir := t.TempDir()
+	f, err := os.Create(filepath.Join(dir, "other.pprof"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+	require.NoError(t, pprof.StartCPUProfile(f))
+	t.Cleanup(pprof.StopCPUProfile)
+
+	p := &Profile{path: dir}
+	require.ErrorContains(t, p.startCPUProfile(), "failed to start cpu profile")
+}
+
+// TestStopTwice re-runs the closers against the files they already closed, which
+// exercises the Sync/Close/WriteTo error branches inside them. Those errors are
+// only logged, so the assertion left is that Stop puts the process-wide memory
+// profile rate back and stays idempotent.
+//
+//nolint:paralleltest // manipulates process-wide profiling state
+func TestStopTwice(t *testing.T) {
+	before := runtime.MemProfileRate
+	p, err := New(WithPath(t.TempDir()), WithAll())
+	require.NoError(t, err)
+	require.NoError(t, p.Start())
+	p.Stop()
+	require.Equal(t, before, runtime.MemProfileRate, "Stop should restore MemProfileRate")
+	p.Stop()
+	require.Equal(t, before, runtime.MemProfileRate)
 }
 
 //nolint:paralleltest

--- a/node/start/start_test.go
+++ b/node/start/start_test.go
@@ -10,6 +10,7 @@ package start
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"syscall"
 	"testing"
 
@@ -86,6 +87,19 @@ func TestServe_ProfilerEnabled(t *testing.T) { //nolint:paralleltest
 	err := serve(n)
 	require.Error(t, err)
 	<-n.ch
+}
+
+// A config path that is a regular file makes the profiler's MkdirAll fail, so
+// serve() bails out on profiler.Start() before ever reaching n.Start().
+func TestServe_ProfilerStartError(t *testing.T) { //nolint:paralleltest
+	file := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(file, nil, 0o644))
+	t.Setenv("FSCNODE_PROFILER", "true")
+	t.Setenv("FSCNODE_CFG_PATH", file)
+
+	n := newMockStartNode(nil)
+	require.ErrorContains(t, serve(n), "failed to create profile directory")
+	require.Error(t, <-n.ch)
 }
 
 func TestServe_HappyPath(t *testing.T) {


### PR DESCRIPTION
Closes #1719 

Raise node package coverage from 83% to 98% by testing the error paths that were previously unexercised. Two of those paths turned out to be buggy:

- profile: `Stop()` left runtime.MemProfileRate at the profiling rate instead of the value it found. With both memory profiles enabled, `startMemProfile("allocs")` captured the rate that `startMemProfile("heap")` had already overwritten, and its closer ran last, so the process was left at `DefaultMemProfileRate`. Only the profile that actually changes the rate now restores it.
- profile: `startCPUProfile` leaked the profile file when `pprof.StartCPUProfile` failed. Close it before returning.

New tests:

- node: both panic branches in `listen()`, via a helper that recovers; the nil-error cases reuse the same helper.
- start: the `profiler.Start()` failure path, reached by pointing `FSCNODE_CFG_PATH` at a regular file so `MkdirAll` fails.
- profile: the option-error return from New; the `os.Create` failure in every start*Profile plus its propagation out of Start, reached by planting a directory where each profile file would go; the "cpu profiling already in use" branch; and the Sync/Close/WriteTo error branches inside the closers, reached by calling `Stop()` twice, which also asserts the MemProfileRate round-trip.

profile.go reaches 100%. The two remaining uncovered statements (`os.Exit` in Node.Execute, and the `profile.New` error path in `serve()`, which is unreachable because `configPath` defaults to "./") would each need a test seam in production code, so they are left alone.