### PR TITLE
docs(dev): align the dev guides with the Makefile and document the PR flow

### DIFF
--- a/.github/workflows/gofix.yml
+++ b/.github/workflows/gofix.yml
@@ -1,30 +1,38 @@
 name: Go Fix Check
+
 on:
-  pull_request:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+
+permissions:
+  contents: read
 
 jobs:
+  # `make go-fix` runs `go fix -diff` in every module, so this job cannot drift
+  # out of sync with what `make checks` enforces locally.
   gofix:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # ratchet:actions/setup-go@v7.0.0
         with:
-          go-version-file: go.mod
-
-      - name: Download Go modules
-        run: go mod download
+          go-version-file: "go.mod"
+          cache-dependency-path: "**/*.sum"
 
       - name: Check for go fix suggestions
         run: |-
-          OUTPUT=$(go fix -diff ./... 2>&1)
-          if [ -n "$OUTPUT" ]; then
-            echo "::error::go fix found modernization opportunities"
-            echo ""
-            echo "$OUTPUT"
-            echo ""
-            echo "Run 'go fix ./...' locally and commit the changes."
+          make go-fix || {
+            echo "::error::go fix found modernization opportunities — run 'make go-fix-apply' and commit the result."
             exit 1
-          fi
-          echo "✓ No go fix suggestions - code is up to date."
+          }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ built with `make`. `CLAUDE.md` is a symlink to this file.
 ## Essential commands
 
 ```bash
-make checks         # license, gofmt, goimports, vet, misspell, staticcheck
+make checks         # golangci-lint + `go fix` in every module; apply fixes with `make go-fix-apply`
 make lint           # golangci-lint (use make lint-auto-fix to autofix)
 make tidy           # go mod tidy across all modules
 make generate-protos     # regenerate protobuf files
@@ -19,6 +19,15 @@ make install-tools       # install dev tools (source of truth: tools/tools.go)
 make unit-tests     # unit tests, excluding Postgres (-race -cover)
 make integration-tests   # integration tests (need Fabric binaries + Docker)
 ```
