### PR TITLE
test(integration): share one network per Describe, drop four redundant specs

### DIFF
--- a/docs/agents/integration-tests.md
+++ b/docs/agents/integration-tests.md
@@ -56,8 +56,9 @@ opts := &Opts{
 
 New suites use `fsc.WebSocket`. Add a `fsc.LibP2P` variant only when the suite
 exercises something transport-specific that the host conformance tests in
-`platform/view/services/comm` cannot reach — every extra comm type costs a full
-network bootstrap per spec, because each `It` re-runs `Setup`/`TearDown`.
+`platform/view/services/comm` cannot reach — every extra comm type costs at least
+one more network bootstrap, and one per spec unless the `Describe` is `Ordered`
+(see [one network per `Describe`](testing.md#one-network-per-describe)).
 
 Label each `Describe` with its comm type so a suite can be run one transport at
 a time (`ginkgo --label-filter=libp2p`) and split into parallel CI entries:
@@ -69,6 +70,12 @@ a time (`ginkgo --label-filter=libp2p`) and split into parallel CI entries:
 Label websocket-only variants (replication, no-TLS) with `Label(fsc.WebSocket)`
 too: `--label-filter` selects only labelled specs, so an unlabelled `Describe`
 is silently skipped when a filter is in play.
+
+Label a `Describe` for the transport it *runs*, not the one it was handed. A suite
+that loads committed artifacts runs whatever those artifacts say, because
+`fsc.Platform.Load` is a no-op and never rewrites `core.yaml` — `integration/fsc/pingpong`
+keeps its loading specs in one libp2p-labelled `Describe` for exactly this reason.
+A label that lies puts specs in the wrong CI job.
 
 ## Declaring a namespace
 

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -33,17 +33,34 @@ prerequisites. See also [integration-tests.md](integration-tests.md).
 ## Integration test structure
 
 ```go
-var _ = Describe("Feature", func() {
+var _ = Describe("Feature", Ordered, func() {
     s := NewTestSuite(opts...)
-    BeforeEach(s.Setup)
-    AfterEach(s.TearDown)
+    BeforeAll(s.Setup)
+    AfterAll(s.TearDown)
     It("test case", s.TestFunction)
+    It("another test case", s.TestOtherFunction)
 })
 ```
 
 - Define the network topology in `<test>/topology.go` via `integration.Generate()`.
 - Put reusable test logic in `<test>/<test>.go`.
 - For multi-node scenarios, use `integration.ReplicationOptions`.
+
+### One network per `Describe`
+
+`Setup` generates or loads artifacts and starts every node; `TearDown` stops them. Under
+`BeforeEach`/`AfterEach` that cycle runs **per `It`** — roughly 90-110s for a Fabric
+topology, against 10-20s for the assertions inside it. A five-spec `Describe` then spends
+most of its runtime booting the same network five times.
+
+So default to `Ordered` with `BeforeAll`/`AfterAll` and share one network across the
+group. Reach for `BeforeEach` only when a spec genuinely needs a pristine one: it stops a
+node, or it writes state a later spec would read. A spec that needs a *different*
+topology belongs in its own `Describe` regardless — the topology is fixed when
+`NewTestSuite` is called.
+
+Specs that could share a network but would collide on fixed data (the same asset ID, say)
+either parameterise that data or stay in separate `Describe`s.
 
 ## Focused runs (never commit)
 

--- a/integration/fabric/atsa/atsa_test.go
+++ b/integration/fabric/atsa/atsa_test.go
@@ -51,11 +51,10 @@ var _ = Describe("EndToEnd", func() {
 
 		BeforeEach(s.Setup)
 		AfterEach(s.TearDown)
-		It("succeeded 1", func() {
+		// One spec: alice.0 agrees to sell and alice.1 transfers, which is the
+		// cross-replica read replication adds. Permuting the indices adds nothing.
+		It("succeeded", func() {
 			s.TestSucceededWithUsers(node{"issuer", "fsc.issuer.0"}, node{"alice", "fsc.alice.0"}, node{"bob", "fsc.bob.0"}, node{"alice", "fsc.alice.1"})
-		})
-		It("succeeded 2", func() {
-			s.TestSucceededWithUsers(node{"issuer", "fsc.issuer.1"}, node{"alice", "fsc.alice.1"}, node{"bob", "fsc.bob.1"}, node{"alice", "fsc.alice.1"})
 		})
 	})
 })

--- a/integration/fabric/stoprestart/stoprestart_test.go
+++ b/integration/fabric/stoprestart/stoprestart_test.go
@@ -28,23 +28,13 @@ var _ = Describe("EndToEnd", func() {
 		})
 	}
 
+	// Many-to-one only: StopFSCNode stops the first matching replica and returns, so
+	// bob: 4 would leave three responders up and check less than bob: 1 does.
 	Describe("Stop and Restart with Fabric With Replicas many to one", Label(fsc.WebSocket), func() {
 		s := NewTestSuite(fsc.WebSocket, &integration.ReplicationOptions{
 			ReplicationFactors: map[string]int{
 				"alice": 4,
 				"bob":   1,
-			},
-		})
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("stop and restart successfully", s.TestSucceededWithReplicas)
-	})
-
-	Describe("Stop and Restart with Fabric With Replicas many to many", Label(fsc.WebSocket), func() {
-		s := NewTestSuite(fsc.WebSocket, &integration.ReplicationOptions{
-			ReplicationFactors: map[string]int{
-				"alice": 4,
-				"bob":   4,
 			},
 		})
 		BeforeEach(s.Setup)

--- a/integration/fsc/pingpong/pingpong_test.go
+++ b/integration/fsc/pingpong/pingpong_test.go
@@ -13,7 +13,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/atomic"
 
 	"github.com/hyperledger-labs/fabric-smart-client/integration"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/fsc/pingpong"
@@ -137,62 +136,47 @@ var _ = Describe("EndToEnd", func() {
 		})
 	})
 
-	// libp2p keeps only the specs that put bytes on the wire. The four dropped
-	// ones vary the client API (REST, web client, artifact generate-vs-load,
-	// stream-vs-call), which is transport-agnostic and fully covered by the
-	// websocket Describe below.
-	Describe("Network-based Ping pong With LibP2P", Label(fsc.LibP2P), func() {
-		s := NewTestSuite(fsc.LibP2P, false, integration.NoReplication)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("load artifact & successful pingpong", func() { s.TestLoadAndPingPong("initiator") })
-		It("load artifact & successful stream", func() { s.TestLoadAndStream("initiator") })
+	// Loading runs libp2p whatever transport it is handed -- the committed
+	// ./testdata fixture is type: libp2p and fsc.Platform.Load never rewrites it.
+	// Hence one loading group, labelled for what it runs; see
+	// docs/agents/integration-tests.md#choosing-a-p2p-comm-type.
+	Describe("Network-based Ping pong, loaded artifacts", Label(fsc.LibP2P), Ordered, func() {
+		s := NewTestSuite(fsc.LibP2P, doLoad, integration.NoReplication)
+		BeforeAll(s.Setup)
+		AfterAll(s.TearDown)
+		It("successful pingpong", func() { s.TestPingPong("initiator") })
+		It("successful pingpong with stream", func() { s.TestPingPongStream("initiator") })
+		It("successful stream", func() { s.TestStream("initiator") })
+		It("successful stream with websocket", func() { s.TestStreamWebsocket("initiator") })
+		It("init clients & successful pingpong", s.TestLoadInitPingPong)
 	})
 
-	// The label describes this Describe's first spec only. Artifacts are generated
-	// on the first Setup and loaded from ./testdata thereafter (fsc.Platform.Load
-	// is a no-op, so core.yaml is never rewritten), and that committed fixture is
-	// libp2p -- see the node-based Describe above for why it cannot be websocket.
-	// So do not split this suite by label expecting a clean transport partition.
-	Describe("Network-based Ping pong With Websockets", Label(fsc.WebSocket), func() {
-		s := NewTestSuite(fsc.WebSocket, false, integration.NoReplication)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("generate artifacts & successful pingpong", func() { s.TestGenerateAndPingPong("initiator") })
-		It("load artifact & successful pingpong", func() { s.TestLoadAndPingPong("initiator") })
-		It("load artifact & successful pingpong with stream", func() { s.TestLoadAndPingPongStream("initiator") })
-		It("load artifact & successful stream", func() { s.TestLoadAndStream("initiator") })
-		It("load artifact & successful stream with websocket", func() { s.TestLoadAndStreamWebsocket("initiator") })
-		It("load artifact & init clients & successful pingpong", s.TestLoadInitPingPong)
-	})
+	// Generating honours the transport, so both get a group. What it adds over the
+	// loading group is config writing and node bootstrap, not client API surface.
+	for _, c := range []fsc.P2PCommunicationType{fsc.LibP2P, fsc.WebSocket} {
+		Describe("Network-based Ping pong, generated artifacts", Label(c), Ordered, func() {
+			s := NewTestSuite(c, doGenerate, integration.NoReplication)
+			BeforeAll(s.Setup)
+			AfterAll(s.TearDown)
+			It("successful pingpong", func() { s.TestPingPong("initiator") })
+			It("successful mock pingpong", s.TestMockPingPong)
+		})
+	}
 
-	Describe("Network-based Ping pong With Websockets and replication", Label(fsc.WebSocket), func() {
-		s := NewTestSuite(fsc.WebSocket, true, &integration.ReplicationOptions{
+	// Replication generates, so this group is genuinely websocket.
+	Describe("Network-based Ping pong With Websockets and replication", Label(fsc.WebSocket), Ordered, func() {
+		s := NewTestSuite(fsc.WebSocket, doGenerate, &integration.ReplicationOptions{
 			ReplicationFactors: map[string]int{
 				"initiator": 3,
 			},
 		})
 		initiatorReplicas := GetFSCReplicaNames("initiator", 3)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("generate artifacts & successful pingpong", func() { s.TestGenerateAndPingPong(initiatorReplicas...) })
-		It("load artifact & successful pingpong", func() { s.TestLoadAndPingPong(initiatorReplicas...) })
-		It("load artifact & successful pingpong with stream", func() { s.TestLoadAndPingPongStream(initiatorReplicas...) })
-		It("load artifact & successful stream", func() { s.TestLoadAndStream(initiatorReplicas...) })
-		It("load artifact & successful stream with websocket", func() { s.TestLoadAndStreamWebsocket(initiatorReplicas...) })
-	})
-
-	Describe("Network-based Mock Ping pong With LibP2P", Label(fsc.LibP2P), func() {
-		s := NewTestSuite(fsc.LibP2P, false, integration.NoReplication)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("generate artifacts & successful mock pingpong", s.TestGenerateAndMockPingPong)
-	})
-	Describe("Network-based Mock Ping pong With Websockets", Label(fsc.WebSocket), func() {
-		s := NewTestSuite(fsc.WebSocket, false, integration.NoReplication)
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("generate artifacts & successful mock pingpong", s.TestGenerateAndMockPingPong)
+		BeforeAll(s.Setup)
+		AfterAll(s.TearDown)
+		It("successful pingpong", func() { s.TestPingPong(initiatorReplicas...) })
+		It("successful pingpong with stream", func() { s.TestPingPongStream(initiatorReplicas...) })
+		It("successful stream", func() { s.TestStream(initiatorReplicas...) })
+		It("successful stream with websocket", func() { s.TestStreamWebsocket(initiatorReplicas...) })
 	})
 })
 
@@ -211,31 +195,38 @@ func newNode(conf string) FSCNode {
 
 const testdataDir = "./testdata"
 
+// Named because `NewTestSuite(commType, true, opts)` reads as neither.
+const (
+	doGenerate = true
+	doLoad     = false
+)
+
 type TestSuite struct {
 	*integration.TestSuite
-	commType fsc.P2PCommunicationType
-	nodeOpts *integration.ReplicationOptions
 }
 
-func NewTestSuite(commType fsc.P2PCommunicationType, alwaysGenerate bool, nodeOpts *integration.ReplicationOptions) *TestSuite {
-	init := atomic.NewBool(false)
+func NewTestSuite(commType fsc.P2PCommunicationType, generate bool, nodeOpts *integration.ReplicationOptions) *TestSuite {
 	return &TestSuite{
 		TestSuite: integration.NewTestSuite(func() (ii *integration.Infrastructure, err error) {
 			topologies := pingpong.Topology(commType, nodeOpts)
-			if alwaysGenerate || init.CompareAndSwap(false, true) {
+			// Independent paths: Generate writes a fresh config into a temp dir,
+			// Load reads ./testdata and leaves it alone.
+			if generate {
 				ii, err = integration.Generate(StartPortWithGeneration(), integration.WithRaceDetection, topologies...)
 			} else {
 				ii, err = integration.Load(0, testdataDir, integration.WithRaceDetection, topologies...)
 			}
+			if err != nil {
+				// Both constructors return a nil Infrastructure on failure.
+				return nil, err
+			}
 			ii.DeleteOnStop = false
-			return ii, err
+			return ii, nil
 		}),
-		commType: commType,
-		nodeOpts: nodeOpts,
 	}
 }
 
-func (s *TestSuite) TestGenerateAndPingPong(clients ...string) {
+func (s *TestSuite) TestPingPong(clients ...string) {
 	// Initiate a view and check the output
 	for _, clientName := range clients {
 		res, err := s.II.Client(clientName).CallView("init", nil)
@@ -244,16 +235,7 @@ func (s *TestSuite) TestGenerateAndPingPong(clients ...string) {
 	}
 }
 
-func (s *TestSuite) TestLoadAndPingPong(clients ...string) {
-	// Initiate a view and check the output
-	for _, clientName := range clients {
-		res, err := s.II.Client(clientName).CallView("init", nil)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(common.JSONUnmarshalString(res)).To(BeEquivalentTo("OK"))
-	}
-}
-
-func (s *TestSuite) TestLoadAndPingPongStream(clients ...string) {
+func (s *TestSuite) TestPingPongStream(clients ...string) {
 	// Initiate a view and check the output
 	for _, clientName := range clients {
 		channel, err := s.II.Client(clientName).StreamCallView("init", nil)
@@ -265,7 +247,7 @@ func (s *TestSuite) TestLoadAndPingPongStream(clients ...string) {
 	}
 }
 
-func (s *TestSuite) TestLoadAndStream(clients ...string) {
+func (s *TestSuite) TestStream(clients ...string) {
 	for _, clientName := range clients {
 		channel, err := s.II.Client(clientName).StreamCallView("stream", nil)
 		Expect(err).NotTo(HaveOccurred())
@@ -280,7 +262,7 @@ func (s *TestSuite) TestLoadAndStream(clients ...string) {
 	}
 }
 
-func (s *TestSuite) TestLoadAndStreamWebsocket(clients ...string) {
+func (s *TestSuite) TestStreamWebsocket(clients ...string) {
 	for _, clientName := range clients {
 		// Get a client for the fsc node labelled initiator
 		initiator := s.II.WebClient(clientName)
@@ -319,7 +301,7 @@ func (s *TestSuite) TestLoadInitPingPong() {
 	Expect(common.JSONUnmarshalString(res)).To(BeEquivalentTo("OK"))
 }
 
-func (s *TestSuite) TestGenerateAndMockPingPong() {
+func (s *TestSuite) TestMockPingPong() {
 	// Init with mock=false, a failure must happen
 	_, err := s.II.Client("initiator").CallView("mockInit", common.JSONMarshall(&fake.Params{Mock: false}))
 	Expect(err).To(HaveOccurred())

--- a/integration/fsc/stoprestart/stoprestart_test.go
+++ b/integration/fsc/stoprestart/stoprestart_test.go
@@ -28,23 +28,13 @@ var _ = Describe("EndToEnd", func() {
 		})
 	}
 
+	// Many-to-one only: StopFSCNode stops the first matching replica and returns, so
+	// bob: 4 would leave three responders up and check less than bob: 1 does.
 	Describe("Stop and Restart With Replicas many to one", Label(fsc.WebSocket), func() {
 		s := NewTestSuite(fsc.WebSocket, &integration.ReplicationOptions{
 			ReplicationFactors: map[string]int{
 				"alice": 4,
 				"bob":   1,
-			},
-		})
-		BeforeEach(s.Setup)
-		AfterEach(s.TearDown)
-		It("stop and restart successfully", s.TestSucceededWithReplicas)
-	})
-
-	Describe("Stop and Restart With Replicas many to many", Label(fsc.WebSocket), func() {
-		s := NewTestSuite(fsc.WebSocket, &integration.ReplicationOptions{
-			ReplicationFactors: map[string]int{
-				"alice": 4,
-				"bob":   4,
 			},
 		})
 		BeforeEach(s.Setup)

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/stretchr/testify v1.12.0
 	github.com/tedsuo/ifrit v0.0.0-20230516164442-7862c310ad26
 	go.opentelemetry.io/otel/trace v1.45.0
-	go.uber.org/atomic v1.11.0
 	go.uber.org/zap v1.28.0
 	go.yaml.in/yaml/v3 v3.0.5
 	golang.org/x/sync v0.22.0

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -1385,8 +1385,6 @@ go.opentelemetry.io/proto/otlp v0.15.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
 go.opentelemetry.io/proto/otlp v1.11.0 h1:5rrYs0Ykyj50sdU/JU0x8etU+LubXWb+gED6TbEdMIk=
 go.opentelemetry.io/proto/otlp v1.11.0/go.mod h1:SmVizdCOAm3XBtG1g1NnOdhW6jtddT72hLMhv8VwA8E=
-go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
-go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/dig v1.19.0 h1:BACLhebsYdpQ7IROQ1AGPjrXcP5dF80U3gKoFzbaq/4=
 go.uber.org/dig v1.19.0/go.mod h1:Us0rSJiThwCv2GteUN0Q7OKvU7n5J4dxZ9JKUXozFdE=
 go.uber.org/fx v1.24.0 h1:wE8mruvpg2kiiL1Vqd0CC+tr0/24XIB10Iwp2lLWzkg=


### PR DESCRIPTION
Closes #1729

Integration CI is bootstrap-bound, not assertion-bound: a Fabric network generate/start/stop cycle costs 90-110s against 10-20s for the assertions inside it. `integration/fabric/events` was the only suite using `Ordered` with `BeforeAll`, and it ran more specs than `integration/fabric/atsa` in half the time. This applies that pattern to `integration/fsc/pingpong` (15 networks to 4) and drops four specs that assert nothing a sibling does not.

While restructuring pingpong I found that its "load artifact" specs never honoured `Label(fsc.WebSocket)`. The committed `testdata/fsc/nodes/*/core.yaml` is `type: libp2p` and `fsc.Platform.Load` (`integration/nwo/fsc/fsc.go:217`) is a no-op, so `core.yaml` is never rewritten and those nodes come up libp2p. The loading specs now live in one libp2p-labelled Describe, which also made the old libp2p Describe redundant — its two specs were a subset of the loading group running the same fixture. This matters beyond tidiness: the Makefile splits CI targets by label, so a label that lies files specs into the wrong job.

The four dropped specs:

- `fabric/atsa` `succeeded 2` permuted the replica indices of `succeeded 1` and then sold and transferred both on `fsc.alice.1`, so it stopped covering the cross-replica read that `succeeded 1` does.
- `fabric/stoprestart` and `fsc/stoprestart` `many to many` shared their test body verbatim with `many to one`. `nwo.StopFSCNode` stops the first matching replica and returns, so `bob: 4` left three responders up and `alice` could pass without the restarted node taking a session — a weaker check, asserting nothing extra.
- `fsc/pingpong`'s replication Describe ran `TestGenerateAndPingPong` and `TestLoadAndPingPong`: identical bodies, and `alwaysGenerate` meant both generated. The two helpers are now one `TestPingPong`.

Replacing the `alwaysGenerate` flag and its atomic CAS with an explicit `generate` bool drops `go.uber.org/atomic` from the integration module.

Spec and network counts:

| suite | specs | networks |
|---|---|---|
| `fsc/pingpong` | 18 → 16 | 15 → 4 |
| `fabric/atsa` | 3 → 2 | 3 → 2 |
| `fabric/stoprestart` | 3 → 2 | 3 → 2 |
| `fsc/stoprestart` | 4 → 3 | 4 → 3 |

`fabric/iou`'s no-TLS spec is untouched — it is the only `TLSEnabled=false` coverage in the repo. `fabric/iouhsm` is untouched: replicas × HSM is a real concurrent-session interaction, not a free cut.

## How it was verified

- `make checks` — 0 issues across all five modules.
- `go build ./...` and `go vet ./...` clean in the `integration` module.
- `ginkgo --dry-run` on each changed suite, confirming the spec trees above: pingpong `Ran 16 of 16`, `fabric/atsa` and `fabric/stoprestart` `Ran 2 of 2`, `fsc/stoprestart` `Ran 3 of 3`.
- `make tidy` after the `go.uber.org/atomic` drop.
- Checked that folding the mock specs into the generated-artifacts groups is safe: `init`, `stream` and `mockInit` are all registered in the same node binary (`integration/fsc/pingpong/cmd/initiator/main.go`).

## Notes for reviewers

Start at `integration/fsc/pingpong/pingpong_test.go` — it carries most of the diff and the only structural change.

One deliberate trade-off: inside an `Ordered` container a failing spec skips the rest of the group, so a first failure now masks siblings it would previously have run past (`--keep-going` works across packages, not within a container). `fabric/events` already accepted this; it now applies to the 11 regrouped pingpong specs.

Wall clock floors at `utest` (404s in one serial job) once these land, so squeezing the integration matrix further has little left to give. Splitting `utest` is the next lever and is covered in https://github.com/hyperledger-labs/fabric-smart-client/pull/1727.
