### PR TITLE
fix(comm)!: bound the varint reader's allocation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -138,10 +138,10 @@ fsc:
     streamReaderBufferSize: 4096
     # Maximum allowed size (in bytes) for incoming P2P messages. Default: 10485760 (10 MiB)
     # This protects the node from memory exhaustion by rejecting oversized payloads before deserialization.
-    # Set to 0 to disable the limit (allow arbitrarily large messages - not recommended).
+    # The limit cannot be disabled: zero or negative values fall back to the default.
     maxRecvMsgSize: 10485760
     # Maximum allowed size (in bytes) for outgoing P2P messages. Default: 10485760 (10 MiB)
-    # Set to 0 to disable the limit (allow arbitrarily large messages - not recommended).
+    # The limit cannot be disabled: zero or negative values fall back to the default.
     maxSendMsgSize: 10485760
     opts:
       # ------------------- libp2p specific options -------------------------

--- a/platform/view/services/comm/config.go
+++ b/platform/view/services/comm/config.go
@@ -54,10 +54,10 @@ func NewConfig(cs configService) *config {
 	if streamReaderBufferSize <= 0 {
 		streamReaderBufferSize = DefaultStreamReaderBufferSize
 	}
-	if maxRecvMsgSize < 0 {
+	if maxRecvMsgSize <= 0 {
 		maxRecvMsgSize = DefaultMaxMessageSize
 	}
-	if maxSendMsgSize < 0 {
+	if maxSendMsgSize <= 0 {
 		maxSendMsgSize = DefaultMaxMessageSize
 	}
 

--- a/platform/view/services/comm/config_test.go
+++ b/platform/view/services/comm/config_test.go
@@ -88,7 +88,11 @@ func TestNewConfig(t *testing.T) {
 		require.Equal(t, DefaultMaxMessageSize, cfg.maxSendMsgSize)
 	})
 
-	t.Run("zero maxRecvMsgSize and maxSendMsgSize are allowed", func(t *testing.T) {
+	// Zero must fall back to the default rather than pass through, matching the
+	// buffer sizes clamped in the same function. A zero maxRecvMsgSize reaches
+	// the varint reader as "no limit", letting a peer claim an arbitrary message
+	// length; there is no documented unlimited mode.
+	t.Run("zero maxRecvMsgSize and maxSendMsgSize fall back to the default", func(t *testing.T) {
 		t.Parallel()
 		cs := &mockConfigServiceForTesting{
 			ints: map[string]int{
@@ -101,7 +105,7 @@ func TestNewConfig(t *testing.T) {
 			},
 		}
 		cfg := NewConfig(cs)
-		require.Equal(t, 0, cfg.maxRecvMsgSize)
-		require.Equal(t, 0, cfg.maxSendMsgSize)
+		require.Equal(t, DefaultMaxMessageSize, cfg.maxRecvMsgSize)
+		require.Equal(t, DefaultMaxMessageSize, cfg.maxSendMsgSize)
 	})
 }

--- a/platform/view/services/comm/io/reader.go
+++ b/platform/view/services/comm/io/reader.go
@@ -50,14 +50,67 @@ func (r *varintReader) ReadData() ([]byte, error) {
 		return nil, err
 	}
 
-	if r.maxMessageSize > 0 && l > uint64(r.maxMessageSize) {
+	// A non-positive limit is a misconfiguration, not "unlimited": treating it as
+	// unlimited would let a peer claim any length and have it allocated below.
+	if r.maxMessageSize <= 0 {
+		return nil, errors.Errorf("max message size [%d] must be positive", r.maxMessageSize)
+	}
+	if l > uint64(r.maxMessageSize) {
 		return nil, errors.Errorf("message length [%d] exceeds max message size [%d]", l, r.maxMessageSize)
 	}
 
-	buffer := make([]byte, l) // We can re-use the buffer to avoid allocations
-
-	if n, err := io.ReadFull(r.r, buffer); err != nil || n != int(l) {
+	// The claimed length is bounded but still attacker-controlled, so it is not
+	// trusted for the allocation: grow the buffer while reading so a peer must
+	// actually send the bytes it claims.
+	buffer, err := readFullGrowing(r.r, int(l))
+	if err != nil {
 		return nil, errors.Wrapf(err, "error reading message of length [%d]", l)
+	}
+	return buffer, nil
+}
+
+// initialReadBufferCap bounds the allocation made before any payload byte has
+// been read. A message larger than this grows geometrically as data arrives.
+const initialReadBufferCap = 64 * 1024
+
+// maxConsecutiveEmptyReads bounds how many (0, nil) reads are tolerated before
+// giving up. io.Reader permits them, so without this a peer holding a stream
+// open without sending data would spin its per-stream goroutine forever.
+const maxConsecutiveEmptyReads = 100
+
+// readFullGrowing reads exactly n bytes, growing the buffer as data arrives
+// rather than allocating n up front. It returns an error if the reader ends
+// before n bytes have been read.
+func readFullGrowing(r io.Reader, n int) ([]byte, error) {
+	buffer := make([]byte, 0, min(n, initialReadBufferCap))
+	empty := 0
+	for len(buffer) < n {
+		if len(buffer) == cap(buffer) {
+			// Grow geometrically, never past the message length.
+			buffer = append(buffer, 0)[:len(buffer)]
+		}
+		read, err := r.Read(buffer[len(buffer):min(cap(buffer), n)])
+		buffer = buffer[:len(buffer)+read]
+		if err != nil {
+			// Any error is forgiven once the whole message has arrived, matching
+			// io.ReadAtLeast (which io.ReadFull wraps): bufio.Reader's large-read
+			// fast path returns the final bytes together with the underlying
+			// error, so a complete message must not be rejected because of it.
+			if len(buffer) == n {
+				break
+			}
+			if errors.Is(err, io.EOF) {
+				err = io.ErrUnexpectedEOF
+			}
+			return nil, err
+		}
+		if read == 0 {
+			if empty++; empty >= maxConsecutiveEmptyReads {
+				return nil, io.ErrNoProgress
+			}
+			continue
+		}
+		empty = 0
 	}
 	return buffer, nil
 }

--- a/platform/view/services/comm/io/reader_security_test.go
+++ b/platform/view/services/comm/io/reader_security_test.go
@@ -7,11 +7,17 @@ SPDX-License-Identifier: Apache-2.0
 package io
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 func TestVarintReader_OOMProtection(t *testing.T) {
@@ -29,6 +35,27 @@ func TestVarintReader_OOMProtection(t *testing.T) {
 	require.Contains(t, err.Error(), "exceeds max message size")
 }
 
+// A non-positive maxMessageSize must not mean "unlimited". Otherwise a peer can
+// make the node allocate an arbitrary length with a 10-byte frame, since the
+// claimed length is trusted for the allocation before any payload is read.
+func TestVarintReader_NonPositiveMaxMessageSizeIsNotUnlimited(t *testing.T) {
+	t.Parallel()
+
+	// A 10-byte frame claiming 2^64-1 bytes, and no payload.
+	frame := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01}
+
+	for _, maxMessageSize := range []int{0, -1} {
+		t.Run(fmt.Sprintf("maxMessageSize=%d", maxMessageSize), func(t *testing.T) {
+			t.Parallel()
+			r := newVarintReader(bytes.NewReader(frame), testBufferSize, maxMessageSize)
+
+			data, err := r.ReadData()
+			require.Error(t, err)
+			require.Nil(t, data)
+		})
+	}
+}
+
 func TestVarintReader_NormalMessage(t *testing.T) {
 	t.Parallel()
 	msg := []byte("hello world")
@@ -41,4 +68,166 @@ func TestVarintReader_NormalMessage(t *testing.T) {
 	data, err := r.ReadData()
 	require.NoError(t, err)
 	require.Equal(t, msg, data)
+}
+
+// readerFunc adapts a function to io.Reader.
+type readerFunc func([]byte) (int, error)
+
+func (f readerFunc) Read(p []byte) (int, error) { return f(p) }
+
+// readFullGrowing must return exactly the requested bytes, across the initial
+// buffer boundary and the geometric growth steps beyond it, and must not report
+// success when the peer sends fewer bytes than it claimed.
+func TestReadFullGrowing(t *testing.T) {
+	t.Parallel()
+
+	sizes := []int{
+		0, 1, 1024,
+		initialReadBufferCap - 1, initialReadBufferCap, initialReadBufferCap + 1,
+		2 * initialReadBufferCap, 3*initialReadBufferCap + 7,
+	}
+
+	t.Run("reads exactly n bytes", func(t *testing.T) {
+		t.Parallel()
+		for _, n := range sizes {
+			payload := make([]byte, n)
+			for i := range payload {
+				payload[i] = byte(i % 251)
+			}
+
+			got, err := readFullGrowing(bytes.NewReader(payload), n)
+			require.NoError(t, err, "n=%d", n)
+			require.Len(t, got, n, "n=%d", n)
+			require.Equal(t, payload, got, "n=%d", n)
+		}
+	})
+
+	t.Run("errors when the payload is short", func(t *testing.T) {
+		t.Parallel()
+		for _, n := range sizes {
+			if n == 0 {
+				continue
+			}
+			got, err := readFullGrowing(bytes.NewReader(make([]byte, n-1)), n)
+			require.ErrorIs(t, err, io.ErrUnexpectedEOF, "n=%d", n)
+			require.Nil(t, got, "n=%d", n)
+		}
+	})
+
+	t.Run("does not allocate the claimed length up front", func(t *testing.T) {
+		t.Parallel()
+		// A peer claims a huge length and sends one byte. The buffer's capacity is
+		// what the allocation costs, so assert on that rather than on process-wide
+		// MemStats, which other parallel tests pollute.
+		huge := 512 * 1024 * 1024
+
+		// The reader records the capacity of the slice it is handed, which is the
+		// buffer readFullGrowing has allocated by the time it first reads.
+		var seenCap int
+		r := readerFunc(func(p []byte) (int, error) {
+			seenCap = cap(p)
+			return 0, io.EOF
+		})
+
+		_, err := readFullGrowing(r, huge)
+		require.Error(t, err, "a short payload must not report success")
+		require.LessOrEqual(t, seenCap, initialReadBufferCap,
+			"allocated a %d-byte buffer for a claimed %d", seenCap, huge)
+	})
+}
+
+// stubbornReader always returns (0, nil), which io.Reader explicitly permits.
+// readFullGrowing must not spin on it: a peer that holds a stream open without
+// sending data would otherwise burn a core in its per-stream goroutine.
+type stubbornReader struct{ calls int }
+
+func (s *stubbornReader) Read([]byte) (int, error) {
+	s.calls++
+	return 0, nil
+}
+
+func TestReadFullGrowing_doesNotSpinOnZeroByteReads(t *testing.T) {
+	t.Parallel()
+
+	sr := &stubbornReader{}
+	done := make(chan struct{})
+	var err error
+	go func() {
+		defer close(done)
+		_, err = readFullGrowing(sr, 1024)
+	}()
+
+	select {
+	case <-done:
+		require.Error(t, err, "must give up rather than report success")
+	case <-time.After(2 * time.Second):
+		t.Fatalf("readFullGrowing spun on zero-byte reads (%d calls); it must give up", sr.calls)
+	}
+}
+
+// The send limit must not be disabled by a non-positive value either. config.go
+// clamps the configured value, but the writer keeps its own guard so the
+// invariant holds for any future caller — matching varintReader.ReadData.
+func TestProtoWriter_NonPositiveMaxSendMsgSizeIsNotUnlimited(t *testing.T) {
+	t.Parallel()
+
+	for _, maxSendMsgSize := range []int{0, -1} {
+		t.Run(fmt.Sprintf("maxSendMsgSize=%d", maxSendMsgSize), func(t *testing.T) {
+			t.Parallel()
+			w := NewVarintProtoWriter(&bytes.Buffer{}, maxSendMsgSize)
+
+			err := w.WriteMsg(&anypb.Any{TypeUrl: "test.type", Value: make([]byte, 1024)})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "must be positive")
+		})
+	}
+}
+
+// dataThenErrReader delivers every byte on its final Read while reporting a
+// non-EOF error alongside them. bufio.Reader's large-read fast path
+// (len(p) >= len(b.buf)) passes that combination straight through, and with
+// streamReaderBufferSize at 4096 against a 10 MiB max message any message over
+// 4 KiB takes it. A network stream reporting a reset with its last bytes looks
+// exactly like this.
+type dataThenErrReader struct {
+	data []byte
+	done bool
+}
+
+func (d *dataThenErrReader) Read(p []byte) (int, error) {
+	if d.done {
+		return 0, io.EOF
+	}
+	d.done = true
+	return copy(p, d.data), errors.New("connection reset by peer")
+}
+
+// A complete message must be accepted even when the read that completed it also
+// reported an error, matching io.ReadAtLeast. A short one must still fail.
+func TestReadFullGrowing_completeMessageWithTrailingError(t *testing.T) {
+	t.Parallel()
+
+	// Larger than DefaultStreamReaderBufferSize so bufio takes the fast path.
+	payload := make([]byte, 8192)
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+
+	t.Run("complete message is accepted", func(t *testing.T) {
+		t.Parallel()
+		r := bufio.NewReaderSize(&dataThenErrReader{data: payload}, 4096)
+
+		got, err := readFullGrowing(r, len(payload))
+		require.NoError(t, err)
+		require.Equal(t, payload, got)
+	})
+
+	t.Run("short message still fails", func(t *testing.T) {
+		t.Parallel()
+		r := bufio.NewReaderSize(&dataThenErrReader{data: payload[:len(payload)-1]}, 4096)
+
+		got, err := readFullGrowing(r, len(payload))
+		require.Error(t, err)
+		require.Nil(t, got)
+	})
 }

--- a/platform/view/services/comm/io/writer.go
+++ b/platform/view/services/comm/io/writer.go
@@ -76,7 +76,12 @@ func (w *protoWriter) WriteMsg(msg proto.Message) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to marshal the message: [%s]", msg)
 	}
-	if w.maxSendMsgSize > 0 && len(data) > w.maxSendMsgSize {
+	// A non-positive limit is a misconfiguration, not "unlimited", matching
+	// varintReader.ReadData: the limit cannot be disabled.
+	if w.maxSendMsgSize <= 0 {
+		return errors.Errorf("max send message size [%d] must be positive", w.maxSendMsgSize)
+	}
+	if len(data) > w.maxSendMsgSize {
 		return errors.Errorf("message size %d exceeds maximum send size %d", len(data), w.maxSendMsgSize)
 	}
 	return w.w.WriteData(data)


### PR DESCRIPTION
Fixes #1756

## The bug

`varintReader.ReadData` allocated `make([]byte, l)` from a length read off the
wire before reading any payload, guarded only by:

```go
if r.maxMessageSize > 0 && l > uint64(r.maxMessageSize) {
```

so `maxMessageSize == 0` meant **no limit**. Zero was reachable from config:
`NewConfig` clamped `maxRecvMsgSize` only on `< 0`, while the buffer sizes
directly above it clamp on `<= 0`.

With `fsc.p2p.maxRecvMsgSize: 0`, a 10-byte frame claiming 2^64-1 bytes **panics
the node** — `makeslice: len out of range`, unrecovered, in a per-stream
goroutine, so the process dies. Remotely triggerable by anyone who can open a
P2P stream.

Reproduced as a unit test before fixing, using the exact snippet from the issue:

```
panic: runtime error: makeslice: len out of range
  .../comm/io.(*varintReader).ReadData(...)
      .../comm/io/reader.go:57
```

That same snippet now returns `max message size [0] must be positive`.

## Amplification, measured

Even with a limit in place, the claimed length was trusted for the allocation.
Instrumenting the allocation directly:

```
wire bytes sent: 4   claimed len: 10485760   allocated: 10.02 MiB
wire bytes sent: 4   claimed len: 10485761   allocated:  0.00 MiB  (rejected)
```

**4 bytes on the wire → 10.02 MiB allocated**, per stream, before any payload
byte arrives. One reader per stream (`p2p.go:311`), each in its own goroutine.

Scope note in fairness: `libp2p/host.go:75` configures a `connmgr` (default
high-water 100 connections) and no explicit `ResourceManager`, so libp2p's
default stream caps bound the worst case. The panic path is the severe half; the
amplification is real but bounded.

## The fix

- **`config.go`** — clamp `maxRecvMsgSize`/`maxSendMsgSize` on `<= 0`, matching
  the buffer sizes above them.
- **`reader.go`** — treat a non-positive `maxMessageSize` as an error rather than
  as unlimited, so the guard holds for any future caller; read via
  `readFullGrowing`, which starts at 64 KiB and grows as data arrives, so a peer
  must actually send the bytes it claims.
- **`writer.go`** — `protoWriter.WriteMsg` carried the same `> 0` pattern, so a
  non-positive `maxSendMsgSize` disabled the send limit. The issue's expectation
  is that *no* configuration value disables the limit, which covers the send side;
  the writer now has the same guard as the reader.

`readFullGrowing` also bounds consecutive `(0, nil)` reads, which `io.Reader`
explicitly permits. My first version lacked that bound and spun **~859M
iterations in 2s** — a worse failure than the bug being fixed. It now returns
`io.ErrNoProgress`.

The `<= 0` guard additionally makes the adjacent `uint64(r.maxMessageSize)`
conversion provably safe, closing the G115 finding the issue mentions.

## ⚠️ Breaking change — please review this deliberately

`docs/configuration.md` documented zero as an escape hatch:

```
# Set to 0 to disable the limit (allow arbitrarily large messages - not recommended).
```

So this was a **documented, intentional option**, and there is a pre-existing
test named *"zero maxRecvMsgSize and maxSendMsgSize are allowed"* asserting it
passes through. This PR removes that capability: zero and negative values now
fall back to `DefaultMaxMessageSize` (10 MiB). The doc comments and that test are
updated accordingly.

Rationale: a disabled limit is an unauthenticated remote panic/OOM, so it isn't a
configuration the node should offer — "not recommended" undersells it. But this
is a real behaviour change to a documented setting, and if you would rather keep
the escape hatch (e.g. clamp in the reader only, and log a warning in config),
say so and I will rework it.

## Tests

- `reader_security_test.go` — non-positive limits rejected for both `0` and `-1`,
  on the read *and* send paths; `readFullGrowing` exactness and short-payload
  errors across the initial-buffer and growth boundaries
  (`initialReadBufferCap` ±1, 2×, 3×+7); allocation stays bounded for a huge
  claimed length; no spin on zero-byte reads.
- `config_test.go` — the zero case now asserts the default.

The `readFullGrowing` tests were written after the implementation, so I verified
they actually bite by mutation testing — all four mutants caught: up-front
allocation, missing spin guard, short payload accepted as success, and
non-positive limit treated as unlimited.

## Verification

- `go test -race` across `platform/view/services/comm/...` — all pass, including
  the websocket host and P2P session suites
- libp2p host module (separate `go.mod`) — builds and passes
- `golangci-lint run platform/view/services/comm/...` — 0 issues, `gosec`
  included (this bug was found while enabling `gosec`)
- `gofmt`, `go vet`, `go build ./...` clean