### PR TITLE
chore(lint): enable loggercheck in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - gosec
     - govet
     - ineffassign
+    - loggercheck
     - misspell
     - paralleltest
     - staticcheck


### PR DESCRIPTION
`loggercheck` flags unbalanced key/value pairs in structured logging calls (`zap`, `logr`, `klog`, `slog`).

Part of #1755.

### Scoping

Measured at zero findings across all four modules — but the zero is structural, not incidental: this codebase logs exclusively through its own facade at `platform/common/services/logging`, which `loggercheck` does not recognize or follow. No finding was possible either way. Enabled as a guard against any future direct `zap`/`slog`/`logr` use bypassing the facade.

### Verification

`make checks` exits 0 across all four modules — re-measured against current
`main` (including #1739's new test files) before opening this PR.

### Note for reviewers

This is one of four independent single-line commits (durationcheck, loggercheck, makezero, nilnesserr — #1767-#1770) stacked on the same branch. Each later PR's diff includes the earlier ones' lines until they merge; merge in order #1767 → #1768 → #1769 → #1770 and each will shrink to its own single line.
