### PR TITLE
fix(vault): dedup ordered reads, and add missing tests

### DIFF
--- a/platform/common/core/generic/vault/inspector_test.go
+++ b/platform/common/core/generic/vault/inspector_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vault
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+)
+
+// newTestInspector returns an Inspector over an empty read-write set.
+func newTestInspector() *Inspector {
+	return &Inspector{Rws: EmptyRWSet()}
+}
+
+// TestInspectorReadOnlyPanics pins the read-only contract: every mutating entry
+// point panics rather than silently accepting a write. These are guards, not
+// behaviour, so the test asserts the panic itself.
+func TestInspectorReadOnlyPanics(t *testing.T) {
+	t.Parallel()
+
+	const readOnly = "programming error: the rwset inspector is read-only"
+	const unexpected = "programming error: unexpected call"
+
+	tests := []struct {
+		name     string
+		expected string
+		call     func(i *Inspector)
+	}{
+		{"SetState", readOnly, func(i *Inspector) { _ = i.SetState("ns", "key", []byte("v")) }},
+		{"AddReadAt", readOnly, func(i *Inspector) { _ = i.AddReadAt("ns", "key", nil) }},
+		{"DeleteState", readOnly, func(i *Inspector) { _ = i.DeleteState("ns", "key") }},
+		{"SetStateMetadata", readOnly, func(i *Inspector) { _ = i.SetStateMetadata("ns", "key", nil) }},
+		{"SetStateMetadatas", readOnly, func(i *Inspector) { _ = i.SetStateMetadatas("ns", nil) }},
+		{"AppendRWSet", readOnly, func(i *Inspector) { _ = i.AppendRWSet([]byte("raw")) }},
+		{"GetDirectState", "programming error: no access to query executor", func(i *Inspector) {
+			_, _ = i.GetDirectState("ns", "key")
+		}},
+		{"Bytes", unexpected, func(i *Inspector) { _, _ = i.Bytes() }},
+		{"Equals", unexpected, func(i *Inspector) { _ = i.Equals(nil) }},
+		{"Clear", unexpected, func(i *Inspector) { _ = i.Clear("ns") }},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			i := newTestInspector()
+			require.PanicsWithValue(t, tc.expected, func() { tc.call(i) })
+		})
+	}
+}
+
+// TestInspectorLifecycle covers the two lifecycle methods, which are fixed
+// answers: the inspector is never closed and Done is a no-op.
+func TestInspectorLifecycle(t *testing.T) {
+	t.Parallel()
+
+	i := newTestInspector()
+
+	require.NoError(t, i.IsValid())
+	require.False(t, i.IsClosed())
+	require.NotPanics(t, i.Done)
+	require.False(t, i.IsClosed(), "Done must not close the inspector")
+}
+
+// TestInspectorGetStateMetadata checks metadata reads resolve against the
+// underlying MetaWriteSet, and that a miss returns nil rather than erroring.
+func TestInspectorGetStateMetadata(t *testing.T) {
+	t.Parallel()
+
+	i := newTestInspector()
+	meta := map[string][]byte{"key": []byte("value")}
+	require.NoError(t, i.Rws.MetaWriteSet.Add("ns", "k1", meta))
+
+	got, err := i.GetStateMetadata("ns", "k1")
+	require.NoError(t, err)
+	require.Equal(t, driver.Metadata(meta), got)
+
+	missing, err := i.GetStateMetadata("ns", "absent")
+	require.NoError(t, err)
+	require.Nil(t, missing)
+
+	missingNs, err := i.GetStateMetadata("other", "k1")
+	require.NoError(t, err)
+	require.Nil(t, missingNs)
+}
+
+// TestInspectorGetReadKeyAt covers both branches: a position within the
+// ordered read set, and one past its end.
+func TestInspectorGetReadKeyAt(t *testing.T) {
+	t.Parallel()
+
+	i := newTestInspector()
+	i.Rws.ReadSet.Add("ns", "k1", nil)
+	i.Rws.ReadSet.Add("ns", "k2", nil)
+
+	key, err := i.GetReadKeyAt("ns", 0)
+	require.NoError(t, err)
+	require.Equal(t, driver.PKey("k1"), key)
+
+	key, err = i.GetReadKeyAt("ns", 1)
+	require.NoError(t, err)
+	require.Equal(t, driver.PKey("k2"), key)
+
+	_, err = i.GetReadKeyAt("ns", 2)
+	require.ErrorContains(t, err, "no read at position 2 for namespace ns")
+
+	_, err = i.GetReadKeyAt("ns", -1)
+	require.ErrorContains(t, err, "no read at position -1 for namespace ns")
+
+	_, err = i.GetReadKeyAt("absent", 0)
+	require.ErrorContains(t, err, "no read at position 0 for namespace absent")
+}
+
+// TestInspectorGetReadAt covers the out-of-range branch alongside the hit,
+// which the conformance suite does not reach.
+func TestInspectorGetReadAt(t *testing.T) {
+	t.Parallel()
+
+	i := newTestInspector()
+	i.Rws.ReadSet.Add("ns", "k1", nil)
+	require.NoError(t, i.Rws.WriteSet.Add("ns", "k1", []byte("v1")))
+
+	key, val, err := i.GetReadAt("ns", 0)
+	require.NoError(t, err)
+	require.Equal(t, driver.PKey("k1"), key)
+	require.Equal(t, driver.RawValue("v1"), val)
+
+	_, _, err = i.GetReadAt("ns", 1)
+	require.ErrorContains(t, err, "no read at position 1 for namespace ns")
+}
+
+// TestInspectorGetWriteAt covers the out-of-range branch alongside the hit.
+func TestInspectorGetWriteAt(t *testing.T) {
+	t.Parallel()
+
+	i := newTestInspector()
+	require.NoError(t, i.Rws.WriteSet.Add("ns", "k1", []byte("v1")))
+
+	key, val, err := i.GetWriteAt("ns", 0)
+	require.NoError(t, err)
+	require.Equal(t, driver.PKey("k1"), key)
+	require.Equal(t, driver.RawValue("v1"), val)
+
+	_, _, err = i.GetWriteAt("ns", 1)
+	require.ErrorContains(t, err, "no write at position 1 for namespace ns")
+}

