### PR TITLE
fix(fabric): return UnknownTxTimeout from its own accessor

### DIFF
--- a/platform/fabric/core/generic/config/ds.go
+++ b/platform/fabric/core/generic/config/ds.go
@@ -224,7 +224,7 @@ func (c *Channel) CommitterFinalityUnknownTXTimeout() time.Duration {
 	if c.Committer.Finality.UnknownTxTimeout == 0 {
 		return 100 * time.Millisecond
 	}
-	return c.Discovery.Timeout
+	return c.Committer.Finality.UnknownTxTimeout
 }
 
 func (c *Channel) FinalityForPartiesWaitTimeout() time.Duration {

--- a/platform/fabric/core/generic/config/service_test.go
+++ b/platform/fabric/core/generic/config/service_test.go
@@ -167,6 +167,40 @@ func TestChannelHelpers(t *testing.T) {
 	require.Equal(t, "cc1", arr[0].ID())
 }
 
+// CommitterFinalityUnknownTXTimeout must return its own configured field and
+// never Discovery.Timeout. The two are set to different non-zero values below so
+// that returning the wrong field cannot pass, and so that neither value can be
+// mistaken for the other's default.
+func TestCommitterFinalityUnknownTXTimeout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns the configured value, not the discovery timeout", func(t *testing.T) {
+		t.Parallel()
+		ch := &cfg.Channel{}
+		ch.Committer.Finality.UnknownTxTimeout = 1 * time.Second
+		ch.Discovery.Timeout = 5 * time.Minute
+
+		require.Equal(t, 1*time.Second, ch.CommitterFinalityUnknownTXTimeout())
+	})
+
+	t.Run("does not fall back to an unset discovery timeout", func(t *testing.T) {
+		t.Parallel()
+		ch := &cfg.Channel{}
+		ch.Committer.Finality.UnknownTxTimeout = 1 * time.Second
+		// Discovery.Timeout deliberately left unset.
+
+		require.Equal(t, 1*time.Second, ch.CommitterFinalityUnknownTXTimeout())
+	})
+
+	t.Run("defaults to 100ms when unset, whatever the discovery timeout", func(t *testing.T) {
+		t.Parallel()
+		ch := &cfg.Channel{}
+		ch.Discovery.Timeout = 5 * time.Minute
+
+		require.Equal(t, 100*time.Millisecond, ch.CommitterFinalityUnknownTXTimeout())
+	})
+}
+
 func TestCreatePeerMapAndPickPeer(t *testing.T) {
 	t.Parallel()
 	m := &mock.Configuration{}


### PR DESCRIPTION
## What

`Channel.CommitterFinalityUnknownTXTimeout()` guarded on
`Committer.Finality.UnknownTxTimeout` but returned `Discovery.Timeout` on the
non-zero path, so any node that actually configured the key got the wrong value:

| `committer.finality.unknownTxTimeout` | `discovery.timeout` | returned |
|---|---|---|
| unset | any | `100ms` — correct by accident, via the zero branch |
| `1s` | unset | `0` — no backoff at all |
| `1s` | `5m` | `5m` — a five-minute sleep before the remote probe |

One-line fix in `platform/fabric/core/generic/config/ds.go`:

```go
-	return c.Discovery.Timeout
+	return c.Committer.Finality.UnknownTxTimeout
```

## Why it matters

The value's only consumer is the sleep before the remote finality probe
(`platform/fabric/core/generic/committer/committer.go:391-395`). With a typical
multi-minute `discovery.timeout`, any node setting `unknownTxTimeout` stalled
inside `IsFinal()` for every unknown transaction — and twice over, since the
sleep runs for `iter <= 1`. With `discovery.timeout` unset, the backoff
disappeared entirely.

The affected population is exactly the operators who read
`docs/configuration.md` and set the key.

## Tests

The existing assertion only covered the zero branch, which is why CI never saw
this. The new test pins both fields to **different non-zero values** so
returning the wrong field cannot pass, and so neither value can be mistaken for
the other's default.

Written test-first: it failed with `5m0s` and `0s` before the fix, and the
default-path subtest passed while red — confirming `100ms` was only ever correct
by accident.

## Notes

- `docs/configuration.md` already documents the intended behaviour
  (`unknownTxTimeout: 100ms`), so no doc change is needed — the code was wrong,
  not the docs.
- I scanned the other `*Channel` accessors in `ds.go` for the same copy-paste
  shape; every guard field now matches its return field, so there is no second
  instance of this bug.
- Possibly worth a separate look: `DiscoveryDefaultTTLS()` and
  `DiscoveryTimeout()` both read `Discovery.Timeout` but default to `5m` and
  `20s` respectively. The `Discovery` struct has no `defaultTTLS` field, so one
  config value feeds two semantically different settings with contradictory
  defaults. Self-consistent code rather than a field mix-up, so left out of this
  PR.

Verified with `go test -race` on the config and committer packages, plus
`golangci-lint` (0 issues), `gofmt`, `go vet`, and `go build ./...`.

Fixes #1734