### PR TITLE
chore(lint): name the standard linters explicitly in golangci config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,12 +6,21 @@
 version: "2"
 linters:
   enable:
+    # errcheck, govet, ineffassign, staticcheck and unused come from
+    # golangci-lint's implicit `default: standard` set. They are named here so
+    # the config states what it enforces rather than inheriting it, and so a
+    # future `default: none` cannot silently drop them.
+    - errcheck
     - goheader
     - gosec
+    - govet
+    - ineffassign
     - misspell
+    - paralleltest
+    - staticcheck
     - thelper
     - tparallel
-    - paralleltest
+    - unused
   settings:
     goheader:
       # Two header forms are accepted: the SPDX form used by code written for


### PR DESCRIPTION
golangci-lint v2 applies an implicit `linters.default: standard`, which was silently enabling `errcheck`, `govet`, `ineffassign`, `staticcheck` and `unused` — the config never said so. `golangci-lint linters` reported ten linters enabled while `.golangci.yml` named only five.

This lists all five in `linters.enable` explicitly, so the config states what it enforces rather than inheriting it, and so a future `default: none` cannot silently drop them.

Part of #1755.

### Scoping

Config-only — no `.go` file is touched. The enabled set is **identical** before and after: the same ten linters, five already named plus the five that were implicit.

### Verification

`make checks` exits 0 — 0 issues across all four linted modules, `go fix` clean. The `golangci-lint linters` listing was captured before and after the edit and diffed: byte-identical. That equality is the whole point of the commit, so it is the thing that was verified rather than asserted.

### Note for reviewers

This is the first of a series enabling the remaining linters from #1755, one per commit. It comes first deliberately: `linters.enable` on `main` is not alphabetical (`… misspell, thelper, tparallel, paralleltest`), and this commit normalises the ordering as well as adding the five names. Every later PR in the series inserts into the normalised list, so landing this one first keeps those conflicts to a single line each.