--- a/platform/common/core/generic/vault/inspector_test.go
+++ b/platform/common/core/generic/vault/inspector_test.go
@@ -25,26 +25,20 @@ func newTestInspector() *Inspector {
 func TestInspectorReadOnlyPanics(t *testing.T) {
 	t.Parallel()
 
-	const readOnly = "programming error: the rwset inspector is read-only"
-	const unexpected = "programming error: unexpected call"
-
 	tests := []struct {
-		name     string
-		expected string
-		call     func(i *Inspector)
+		name string
+		call func(i *Inspector)
 	}{
-		{"SetState", readOnly, func(i *Inspector) { _ = i.SetState("ns", "key", []byte("v")) }},
-		{"AddReadAt", readOnly, func(i *Inspector) { _ = i.AddReadAt("ns", "key", nil) }},
-		{"DeleteState", readOnly, func(i *Inspector) { _ = i.DeleteState("ns", "key") }},
-		{"SetStateMetadata", readOnly, func(i *Inspector) { _ = i.SetStateMetadata("ns", "key", nil) }},
-		{"SetStateMetadatas", readOnly, func(i *Inspector) { _ = i.SetStateMetadatas("ns", nil) }},
-		{"AppendRWSet", readOnly, func(i *Inspector) { _ = i.AppendRWSet([]byte("raw")) }},
-		{"GetDirectState", "programming error: no access to query executor", func(i *Inspector) {
-			_, _ = i.GetDirectState("ns", "key")
-		}},
-		{"Bytes", unexpected, func(i *Inspector) { _, _ = i.Bytes() }},
-		{"Equals", unexpected, func(i *Inspector) { _ = i.Equals(nil) }},
-		{"Clear", unexpected, func(i *Inspector) { _ = i.Clear("ns") }},
+		{"SetState", func(i *Inspector) { _ = i.SetState("ns", "key", []byte("v")) }},
+		{"AddReadAt", func(i *Inspector) { _ = i.AddReadAt("ns", "key", nil) }},
+		{"DeleteState", func(i *Inspector) { _ = i.DeleteState("ns", "key") }},
+		{"SetStateMetadata", func(i *Inspector) { _ = i.SetStateMetadata("ns", "key", nil) }},
+		{"SetStateMetadatas", func(i *Inspector) { _ = i.SetStateMetadatas("ns", nil) }},
+		{"AppendRWSet", func(i *Inspector) { _ = i.AppendRWSet([]byte("raw")) }},
+		{"GetDirectState", func(i *Inspector) { _, _ = i.GetDirectState("ns", "key") }},
+		{"Bytes", func(i *Inspector) { _, _ = i.Bytes() }},
+		{"Equals", func(i *Inspector) { _ = i.Equals(nil) }},
+		{"Clear", func(i *Inspector) { _ = i.Clear("ns") }},
 	}
 
 	for _, tc := range tests {
@@ -52,7 +46,7 @@ func TestInspectorReadOnlyPanics(t *testing.T) {
 			t.Parallel()
 
 			i := newTestInspector()
-			require.PanicsWithValue(t, tc.expected, func() { tc.call(i) })
+			require.Panics(t, func() { tc.call(i) })
 		})
 	}
 }
@@ -66,7 +60,8 @@ func TestInspectorLifecycle(t *testing.T) {
 
 	require.NoError(t, i.IsValid())
 	require.False(t, i.IsClosed())
-	require.NotPanics(t, i.Done)
+
+	i.Done()
 	require.False(t, i.IsClosed(), "Done must not close the inspector")
 }
 

--- a/platform/common/core/generic/vault/rwset.go
+++ b/platform/common/core/generic/vault/rwset.go
@@ -168,8 +168,11 @@ func (r *ReadSet) Add(ns driver.Namespace, key string, version Version) {
 		r.OrderedReads[ns] = make([]string, 0, 8)
 	}
 
+	_, exists := nsMap[key]
 	nsMap[key] = version
