### PR TITLE
fix(fabricx): retry the block-index lookup after finality

### DIFF
--- a/integration/fabricx/simple/views/create.go
+++ b/integration/fabricx/simple/views/create.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	views2 "github.com/hyperledger-labs/fabric-smart-client/integration/fabric/common/views"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
@@ -124,7 +125,9 @@ func (i *CreateView) Call(viewCtx view.Context) (any, error) {
 	}
 	logger.Infof("Ledger info: height=%v", info.Height)
 
-	pt, err := l.GetTransactionByID(tx.ID())
+	// The block index lags finality -- see ledger.GetTransactionByID.
+	pt, err := utils.NewTypedRetryRunner[fdriver.ProcessedTransaction](30, 500*time.Millisecond, false).
+		Run(func() (fdriver.ProcessedTransaction, error) { return l.GetTransactionByID(tx.ID()) })
 	if err != nil {
 		return nil, err
 	}

--- a/platform/fabricx/core/ledger/ledger.go
+++ b/platform/fabricx/core/ledger/ledger.go
@@ -58,6 +58,10 @@ func (c *ledger) GetLedgerInfo() (*driver.LedgerInfo, error) {
 }
 
 // GetTransactionByID returns the processed transaction for the given transaction ID.
+//
+// The committer indexes blocks into its block store independently of the finality it
+// reports, so a caller that queries right after finality must retry on
+// finality.TxNotFound.
 func (c *ledger) GetTransactionByID(txID string) (driver.ProcessedTransaction, error) {
 	env, err := c.client.GetTxByID(c.baseCtx, &committerpb.TxID{TxId: txID})
 	if err != nil {

--- a/platform/fabricx/core/ledger/ledger.go
+++ b/platform/fabricx/core/ledger/ledger.go
@@ -60,8 +60,8 @@ func (c *ledger) GetLedgerInfo() (*driver.LedgerInfo, error) {
 // GetTransactionByID returns the processed transaction for the given transaction ID.
 //
 // The committer indexes blocks into its block store independently of the finality it
-// reports, so a caller that queries right after finality must retry on
-// finality.TxNotFound.
+// reports, so this can still answer finality.TxNotFound for a transaction that is
+// already final; a caller that queries right after finality has to retry.
 func (c *ledger) GetTransactionByID(txID string) (driver.ProcessedTransaction, error) {
 	env, err := c.client.GetTxByID(c.baseCtx, &committerpb.TxID{TxId: txID})
 	if err != nil {


### PR DESCRIPTION
Closes #1721.

The committer reports finality from its notification service but indexes blocks into its block store independently, so `GetTransactionByID` can answer `NotFound` for a transaction that is already final. `CreateView` queried it 1 ms after finality.

- `integration/fabricx/simple/views/create.go` retries `GetTransactionByID` (30 × 500 ms) until the index catches up. `GetBlockNumberByTxID` reads the same txID index, so it needs no retry of its own.
- `platform/fabricx/core/ledger.GetTransactionByID` documents the lag, so the next caller does not write the same bug.

No production behaviour change — the platform still returns `NotFound` rather than blocking, because how long to wait is the caller's policy.

Testing: fabricx-deployment, fabricx-simple, fabricx-multiendorsement pass locally; make checks clean. Verified against the failure by instrumenting the retry: attempt 1 fails at 10 ms, attempt 2 succeeds at 619 ms.