### PR TITLE
chore(lint): enable gosec in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ version: "2"
 linters:
   enable:
     - goheader
+    - gosec
     - misspell
     - thelper
     - tparallel
@@ -23,11 +24,34 @@ linters:
           copyright: '(?:Copyright (?:IBM Corp\.? (?:\d{4} )?All Rights Reserved\.|State Street Corp\. \d{4} All Rights Reserved\.)\s*)?'
           license: '(?s)(?:SPDX-License-Identifier: Apache-2\.0|Licensed under the Apache License.*limitations under the License\.)'
       template: '{{ copyright }}{{ license }}'
+    gosec:
+      excludes:
+        # G304/G703: file paths here come from operator-supplied core.yaml or
+        # MSP directory configuration, not from untrusted input; wrapping them
+        # in filepath.Clean would silence the finding without adding security.
+        - G304
+        - G703
+        # G404: math/rand is used for retry jitter and peer/orderer
+        # load-balancing, never for a secret, nonce or identifier.
+        - G404
+        # G115: the flagged conversions are vault block/tx version encoding
+        # (uint64->uint32) and proto int32 fields; truncation is only
+        # reachable past 2^32 blocks. Revisit if the vault gains a 64-bit
+        # version format.
+        - G115
   exclusions:
     paths:
       # nwo writes generated node commands here during integration tests; the
       # trees are gitignored build artifacts, absent from a clean checkout.
       - (^|/)out/
+    rules:
+      # Test fixtures and the nwo integration harness: 0644 fixture certs,
+      # 0755 scratch dirs, subprocess launches with generated paths and
+      # deliberately-weak TLS in benchmarks are what that code is for, not
+      # defects.
+      - path: (^integration/|^ci/|_test\.go$|_test_utils\.go$)
+        linters:
+          - gosec
 formatters:
   enable:
     - gci

--- a/node/start/profile/profile.go
+++ b/node/start/profile/profile.go
@@ -77,7 +77,7 @@ func New(opts ...Option) (*Profile, error) {
 func (p *Profile) Start() error {
 	logger.Infof("Starting profiling")
 
-	if err := os.MkdirAll(p.path, 0o755); err != nil {
+	if err := os.MkdirAll(p.path, 0o750); err != nil {
 		return errors.Wrapf(err, "failed to create profile directory: %s", p.path)
 	}
 	if p.cpu {

--- a/platform/fabric/core/generic/delivery/delivery.go
+++ b/platform/fabric/core/generic/delivery/delivery.go
@@ -193,7 +193,7 @@ func (d *Delivery) Run(ctx context.Context) error {
 	}
 	ch := make(chan blockResponse, d.bufferSize)
 	go d.readBlocks(ch)
-	go d.runReceiver(ctx, ch)
+	go d.runReceiver(ctx, ch) //nolint:gosec // G118: documented nil-ctx fallback, not a dropped request context
 	return d.untilStop()
 }
 

--- a/platform/fabricx/core/vault/vault.go
+++ b/platform/fabricx/core/vault/vault.go
@@ -598,7 +598,7 @@ func (r *rwSetWrapper) Equals(rws any, nss ...cdriver.Namespace) error {
 	if r == other {
 		r.mu.Lock()
 		defer r.mu.Unlock()
-	} else if uintptr(unsafe.Pointer(r)) < uintptr(unsafe.Pointer(other)) {
+	} else if uintptr(unsafe.Pointer(r)) < uintptr(unsafe.Pointer(other)) { //nolint:gosec // G103: pointer-address comparison for deterministic lock ordering
 		r.mu.Lock()
 		defer r.mu.Unlock()
 		other.mu.Lock()

--- a/platform/view/services/grpc/client.go
+++ b/platform/view/services/grpc/client.go
@@ -185,6 +185,9 @@ func (client *Client) parseSecureOptions(opts SecureOptions) error {
 	client.tlsConfig = &tls.Config{
 		VerifyPeerCertificate: opts.VerifyCertificate,
 		MinVersion:            tls.VersionTLS12, // TLS 1.2 only
+		// VerifyPeerCertificate does not run on a resumed session, so disable
+		// client-side session tickets to force a full handshake every time.
+		SessionTicketsDisabled: true,
 	}
 	if len(opts.ServerRootCAs) > 0 {
 		client.tlsConfig.RootCAs = x509.NewCertPool()

--- a/platform/view/services/storage/driver/sql/sqlite/persistence.go
+++ b/platform/view/services/storage/driver/sql/sqlite/persistence.go
@@ -80,7 +80,7 @@ func open(opts Opts) (*common.RWDB, error) {
 func openDB(dataSourceName string, maxOpenConns, maxIdleConns int, maxIdleTime time.Duration, skipPragmas bool, tracing *common2.TracingConfig) (*sql.DB, error) {
 	// Create directories if they do not exist to avoid error "out of memory (14)", see below
 	path := getDir(dataSourceName)
-	if err := os.MkdirAll(path, 0o777); err != nil {
+	if err := os.MkdirAll(path, 0o750); err != nil {
 		logger.Warnf("failed creating dir [%s]: %s", path, err)
 	}
 


### PR DESCRIPTION
Enables `gosec` and scopes it to the code that ships. `make checks` is green. 

This is part of #1755 and #1741 

### Scoping

A bare enable reports **220 findings**: 95 in `_test.go`, 72 in the `integration/` nwo harness, 1 in `ci/`, 52 in library code. The test and harness findings describe what that code is for — 0644 fixture certs, 0755 scratch dirs, subprocess launches with generated paths, deliberately weak TLS in benchmarks — so they are excluded by path. Four rule classes are excluded globally, each with its reasoning in `.golangci.yml`:

| Rule | Why |
|---|---|
| G304, G703 | file paths come from operator-supplied `core.yaml` / MSP config, not untrusted input; `filepath.Clean` would silence without securing |
| G404 | `math/rand` is retry jitter and peer/orderer load-balancing, never a secret or nonce |
| G115 | flagged conversions are vault version encoding and proto `int32` fields; truncation only past 2^32 blocks |

### Fixes

- **`platform/view/services/grpc/client.go`** — `VerifyPeerCertificate` does not run on a resumed TLS session, so a custom certificate check could be bypassed. Disables client-side session tickets to force a full handshake (G123). The one genuine security finding in the set.
- **`platform/view/services/storage/driver/sql/sqlite/persistence.go`** — database directory was created `0777` (world-writable), now `0750`.
- **`node/start/profile/profile.go`** — profile output directory `0755` → `0750`.

### Annotated false positives

- `platform/fabricx/core/vault/vault.go` — `unsafe.Pointer` comparison is deterministic lock ordering (G103).
- `platform/fabric/core/generic/delivery/delivery.go` — the nil-ctx fallback is documented behaviour, not a dropped request context (G118).

### Verification

`make checks` exits 0 — 0 issues across all four linted modules, `go fix` clean. Unit tests pass for every touched package.

### Follow-up

Enabling gosec surfaced an unrelated remote-OOM in `comm/io/reader.go` (unbounded `make([]byte, l)` from a wire varint when `fsc.p2p.maxRecvMsgSize` is 0). Tracked separately in #1756 — not in this PR.