### PR TITLE
docs: align the project docs with the OpenSSF passing criteria

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,13 +35,15 @@ Once assigned, follow the [Development Guide](docs/dev/development.md) to:
 1. Fork the repository and create a branch
 2. Make your changes, signing every commit (`-s -S`). See the
    [Commit Signing Guide](docs/dev/signing.md)
-3. Push the branch whenever you like — opening a **draft** pull request early gets CI
+3. Add or extend the tests that cover your change. See [Tests](docs/dev/workflow.md#tests)
+   and [Testing conventions](docs/agents/testing.md)
+4. Push the branch whenever you like — opening a **draft** pull request early gets CI
    running and makes the work visible
-4. Before requesting review, squash the branch into a single commit whose message
+5. Before requesting review, squash the branch into a single commit whose message
    describes the change, and write a brief, structured PR description. See
    [Commit Hygiene](docs/dev/workflow.md#commit-hygiene) and
    [Writing a PR Description](docs/dev/workflow.md#writing-a-pr-description)
-5. Mark the pull request ready for review
+6. Mark the pull request ready for review
 
 ## Submitting an Issue
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Fabric Smart Client
 
 [![License](https://img.shields.io/badge/license-Apache%202-blue)](LICENSE)
-[![Go Report Card](https://goreportcard.com/badge/github.com/hyperledger-labs/fabric-smart-client)](https://goreportcard.com/badge/github.com/hyperledger-labs/fabric-smart-client)
-[![Go](https://github.com/hyperledger-labs/fabric-smart-client/actions/workflows/tests.yml/badge.svg)](https://github.com/hyperledger-labs/fabric-smart-client/actions/workflows/go.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/hyperledger-labs/fabric-smart-client.svg)](https://pkg.go.dev/github.com/hyperledger-labs/fabric-smart-client)
+[![Tests](https://github.com/hyperledger-labs/fabric-smart-client/actions/workflows/tests.yml/badge.svg)](https://github.com/hyperledger-labs/fabric-smart-client/actions/workflows/tests.yml)
 [![CodeQL](https://github.com/hyperledger-labs/fabric-smart-client/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/hyperledger-labs/fabric-smart-client/actions/workflows/codeql-analysis.yml)
 [![Coverage Status](https://coveralls.io/repos/github/hyperledger-labs/fabric-smart-client/badge.svg?branch=main)](https://coveralls.io/github/hyperledger-labs/fabric-smart-client?branch=main)
 
@@ -20,6 +20,7 @@ FSC abstracts away the complexity of a DLT network, enabling developers to build
 
 ## Quick links
 - **Documentation:** [docs/README.md](docs/README.md)
+- **API reference (Godoc):** [pkg.go.dev/github.com/hyperledger-labs/fabric-smart-client](https://pkg.go.dev/github.com/hyperledger-labs/fabric-smart-client)
 - **Examples and integration tests:** [`integration/fabric/`](integration/fabric/) and [`integration/fabricx/`](integration/fabricx/)  
 - **Token SDK:** https://github.com/hyperledger-labs/fabric-token-sdk
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,54 @@
-# Hyperledger Security Policy
+# Security Policy
 
-## Reporting a Security Bug
+## Supported Versions
 
-If you think you have discovered a security issue in any of the Hyperledger projects, we'd love to hear from you. We will take all security bugs seriously and if confirmed upon investigation we will patch it within a reasonable amount of time and release a public security bulletin discussing the impact and credit the discoverer.
+The Fabric Smart Client is developed on `main` and shipped as tagged releases (see
+[Versioning](README.md#versioning)). There are no maintenance branches: fixes land on
+`main` and go out in the next release. Only the **latest release** receives security
+fixes, so please confirm a report against it before filing.
 
-The easiest is to email a description of the flaw and any related information (e.g. reproduction steps, version) to [security at hyperledger dot org](mailto:security@hyperledger.org).
+## Reporting a Vulnerability
 
-The process by which the Hyperledger Security Team handles security bugs is documented further in our [Defect Response page](https://wiki.hyperledger.org/display/SEC/Defect+Response) on our [wiki](https://wiki.hyperledger.org).
+**Do not open a public issue for a security vulnerability.** Use one of these private
+channels instead:
+
+1. **GitHub private vulnerability reporting** (preferred) — file it directly at
+   [Report a vulnerability](https://github.com/hyperledger-labs/fabric-smart-client/security/advisories/new).
+   The report, the discussion, and the resulting advisory stay in one place, visible only
+   to you and the maintainers.
+2. **Email the LFDT security team** at
+   [security@lists.hyperledger.org](mailto:security@lists.hyperledger.org) — use this if
+   you cannot use GitHub, or if the issue affects several LFDT projects.
+
+Please include as much of the following as you have:
+
+- a description of the flaw and the impact you believe it has,
+- the affected release or commit,
+- steps, a test, or a minimal program that reproduces it,
+- any mitigation or fix you would suggest.
+
+## What to Expect
+
+| Step | Timeline |
+|------|----------|
+| Acknowledgement that we received your report | within **14 days**, usually much sooner |
+| Assessment — accepted, rejected, or needs more detail | in the private channel, after acknowledgement |
+| Fix, release, and public advisory | coordinated with you before anything is published |
+
+Confirmed vulnerabilities are fixed on `main`, released in a tagged version, and published
+as a
+[GitHub Security Advisory](https://github.com/hyperledger-labs/fabric-smart-client/security/advisories),
+with a CVE where one applies. We credit reporters in the advisory unless you ask us not
+to, and nothing about the report is made public before the fix is available.
+
+The broader process the LFDT security team follows is documented on the
+[Defect Response](https://lf-hyperledger.atlassian.net/wiki/spaces/SEC/pages/20283618/Defect+Response)
+page.
+
+## Scope
+
+FSC is a client-side framework and has **not been formally audited** (see the
+[disclaimer](README.md#disclaimer-and-license)). In scope: FSC's own code, its default
+configuration, and its handling of keys, identities, sessions, and TLS. Vulnerabilities in
+Hyperledger Fabric, Fabric-x, or another dependency belong to that project and should be
+reported there — if you are unsure which, report it here and we will route it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ Each platform section includes a local `README.md` plus a `configuration.md` pag
 
 ## Guides and Tutorials
 
+- [Go API reference (pkg.go.dev)](https://pkg.go.dev/github.com/hyperledger-labs/fabric-smart-client)
 - [FSC CLI reference](reference/fsc-cli.md)
 - [Node CLI reference](reference/node-cli.md)
 - [Benchmark examples](../integration/benchmark/README.md)

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -1,5 +1,8 @@
 # Testing
 
+New functionality comes with tests in the same PR — the policy, and the few changes it
+exempts, is in [Contribution Workflow → Tests](../dev/workflow.md#tests).
+
 ## Frameworks
 
 - **Unit tests**: `github.com/stretchr/testify/require`.

--- a/docs/dev/workflow.md
+++ b/docs/dev/workflow.md
@@ -137,6 +137,25 @@ There is no PR template; this is the convention:
 Keep it structured and short. A file-by-file walkthrough only duplicates the diff; omit
 it. The PR title should read like the final commit subject below.
 
+### Tests
+
+New functionality comes with tests, in the same PR. A change that adds or alters behaviour
+is expected to add or extend an automated test that covers it:
+
+- new or changed behaviour inside a package → a unit test in that package
+- a new user-facing capability, or anything spanning nodes and the ledger → an integration
+  test target, or a case added to an existing one
+- a bug fix → a test that fails before the fix and passes after it
+
+Changes with nothing to assert are exempt: documentation, comments, renames, dependency
+bumps, and CI or build changes that the pipeline exercises itself. A change that genuinely
+cannot be tested is fine too — say so in the PR description under *How it was verified*.
+
+Reviewers ask for the missing test rather than merging on a promise, and CI reports
+coverage on every PR, so untested new code shows up as a coverage drop.
+[`docs/agents/testing.md`](../agents/testing.md) covers the frameworks and conventions, and
+the [Development Guide](development.md#running-tests) covers the commands.
+
 ### Commit Hygiene
 
 Every PR is merged as a **single squashed commit**, and the branch reaches that state in


### PR DESCRIPTION
Closes the documentation gaps found auditing FSC against the [OpenSSF Best Practices passing criteria](https://www.bestpractices.dev/en/criteria/0). Four changes, all docs-only, all in the same few files:

- **`SECURITY.md`** rewritten. It was generic Hyperledger boilerplate — retired wiki link, email only, and no mention that GitHub private vulnerability reporting is already enabled here. It now covers supported releases, both private channels, what a report should contain, a 14-day acknowledgement commitment, how advisories are published, and scope.
- **Test policy written down** (`docs/dev/workflow.md#tests`), referenced from `CONTRIBUTING.md` and `docs/agents/testing.md`. This was the audit's one outright MUST failure: we already follow the practice, nothing stated it.
- **Go API linked** from the README, the docs index, and a badge — it is our main external interface and was linked from nowhere.
- **Two dead badges fixed**: Go Report Card is retired (its badge now renders `go report: retired`), and the tests badge linked to `workflows/go.yml`, which does not exist.

Part of #1741

### How it was verified

No code changes, so nothing to test. Checked by hand: every anchor target exists (`#versioning`, `#disclaimer-and-license`, `#tests`, `#running-tests`), pkg.go.dev serves the module at v0.20.0, and the new external links resolve — including the LFDT Defect Response page that the old wiki URL redirects to, which is where the `security@lists.hyperledger.org` address comes from.
