### PR TITLE
test(ci): split unit tests per module and stop rebuilding what CI alr…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,43 +28,51 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # One entry per `make unit-tests` module, on its own runner.
   utest:
+    name: utest-${{ matrix.suite }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: root
+            target: unit-tests-root
+            coverage: true
+          - suite: postgres
+            target: unit-tests-postgres
+            coverage: true
+            database: true
+          # No coverage: filter-coverage.sh drops every path under /integration/.
+          - suite: integration
+            target: unit-tests-integration
+            fabric: true
+          - suite: extensions
+            target: unit-tests-extensions
+            coverage: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # ratchet:actions/setup-go@v7.0.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "**/*.sum"
-      - run: make install-fabric-bins
-      - name: unit-tests
-        run: |
-          GO_TEST_PARAMS="-race -coverprofile=coverage.profile" make unit-tests
-          ./scripts/filter-coverage.sh coverage.profile coverage.profile
-      - uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # ratchet:coverallsapp/github-action@v2.3.8
-        with:
-          file: coverage.profile
-          flag-name: utest
-          parallel: true
-          fail-on-error: false
 
-  utest-postgres:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # ratchet:actions/setup-go@v7.0.0
-        with:
-          go-version-file: "go.mod"
-          cache-dependency-path: "**/*.sum"
-      - run: make pull-images-database
-      - name: unit-tests-postgres
-        run: |
-          GO_TEST_PARAMS="-race -coverprofile=coverage.profile" make unit-tests-postgres
-          ./scripts/filter-coverage.sh coverage.profile coverage.profile
+      - name: Set up the database
+        if: matrix.database
+        run: make pull-images-database
+
+      - name: Set up Fabric
+        if: matrix.fabric
+        run: make install-fabric-bins
+
+      - name: Run the unit tests
+        run: GO_TEST_PARAMS=-race COVERAGE=${{ matrix.coverage }} make ${{ matrix.target }}
+
       - uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # ratchet:coverallsapp/github-action@v2.3.8
+        if: matrix.coverage
         with:
           file: coverage.profile
-          flag-name: utest-postgres
+          flag-name: utest-${{ matrix.suite }}
           parallel: true
           fail-on-error: false
 
@@ -101,7 +109,12 @@ jobs:
       - name: Set up Fabric
         if: startsWith(matrix.tests, 'fabric-')
         run: |
-          make -j4 install-fabric-bins pull-images-fabric pull-images-database
+          make -j4 install-fabric-bins pull-images-database
+
+      - name: Set up the legacy chaincode builder
+        # pull-images-fabric serve only the legacy source-packaging which is used it fabric-atsa
+        if: matrix.tests == 'fabric-atsa'
+        run: make -j4 pull-images-fabric
 
       - name: Set up Fabric-x
         if: startsWith(matrix.tests, 'fabricx-')
@@ -142,12 +155,12 @@ jobs:
   publish-coverage:
     needs:
       - utest
-      - utest-postgres
       - itest
     runs-on: ubuntu-latest
     steps:
-      # Close the parallel Coveralls build. Every test job in this run reports a
-      # flag (the itest matrix has no job-level skips), so all flags are present
+      # Close the parallel Coveralls build. Every job that reports a flag runs
+      # unconditionally (neither matrix has job-level skips; the utest
+      # integration entry reports no flag by design), so all flags are present
       # and no `carryforward` is needed. Omitting carryforward is deliberate: it
       # previously masked missing integration-test jobs by silently reusing a
       # prior build's coverage, so an incomplete run reported a stale-but-

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,9 @@ integration/**/out/
 integration/nwo/cmd/fsccli/cmd
 /.bob/notes/pending-notes.txt
 
+# local coverage output (COVERAGE=1, make coverage-local)
+/coverage.profile
+/coverage.out
+
 # compiled cc/query chaincode binary (go build artifact)
 platform/fabric/services/state/cc/query/query

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,8 @@ make lint           # golangci-lint (use make lint-auto-fix to autofix)
 make tidy           # go mod tidy across all modules
 make generate-protos     # regenerate protobuf files
 make install-tools       # install dev tools (source of truth: tools/tools.go)
-make unit-tests     # unit tests, excluding Postgres (-race -cover)
+make unit-tests     # unit tests in every module, excluding Postgres (-race -cover)
+make unit-tests-root     # one module only: -root, -integration or -extensions
 make integration-tests   # integration tests (need Fabric binaries + Docker)
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ GINKGO_TEST_OPTS += --keep-going
 .PHONY: help
 help: ## List all commands with documentation
 	@echo "Available commands:"
-	@awk 'BEGIN {FS = ":.*?## "}; /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*?## "}; /^[a-zA-Z0-9_-]+:.*?## / {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 #########################
 # Install tools
@@ -156,10 +156,10 @@ GO_PACKAGES = $$(go list ./...)
 # Unit-testable packages of the integration module: the nwo harness plus the shared
 # helpers the suites import. The suites themselves are integration tests, not unit tests.
 INTEGRATION_UNIT_PACKAGES = ./nwo/... ./fabric/common/...
-# The libp2p comm host is its own module, so the root `go list ./...` cannot see
-# it. Named here so `unit-tests` can step into it explicitly -- without this its
+# Extension modules: optional drivers with their own go.mod, invisible to the root
+# `go list ./...`. Without stepping into them explicitly, the libp2p
 # host-conformance tests (shared with the websocket host) never run.
-LIBP2P_HOST_MODULE = platform/view/services/comm/host/libp2p
+EXTENSION_MODULES = platform/view/services/comm/host/libp2p
 GO_PACKAGES_SDK = $$(go list ./... | grep '/sdk/dig$$')
 GO_TEST_PARAMS ?= -race -cover
 TEST_PKGS ?= $(GO_PACKAGES)
@@ -170,27 +170,53 @@ TEST_PKGS ?= $(GO_PACKAGES)
 # Kept separate from GO_TEST_PARAMS because CI overrides GO_TEST_PARAMS wholesale.
 GO_COVERPKG ?= -coverpkg=./...
 
+# COVERAGE=1 leaves a filtered profile in COVERAGE_PROFILE, which has to be
+# absolute: `go test -C` resolves it inside the module it tested. -count=1
+# because a cached result replays its summary line but writes no profile data.
+COVERAGE_PROFILE ?= $(CURDIR)/coverage.profile
+ifdef COVERAGE
+COVER_FLAGS = -count=1 -coverprofile=$(COVERAGE_PROFILE)
+FILTER_COVERAGE = ./scripts/filter-coverage.sh $(COVERAGE_PROFILE) $(COVERAGE_PROFILE)
+else
+FILTER_COVERAGE = true
+endif
+
+UNIT_TEST_ENV = FABRIC_LOGGING_SPEC=error FAB_BINS=$(FAB_BINS)
+
 .PHONY: unit-tests
-unit-tests: ## Run unit tests
-	@echo "Running unit tests..."
-	export FABRIC_LOGGING_SPEC=error; \
-	export FAB_BINS=$(FAB_BINS); \
-	rc=0; \
-	go test $(GO_TEST_PARAMS) $(GO_COVERPKG) --skip '(Postgres)' $(TEST_PKGS) || rc=1; \
-	go test -C integration $(GO_TEST_PARAMS) --skip '(Postgres)' $(INTEGRATION_UNIT_PACKAGES) || rc=1; \
-	go test -C $(LIBP2P_HOST_MODULE) $(GO_TEST_PARAMS) ./... || rc=1; \
-	exit $$rc
+unit-tests: ## Run unit tests in every module
+	@$(MAKE) -k unit-tests-root unit-tests-integration unit-tests-extensions
+
+.PHONY: unit-tests-root
+unit-tests-root: ## Run unit tests of the root module
+	@env $(UNIT_TEST_ENV) go test $(GO_TEST_PARAMS) $(GO_COVERPKG) $(COVER_FLAGS) --skip '(Postgres)' $(TEST_PKGS)
+	@$(FILTER_COVERAGE)
+
+.PHONY: unit-tests-integration
+unit-tests-integration: ## Run unit tests of the integration module (nwo harness + shared helpers)
+	@env $(UNIT_TEST_ENV) go test -C integration $(GO_TEST_PARAMS) $(COVER_FLAGS) --skip '(Postgres)' $(INTEGRATION_UNIT_PACKAGES)
+	@$(FILTER_COVERAGE)
+
+.PHONY: unit-tests-extensions
+unit-tests-extensions: ## Run unit tests of the extension modules (optional drivers with their own go.mod)
+	@rc=0; raw=$$(mktemp -d); \
+	for m in $(EXTENSION_MODULES); do \
+		env $(UNIT_TEST_ENV) go test -C $$m $(GO_TEST_PARAMS) $(GO_COVERPKG) \
+			$(if $(COVERAGE),-count=1 -coverprofile=$$raw/$$(echo $$m | tr / _)) ./... || rc=1; \
+	done; \
+	if [ -n "$(COVERAGE)" ] && [ $$rc -eq 0 ]; then \
+		cat $$raw/* > $(COVERAGE_PROFILE) && $(FILTER_COVERAGE); \
+	fi; \
+	rm -rf $$raw; exit $$rc
 
 .PHONY: unit-tests-postgres
 unit-tests-postgres: ## Run unit tests for postgres (requires container images as defined in testing-docker-images)
-	@echo "Running unit tests..."
-	export FABRIC_LOGGING_SPEC=error; \
-	go test $(GO_TEST_PARAMS) $(GO_COVERPKG) --run '(Postgres)' $(TEST_PKGS)
+	@env $(UNIT_TEST_ENV) go test $(GO_TEST_PARAMS) $(GO_COVERPKG) $(COVER_FLAGS) --run '(Postgres)' $(TEST_PKGS)
+	@$(FILTER_COVERAGE)
 
 .PHONY: unit-tests-sdk
 unit-tests-sdk: ## Run sdk wiring tests
-	@echo "Running SDK tests..."
-	go test $(GO_TEST_PARAMS) --run "(TestWiring)" $(GO_PACKAGES_SDK)
+	@env $(UNIT_TEST_ENV) go test $(GO_TEST_PARAMS) --run "(TestWiring)" $(GO_PACKAGES_SDK)
 
 run-otlp:
 	cd platform/view/services/tracing; docker-compose up -d
@@ -296,8 +322,5 @@ clean-fabric-peer-images: ## Clean up generated fabric peer images
 
 .PHONY: coverage-local
 coverage-local: ## Run unit tests and show filtered coverage
-	@echo "Running unit tests with coverage..."
-	@env FABRIC_LOGGING_SPEC=error FAB_BINS=$(FAB_BINS) go test $(GO_TEST_PARAMS) $(GO_COVERPKG) -coverprofile=coverage.tmp $(TEST_PKGS)
-	@./scripts/filter-coverage.sh coverage.tmp coverage.out
+	@$(MAKE) unit-tests-root COVERAGE=1 COVERAGE_PROFILE=$(CURDIR)/coverage.out
 	@go tool cover -func=coverage.out | tail -n 1
-	@rm coverage.tmp

--- a/docs/agents/integration-tests.md
+++ b/docs/agents/integration-tests.md
@@ -105,8 +105,10 @@ The chaincode's `main` must start a `shim.ChaincodeServer` reading `CHAINCODE_ID
 and `CHAINCODE_SERVER_ADDRESS`; copy one of the existing mains.
 
 To have the peer build your chaincode from Go source instead, use
-`WithLegacyChaincode(importPath)`. That path needs the `ccenv` image and a
-`shim.Start` main. `integration/fabric/atsa` is the in-tree example.
+`WithLegacyChaincode(importPath)`. That path needs a `shim.Start` main and the
+`ccenv` and `baseos` images (`make pull-images-fabric`) -- peers compile the
+chaincode in the first and run it in the second. `integration/fabric/atsa` is
+the in-tree example, and the only suite CI pulls those images for.
 
 The remaining options are `WithCtor(ctor)` (which also turns on init),
 `WithVersion(v)` and `WithPackageFile(path)` for a package you built yourself.

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -13,9 +13,10 @@ will be migrated — follow the convention, not the neighbouring file.
 Scope every run to what you changed:
 
 ```bash
-make unit-tests                                        # all unit tests except Postgres
-go test -run TestMyTest ./platform/view/...             # one test
-TEST_PKGS=./platform/common/utils/... make unit-tests   # one package tree
+make unit-tests                                             # all unit tests except Postgres
+make unit-tests-root                                        # only the root module
+go test -run TestMyTest ./platform/view/...                  # one test
+TEST_PKGS=./platform/common/utils/... make unit-tests-root   # one package tree
 ```
 
 Never run the whole integration suite to check a change — it is slow and needs Fabric

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -151,18 +151,30 @@ Use `make unit-tests` for the default unit-test suite.
 Use `make unit-tests-postgres` only for tests that explicitly exercise the PostgreSQL-backed storage implementations.
 Use `make unit-tests-sdk` when validating dependency-injection wiring in SDK packages.
 
-To keep the feedback loop fast while working on a single package, scope the test run with `TEST_PKGS`:
+When your change is confined to one module, run just that module's target:
 
 ```bash
-TEST_PKGS=./platform/common/utils/... make unit-tests
+make unit-tests-root           # the framework itself
+make unit-tests-integration    # the nwo harness and the helpers the suites share
+make unit-tests-extensions     # optional driver modules (today: the libp2p comm host)
+```
+
+To keep the feedback loop fast while working on a single package, scope the root-module
+run with `TEST_PKGS`:
+
+```bash
+TEST_PKGS=./platform/common/utils/... make unit-tests-root
 TEST_PKGS=./platform/common/utils/dig go test -race -cover ./platform/common/utils/dig
 ```
 
-For coverage analysis:
+For coverage analysis, `COVERAGE=1` makes any unit-test target leave a filtered
+profile (the same filter CI reports through) in `./coverage.profile`; override the
+path with `COVERAGE_PROFILE`:
+
 ```bash
-GO_TEST_PARAMS="-coverprofile=cov.out" make unit-tests
-go tool cover -func=cov.out
-go tool cover -html=cov.out
+COVERAGE=1 make unit-tests-root
+go tool cover -func=coverage.profile
+go tool cover -html=coverage.profile
 ```
 
 To reproduce the filtered local coverage used in CI:

--- a/integration/nwo/fabric/platform.go
+++ b/integration/nwo/fabric/platform.go
@@ -32,7 +32,13 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/logging"
 )
 
-const CCEnvDefaultImage = "hyperledger/fabric-ccenv:latest"
+// The images the legacy source-packaging path needs: peers compile the
+// chaincode in ccenv and run the result in baseos. Both are named in
+// core_template.go as $(DOCKER_NS)/... , which the peer expands to hyperledger.
+const (
+	CCEnvDefaultImage  = "hyperledger/fabric-ccenv:latest"
+	BaseOSDefaultImage = "hyperledger/fabric-baseos:latest"
+)
 
 var logger = logging.MustGetLogger()
 
@@ -142,6 +148,16 @@ func topologyHasCCaaSChaincode(t *topology.Topology) bool {
 	return false
 }
 
+// requiredImagesFor lists the images that must be present locally for the
+// topology's chaincodes to launch. A CCaaS image is checked separately, when
+// the namespace is deployed.
+func requiredImagesFor(t *topology.Topology) []string {
+	if topologyHasLegacyChaincode(t) {
+		return []string{CCEnvDefaultImage, BaseOSDefaultImage}
+	}
+	return nil
+}
+
 func NewPlatform(context api.Context, t api.Topology, components BuilderClient) *Platform {
 	// create a new network name
 	networkID := common.UniqueName()
@@ -165,14 +181,12 @@ func NewPlatform(context api.Context, t api.Topology, components BuilderClient) 
 				"fabric distribution that ships builders/ccaas")
 	}
 
-	var requiredImages []string
-	if topologyHasLegacyChaincode(t.(*topology.Topology)) {
-		requiredImages = append(requiredImages, CCEnvDefaultImage)
-	}
-
 	p := &Platform{
 		Network: n,
-		Docker:  &Docker{NetworkID: networkID, RequiredImages: requiredImages},
+		Docker: &Docker{
+			NetworkID:      networkID,
+			RequiredImages: requiredImagesFor(t.(*topology.Topology)),
+		},
 	}
 
 	return p

--- a/integration/nwo/fabric/platform_ccaas_test.go
+++ b/integration/nwo/fabric/platform_ccaas_test.go
@@ -77,3 +77,19 @@ func TestTopologyPredicates(t *testing.T) { //nolint:paralleltest
 	require.False(t, topologyHasCCaaSChaincode(empty))
 	require.False(t, topologyHasLegacyChaincode(empty))
 }
+
+func TestRequiredImagesFor(t *testing.T) { //nolint:paralleltest
+	// Both images: peers compile a source-packaged chaincode in ccenv and run
+	// the result in baseos, so checking only ccenv would let a missing baseos
+	// surface as an opaque chaincode-launch failure instead.
+	legacy := &topology.Topology{Chaincodes: []*topology.ChannelChaincode{
+		{Chaincode: topology.Chaincode{Path: "github.com/acme/cc"}},
+	}}
+	require.Equal(t, []string{CCEnvDefaultImage, BaseOSDefaultImage}, requiredImagesFor(legacy))
+
+	ccaasOnly := &topology.Topology{Chaincodes: []*topology.ChannelChaincode{
+		{Chaincode: topology.Chaincode{Image: "fsc-cc/base:latest"}},
+	}}
+	require.Empty(t, requiredImagesFor(ccaasOnly))
+	require.Empty(t, requiredImagesFor(&topology.Topology{}))
+}

--- a/scripts/chaincode/Dockerfile
+++ b/scripts/chaincode/Dockerfile
@@ -1,20 +1,5 @@
-# syntax=docker/dockerfile:1
+# The one recipe for packaging an in-tree Go chaincode into a CCaaS image.
 #
-# The one recipe for building an in-tree Go chaincode into a CCaaS image.
-# MODULE is the module directory relative to the repo root; PKG is the package
-# within that module. A chaincode needing something else drops its own
-# Dockerfile next to its source and build-image.sh picks that up instead.
-ARG GO_VERSION=1.26
-FROM golang:${GO_VERSION}-bookworm AS build
-ARG MODULE=.
-ARG PKG=.
-WORKDIR /src
-COPY . .
-WORKDIR /src/${MODULE}
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg/mod \
-    CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o /cc ${PKG}
-
 FROM scratch
-COPY --from=build /cc /cc
+COPY cc /cc
 ENTRYPOINT ["/cc"]

--- a/scripts/chaincode/build-image.sh
+++ b/scripts/chaincode/build-image.sh
@@ -5,10 +5,12 @@
 #
 # build-image.sh <image> <module> <pkg>
 #
-# Builds one chaincode container image tagged <image>:latest. The build context
-# is always the repo root, so a chaincode may import from sibling modules.
-# If a Dockerfile sits next to the chaincode source it is used; otherwise the
-# shared recipe in this directory is, parameterised by MODULE and PKG.
+# Builds one chaincode container image tagged <image>:latest: compiles with the
+# host toolchain, then packages the static binary into a scratch image.
+#
+# If a Dockerfile sits next to the chaincode source it is used instead, with the
+# repo root as the build context -- the escape hatch for a chaincode that needs
+# more than a static binary.
 set -euo pipefail
 
 if [ "$#" -ne 3 ]; then
@@ -23,14 +25,6 @@ PKG="$3"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
-# Track the repo's Go version rather than pinning a second copy in the
-# Dockerfile: "go 1.26.5" -> "1.26".
-GO_VERSION="$(awk '/^go /{split($2,v,"."); print v[1]"."v[2]; exit}' "${ROOT}/go.mod")"
-if [ -z "${GO_VERSION}" ]; then
-    echo "==> could not read the go version from ${ROOT}/go.mod" >&2
-    exit 1
-fi
-
 OWN_DOCKERFILE="${ROOT}/${MODULE}/${PKG#./}/Dockerfile"
 if [ -f "${OWN_DOCKERFILE}" ]; then
     echo "==> building ${IMAGE}:latest from ${OWN_DOCKERFILE#"${ROOT}/"}"
@@ -41,11 +35,21 @@ if [ -f "${OWN_DOCKERFILE}" ]; then
     exit 0
 fi
 
-echo "==> building ${IMAGE}:latest from ${MODULE}/${PKG} (go ${GO_VERSION})"
-DOCKER_BUILDKIT=1 docker build \
+# Nothing in a scratch image pins its platform, so label it to match the binary.
+ARCH="$(go env GOARCH)"
+
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "${BUILD_DIR}"' EXIT
+
+echo "==> building ${IMAGE}:latest from ${MODULE}/${PKG} (linux/${ARCH})"
+CGO_ENABLED=0 GOOS=linux go build \
+    -C "${ROOT}/${MODULE}" \
+    -buildvcs=false \
+    -o "${BUILD_DIR}/cc" \
+    "${PKG}"
+
+docker build \
+    --platform "linux/${ARCH}" \
     -t "${IMAGE}:latest" \
     -f "${SCRIPT_DIR}/Dockerfile" \
-    --build-arg "GO_VERSION=${GO_VERSION}" \
-    --build-arg "MODULE=${MODULE}" \
-    --build-arg "PKG=${PKG}" \
-    "${ROOT}"
+    "${BUILD_DIR}"

--- a/scripts/filter-coverage.sh
+++ b/scripts/filter-coverage.sh
@@ -27,8 +27,8 @@ trap 'rm -f "$tmp"' EXIT
 
 # We filter some of the files for test coverage reporting.
 awk '
-  # Preserve mode line
-  /^mode:/ { print; next }
+  # Preserve the mode line, once: concatenated profiles each carry one.
+  /^mode:/ { if (!seen++) print; next }
 
   # Exclude main.go
   /main\.go/ { next }


### PR DESCRIPTION
Closes #1726 

This PR improves the make targets for unit testing and improve fabric chaincode container builds.

## Unit tests: one target per module group

```
make unit-tests               # all three, via $(MAKE) -k
make unit-tests-root          # the framework
make unit-tests-integration   # the nwo harness and the helpers the suites share
make unit-tests-extensions    # optional driver modules (today: the libp2p comm host)
```

`unit-tests` recurses with `-k` rather than listing the three as prerequisites, so one module's failure still does not hide the others — the behaviour the old `rc=0; … || rc=1` accumulator provided — while each failure now arrives labelled with its target.

Extension modules are a list (`EXTENSION_MODULES`), not a target apiece: adding a second optional driver is one word and needs no CI change. `TEST_PKGS` now scopes `unit-tests-root`, which is the module it was ever able to scope.

All five unit-test targets are consistent: `@env $(UNIT_TEST_ENV) go test …`. `unit-tests-postgres` had inlined its own `FABRIC_LOGGING_SPEC`, and `unit-tests-sdk` set no environment at all, so it logged at default verbosity.

## CI: a four-entry matrix instead of two duplicated jobs

`utest` becomes a matrix over root / postgres / integration / extensions, each on its own runner, replacing ~80 lines of near-duplicate YAML with one set of steps — matching the `itest` matrix convention already in the file.

Two entries deserve their comments:

- **integration reports no coverage.** `filter-coverage.sh` drops every path under `/integration/` by design, so a profile from that suite filters down to just its `mode:` line. Uploading it would add an empty flag to the parallel Coveralls build, reading as 0% rather than as absent.
- **extensions reports coverage that was previously discarded.** `go test -C` chdirs before resolving `-coverprofile`, so the profile lands inside the module; the entry uploads that path under its own flag. `$(GO_COVERPKG)` is applied in the extensions loop so each module credits its own packages the way root does (which moves libp2p from 52.4% package-scoped to 39.1% module-scoped — same code, honest denominator).

Only the integration module reads `FAB_BINS`, so `install-fabric-bins` is scoped to that entry instead of gating every unit-test run.

## Chaincode images: compile on the host, package with Docker

The image is `FROM scratch` plus one static binary, so the `golang:` builder stage bought each CI job a cold Go environment and nothing else. `build-image.sh` now compiles with the host toolchain — warm via `actions/setup-go` on CI, the developer's own cache locally — and Docker only wraps the binary.

Measured: **~4s for all four images** against ~3min of cold container per job. The build context shrinks from the whole repo to a temp dir holding one binary, so the `COPY . .` layer is gone too.

`--platform linux/$(go env GOARCH)` is new: the builder stage used to fix the image's architecture implicitly by pulling `golang:` for the host platform, and nothing in a scratch image pins it otherwise. The per-chaincode `Dockerfile` escape hatch is unchanged, still repo-root context.

`make chaincode-images` is unchanged for local use.

## Fabric images: pull ccenv and baseos for the one suite that needs them

Both serve only the legacy source-packaging path, so CI pulls them for
`fabric-atsa` rather than all ten fabric targets — 880MB × 9 jobs.

`requiredImagesFor` (extracted from `NewPlatform`) now requires **both** images for that path. It listed only `ccenv`, so a missing `baseos` surfaced as an opaque chaincode-launch failure rather than nwo's actionable error — which is also what makes the CI gating safe: a suite that starts packaging from source and is not listed fails with the missing image named.

## Verification

- `make checks`: 0 issues across all four modules.
- `make unit-tests-root` (scoped), `unit-tests-integration`, `unit-tests-extensions`, `unit-tests-sdk`: pass. `unit-tests-postgres` dry-run only (needs the DB image); its only change is the env line.
- `-k` aggregation: `make unit-tests-extensions EXTENSION_MODULES="nope1 nope2"` attempts both and exits non-zero.
- `make chaincode-images` for real: four single-layer `linux/arm64` images, 16.7–22.9MB, and `docker run --rm fsc-cc/base:latest` reaches the chaincode's own `ccid must be specified` — so nothing was missing from the empty base.
- The coverage claims were checked against `filter-coverage.sh` with synthesised profiles: an integration profile filters to its `mode:` line; a libp2p one keeps production paths and drops `/mock/`.
- `TestRequiredImagesFor` covers legacy / CCaaS-only / empty topologies.

Not run: `make integration-tests-fabric-atsa`, the one suite whose behaviour the last section touches. Worth a look in CI.

## Docs

`docs/dev/development.md`, `docs/agents/testing.md` and `AGENTS.md` cover the new targets. `docs/agents/integration-tests.md` said the legacy path needs "the `ccenv` image" — now both, with what each does.
