### PR TITLE
fix(comm): stop reusing the JSON decode target in readIncoming

### DIFF
--- a/platform/view/services/comm/host/websocket/ws/multiplexed_provider.go
+++ b/platform/view/services/comm/host/websocket/ws/multiplexed_provider.go
@@ -264,8 +264,11 @@ func (c *multiplexedClientConn) readIncoming() {
 		err := c.Kill()
 		logger.Debugf("Client connection closed: %v", err)
 	}()
-	var mm MultiplexedMessage
 	for {
+		// Declared per iteration on purpose: mm.Msg is handed to another goroutine
+		// below, and encoding/json reuses a non-nil []byte field's backing array,
+		// so reusing mm would let the next read overwrite a payload still in flight.
+		var mm MultiplexedMessage
 		err := c.conn.ReadJSON(&mm)
 		if err != nil {
 			logger.Debugf("Client connection errored: %v", err)
@@ -318,8 +321,9 @@ func (c *multiplexedServerConn) readIncoming(newStreamCallback func(pStream host
 		err := c.Kill()
 		logger.Debugf("Server connection closed: %v", err)
 	}()
-	var mm MultiplexedMessage
 	for {
+		// Declared per iteration on purpose: see the note in the client's readIncoming.
+		var mm MultiplexedMessage
 		_ = c.conn.SetReadDeadline(time.Now().Add(readTimeout))
 		err := c.conn.ReadJSON(&mm)
 		if err != nil {


### PR DESCRIPTION
# PR description

Both multiplexed `readIncoming` loops declared a single `MultiplexedMessage` outside the loop and decoded every frame into it, then handed `mm.Msg` — a `[]byte` aliasing that struct's field — to a consumer goroutine over a channel. Go 1.26's `encoding/json` allocated a fresh slice per `[]byte` field, so that was safe by accident; Go 1.27 routes `[]byte` through `base64.(*Encoding).AppendDecode`, which reuses a non-nil destination's backing array, so the next `ReadJSON` overwrites a payload that is still being read. Declaring `mm` per iteration makes each decode start from a nil slice, so `encoding/json` allocates a payload the reader owns outright.

Two consequences beyond the data race:

- a payload handed to a consumer is no longer aliased by the next frame on that connection;
- a field absent from one frame no longer inherits the previous frame's value, which reuse also allowed.

Fixes #1745

## How it was verified

```bash
# fails on main with a Go 1.27 toolchain, passes here
go test -race -count=1 ./platform/view/services/comm/host/websocket/...
#   ok  .../comm/host/websocket      89.429s
#   ok  .../comm/host/websocket/ws   25.236s

make checks       # 0 issues in every module
make unit-tests   # 146 packages ok, no failures, no races
```

The three tests that fail without this change are `TestP2PLayerTestRound`, `TestSessionsMultipleMessagesTestRound` and `TestConnections/*`. They pass on `main` today only because CI resolves its toolchain from `go-version-file: go.mod`, which still selects Go 1.26 — the bug reproduces on unmodified `main` as soon as the toolchain is 1.27, so this is worth merging on its own rather than as part of the Go upgrade.

## Notes for reviewers

The diff is two moved declarations; the reasoning is in the linked issue, which carries a standalone repro that shows the corruption without any FSC code.

Only these two sites had the pattern — `simple_provider.go:95` reads its `StreamMeta` once rather than in a loop, and `large_message_test.go` already declares per iteration.

Out of scope: the Go 1.27.1 upgrade itself, which is a separate PR that depends on this one landing first.