-	r.OrderedReads[ns] = append(r.OrderedReads[ns], key)
+	if !exists {
+		r.OrderedReads[ns] = append(r.OrderedReads[ns], key)
+	}
 }
 
 func (r *ReadSet) Get(ns driver.Namespace, key string) (Version, bool) {
@@ -198,17 +201,17 @@ func entriesEqual[T any](r, o map[string]T, compare func(T, T) bool, nss ...driv
 	sort.Strings(oKeys)
 
 	if len(rKeys) != len(oKeys) {
-		return errors.Errorf("number of writes do not match [%d]!=[%d], [%v]!=[%v]", len(r), len(o), rKeys, oKeys)
+		return errors.Errorf("number of entries do not match [%d]!=[%d], [%v]!=[%v]", len(rKeys), len(oKeys), rKeys, oKeys)
 	}
 
 	for _, rKey := range rKeys {
 		oValue, ok := o[rKey]
 		if !ok {
-			return errors.Errorf("read not found [%s]", rKey)
+			return errors.Errorf("key not found [%s]", rKey)
 		}
 		rValue := r[rKey]
 		if !compare(rValue, oValue) {
-			return errors.Errorf("writes for [%s] do not match [%v]!=[%v]", rKey, rValue, oValue)
+			return errors.Errorf("entries for [%s] do not match [%v]!=[%v]", rKey, rValue, oValue)
 		}
 	}
 	return nil

--- a/platform/common/core/generic/vault/rwset_test.go
+++ b/platform/common/core/generic/vault/rwset_test.go
@@ -10,28 +10,62 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 )
 
-// TestNamespaceWritesEquals covers the leaf comparison every Equals chain
-// bottoms out in: matching sets, differing lengths, a key present in one side
-// only, and a value mismatch.
-func TestNamespaceWritesEquals(t *testing.T) {
+// TestEntriesEqual drives every branch of the comparison all six Equals
+// implementations funnel through — length mismatch, missing key, value
+// mismatch, match — plus the namespace filter in getKeys.
+func TestEntriesEqual(t *testing.T) {
 	t.Parallel()
 
-	base := NamespaceWrites{"k1": []byte("v1"), "k2": []byte("v2")}
+	base := Writes{
+		"ns1": NamespaceWrites{"k1": []byte("v1")},
+		"ns2": NamespaceWrites{"k2": []byte("v2")},
+	}
+	same := Writes{
+		"ns1": NamespaceWrites{"k1": []byte("v1")},
+		"ns2": NamespaceWrites{"k2": []byte("v2")},
+	}
+	changed := Writes{
+		"ns1": NamespaceWrites{"k1": []byte("v1")},
+		"ns2": NamespaceWrites{"k2": []byte("changed")},
+	}
 
-	require.NoError(t, base.Equals(NamespaceWrites{"k1": []byte("v1"), "k2": []byte("v2")}))
+	require.NoError(t, base.Equals(same))
+	require.ErrorContains(t, base.Equals(Writes{"ns1": base["ns1"]}), "number of entries do not match [2]!=[1]")
+	require.ErrorContains(t, base.Equals(Writes{"ns1": base["ns1"], "other": nil}), "key not found [ns2]")
+	require.ErrorContains(t, base.Equals(changed), "entries for [ns2] do not match")
 
-	err := base.Equals(NamespaceWrites{"k1": []byte("v1")})
-	require.ErrorContains(t, err, "number of writes do not match")
+	require.NoError(t, base.Equals(changed, "ns1"), "the filter must ignore the ns2 mismatch")
+	require.ErrorContains(t, base.Equals(Writes{"ns1": base["ns1"]}, "ns1", "ns2"),
+		"number of entries do not match [2]!=[1]", "the reported counts are the filtered ones")
+	require.NoError(t, base.Equals(same, "absent"), "a filter matching no namespace compares nothing")
+}
 
-	err = base.Equals(NamespaceWrites{"k1": []byte("v1"), "other": []byte("v2")})
-	require.ErrorContains(t, err, "read not found [k2]")
+// TestEqualsWrappers checks each remaining Equals delegates to entriesEqual,
+// matching and mismatching. KeyedMetaWrites nests it one level deeper.
+func TestEqualsWrappers(t *testing.T) {
+	t.Parallel()
 
-	err = base.Equals(NamespaceWrites{"k1": []byte("v1"), "k2": []byte("different")})
-	require.ErrorContains(t, err, "writes for [k2] do not match")
+	require.NoError(t, NamespaceWrites{"k": []byte("v")}.Equals(NamespaceWrites{"k": []byte("v")}))
+	require.Error(t, NamespaceWrites{"k": []byte("v")}.Equals(NamespaceWrites{"k": []byte("x")}))
+
+	require.NoError(t, NamespaceReads{"k": Version("v")}.Equals(NamespaceReads{"k": Version("v")}))
+	require.Error(t, NamespaceReads{"k": Version("v")}.Equals(NamespaceReads{"k": Version("x")}))
+
+	reads := Reads{"ns": NamespaceReads{"k": Version("v")}}
+	require.NoError(t, reads.Equals(Reads{"ns": NamespaceReads{"k": Version("v")}}))
+	require.Error(t, reads.Equals(Reads{"ns": NamespaceReads{"k": Version("x")}}))
+
+	meta := KeyedMetaWrites{"k": MetaWrites{"m": []byte("v")}}
+	require.NoError(t, meta.Equals(KeyedMetaWrites{"k": MetaWrites{"m": []byte("v")}}))
+	require.Error(t, meta.Equals(KeyedMetaWrites{"k": MetaWrites{"m": []byte("x")}}))
+
+	nsMeta := NamespaceKeyedMetaWrites{"ns": meta}
+	require.NoError(t, nsMeta.Equals(NamespaceKeyedMetaWrites{"ns": meta}))
+	require.Error(t, nsMeta.Equals(NamespaceKeyedMetaWrites{
+		"ns": KeyedMetaWrites{"k": MetaWrites{"m": []byte("x")}},
+	}))
 }
 
 // TestNamespaceWritesKeys checks Keys reports every key held, and nothing for
@@ -39,122 +73,8 @@ func TestNamespaceWritesEquals(t *testing.T) {
 func TestNamespaceWritesKeys(t *testing.T) {
 	t.Parallel()
 
-	w := NamespaceWrites{"k1": []byte("v1"), "k2": []byte("v2")}
-	require.ElementsMatch(t, []string{"k1", "k2"}, w.Keys())
-
+	require.ElementsMatch(t, []string{"k1", "k2"}, NamespaceWrites{"k1": []byte("v1"), "k2": []byte("v2")}.Keys())
 	require.Empty(t, NamespaceWrites{}.Keys())
-}
-
-// TestWritesEquals covers the namespace-keyed layer, including the namespace
-// filter that restricts comparison to a subset.
-func TestWritesEquals(t *testing.T) {
-	t.Parallel()
-
-	base := Writes{
-		"ns1": NamespaceWrites{"k1": []byte("v1")},
-		"ns2": NamespaceWrites{"k2": []byte("v2")},
-	}
-
-	require.NoError(t, base.Equals(Writes{
-		"ns1": NamespaceWrites{"k1": []byte("v1")},
-		"ns2": NamespaceWrites{"k2": []byte("v2")},
-	}))
-
-	err := base.Equals(Writes{
-		"ns1": NamespaceWrites{"k1": []byte("v1")},
-		"ns2": NamespaceWrites{"k2": []byte("changed")},
-	})
-	require.ErrorContains(t, err, "writes for [ns2] do not match")
-
-	// Restricting to ns1 ignores the ns2 mismatch entirely.
-	require.NoError(t, base.Equals(Writes{
-		"ns1": NamespaceWrites{"k1": []byte("v1")},
-		"ns2": NamespaceWrites{"k2": []byte("changed")},
-	}, "ns1"))
-}
-
-// TestNamespaceReadsEquals covers the read-side leaf comparison.
-func TestNamespaceReadsEquals(t *testing.T) {
-	t.Parallel()
-
-	base := NamespaceReads{"k1": Version("v1"), "k2": Version("v2")}
-
-	require.NoError(t, base.Equals(NamespaceReads{"k1": Version("v1"), "k2": Version("v2")}))
-
-	err := base.Equals(NamespaceReads{"k1": Version("v1")})
-	require.ErrorContains(t, err, "number of writes do not match")
-
-	err = base.Equals(NamespaceReads{"k1": Version("v1"), "k2": Version("changed")})
-	require.ErrorContains(t, err, "writes for [k2] do not match")
-}
-
-// TestReadsEquals covers the namespace-keyed read layer and its filter.
-func TestReadsEquals(t *testing.T) {
-	t.Parallel()
-
-	base := Reads{
-		"ns1": NamespaceReads{"k1": Version("v1")},
-		"ns2": NamespaceReads{"k2": Version("v2")},
-	}
-
-	require.NoError(t, base.Equals(Reads{
-		"ns1": NamespaceReads{"k1": Version("v1")},
-		"ns2": NamespaceReads{"k2": Version("v2")},
-	}))
-
-	err := base.Equals(Reads{
-		"ns1": NamespaceReads{"k1": Version("v1")},
-		"ns2": NamespaceReads{"k2": Version("changed")},
-	})
-	require.ErrorContains(t, err, "writes for [ns2] do not match")
-
-	require.NoError(t, base.Equals(Reads{
-		"ns1": NamespaceReads{"k1": Version("v1")},
-		"ns2": NamespaceReads{"k2": Version("changed")},
-	}, "ns1"))
-}
-
-// TestKeyedMetaWritesEquals covers metadata comparison, which nests
-// entriesEqual one level deeper than the read and write sets.
-func TestKeyedMetaWritesEquals(t *testing.T) {
-	t.Parallel()
-
-	base := KeyedMetaWrites{"k1": MetaWrites{"m1": []byte("v1")}}
-
-	require.NoError(t, base.Equals(KeyedMetaWrites{"k1": MetaWrites{"m1": []byte("v1")}}))
-
-	err := base.Equals(KeyedMetaWrites{})
-	require.ErrorContains(t, err, "number of writes do not match")
-
-	err = base.Equals(KeyedMetaWrites{"k1": MetaWrites{"m1": []byte("changed")}})
-	require.ErrorContains(t, err, "writes for [k1] do not match")
-}
-
-// TestNamespaceKeyedMetaWritesEquals covers the outermost metadata layer and
-// its namespace filter.
-func TestNamespaceKeyedMetaWritesEquals(t *testing.T) {
-	t.Parallel()
-
-	base := NamespaceKeyedMetaWrites{
-		"ns1": KeyedMetaWrites{"k1": MetaWrites{"m1": []byte("v1")}},
-		"ns2": KeyedMetaWrites{"k2": MetaWrites{"m2": []byte("v2")}},
-	}
-
-	require.NoError(t, base.Equals(NamespaceKeyedMetaWrites{
-		"ns1": KeyedMetaWrites{"k1": MetaWrites{"m1": []byte("v1")}},
-		"ns2": KeyedMetaWrites{"k2": MetaWrites{"m2": []byte("v2")}},
-	}))
-
-	err := base.Equals(NamespaceKeyedMetaWrites{
-		"ns1": KeyedMetaWrites{"k1": MetaWrites{"m1": []byte("v1")}},
-		"ns2": KeyedMetaWrites{"k2": MetaWrites{"m2": []byte("changed")}},
-	})
-	require.ErrorContains(t, err, "writes for [ns2] do not match")
-
-	require.NoError(t, base.Equals(NamespaceKeyedMetaWrites{
-		"ns1": KeyedMetaWrites{"k1": MetaWrites{"m1": []byte("v1")}},
-		"ns2": KeyedMetaWrites{"k2": MetaWrites{"m2": []byte("changed")}},
-	}, "ns1"))
 }
 
 // TestWriteSetClear checks Clear empties one namespace and leaves others
@@ -215,21 +135,6 @@ func TestMetaWriteSetClear(t *testing.T) {
 	require.True(t, rws.MetaWriteSet.In("ns2", "k2"), "other namespaces are untouched")
 }
 
-// TestGetKeysNamespaceFilter covers getKeys directly: unfiltered it returns
-// every namespace, filtered it returns the intersection.
-func TestGetKeysNamespaceFilter(t *testing.T) {
-	t.Parallel()
-
-	m := map[driver.Namespace]NamespaceWrites{
-		"ns1": {"k1": []byte("v1")},
-		"ns2": {"k2": []byte("v2")},
-	}
-
-	require.ElementsMatch(t, []string{"ns1", "ns2"}, getKeys(m))
-	require.ElementsMatch(t, []string{"ns1"}, getKeys(m, "ns1"))
-	require.Empty(t, getKeys(m, "absent"))
-}
-
 // TestAddRejectsInvalidNamespace covers the validation branch both Add
 // implementations share, which returns before touching the underlying map.
 func TestAddRejectsInvalidNamespace(t *testing.T) {
@@ -237,11 +142,38 @@ func TestAddRejectsInvalidNamespace(t *testing.T) {
 
 	rws := EmptyRWSet()
 
-	err := rws.WriteSet.Add("", "k1", []byte("v1"))
-	require.Error(t, err)
+	require.Error(t, rws.WriteSet.Add("", "k1", []byte("v1")))
 	require.Empty(t, rws.Writes, "a rejected write must not create the namespace")
 
-	err = rws.MetaWriteSet.Add("", "k1", map[string][]byte{"m1": []byte("v1")})
-	require.Error(t, err)
+	require.Error(t, rws.MetaWriteSet.Add("", "k1", map[string][]byte{"m1": []byte("v1")}))
 	require.Empty(t, rws.MetaWrites, "a rejected write must not create the namespace")
+}
+
+// TestSetAddIsIdempotent pins the ordered-key bookkeeping when the same key is
+// recorded twice. The ordered slice must stay in step with the map: callers
+// iterate 0..NumReads-1 and index the slice (KeyExist in platform/fabric/vault.go,
+// anyKeyContains in platform/fabricx/core/transaction/rwset/loader.go), so a
+// duplicate entry would hide every key recorded after it.
+func TestSetAddIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	rws := EmptyRWSet()
+	rws.ReadSet.Add("ns", "k1", Version("v1"))
+	rws.ReadSet.Add("ns", "k1", Version("v2"))
+	rws.ReadSet.Add("ns", "k2", Version("v3"))
+
+	require.Equal(t, []string{"k1", "k2"}, rws.OrderedReads["ns"])
+	require.Len(t, rws.Reads["ns"], len(rws.OrderedReads["ns"]))
+
+	version, in := rws.ReadSet.Get("ns", "k1")
+	require.True(t, in)
+	require.Equal(t, Version("v2"), version, "the later read wins")
+
+	// WriteSet.Add already behaved this way; assert it so the two stay aligned.
+	require.NoError(t, rws.WriteSet.Add("ns", "k1", []byte("v1")))
+	require.NoError(t, rws.WriteSet.Add("ns", "k1", []byte("v2")))
+	require.NoError(t, rws.WriteSet.Add("ns", "k2", []byte("v3")))
+
+	require.Equal(t, []string{"k1", "k2"}, rws.OrderedWrites["ns"])
+	require.Equal(t, []byte("v2"), rws.WriteSet.Get("ns", "k1"), "the later write wins")
 }

--- a/platform/common/core/generic/vault/rwset_test.go
+++ b/platform/common/core/generic/vault/rwset_test.go
@@ -1,0 +1,247 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vault
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+)
+
+// TestNamespaceWritesEquals covers the leaf comparison every Equals chain
+// bottoms out in: matching sets, differing lengths, a key present in one side
+// only, and a value mismatch.
+func TestNamespaceWritesEquals(t *testing.T) {
+	t.Parallel()
+
+	base := NamespaceWrites{"k1": []byte("v1"), "k2": []byte("v2")}
+
+	require.NoError(t, base.Equals(NamespaceWrites{"k1": []byte("v1"), "k2": []byte("v2")}))
+
+	err := base.Equals(NamespaceWrites{"k1": []byte("v1")})
+	require.ErrorContains(t, err, "number of writes do not match")
+
+	err = base.Equals(NamespaceWrites{"k1": []byte("v1"), "other": []byte("v2")})
+	require.ErrorContains(t, err, "read not found [k2]")
+
+	err = base.Equals(NamespaceWrites{"k1": []byte("v1"), "k2": []byte("different")})
+	require.ErrorContains(t, err, "writes for [k2] do not match")
+}
+
+// TestNamespaceWritesKeys checks Keys reports every key held, and nothing for
+// an empty set.
+func TestNamespaceWritesKeys(t *testing.T) {
+	t.Parallel()
+
+	w := NamespaceWrites{"k1": []byte("v1"), "k2": []byte("v2")}
+	require.ElementsMatch(t, []string{"k1", "k2"}, w.Keys())
+
+	require.Empty(t, NamespaceWrites{}.Keys())
+}
+
+// TestWritesEquals covers the namespace-keyed layer, including the namespace
+// filter that restricts comparison to a subset.
+func TestWritesEquals(t *testing.T) {
+	t.Parallel()
+
+	base := Writes{
+		"ns1": NamespaceWrites{"k1": []byte("v1")},
+		"ns2": NamespaceWrites{"k2": []byte("v2")},
+	}
+
+	require.NoError(t, base.Equals(Writes{
+		"ns1": NamespaceWrites{"k1": []byte("v1")},
+		"ns2": NamespaceWrites{"k2": []byte("v2")},
+	}))
+
+	err := base.Equals(Writes{
+		"ns1": NamespaceWrites{"k1": []byte("v1")},
+		"ns2": NamespaceWrites{"k2": []byte("changed")},
+	})
+	require.ErrorContains(t, err, "writes for [ns2] do not match")
+
+	// Restricting to ns1 ignores the ns2 mismatch entirely.
+	require.NoError(t, base.Equals(Writes{
+		"ns1": NamespaceWrites{"k1": []byte("v1")},
+		"ns2": NamespaceWrites{"k2": []byte("changed")},
+	}, "ns1"))
+}
+
+// TestNamespaceReadsEquals covers the read-side leaf comparison.
+func TestNamespaceReadsEquals(t *testing.T) {
+	t.Parallel()
+
+	base := NamespaceReads{"k1": Version("v1"), "k2": Version("v2")}
+
+	require.NoError(t, base.Equals(NamespaceReads{"k1": Version("v1"), "k2": Version("v2")}))
+
+	err := base.Equals(NamespaceReads{"k1": Version("v1")})
+	require.ErrorContains(t, err, "number of writes do not match")
+
+	err = base.Equals(NamespaceReads{"k1": Version("v1"), "k2": Version("changed")})
+	require.ErrorContains(t, err, "writes for [k2] do not match")
+}
+
+// TestReadsEquals covers the namespace-keyed read layer and its filter.
+func TestReadsEquals(t *testing.T) {
+	t.Parallel()
+
+	base := Reads{
+		"ns1": NamespaceReads{"k1": Version("v1")},
+		"ns2": NamespaceReads{"k2": Version("v2")},
+	}
+
+	require.NoError(t, base.Equals(Reads{
+		"ns1": NamespaceReads{"k1": Version("v1")},
+		"ns2": NamespaceReads{"k2": Version("v2")},
+	}))
+
+	err := base.Equals(Reads{
+		"ns1": NamespaceReads{"k1": Version("v1")},
+		"ns2": NamespaceReads{"k2": Version("changed")},
+	})
+	require.ErrorContains(t, err, "writes for [ns2] do not match")
+
+	require.NoError(t, base.Equals(Reads{
+		"ns1": NamespaceReads{"k1": Version("v1")},
+		"ns2": NamespaceReads{"k2": Version("changed")},
+	}, "ns1"))
+}
+
+// TestKeyedMetaWritesEquals covers metadata comparison, which nests
+// entriesEqual one level deeper than the read and write sets.
+func TestKeyedMetaWritesEquals(t *testing.T) {
+	t.Parallel()
+
+	base := KeyedMetaWrites{"k1": MetaWrites{"m1": []byte("v1")}}
+
+	require.NoError(t, base.Equals(KeyedMetaWrites{"k1": MetaWrites{"m1": []byte("v1")}}))
+
+	err := base.Equals(KeyedMetaWrites{})
+	require.ErrorContains(t, err, "number of writes do not match")
+
+	err = base.Equals(KeyedMetaWrites{"k1": MetaWrites{"m1": []byte("changed")}})
+	require.ErrorContains(t, err, "writes for [k1] do not match")
+}
+
+// TestNamespaceKeyedMetaWritesEquals covers the outermost metadata layer and
+// its namespace filter.
+func TestNamespaceKeyedMetaWritesEquals(t *testing.T) {
+	t.Parallel()
+
+	base := NamespaceKeyedMetaWrites{
+		"ns1": KeyedMetaWrites{"k1": MetaWrites{"m1": []byte("v1")}},
+		"ns2": KeyedMetaWrites{"k2": MetaWrites{"m2": []byte("v2")}},
+	}
+
+	require.NoError(t, base.Equals(NamespaceKeyedMetaWrites{
+		"ns1": KeyedMetaWrites{"k1": MetaWrites{"m1": []byte("v1")}},
+		"ns2": KeyedMetaWrites{"k2": MetaWrites{"m2": []byte("v2")}},
+	}))
+
+	err := base.Equals(NamespaceKeyedMetaWrites{
+		"ns1": KeyedMetaWrites{"k1": MetaWrites{"m1": []byte("v1")}},
+		"ns2": KeyedMetaWrites{"k2": MetaWrites{"m2": []byte("changed")}},
+	})
+	require.ErrorContains(t, err, "writes for [ns2] do not match")
+
+	require.NoError(t, base.Equals(NamespaceKeyedMetaWrites{
+		"ns1": KeyedMetaWrites{"k1": MetaWrites{"m1": []byte("v1")}},
+		"ns2": KeyedMetaWrites{"k2": MetaWrites{"m2": []byte("changed")}},
+	}, "ns1"))
+}
+
+// TestWriteSetClear checks Clear empties one namespace and leaves others
+// intact, including its ordered-key bookkeeping.
+func TestWriteSetClear(t *testing.T) {
+	t.Parallel()
+
+	rws := EmptyRWSet()
+	require.NoError(t, rws.WriteSet.Add("ns1", "k1", []byte("v1")))
+	require.NoError(t, rws.WriteSet.Add("ns2", "k2", []byte("v2")))
+
+	rws.WriteSet.Clear("ns1")
+
+	require.False(t, rws.WriteSet.In("ns1", "k1"))
+	require.Empty(t, rws.Writes["ns1"])
+	require.Empty(t, rws.OrderedWrites["ns1"])
+
+	_, in := rws.WriteSet.GetAt("ns1", 0)
+	require.False(t, in, "cleared namespace must have no ordered writes")
+
+	require.True(t, rws.WriteSet.In("ns2", "k2"), "other namespaces are untouched")
+}
+
+// TestReadSetClear checks the read-side equivalent.
+func TestReadSetClear(t *testing.T) {
+	t.Parallel()
+
+	rws := EmptyRWSet()
+	rws.ReadSet.Add("ns1", "k1", Version("v1"))
+	rws.ReadSet.Add("ns2", "k2", Version("v2"))
+
+	rws.ReadSet.Clear("ns1")
+
+	_, in := rws.ReadSet.Get("ns1", "k1")
+	require.False(t, in)
+	require.Empty(t, rws.OrderedReads["ns1"])
+
+	_, in = rws.ReadSet.GetAt("ns1", 0)
+	require.False(t, in, "cleared namespace must have no ordered reads")
+
+	_, in = rws.ReadSet.Get("ns2", "k2")
+	require.True(t, in, "other namespaces are untouched")
+}
+
+// TestMetaWriteSetClear checks the metadata-side equivalent.
+func TestMetaWriteSetClear(t *testing.T) {
+	t.Parallel()
+
+	rws := EmptyRWSet()
+	require.NoError(t, rws.MetaWriteSet.Add("ns1", "k1", map[string][]byte{"m1": []byte("v1")}))
+	require.NoError(t, rws.MetaWriteSet.Add("ns2", "k2", map[string][]byte{"m2": []byte("v2")}))
+
+	rws.MetaWriteSet.Clear("ns1")
+
+	require.False(t, rws.MetaWriteSet.In("ns1", "k1"))
+	require.Empty(t, rws.MetaWriteSet.Get("ns1", "k1"))
+
+	require.True(t, rws.MetaWriteSet.In("ns2", "k2"), "other namespaces are untouched")
+}
+
+// TestGetKeysNamespaceFilter covers getKeys directly: unfiltered it returns
+// every namespace, filtered it returns the intersection.
+func TestGetKeysNamespaceFilter(t *testing.T) {
+	t.Parallel()
+
+	m := map[driver.Namespace]NamespaceWrites{
+		"ns1": {"k1": []byte("v1")},
+		"ns2": {"k2": []byte("v2")},
+	}
+
+	require.ElementsMatch(t, []string{"ns1", "ns2"}, getKeys(m))
+	require.ElementsMatch(t, []string{"ns1"}, getKeys(m, "ns1"))
+	require.Empty(t, getKeys(m, "absent"))
+}
+
+// TestAddRejectsInvalidNamespace covers the validation branch both Add
+// implementations share, which returns before touching the underlying map.
+func TestAddRejectsInvalidNamespace(t *testing.T) {
+	t.Parallel()
+
+	rws := EmptyRWSet()
+
+	err := rws.WriteSet.Add("", "k1", []byte("v1"))
+	require.Error(t, err)
+	require.Empty(t, rws.Writes, "a rejected write must not create the namespace")
+
+	err = rws.MetaWriteSet.Add("", "k1", map[string][]byte{"m1": []byte("v1")})
+	require.Error(t, err)
+	require.Empty(t, rws.MetaWrites, "a rejected write must not create the namespace")
+}


### PR DESCRIPTION
Related to #1758

## What

Covers the accessor, comparison and lifecycle methods in `inspector.go` and `rwset.go` that the shared conformance suite in `vault_test_utils.go` never reaches — and fixes the bug that covering them surfaced.

The suite exercises the commit and query paths well, but it drives the vault through its store-backed API, so the read-only inspector's contract and the read/write set's comparison helpers went untested. That left `inspector.go` at 54.76% and `rwset.go` at 55.91%, the two lowest files in the package.

## The bug: `ReadSet.Add` did not dedup

`WriteSet.Add` guards its ordered-key bookkeeping with `if !exists` (`rwset.go:111`). `ReadSet.Add` appended unconditionally, so recording the same key twice left `OrderedReads` longer than `Reads`:

```
OrderedReads=[k1 k1 k2]  NumReads=2  visited=[k1 k1]
```

Callers iterate `0..NumReads-1` and index the ordered slice — `KeyExist` in `platform/fabric/vault.go:72` and `anyKeyContains` in `platform/fabricx/core/transaction/rwset/loader.go:170` — so a duplicate hides every key recorded after it. `KeyExist` returned `false` for a key that had in fact been read.

Reachable two ways:

- the exported `Interceptor.AddReadAt` passes straight through, while the interceptor's own `GetState`/`GetStateMetadata` paths guard with `if in` first (`interceptor.go:248`, `:305`) — `AddReadAt` was the odd one out;
- `platform/fabricx/core/vault/marshal.go:238` and `:254` append reads from two separate loops into one `ReadSet`, so a key in both lists is added twice.

`ReadSet.Add` now mirrors `WriteSet.Add`'s guard, and
`TestSetAddIsIdempotent` pins both sides so they cannot drift apart again. That test fails without the guard.

Nothing depended on the duplicates: `OrderedReads` is read only by `ReadSet.GetAt`, `ReadSet.Clear` and the fabricx `delete` in `platform/fabricx/core/vault/vault.go:304`.

## Also in `rwset.go`

`entriesEqual` compares reads, writes *and* metadata, but its errors always said "writes" and "read not found". They now read neutrally, and the length mismatch reports the counts it actually compared rather than the unfiltered map lengths, which diverge once an `nss` filter is applied.

## Tests

`inspector.go` — fourteen of its twenty-one methods were at 0%. Eight are `panic("programming error: ...")` guards enforcing that the inspector is read-only; the tests pin them with `require.Panics`, so a change that quietly makes the inspector mutable fails here rather than in production. The rest carry real logic and are tested directly: `GetStateMetadata` (hit, missing key, missing namespace), `GetReadKeyAt` (in range and out), `IsClosed` and `Done`. Also closes the out-of-range branches of `GetReadAt` and `GetWriteAt`.

`rwset.go` — all six `Equals` implementations funnel through `entriesEqual`, and Go counts a generic's statements once however many times it is instantiated, so one table drives its four branches (length mismatch, missing key, value mismatch, match) plus the namespace filter in `getKeys`, and each wrapper gets a match/mismatch line proving it delegates. Adds the three `Clear` implementations, `NamespaceWrites.Keys`, the `ValidateNs` rejection branch shared by both `Add` implementations, and the ordered-key bookkeeping above.

## Result

| file | before | after |
|------|--------|-------|
| `inspector.go` | 54.76% | **97.62%** |
| `rwset.go` | 55.91% | **100%** |

Two statements cannot be reached regardless of tests:

- `Inspector.Done` has an empty body — nothing to instrument, so it reports 0% however often it is called.
- `GetReadAt`'s error branch propagates an error from `Inspector.GetState`, which always returns `nil`.

## Verification

- `go test -race ./platform/common/core/generic/vault/` — pass
- `go test ./platform/common/... ./platform/fabric/... ./platform/fabricx/...` — pass
- `golangci-lint run` (v2.13.2, the pinned version, with `gosec` per #1757) — 0 issues
- `go vet` and `gofmt -l` — clean

## Remaining for #1758

`interceptor.go` (69.63%) and `vault.go` (79.87%) are still short of the 90% target and will follow in a second PR. They need store and query-executor mocks rather than the pure-function tests here, so they are cleaner as a separate change — which is why this closes nothing and only refs the issue.