+
+If `make lint` reports a file outside your working tree, the `golangci-lint` cache is
+stale — common with several worktrees. Run `golangci-lint cache clean` and re-run; see
+[`docs/dev/development.md`](docs/dev/development.md#lint-failures-in-files-you-never-touched).
+
+The `make` defaults assume the **primary checkout**: `FABRIC_BINARY_BASE` is
+`$(PWD)/../fabric`, so `make install-fabric-bins` run from a worktree installs a second
+Fabric next to that worktree. Pass `FABRIC_BINARY_BASE` explicitly, or run it from the
+primary checkout — see [`docs/dev/development.md`](docs/dev/development.md#fabric).
 
 Run one unit test: `go test -run TestMyTest ./platform/view/...`. The full
 integration suite is slow and needs Fabric binaries + Docker — run a focused
@@ -68,9 +77,10 @@ Read these on demand — don't load them up front.
 - **Errors**: use `pkg/utils/errors` (`errors.New/Errorf/Wrap/Wrapf/WithMessage/WithMessagef/Join`); do not build or wrap errors with `fmt.Errorf`.
 - **Logging**: `platform/common/services/logging`.
 - **New code**: platform code → `platform/<name>/`; shared → `pkg/utils/` or `platform/common/`.
-- **DI**: register in `sdk/dig/sdk.go`; `Install()` must call the parent `p.SDK.Install()`.
-- **Mocks**: `counterfeiter` via `go generate ./...` (see [`docs/dev/mocks.md`](docs/dev/mocks.md)).
-- **Git**: sign off every commit (`git commit -s`, DCO); rebase, don't merge. See [`docs/dev/signing.md`](docs/dev/signing.md), [`docs/dev/rebasing.md`](docs/dev/rebasing.md).
+- **DI**: register in the platform's `sdk/dig/sdk.go` (e.g. `platform/view/sdk/dig/sdk.go`); `Install()` must call the parent `p.SDK.Install()`.
+- **Mocks**: `counterfeiter` via `make generate-mocks` (see [`docs/dev/mocks.md`](docs/dev/mocks.md)).
+- **Git**: run `make checks` before committing; sign off every commit (`git commit -s`, DCO); rebase, don't merge. Fixups during review, then autosquash: a PR merges as one commit whose message describes the PR. See [`docs/dev/workflow.md`](docs/dev/workflow.md#commit-hygiene), [`docs/dev/signing.md`](docs/dev/signing.md), [`docs/dev/rebasing.md`](docs/dev/rebasing.md).
+- **Docs**: a change that leaves [`docs/agents/`](docs/agents/) or [`docs/dev/`](docs/dev/) wrong is not finished — update the affected guide in the same commit.
 
 ## Related projects
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,9 +33,15 @@ If you don't meet the prerequisites, the bot will show your progress and link to
 
 Once assigned, follow the [Development Guide](docs/dev/development.md) to:
 1. Fork the repository and create a branch
-2. Make your changes
-3. Sign your commits (`-s -S`). See the [Commit Signing Guide](docs/dev/signing.md)
-4. Open a pull request
+2. Make your changes, signing every commit (`-s -S`). See the
+   [Commit Signing Guide](docs/dev/signing.md)
+3. Push the branch whenever you like — opening a **draft** pull request early gets CI
+   running and makes the work visible
+4. Before requesting review, squash the branch into a single commit whose message
+   describes the change, and write a brief, structured PR description. See
+   [Commit Hygiene](docs/dev/workflow.md#commit-hygiene) and
+   [Writing a PR Description](docs/dev/workflow.md#writing-a-pr-description)
+5. Mark the pull request ready for review
 
 ## Submitting an Issue
 

--- a/checks.mk
+++ b/checks.mk
@@ -1,12 +1,12 @@
 .PHONY: checks
-checks: lint
+checks: lint go-fix ## Run all code checks (lint + go fix)
 
 #########################
 # Lint
 #########################
 
-# golangci-lint only ever sees a single module, so it has to be run once per
-# module.
+# golangci-lint and go fix both only ever see a single module, so they have to
+# be run once per module.
 #
 # Modules are discovered through git rather than a filesystem walk: a plain
 # `find` also descends into untracked scratch directories and into nested git
@@ -23,19 +23,19 @@ GO_MODULE_DIRS = $(shell cd $(TOP) && git ls-files \
 	| grep -vx tools \
 	| sort)
 
-# run golangci-lint in every module, reporting every module that fails rather
+# run a command in every module, reporting every module that fails rather
 # than stopping at the first
-define lint_all_modules
+define in_all_modules
 	rc=0; \
 	for dir in $(GO_MODULE_DIRS); do \
 		echo "  -> $$dir"; \
-		(cd $$dir && golangci-lint $(1)) || rc=1; \
+		(cd $$dir && $(1)) || rc=1; \
 	done; \
 	exit $$rc
 endef
 
 .PHONY: list-go-modules
-list-go-modules: ## List the go modules covered by `make lint`
+list-go-modules: ## List the go modules covered by `make checks`
 	@$(foreach dir,$(GO_MODULE_DIRS),echo "$(dir)";)
 
 # Deliberately not --new-from-rev: that reports only issues attributable to
@@ -46,14 +46,30 @@ list-go-modules: ## List the go modules covered by `make lint`
 .PHONY: lint
 lint: ## Run linter
 	@echo "Running Go Linters..."
-	@$(call lint_all_modules,run --color=always --timeout=4m)
+	@$(call in_all_modules,golangci-lint run --color=always --timeout=4m)
 
 .PHONY: lint-auto-fix
 lint-auto-fix: ## Run linter with auto-fix
 	@echo "Running Go Linters with auto-fix..."
-	@$(call lint_all_modules,run --color=always --timeout=4m --fix)
+	@$(call in_all_modules,golangci-lint run --color=always --timeout=4m --fix)
 
 .PHONY: lint-fmt
 lint-fmt:
 	@echo "Running Go Formatters..."
-	@$(call lint_all_modules,fmt)
+	@$(call in_all_modules,golangci-lint fmt)
+
+#########################
+# Go fix
+#########################
+
+# `go-fix` only reports, which keeps `checks` read-only like `lint`.
+# `go-fix-apply` is the same analysis, rewriting the code in place.
+.PHONY: go-fix
+go-fix: ## Report go fix modernizations (dry run)
+	@echo "Running go fix..."
+	@$(call in_all_modules,go fix -diff ./...)
+
+.PHONY: go-fix-apply
+go-fix-apply: ## Apply go fix modernizations in every module
+	@echo "Applying go fix..."
+	@$(call in_all_modules,go fix ./...)

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,8 @@ Each platform section includes a local `README.md` plus a `configuration.md` pag
 - [Development guide](dev/development.md)
 - [Testing - Mocks and fakes](dev/mocks.md)
 - [Commit signing (DCO + GPG)](dev/signing.md)
+- [Rebasing onto upstream main](dev/rebasing.md)
+- [Resolving merge conflicts](dev/merge-conflicts.md)
 - [Contribution workflow](dev/workflow.md)
 - [Contributor guide](../CONTRIBUTING.md)
 

--- a/docs/agents/integration-tests.md
+++ b/docs/agents/integration-tests.md
@@ -9,13 +9,41 @@ Ginkgo v2 + Gomega.
 2. Define the topology in `topology.go` (via `integration.Generate()`).
 3. Implement the test logic in `<test-name>.go`.
 4. Add the Ginkgo suite entry point in `<test-name>_test.go`.
-5. Register the target in `INTEGRATION_TARGETS` in the `Makefile`.
+5. Register the target in the `Makefile` — see below.
+
+### Registering the target
+
+Appending the target to `INTEGRATION_TARGETS` in the [`Makefile`](../../Makefile) is
+enough when the name follows the `<platform>-<suite>` convention, which maps to
+`integration/<platform>/<suite>`. Otherwise:
+
+- **Name does not match the directory** → set `INTEGRATION_DIR_<target>`.
+- **The suite needs ginkgo flags** (e.g. a `--label-filter` so one suite becomes several
+  parallel CI entries) → set `INTEGRATION_FLAGS_<target>`.
+- **The suite needs `-tags pkcs11`** → add it to `HSM_INTEGRATION_TARGETS` instead of
+  `INTEGRATION_TARGETS`; that list compiles the test binary with the build tag.
 
 ## Network topology options
 
+There is no shared `integration.Opts`. Each suite declares its own `Opts` in its
+`topology.go`, carrying only the fields that suite varies; `ReplicationOptions` is the
+part the framework provides (`integration/utils.go`):
+
 ```go
-opts := &integration.Opts{
-    CommType:   fsc.WebSocket, // the default; use fsc.LibP2P only with a reason
+// integration/<platform>/<test-name>/topology.go
+type Opts struct {
+    CommType        fsc.P2PCommunicationType
+    ReplicationOpts *integration.ReplicationOptions
+    TLSEnabled      bool
+}
+```
+
+The suite's `_test.go` then fills it in. `fsc.WebSocket` is the default comm type; use
+`fsc.LibP2P` only with a reason:
+
+```go
+opts := &Opts{
+    CommType:   fsc.WebSocket,
     TLSEnabled: true,
     ReplicationOpts: &integration.ReplicationOptions{
         ReplicationFactors: map[string]int{"node": 3},
@@ -85,9 +113,8 @@ The remaining options are `WithCtor(ctor)` (which also turns on init),
 ## Running
 
 ```bash
-make list-integration-tests
-make integration-tests-fabric-iou                       # a single target
-make integration-tests                                  # all targets
+make list-integration-tests                             # every target
+make integration-tests-fabric-iou                       # one target
 GINKGO_TEST_OPTS="--focus='IOU Life Cycle'" make integration-tests-fabric-iou
 ```
 
@@ -97,5 +124,5 @@ need `make install-fabricx-tools` (tools in `$FAB_BINS/fabric-x`, kept apart
 because both toolchains ship a `configtxgen`). Installing both is safe, and
 `fsc-*` targets need neither.
 
-Prerequisites (Fabric binaries, Docker images) are covered in
-[`docs/dev/development.md`](../dev/development.md).
+Prerequisites (Fabric binaries, Docker images) and the remaining variants are in
+[`docs/dev/development.md`](../dev/development.md#integration-tests).

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -5,26 +5,30 @@
 - **Unit tests**: `github.com/stretchr/testify/require`.
 - **Integration tests**: Ginkgo v2 + Gomega.
 
+That is the project convention. Some existing unit suites still use Ginkgo/Gomega and
+will be migrated — follow the convention, not the neighbouring file.
+
 ## Running tests
 
-```bash
-make unit-tests            # all unit tests except Postgres (-race -cover)
-make unit-tests-postgres   # Postgres tests (requires Docker)
-make unit-tests-sdk        # SDK wiring tests (TestWiring)
+Scope every run to what you changed:
 
-go test -run TestMyTest ./platform/view/...   # a single unit test
+```bash
+make unit-tests                                        # all unit tests except Postgres
+go test -run TestMyTest ./platform/view/...             # one test
+TEST_PKGS=./platform/common/utils/... make unit-tests   # one package tree
 ```
 
-The full integration suite is slow and needs Fabric binaries + Docker. Run a
-focused target locally and let CI run the rest:
+Never run the whole integration suite to check a change — it is slow and needs Fabric
+binaries plus Docker. Pick one target, and let CI run the rest:
 
 ```bash
 make integration-tests-fabric-iou
 GINKGO_TEST_OPTS="--focus='IOU Life Cycle'" make integration-tests-fabric-iou
 ```
 
-See [integration-tests.md](integration-tests.md) and
-[`docs/dev/development.md`](../dev/development.md).
+[`docs/dev/development.md`](../dev/development.md#running-tests) is the source of truth
+for test commands: the remaining targets, the Postgres and coverage variants, and their
+prerequisites. See also [integration-tests.md](integration-tests.md).
 
 ## Integration test structure
 
@@ -47,10 +51,14 @@ Use `FIt`/`FDescribe` to focus a spec or `XIt` to skip one while iterating —
 never commit them (CI treats a stray focus as a failure). Prefer the
 `GINKGO_TEST_OPTS="--focus=..."` flag for anything you might commit.
 
+Check that a focused run actually ran something. `go test` prints nothing for a passing
+package, so a filter matching **zero specs** reports `ok ... 9.5s`, which reads exactly
+like success. Pass `-v` and read `Ran N of M Specs` before believing it.
+
 ## Mocks and fakes
 
 Mocks are generated with [counterfeiter](https://github.com/maxbrunsfeld/counterfeiter)
-(pinned in `tools/tools.go`). Regenerate with `go generate ./...` after changing a
+(pinned in `tools/tools.go`). Regenerate with `make generate-mocks` after changing a
 mocked interface. See [`docs/dev/mocks.md`](../dev/mocks.md).
 
 ## Shared test helpers
@@ -74,7 +82,7 @@ Do not rely on generic names either way — `platform/fabric/services/state/help
 production code despite the name.
 
 When a file mixes production code with a single test helper —
-`platform/common/services/logging/logger.go` (`NewTestLogger`),
 `platform/common/utils/assert/retry.go` (`EventuallyWithRetry`) — it stays in the
-report, because excluding it would drop shipped code too. Prefer splitting such a
-helper into a `*_test_utils.go` file over leaving it mixed.
+report, because excluding it would drop shipped code too. Prefer splitting such a helper
+out into a `*_test_utils.go` file, as `platform/common/services/logging` does with
+`logging_test_utils.go`.

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -43,6 +43,17 @@ Install the Fabric binaries and Docker images:
 make install-fabric-bins pull-images-fabric
 ```
 
+> [!IMPORTANT]
+> `FABRIC_BINARY_BASE` defaults to `$(PWD)/../fabric`, which assumes you are in your
+> primary checkout. Run this from a worktree under `.claude/worktrees/<name>/` and it
+> resolves to a sibling of the *worktree* — a second Fabric install, in the wrong
+> place, inside the repository, with no warning. From a worktree, either run the target
+> from the primary checkout or pass the base explicitly:
+>
+> ```bash
+> FABRIC_BINARY_BASE=$HOME/fabric make install-fabric-bins
+> ```
+
 Integration tests that deploy chaincode as a container also need the chaincode
 images built once:
 
@@ -99,17 +110,33 @@ Integration tests are powered by the NWO (Network Orchestrator), which programma
 
 ### Code Checks
 
-Run static analysis and linting:
+`make checks` runs everything CI gates on — the linter and `go fix` — across every
+module in the repository:
+
 ```bash
 make checks
-make lint
-make lint-auto-fix
-make lint-fmt
 ```
 
-Use `make lint` to run the configured linters on the changes in your branch.
-Use `make lint-auto-fix` to apply automatic fixes where `golangci-lint` supports them.
-Use `make lint-fmt` to apply the formatter configuration used by CI before pushing a branch.
+| Target               | What it does                                                          |
+|----------------------|-----------------------------------------------------------------------|
+| `make lint`          | `golangci-lint run` in every module                                   |
+| `make lint-auto-fix` | the same, with `--fix` to apply what `golangci-lint` can fix itself   |
+| `make lint-fmt`      | `golangci-lint fmt`, applying the formatter configuration CI enforces  |
+| `make fmt`           | `gofmt -s -w` over the whole tree                                     |
+| `make go-fix`        | reports the modernizations `go fix` suggests, without applying them    |
+| `make go-fix-apply`  | applies those modernizations, in every module                          |
+
+Run `make list-go-modules` to see which modules these targets cover.
+
+> [!NOTE]
+> Checking formatting by path — `gofmt -l platform integration` — also walks gitignored
+> generated files, such as everything an integration run leaves under
+> `integration/**/out/`, so your source looks unformatted when it is not. Check the
+> tracked files instead:
+>
+> ```bash
+> gofmt -l $(git ls-files '*.go')
+> ```
 
 ### Unit Tests
 
@@ -144,15 +171,6 @@ To reproduce the filtered local coverage used in CI:
 make coverage-local
 ```
 
-The CI workflow runs:
-- `make checks`
-- `make lint-fmt`
-- `make unit-tests`
-- `make unit-tests-postgres`
-- `make integration-tests-*`
-
-If you are preparing a pull request that only touches unit-tested code, running `make lint-fmt`, `make checks`, and a targeted `make unit-tests` command is usually the fastest high-signal validation pass before pushing.
-
 ### Integration Tests
 
 List all available integration tests:
@@ -171,6 +189,12 @@ Run a specific integration test (e.g., Fabric IOU test):
 make integration-tests-fabric-iou
 ```
 
+> [!IMPORTANT]
+> `go test` prints nothing for a package that passes, so a ginkgo suite whose filter
+> matched **zero specs** reports `ok ... 9.5s` — indistinguishable from real success.
+> Never take that as evidence that a focused run exercised anything. Add `-v` and read
+> the `Ran N of M Specs` line; `N == 0` means the filter matched nothing.
+
 Enable profiling for deeper analysis:
 ```bash
 export FSCNODE_PROFILER=true
@@ -184,7 +208,48 @@ GOCOVERDIR=covdata make integration-tests
 go tool covdata textfmt -i=covdata -o profile.txt
 ```
 
-## Troubleshooting Test Setup
+### What CI Gates
+
+CI gates every pull request on the following. It drives the linter through
+`golangci-lint-action` and `go fix` through its own workflow rather than through these
+targets, so the right-hand column is the local equivalent, not the literal CI command:
+
+| CI check                     | Local equivalent                  |
+|------------------------------|-----------------------------------|
+| `golangci-lint`, per module  | `make lint`                       |
+| `go fix -diff`               | `make go-fix`                     |
+| `go mod tidy` leaves no diff | `make tidy`                       |
+| unit tests                   | `make unit-tests`                 |
+| PostgreSQL unit tests        | `make unit-tests-postgres`        |
+| integration suites           | `make integration-tests-<target>` |
+
+If your pull request only touches unit-tested code, `make checks` plus a targeted
+`make unit-tests` is usually the fastest high-signal validation pass before pushing.
+Before pushing for review, read [Commit Hygiene](workflow.md#commit-hygiene).
+
+## Troubleshooting
+
+### Lint failures in files you never touched
+
+`golangci-lint` keeps one machine-wide cache — `golangci-lint cache status` prints the
+directory — shared by every checkout of the repository. Working in more than one
+checkout, a second clone or a worktree under `.claude/worktrees/`, can therefore surface
+findings against files outside the tree you are linting. The giveaway is a path that
+leaves your working directory:
+
+```
+../other-worktree/node/start/profile/profile_test.go:119:1: ...
+```
+
+Those findings are stale, not real. Clear the cache and re-run:
+
+```bash
+golangci-lint cache clean
+make checks
+```
+
+`cache clean` can take a couple of minutes. Do this before chasing a `make lint`
+failure you cannot reproduce by reading the code.
 
 ### Missing `FAB_BINS`
 
@@ -237,7 +302,7 @@ ls $(dirname $FAB_BINS)/builders/ccaas/bin
 
 ### PostgreSQL unit tests
 
-The PostgreSQL-specific unit tests expect the container image pulled by `make testing-docker-images`.
+The PostgreSQL-specific unit tests expect the container image pulled by `make pull-images-database`.
 Run that target once before `make unit-tests-postgres` on a new machine.
 
 ### Coverage for a single package

--- a/docs/dev/rebasing.md
+++ b/docs/dev/rebasing.md
@@ -41,10 +41,11 @@ git rebase main -S
 > - Do NOT merge `main` into your branch
 
 ## Verify Sign Status
-Verify after the rebase operation, your n commits are still signed correctly:
+Verify after the rebase operation that your commits are still signed correctly —
+replace `3` with the number of commits on your branch:
 
 ```bash
-git log -n --pretty=format:'%h %an %G? %s'
+git log -n 3 --pretty=format:'%h %an %G? %s'
 ```
 You should see `G` (valid signature). If you experience signing issues, read [Signing Guide](signing.md).
 

--- a/docs/dev/signing.md
+++ b/docs/dev/signing.md
@@ -82,11 +82,10 @@ git log --show-signature
 
 * Ensure each commit shows both **GPG verified** and **DCO signed-off**.
 
-For a quick check of recent n commits:
-Note how many commits you have added, and make n equal to that.
+For a quick check of your most recent commits — replace `3` with the number you added:
 
 ```bash
-git log -n --pretty=format:'%h %an %G? %s'
+git log -n 3 --pretty=format:'%h %an %G? %s'
 ```
 Legend:
 

--- a/docs/dev/workflow.md
+++ b/docs/dev/workflow.md
@@ -209,12 +209,14 @@ Once the PR is approved, collapse the fixups into their target commit and force-
 the branch is a single commit again and ready to merge:
 
 ```bash
-git rebase --autosquash -S main
+git rebase -i --autosquash -S main
 git push --force-with-lease
 ```
 
-The check turns green and the final message is yours. Add `-i` to inspect the todo list
-before it runs.
+`--autosquash` alone is not reliable without `-i` — on some git versions it silently
+does nothing, leaving the fixups unsquashed and force-pushed as-is. `-i` opens your
+editor on the rebase todo list, already reordered with the fixups placed after their
+targets and marked `fixup`; save and close it as-is unless you want to change something.
 
 > [!IMPORTANT]
 > Rebasing rewrites commits, which drops their signatures unless you pass `-S`. The

--- a/docs/dev/workflow.md
+++ b/docs/dev/workflow.md
@@ -29,6 +29,11 @@ And one of the following status labels:
 
 An issue without a `status: ready for dev` label is **not ready for contribution**.
 
+Maintainers may also apply a priority label — `priority: critical`, `priority: high`,
+`priority: medium`, or `priority: low` — at their discretion. Priority is otherwise
+optional: an issue with no priority label is perfectly normal. It becomes required only
+when finalizing through `/finalize`, which refuses to run without exactly one.
+
 ### Skill System
 
 Every issue carries a skill-level label that determines who can claim it:
@@ -49,6 +54,30 @@ A contributor who has already completed any issue at a given level or higher aut
 Anyone may open an issue using the `bug`, `feature`, or `task` template. New issues start untriaged.
 
 Maintainers and core contributors review new issues and apply `status: ready for dev` once the issue is well-defined, scoped, and accepted.
+
+#### Writing a Good Description
+
+The template's fields *are* the expected structure: keep the `### ` headings it
+generates and write your content underneath them.
+
+> [!IMPORTANT]
+> `/finalize` rebuilds the issue body by parsing `### ` headings, and it discards
+> anything written **above the first one**. Do not open with a preamble, and do not
+> demote the headings to `##` or `####` — only `### ` is recognized.
+
+Keep each section brief and concrete: contributors read these to decide whether they
+can pick the issue up, and maintainers to decide whether it is ready. Relevant file
+paths, package names, and symbol names are worth more than narrative.
+
+| Type      | What the description has to establish                                                       |
+|-----------|---------------------------------------------------------------------------------------------|
+| `Bug`     | What you observed vs. what you expected, numbered steps that reproduce it, and the environment |
+| `Feature` | The problem first, then the proposed API or behavior; alternatives if you weighed any        |
+| `Task`    | The current state, the target state, and the implementation steps as a checklist             |
+
+Leave `Additional Information` empty when you have nothing to add — `_No response_` and
+`Optional.` are both treated as empty, so filler costs a reader time without telling
+them anything.
 
 #### Parent and Child Issues
 
@@ -95,6 +124,121 @@ PRs by maintainers, core contributors, and `dependabot` are exempt from both req
 
 If either condition is not met for a contributor's PR, the bot posts a warning comment.
 
+### Writing a PR Description
+
+There is no PR template; this is the convention:
+
+1. **What and why** — a short paragraph. The diff already shows *what* changed, so the
+   description carries the reasoning and whatever is not deducible from the code.
+2. **The issue link** — `Fixes #123`, in the body (see [above](#linking-a-pr-to-an-issue)).
+3. **How it was verified** — the commands you ran, or the test that now covers it.
+4. **Notes for reviewers** — optional: where to look first, what is deliberately out of scope.
+
+Keep it structured and short. A file-by-file walkthrough only duplicates the diff; omit
+it. The PR title should read like the final commit subject below.
+
+### Commit Hygiene
+
+Every PR is merged as a **single squashed commit**, and the branch reaches that state in
+four steps:
+
+1. **Develop locally** on a branch. Commit as often as you find useful — WIP commits are
+   fine here. You can push the branch and open a **draft PR** at any point, to get CI
+   running and make the work visible; the history does not have to be tidy yet.
+2. **Before requesting review**, squash the branch into one commit with a meaningful
+   message, and take the PR out of draft.
+3. **During review**, address comments with fixup commits, so reviewers see only what
+   changed since their last pass.
+4. **Once the PR is approved**, autosquash the fixups and force-push, leaving the single
+   commit that gets merged.
+
+Squashing locally rather than through GitHub keeps the message that lands on `main` the
+one you wrote, instead of a concatenation of every subject on the branch.
+
+#### The commit message
+
+The message describes what the PR changes — not the path you took to get there.
+`addressed reviewer comments`, `fix typo`, and `wip` are useful while a branch is under
+review, but none of them belong in the merged message. Use the
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format already in
+use on `main`, appending `!` to the scope for a breaking change:
+
+```
+<type>(<scope>): <short imperative summary>
+```
+
+```
+fix(fabricx): report the status of an already-final transaction
+test(integration): run libp2p in four targets instead of nine
+refactor(storage)!: replace squirrel with an internal SQL builder
+```
+
+#### Step 2: squash before requesting review
+
+Rebase onto the current `main`, collapse the branch into one commit, and write the
+message:
+
+```bash
+git rebase main -S
+git reset --soft main
+git commit -s -S
+git push --force-with-lease
+```
+
+A branch that genuinely contains two independent changes is two PRs, not two commits.
+
+#### Step 3: fixups during review
+
+Address review comments with fixup commits rather than by amending and force-pushing.
+Reviewers then see exactly what changed since their last pass, and their comment threads
+stay anchored to the lines they were written against:
+
+```bash
+git commit --fixup <sha> -s -S
+git push
+```
+
+Keep `-s` so the DCO check stays green while the fixups are on the branch.
+
+The **Git Checks / block-fixup** job fails for as long as `fixup!` commits are present.
+That is intentional — it marks the branch as not yet ready to merge.
+
+#### Step 4: autosquash once approved
+
+Once the PR is approved, collapse the fixups into their target commit and force-push, so
+the branch is a single commit again and ready to merge:
+
+```bash
+git rebase --autosquash -S main
+git push --force-with-lease
+```
+
+The check turns green and the final message is yours. Add `-i` to inspect the todo list
+before it runs.
+
+> [!IMPORTANT]
+> Rebasing rewrites commits, which drops their signatures unless you pass `-S`. The
+> `Signed-off-by` trailer lives in the message and survives, but verify both afterwards —
+> see [Verify Sign Status](rebasing.md#verify-sign-status).
+
+GitHub's *Squash and merge* button can also collapse a branch that carries only a base
+commit plus fixups, but it composes the message out of the concatenated commit subjects,
+so whoever merges has to rewrite it in the merge dialog. Squashing locally is preferred:
+you keep control of the message, and the branch is mergeable without an override.
+
+### Keeping the Guides Current
+
+A change that leaves the documentation wrong is not finished. Update the affected guide
+in the same PR:
+
+- `make` targets, CI checks, or test prerequisites → [Development Guide](development.md)
+- the contribution, review, or release process → this document
+- conventions, framework snippets, or paths that coding agents are told to follow →
+  [`AGENTS.md`](../../AGENTS.md) and [`docs/agents/`](../agents/)
+
+Reviewers should ask for the doc update rather than filing a follow-up: the author has
+the context now, and a stale guide costs every later reader.
+
 ### PR Labels
 
 | Label                    | Meaning                                                                               |
@@ -138,7 +282,7 @@ Maintainers and core contributors are exempt from all assignment and PR-linking 
 
 | Command     | Who can use                       | Effect                                                                                                                                                                  |
 |-------------|-----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `/finalize` | Maintainers and core contributors | Validates that the issue has a skill-level label, updates the issue title and body to the expected format, and transitions the status label to `status: ready for dev`. |
+| `/finalize` | Maintainers and core contributors | Validates that the issue carries `status: awaiting triage`, exactly one `skill:` label, exactly one `priority:` label, and a recognized type; rebuilds the body in the expected format, leaving the title unchanged; and transitions the status label to `status: ready for dev`. |
 
 ## References
 

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -150,7 +150,7 @@ outer:
 // there is the standard way for a consumer to select the packages instrumented
 // in the cover-built node binaries.
 func goflagsHasCoverpkg() bool {
-	for _, f := range strings.Fields(os.Getenv("GOFLAGS")) {
+	for f := range strings.FieldsSeq(os.Getenv("GOFLAGS")) {
 		if strings.HasPrefix(f, "-coverpkg") || strings.HasPrefix(f, "--coverpkg") {
 			return true
 		}

--- a/integration/nwo/fabricx/extensions/scv2/orderer.go
+++ b/integration/nwo/fabricx/extensions/scv2/orderer.go
@@ -9,6 +9,7 @@ package scv2
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabricx/network"
 )
@@ -38,7 +39,8 @@ func ordererConsenters(n *network.Network) []consenter {
 // NOTE: This is a simplified mock configuration. The consenter-msp-identities
 // are hardcoded and must match the actual network topology.
 func generateMockOrdererConfigFile(configPath string, consenters []consenter) error {
-	configContent := `
+	var configContent strings.Builder
+	configContent.WriteString(`
 logging:
   logSpec: info:grpc=error
   format: >-
@@ -63,10 +65,10 @@ artifacts-path:
 # as they must be set via the config yaml in order to override via env vars
 genesis-block-path: /root/artifacts/config-block.pb.bin
 consenter-msp-identities:
-`
+`)
 	for _, c := range consenters {
-		configContent += fmt.Sprintf("  - msp-id: %s\n    msp-dir: %s\n", c.MSPID, c.MSPDir)
+		fmt.Fprintf(&configContent, "  - msp-id: %s\n    msp-dir: %s\n", c.MSPID, c.MSPDir)
 	}
 
-	return os.WriteFile(configPath, []byte(configContent), 0o600)
+	return os.WriteFile(configPath, []byte(configContent.String()), 0o600)
 }


### PR DESCRIPTION
## What and why

The developer and agent guides (`AGENTS.md`, `docs/agents/`, `docs/dev/`) had drifted from the `Makefile`, the CI workflows, and the bot scripts: stale target names, a `make` target that never existed, snippets that don't actually run, and no documentation at all for `go fix`, local squashing, or how issues/PRs are expected to be described. This PR closes that gap and adds the `go-fix`/`go-fix-apply` targets the docs now describe.

**No dedicated issue** — this is a documentation/tooling alignment task discovered and scoped during the work itself, not tied to a pre-existing bug or feature request.

## Changes

- **`checks.mk`**: new `go-fix` (report) and `go-fix-apply` (apply) targets, generalized across every module; `make checks` now runs both. `.github/workflows/gofix.yml` calls `make go-fix` instead of re-implementing the check inline, so it can no longer drift out of sync with the local target.
- **`integration/`**: applied the two `go fix` modernizations that had accumulated while the CI check covered the root module only.
- **Docs**: corrected stale references (`integration.Opts`, `sdk/dig/sdk.go`, `make testing-docker-images`, `go generate ./...` for mocks, non-executable `git log -n` snippets) and added:
  - the branch flow — draft PR early, squash before review, fixups during review, autosquash once approved
  - the Conventional Commits message format
  - issue and PR description conventions, including that a priority label is optional except when running `/finalize`
  - how to register a new integration target (`INTEGRATION_DIR_*`, `INTEGRATION_FLAGS_*`, `HSM_INTEGRATION_TARGETS`)
  - three debugging traps: `FABRIC_BINARY_BASE` resolving outside a worktree, `gofmt -l` picking up gitignored generated output, and a zero-spec ginkgo run reporting `ok` indistinguishably from a real pass
  - a standing rule that a change leaving `docs/agents/` or `docs/dev/` wrong isn't finished

## How this was verified

- `make checks` green across all four modules
- Link/anchor check across every guideline doc: 0 broken references
- Both corrected snippets (`git log -n 3 ...`) run as written
- Rebased onto current `main`; no residual conflicts or drift

## Notes for reviewers

- No source behavior changes outside `integration/` — those two files are pure `go fix` output.
- `.github/workflows/gofix.yml` and `checks.mk` are the only non-doc files touched.

