### PR TITLE
chore(lint): enable durationcheck in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     # golangci-lint's implicit `default: standard` set. They are named here so
     # the config states what it enforces rather than inheriting it, and so a
     # future `default: none` cannot silently drop them.
+    - durationcheck
     - errcheck
     - goheader
     - gosec


### PR DESCRIPTION
`durationcheck` flags multiplying two `time.Duration` values together (e.g. `d * time.Second` where `d` is already a `Duration`), a classic units-of-time bug.

Part of #1755.

### Scoping

Measured at zero findings across all four modules. No code change; enabled purely as a regression guard against that bug class going forward.

### Verification

`make checks` exits 0 across all four modules — re-measured against current
`main` (including #1739's new test files) before opening this PR.

### Note for reviewers

This is one of four independent single-line commits (durationcheck, loggercheck, makezero, nilnesserr — #1767-#1770) stacked on the same branch. Each later PR's diff includes the earlier ones' lines until they merge; merge in order #1767 → #1768 → #1769 → #1770 and each will shrink to its own single line.
