### PR TITLE
build(deps): let dependabot update every module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+version: 2
+
+updates:
+  # FSC is a multi-module repository, and the modules are not independent: the
+  # integration module `replace`s the root, cc/query, and libp2p modules, so a
+  # dependency bumped in one go.mod usually has to move in the others' go.sum
+  # too. One `directories` list keeps all five modules in a single Dependabot
+  # job, so a shared dependency is updated across them together instead of
+  # arriving as separate PRs that each leave `make tidy` dirty.
+  #
+  # The list mirrors `make list-go-modules` plus tools/, which that target
+  # excludes because golangci-lint has nothing to analyse there -- but its
+  # dev-tool pins rot like any other dependency, so Dependabot does cover it.
+  - package-ecosystem: gomod
+    directories:
+      - "/"
+      - "/integration"
+      - "/platform/fabric/services/state/cc/query"
+      - "/platform/view/services/comm/host/libp2p"
+      - "/tools"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    commit-message:
+      # Conventional Commits, as required on main -- see docs/dev/workflow.md.
+      prefix: chore
+      include: scope
+    groups:
+      # Everything that is not a major bump travels as one PR: individually
+      # they are noise, and reviewing them together is what makes the weekly
+      # batch cheap. Majors match no group on purpose, so each one arrives
+      # alone, where a breaking change can be read on its own.
+      go-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  # Actions are pinned to SHAs, so without this they never move at all.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Adds `.github/dependabot.yml`. There was none, so nothing bumped dependencies on a schedule: version updates were done by hand, and the SHA-pinned actions never moved at all. Only Dependabot *security* updates were enabled, and those react to advisories rather than keeping the tree current.

- **One `gomod` entry covering all five modules**, via a `directories` list. The modules are not independent — `integration` replaces the root, `cc/query`, and `libp2p` — so a shared dependency has to move in several `go.sum` files at once, and separate per-module PRs would each land with `make tidy` dirty.
- **Minor and patch grouped** into one PR per ecosystem. Majors deliberately match no group, so each breaking bump arrives alone. Security updates stay ungrouped — those are the PRs worth merging immediately.
- **`github-actions` covered too**, since the SHA pins currently never move.

Part of #1741

### How it was verified

YAML parses, and the directory list was diffed against `git ls-files` to confirm it is exactly the tracked `go.mod` directories: `make list-go-modules` plus `tools/`, which that target skips only because golangci-lint has nothing to analyse there.