### PR TITLE
ci(govulncheck): scan every module on main and weekly

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,77 @@
+name: govulncheck
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+  schedule:
+    # Monday, like the Dependabot jobs in .github/dependabot.yml: a new advisory
+    # against an unchanged dependency is only found by re-scanning on a timer.
+    - cron: '17 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  # govulncheck only ever sees a single module, so it is run once per module.
+  # The list is discovered rather than hardcoded so a new module cannot be added
+  # without being scanned -- same reasoning as golangci-lint.yml.
+  #
+  # `make list-go-modules` omits tools/, which is what we want here: its packages
+  # are behind a `tools` build tag, so govulncheck matches nothing there and exits
+  # 2. Dependabot still updates that module's pins.
+  modules:
+    runs-on: ubuntu-latest
+    outputs:
+      dirs: ${{ steps.list.outputs.dirs }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7.0.1
+      - name: list go modules
+        id: list
+        run: |
+          echo "dirs=$(make list-go-modules | jq -R . | jq -s -c .)" >> $GITHUB_OUTPUT
+
+  govulncheck:
+    needs:
+      - modules
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      # Needed by upload-sarif.
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        module: ${{ fromJson(needs.modules.outputs.dirs) }}
+    steps:
+      - name: govulncheck
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # ratchet:golang/govulncheck-action@v1.1.0
+        with:
+          work-dir: ${{ matrix.module }}
+          # govulncheck reports stdlib vulnerabilities against the toolchain it
+          # runs under, so that has to be the version the module declares. The
+          # action defaults go-version-input to 'stable', and setup-go ignores
+          # go-version-file whenever go-version is set, so blank it.
+          go-version-input: ''
+          go-version-file: ${{ matrix.module }}/go.mod
+          cache-dependency-path: "**/*.sum"
+          output-format: sarif
+          output-file: results.sarif
+
+      # govulncheck exits 0 in sarif mode even when it finds something, so the
+      # decision of what fails is left to code scanning rather than this job.
+      #
+      # Uploads are keyed by (ref, category) and replace the previous analysis for
+      # that pair, so every module needs its own category: sharing one would leave
+      # whichever matrix leg finishes last as the only module still reporting, and
+      # close every other module's alerts as fixed.
+      - name: upload results
+        uses: github/codeql-action/upload-sarif@c16c0f3f2812ec4bb3750a5ed64873fe2ce0fbef # ratchet:github/codeql-action/upload-sarif@codeql-bundle-v2.26.3
+        with:
+          sarif_file: results.sarif
+          category: govulncheck-${{ matrix.module }}


### PR DESCRIPTION
## What

Adds `.github/workflows/govulncheck.yml`, which runs [`govulncheck`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) over every Go module and publishes the results to code scanning as SARIF.

Triggers are `push` to `main` and a weekly cron on Monday, matching the Dependabot schedule in `.github/dependabot.yml`. **This PR deliberately does not run on pull requests** — that trigger follows in a second PR, for the reason described below.

This is part of #1741

## Why

Nothing in CI reported known vulnerabilities in our dependencies. Dependabot moves versions, but it does not tell us whether a dependency we already have has an advisory against it, and it has no notion of reachability — whether our code actually calls the vulnerable symbols. `govulncheck` answers both, and at the default `symbol` scan level it only reports vulnerabilities that are genuinely reachable from our code, which is what keeps the signal usable rather than a restatement of the dependency list.

## How

One job per module, because `govulncheck` — like `golangci-lint` — only ever sees a single module. The matrix is built from `make list-go-modules` rather than hardcoded, so a new module cannot be added to the repository without being scanned. This mirrors the two-job structure already in `golangci-lint.yml`, for the reason that file's own comment gives.

`make list-go-modules` omits `tools/`, which is correct here: its packages sit behind a `tools` build tag, so `govulncheck` matches no packages there and exits 2. Dependabot still updates that module's pins.

Scanning is done by `golang/govulncheck-action`, SHA-pinned with a `# ratchet:` comment like every other action in the repository.

### Two details worth flagging for review

**One SARIF category per module.** Uploads are keyed by `(ref, category)` and *replace* the previous analysis for that pair. A shared category would leave whichever matrix leg finished last as the only module still reporting, and would close every other module's alerts as "fixed". Hence `category: govulncheck-${{ matrix.module }}`.

**`go-version-input: ''` is load-bearing.** `govulncheck` reports standard-library vulnerabilities against the toolchain it runs under, so that has to be the version the module declares. The action defaults `go-version-input` to `'stable'`, and `setup-go` ignores `go-version-file` whenever `go-version` is set ([`resolveVersionInput`](https://github.com/actions/setup-go/blob/main/src/main.ts) is `if (version) return version`). Blanking it is what makes each module's own `go.mod` the version source, consistent with the rest of CI.

## Why two PRs

Running a local scan of `main` at the current HEAD turns up a reachable finding with **no fix available upstream**:

| Module | Vulnerability | SARIF level |
|---|---|---|
| `integration`, `platform/view/services/comm/host/libp2p` | `GO-2024-3218` — code calls vulnerable functions in 11 `go-libp2p-kad-dht` packages | `error` |
| `.`, `integration`, `platform/view/services/comm/host/libp2p` | `GO-2026-5932` — depends on vulnerable `golang.org/x/crypto`, does not call it | `note` |
| `platform/fabric/services/state/cc/query` | clean | — |

`GO-2024-3218` is `CVE-2023-26248` / `GHSA-mqr9-hjr8-2m9w`, content censorship via Kademlia DHT abuse. The Go vulnerability database lists `"fixed": []` — it is a design-level issue in the DHT, not a patchable bug, so there is no version to bump to. Note that the root framework module is clean of it; it is reachable only from the test harness and the optional, opt-in libp2p comm driver.

Code scanning treats every finding as new until a branch baseline exists, and `error`-level findings fail pull request checks by default. A `pull_request` trigger added in *this* PR would therefore fail this PR's own check, on something nobody can action, and would need a merge bypass. Landing the scan on `main` first establishes the baseline and lets the unfixable alerts be dismissed; the pull request trigger then arrives green and stays green.

### After merging

1. The first `main` run opens five alerts across three categories.
2. Dismiss the two `GO-2024-3218` alerts as **Won't fix** (no upstream fix exists), under `govulncheck-integration` and `govulncheck-platform/view/services/comm/host/libp2p`. Dismissals survive re-upload, so the weekly run will not reopen them or re-notify.
3. The three `GO-2026-5932` alerts are `note`-level and never fail a check — dismiss or leave them, either is fine.

The weekly cadence does not produce repeated reports: code scanning is stateful, so re-uploading the same SARIF to the same `(ref, category)` updates the existing analysis in place rather than opening new alerts.

## Follow-up PR

Adds the `pull_request` trigger, the `concurrency` block that cancels superseded PR runs (a no-op today, since `push` and `schedule` fall back to a unique `run_id` per run), and the corresponding row in the *What CI Gates* table in `docs/dev/development.md`. That table is documented as what CI gates **on every pull request**, with a local-equivalent column, so a row would be inaccurate until the trigger exists.

## Testing

`govulncheck` was run locally across all five modules to establish the table above, and to confirm two behaviours the workflow depends on:

- `-format sarif` **exits 0 even when findings exist**, so the decision of what fails has to be left to code scanning rather than to the job's exit status. The workflow does not add a `|| exit 1`.
- `tools/` returns `no packages matched the provided patterns` and exits 2, confirming it must stay out of the matrix.

The workflow itself passes `actionlint` cleanly, and `make list-go-modules` was verified to produce the expected four-entry list.
