### PR TITLE
test(integration): keep the fabric and fabric-x tools apart under FAB_BINS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@ FABRIC_X_COMMITTER_VERSION ?= 1.0.4
 # need to install fabric binaries outside of fsc tree for now (due to chaincode packaging issues)
 FABRIC_BINARY_BASE ?= $(PWD)/../fabric
 FAB_BINS ?= $(FABRIC_BINARY_BASE)/bin
+# The fabric-x tools ship a configtxgen and a cryptogen of their own. Installing
+# them into $(FAB_BINS) would overwrite fabric's, so they get their own
+# subdirectory there and both toolchains can be installed at once. Keep in sync
+# with fxconfig.BinSubdir.
+FABRIC_X_BINS ?= $(FAB_BINS)/fabric-x
 
 # integration test options
 GINKGO_TEST_OPTS ?=
@@ -43,10 +48,10 @@ install-linter-tool: ## Install linter in $(go env GOPATH)/bin
 	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $$(go env GOPATH)/bin v2.12.2
 
 .PHONY: install-fabricx-tools
-install-fabricx-tools: ## Install fxconfig in $(FAB_BINS)
-	@env GOBIN=$(FAB_BINS) go install $(GO_FLAGS) github.com/hyperledger/fabric-x/tools/fxconfig@$(FABRIC_X_TOOLS_VERSION)
-	@env GOBIN=$(FAB_BINS) go install $(GO_FLAGS) github.com/hyperledger/fabric-x/tools/configtxgen@$(FABRIC_X_TOOLS_VERSION)
-	@env GOBIN=$(FAB_BINS) go install $(GO_FLAGS) github.com/hyperledger/fabric-x/tools/cryptogen@$(FABRIC_X_TOOLS_VERSION)
+install-fabricx-tools: ## Install the fabric-x tools in $(FABRIC_X_BINS)
+	@env GOBIN=$(FABRIC_X_BINS) go install $(GO_FLAGS) github.com/hyperledger/fabric-x/tools/fxconfig@$(FABRIC_X_TOOLS_VERSION)
+	@env GOBIN=$(FABRIC_X_BINS) go install $(GO_FLAGS) github.com/hyperledger/fabric-x/tools/configtxgen@$(FABRIC_X_TOOLS_VERSION)
+	@env GOBIN=$(FABRIC_X_BINS) go install $(GO_FLAGS) github.com/hyperledger/fabric-x/tools/cryptogen@$(FABRIC_X_TOOLS_VERSION)
 
 .PHONY: install-fabric-bins
 install-fabric-bins: ## Install fabric binaries in $(FABRIC_BINARY_BASE)

--- a/docs/agents/integration-tests.md
+++ b/docs/agents/integration-tests.md
@@ -91,5 +91,11 @@ make integration-tests                                  # all targets
 GINKGO_TEST_OPTS="--focus='IOU Life Cycle'" make integration-tests-fabric-iou
 ```
 
+A target's platform prefix decides which toolchain it needs: `fabric-*` targets
+need `make install-fabric-bins` (binaries in `$FAB_BINS`), `fabricx-*` targets
+need `make install-fabricx-tools` (tools in `$FAB_BINS/fabric-x`, kept apart
+because both toolchains ship a `configtxgen`). Installing both is safe, and
+`fsc-*` targets need neither.
+
 Prerequisites (Fabric binaries, Docker images) are covered in
 [`docs/dev/development.md`](../dev/development.md).

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -70,6 +70,11 @@ Install Fabric-x configuration tools and Docker images:
 make install-fabricx-tools pull-images-fabricx
 ```
 
+Fabric-x ships a `configtxgen` and a `cryptogen` of its own, so the tools are
+installed into a `fabric-x` subdirectory of `FAB_BINS` rather than next to
+fabric's binaries of the same name. Both toolchains can be installed at the same
+time, and neither install target disturbs the other.
+
 ### Set `FAB_BINS`
 
 Most integration tests require Fabric(x) binaries to launch a local test network.
@@ -78,6 +83,10 @@ Set the `FAB_BINS` environment variable to point to the directory containing the
 ```bash
 export FAB_BINS=/home/yourusername/fabric/bin
 ```
+
+One variable covers both platforms: `fabric-*` suites read `$FAB_BINS`, and
+`fabricx-*` suites read `$FAB_BINS/fabric-x`, which is where
+`make install-fabricx-tools` puts its tools.
 
 > [!NOTE]
 > Do *not* store the Fabric binaries inside your fabric-smart-client repository.
