### PR TITLE
chore: drop the committed .env and ignore it

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,0 @@
-GINKGO_TEST_OPTS ?=
-#GINKGO_TEST_OPTS += --keep-going
-GINKGO_TEST_OPTS += --vv
-#GINKGO_TEST_OPTS += --until-it-fails
-GINKGO_TEST_OPTS += --poll-progress-after 60s
-GINKGO_TEST_OPTS += --fail-fast
-#GINKGO_TEST_OPTS += --focus "generate artifacts & successful pingpong"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .build
 *.iml
 .venv
+.env
 # ignoring all generated artifacts in integration tests
 integration/**/out/
 


### PR DESCRIPTION
Removes the committed `.env` and ignores the path.

The file set `GINKGO_TEST_OPTS`, but nothing ever read it: the Makefile defines those options itself (`Makefile:24-25`) and includes only `checks.mk`, and no script, workflow, or test references `.env`. It was a local override that got committed and then went stale.

A committed `.env` is also exactly what secret scanners and the OpenSSF Best Practices review flag, even when — as here — it holds nothing sensitive.

Part of #1741

### How it was verified

Confirmed unreferenced by grepping the Makefile, `checks.mk`, `scripts/`, `ci/`, `.github/workflows/`, and the Go tree, so deleting it changes nothing at build or test time. `git check-ignore -v .env` confirms the new ignore rule takes effect.