@@ -183,7 +192,23 @@ If integration tests fail early because Fabric binaries cannot be found, confirm
 
 ```bash
 echo $FAB_BINS
-ls $FAB_BINS
+ls $FAB_BINS            # fabric binaries
+ls $FAB_BINS/fabric-x   # fabric-x tools
+```
+
+### Fabric suites failing in `configtxgen`
+
+Before the fabric-x tools moved into `$FAB_BINS/fabric-x`,
+`make install-fabricx-tools` installed its `configtxgen` and `cryptogen` on top
+of fabric's. If you ran it against an older checkout, those two binaries in
+`$FAB_BINS` are still the fabric-x ones, and every `fabric-*` suite fails while
+generating artifacts. `make install-fabric-bins` will not repair it, because it
+skips the download whenever `bin/peer version` already matches
+`FABRIC_VERSION`. Remove the directory and re-install once:
+
+```bash
+rm -rf $(dirname $FAB_BINS)
+make install-fabric-bins install-fabricx-tools
 ```
 
 ### Missing chaincode image

--- a/integration/fabricx/atsa/README.md
+++ b/integration/fabricx/atsa/README.md
@@ -29,8 +29,9 @@ design.
 
 ## Running
 
-Integration suites shell out to `configtxgen`/`cryptogen`/`fxconfig` from `$FAB_BINS`. The Makefile
-default is `PWD`-relative and resolves incorrectly from a git worktree, so pass an absolute path:
+Fabric-x suites shell out to `configtxgen`/`fxconfig` from `$FAB_BINS/fabric-x`, where
+`make install-fabricx-tools` installs them. The Makefile default for `FAB_BINS` is `PWD`-relative
+and resolves incorrectly from a linked worktree, so pass an absolute path:
 
 ```bash
 make integration-tests-fabricx-atsa \

--- a/integration/nwo/fabric/network/network.go
+++ b/integration/nwo/fabric/network/network.go
@@ -80,6 +80,14 @@ type Network struct {
 	Templates         *topology.Templates
 	Resolvers         []*Resolver
 
+	// BinSubdir is the subdirectory of $FAB_BINS the network's binaries are
+	// looked up in. Empty for fabric, whose distribution puts them directly in
+	// $FAB_BINS; the fabricx platform sets it so that the fabric-x tools do not
+	// have to overwrite the fabric ones of the same name. It is not a fallback:
+	// a network declaring a subdirectory never reads the other toolchain's
+	// binaries.
+	BinSubdir string
+
 	Extensions      []Extension
 	PackagerFactory PackagerFactory
 

--- a/integration/nwo/fabric/network/network_support.go
+++ b/integration/nwo/fabric/network/network_support.go
@@ -863,15 +863,15 @@ func (n *Network) Cryptogen(command common.Command) (*gexec.Session, error) {
 
 // Idemixgen starts a gexec.Session for the provided idemixgen command.
 func (n *Network) Idemixgen(command common.Command) (*gexec.Session, error) {
-	cmdPath := findOrBuild(idemixgenCMD, n.Builder.Idemixgen)
+	cmdPath := n.findOrBuild(idemixgenCMD, n.Builder.Idemixgen)
 	cmd := common.NewCommand(cmdPath, command)
 	return n.StartSession(cmd, command.SessionName())
 }
 
 // ConfigTxGen starts a gexec.Session for the provided configtxgen command.
 func (n *Network) ConfigTxGen(command common.Command) (*gexec.Session, error) {
-	cmdPath := findCmdAtEnv(configtxgenCMD)
-	gomega.Expect(cmdPath).NotTo(gomega.Equal(""), "could not find %s in %s directory %s", configtxgenCMD, FabricBinsPathEnvKey, os.Getenv(FabricBinsPathEnvKey))
+	cmdPath := n.findCmdAtEnv(configtxgenCMD)
+	gomega.Expect(cmdPath).NotTo(gomega.Equal(""), "could not find %s in %s directory %s", configtxgenCMD, FabricBinsPathEnvKey, n.binDir())
 
 	cmd := common.NewCommand(cmdPath, command)
 	return n.StartSession(cmd, command.SessionName())
@@ -879,8 +879,8 @@ func (n *Network) ConfigTxGen(command common.Command) (*gexec.Session, error) {
 
 // Discover starts a gexec.Session for the provided discover command.
 func (n *Network) Discover(command common.Command) (*gexec.Session, error) {
-	cmdPath := findCmdAtEnv(discoverCMD)
-	gomega.Expect(cmdPath).NotTo(gomega.Equal(""), "could not find %s in %s directory %s", discoverCMD, FabricBinsPathEnvKey, os.Getenv(FabricBinsPathEnvKey))
+	cmdPath := n.findCmdAtEnv(discoverCMD)
+	gomega.Expect(cmdPath).NotTo(gomega.Equal(""), "could not find %s in %s directory %s", discoverCMD, FabricBinsPathEnvKey, n.binDir())
 
 	cmd := common.NewCommand(cmdPath, command)
 	cmd.Args = append(cmd.Args, "--peerTLSCA", n.CACertsBundlePath())
@@ -889,8 +889,8 @@ func (n *Network) Discover(command common.Command) (*gexec.Session, error) {
 
 // Osnadmin starts a gexec.Session for the provided osnadmin command.
 func (n *Network) Osnadmin(command common.Command) (*gexec.Session, error) {
-	cmdPath := findCmdAtEnv(osnadminCMD)
-	gomega.Expect(cmdPath).NotTo(gomega.Equal(""), "could not find %s in %s directory %s", osnadminCMD, FabricBinsPathEnvKey, os.Getenv(FabricBinsPathEnvKey))
+	cmdPath := n.findCmdAtEnv(osnadminCMD)
+	gomega.Expect(cmdPath).NotTo(gomega.Equal(""), "could not find %s in %s directory %s", osnadminCMD, FabricBinsPathEnvKey, n.binDir())
 
 	cmd := common.NewCommand(cmdPath, command)
 	return n.StartSession(cmd, command.SessionName())
@@ -899,8 +899,8 @@ func (n *Network) Osnadmin(command common.Command) (*gexec.Session, error) {
 // OrdererRunner returns an ifrit.Runner for the specified orderer. The runner
 // can be used to start and manage an orderer process.
 func (n *Network) OrdererRunner(o *topology.Orderer) *runner2.Runner {
-	cmdPath := findCmdAtEnv(ordererCMD)
-	gomega.Expect(cmdPath).NotTo(gomega.Equal(""), "could not find %s in %s directory %s", ordererCMD, FabricBinsPathEnvKey, os.Getenv(FabricBinsPathEnvKey))
+	cmdPath := n.findCmdAtEnv(ordererCMD)
+	gomega.Expect(cmdPath).NotTo(gomega.Equal(""), "could not find %s in %s directory %s", ordererCMD, FabricBinsPathEnvKey, n.binDir())
 
 	cmd := exec.Command(cmdPath)
 	cmd.Env = os.Environ()
@@ -1026,8 +1026,8 @@ func (n *Network) PeerGroupRunner() ifrit.Runner {
 }
 
 func (n *Network) peerCommand(command common.Command, tlsDir string, env ...string) *exec.Cmd {
-	cmdPath := findCmdAtEnv(peerCMD)
-	gomega.Expect(cmdPath).NotTo(gomega.Equal(""), "could not find %s in %s directory %s", peerCMD, FabricBinsPathEnvKey, os.Getenv(FabricBinsPathEnvKey))
+	cmdPath := n.findCmdAtEnv(peerCMD)
+	gomega.Expect(cmdPath).NotTo(gomega.Equal(""), "could not find %s in %s directory %s", peerCMD, FabricBinsPathEnvKey, n.binDir())
 	logger.Debugf("Found %s => %s", peerCMD, cmdPath)
 
 	cmd := common.NewCommand(cmdPath, command)

--- a/integration/nwo/fabric/network/utils.go
+++ b/integration/nwo/fabric/network/utils.go
@@ -32,14 +32,21 @@ func pathExists(path string) bool {
 	return true
 }
 
-// findCmdAtEnv tries to find cmd at the path specified via FabricBinsPathEnvKey
+// binDir returns the directory the network's binaries are looked up in: the one
+// named by FabricBinsPathEnvKey, narrowed to BinSubdir when the network sets one.
+func (n *Network) binDir() string {
+	return path.Join(os.Getenv(FabricBinsPathEnvKey), n.BinSubdir)
+}
+
+// findCmdAtEnv tries to find cmd at the path specified via FabricBinsPathEnvKey,
+// inside the network's BinSubdir if it declares one.
 // Returns the full path of cmd if exists; otherwise an empty string
 // Example:
 //
 //	export FAB_BINS=/tmp/fabric/bin/
 //	findCmdAtEnv("peer") will return "/tmp/fabric/bin/peer" if exists
-func findCmdAtEnv(cmd string) string {
-	cmdPath := path.Join(os.Getenv(FabricBinsPathEnvKey), cmd)
+func (n *Network) findCmdAtEnv(cmd string) string {
+	cmdPath := path.Join(n.binDir(), cmd)
 	if !pathExists(cmdPath) {
 		// cmd does not exist in folder provided via FabricBinsPathEnvKey
 		return ""
@@ -50,8 +57,8 @@ func findCmdAtEnv(cmd string) string {
 
 // findOrBuild returns the full path of cmd. It first tries to find the cmd at the path specified via FabricBinsPathEnvKey;
 // otherwise the builder function is used.
-func findOrBuild(cmd string, builder func() string) string {
-	cmdPath := findCmdAtEnv(cmd)
+func (n *Network) findOrBuild(cmd string, builder func() string) string {
+	cmdPath := n.findCmdAtEnv(cmd)
 	if len(cmdPath) == 0 {
 		cmdPath = builder()
 	}

--- a/integration/nwo/fabric/network/utils_test.go
+++ b/integration/nwo/fabric/network/utils_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package network
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindCmdAtEnv(t *testing.T) { //nolint:paralleltest // t.Setenv
+	bins := t.TempDir()
+	subdir := filepath.Join(bins, "fabric-x")
+	require.NoError(t, os.Mkdir(subdir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(bins, "configtxgen"), nil, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(subdir, "configtxgen"), nil, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(bins, "peer"), nil, 0o600))
+	t.Setenv(FabricBinsPathEnvKey, bins)
+
+	// No subdirectory: binaries are resolved in $FAB_BINS itself.
+	fabric := &Network{}
+	require.Equal(t, filepath.Join(bins, "configtxgen"), fabric.findCmdAtEnv(configtxgenCMD))
+
+	// With a subdirectory, its binaries win over the same names in $FAB_BINS...
+	fabricx := &Network{BinSubdir: "fabric-x"}
+	require.Equal(t, filepath.Join(subdir, "configtxgen"), fabricx.findCmdAtEnv(configtxgenCMD))
+
+	// ...and $FAB_BINS is not searched as a fallback, so a binary that only the
+	// other toolchain ships is reported missing rather than silently reused.
+	require.Empty(t, fabricx.findCmdAtEnv(peerCMD))
+
+	t.Setenv(FabricBinsPathEnvKey, "")
+	require.Empty(t, fabric.findCmdAtEnv(configtxgenCMD))
+}

--- a/integration/nwo/fabricx/fxconfig/namespace.go
+++ b/integration/nwo/fabricx/fxconfig/namespace.go
@@ -19,6 +19,13 @@ import (
 const (
 	FabricBinsPathEnvKey = "FAB_BINS"
 	fxconfigCMD          = "fxconfig"
+
+	// BinSubdir is the subdirectory of $FAB_BINS holding the fabric-x tools.
+	// They are kept apart from the fabric ones because the two toolchains ship
+	// binaries of the same name (configtxgen), and a shared directory means
+	// whichever was installed last wins. Keep in sync with FABRIC_X_BINS in the
+	// Makefile.
+	BinSubdir = "fabric-x"
 )
 
 type OrdererConfig struct {
@@ -155,7 +162,7 @@ func (n *ListNamespaces) SessionName() string {
 // CMDPath returns the full path of fxconfig at path specified via FabricBinsPathEnvKey.
 func CMDPath() string {
 	cmdPath := findCmdAtEnv(fxconfigCMD)
-	gomega.Expect(cmdPath).NotTo(gomega.Equal(""), "could not find %s in %s directory %s", fxconfigCMD, FabricBinsPathEnvKey, os.Getenv(FabricBinsPathEnvKey))
+	gomega.Expect(cmdPath).NotTo(gomega.Equal(""), "could not find %s in %s directory %s", fxconfigCMD, FabricBinsPathEnvKey, path.Join(os.Getenv(FabricBinsPathEnvKey), BinSubdir))
 	return cmdPath
 }
 
@@ -166,14 +173,14 @@ func pathExists(path string) bool {
 	return true
 }
 
-// findCmdAtEnv tries to find cmd at the path specified via FabricBinsPathEnvKey
+// findCmdAtEnv tries to find cmd in the BinSubdir of the path specified via FabricBinsPathEnvKey
 // Returns the full path of cmd if exists; otherwise an empty string
 // Example:
 //
 //	export FAB_BINS=/tmp/fabric/bin/
-//	findCmdAtEnv("peer") will return "/tmp/fabric/bin/peer" if exists
+//	findCmdAtEnv("fxconfig") will return "/tmp/fabric/bin/fabric-x/fxconfig" if exists
 func findCmdAtEnv(cmd string) string {
-	cmdPath := path.Join(os.Getenv(FabricBinsPathEnvKey), cmd)
+	cmdPath := path.Join(os.Getenv(FabricBinsPathEnvKey), BinSubdir, cmd)
 	if !pathExists(cmdPath) {
 		// cmd does not exist in folder provided via FabricBinsPathEnvKey
 		return ""

--- a/integration/nwo/fabricx/network/network.go
+++ b/integration/nwo/fabricx/network/network.go
@@ -49,6 +49,8 @@ type Network struct {
 func New(reg api.Context, topology *topology.Topology, builderClient fabric_network.BuilderClient, ccps []fabric_network.ChaincodeProcessor, networkID, committerOrg, committerName string) *Network {
 	fabricNetwork := fabric_network.New(reg, topology, builderClient, ccps, networkID)
 	fabricNetwork.EventuallyTimeout = defaultEventuallyTimeout
+	// The fabric-x tools live apart from the fabric ones of the same name.
+	fabricNetwork.BinSubdir = fxconfig.BinSubdir
 	n := &Network{Network: fabricNetwork, CommitterOrg: committerOrg, CommitterName: committerName}
 	return n
 }


### PR DESCRIPTION
Closes #1723 

### Problem

Both toolchains ship a `configtxgen` and a `cryptogen`, and `install-fabricx-tools` installed its own on top of fabric's — `GOBIN` was `$(FAB_BINS)`, the very directory `install-fabric-bins` unpacks the fabric distribution into. Whichever target ran last won, so a local checkout could not have both platforms set up at once.

CI never noticed: each matrix job installs exactly one toolchain. Locally the state also never heals, because `download_fabric.sh` gates its re-download on `bin/peer version`, which the fabric-x install leaves untouched — so `install-fabric-bins` reports *"already downloaded"* while `configtxgen` stays the fabric-x build and every `fabric-*` suite fails generating artifacts.

### Fix

The fabric-x tools get their own subdirectory:

```
$FAB_BINS/            fabric distribution (peer, orderer, configtxgen, ...)
$FAB_BINS/fabric-x/   fabric-x tools (fxconfig, configtxgen, cryptogen)
```

Developers still export a single `FAB_BINS`, can run both install targets, and neither disturbs the other.

- `Makefile`: `FABRIC_X_BINS ?= $(FAB_BINS)/fabric-x` is the fabric-x `GOBIN`.
- `fxconfig.BinSubdir = "fabric-x"`, the single source of the name on the Go side.
- `fabric_network.Network.BinSubdir` is added to the `path.Join` already in `findCmdAtEnv`, so an empty value is exactly fabric's previous behaviour; the fabricx platform sets it in `New`. Going through the shared `Network` rather than overriding `ConfigTxGen` means every call site is covered, not just the one in `fabricx/network.GenerateArtifacts`.
- The `could not find %s` messages now name the directory that was actually searched instead of `$FAB_BINS` itself.

Deliberately a subdirectory, not a fallback: a network that declares one never reads the other toolchain's binaries, so a missing fabric-x tool is a clear error rather than a silent run of fabric's binary of the same name. The fabricx platform needs nothing else from the parent directory — it starts no peers or orderers, and `idemixgen` goes through `findOrBuild` and is built from `IBM/idemix`.

### Not included

Self-healing `download_fabric.sh` by probing `configtxgen` instead of `peer`: fabric's `configtxgen` has no `version` subcommand, so the probe would fail and re-download the 114 MB tarball on every install. Anyone whose `bin/` is already clobbered gets a troubleshooting entry with the one-time `rm -rf` instead.

### Testing

- New `integration/nwo/fabric/network/utils_test.go`: the subdirectory is honoured, the parent is not searched as a fallback, and an empty subdirectory is unchanged.
- `make install-fabricx-tools FAB_BINS=<tmp>/bin` puts all three tools in `bin/fabric-x/` and nothing at the root.
- `fabricx-simple` passes against a `bin/` containing **only** `fabric-x/` — proof the subdirectory is what resolves.
- Against one clean v3.1.4 distribution with both toolchains installed (`bin/configtxgen` → v3.1.4, `bin/fabric-x/configtxgen` → fabric-x): `fabric-stoprestart` 3/3 passed and `fabricx-simple` 1/1 passed from the same `FAB_BINS`.
- `make checks` clean.

### Docs

`docs/dev/development.md` (Fabric-x install, `FAB_BINS`, plus a troubleshooting entry for an already-clobbered `bin/`), `docs/agents/integration-tests.md` (which toolchain a target's platform prefix needs), and `integration/fabricx/atsa/README.md`.
