### PR TITLE
chore(lint): enable makezero in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - gosec
     - govet
     - ineffassign
+    - makezero
     - loggercheck
     - misspell
     - paralleltest


### PR DESCRIPTION
`makezero` flags `append` onto a slice created with `make([]T, n)` (non-zero length), which leaves `n` zero values ahead of whatever gets appended.

Part of #1755.

### Scoping

Measured at zero findings across all four modules. No code change; enabled as a regression guard.

### Verification

`make checks` exits 0 across all four modules — re-measured against current
`main` (including #1739's new test files) before opening this PR.

### Note for reviewers

This is one of four independent single-line commits (durationcheck, loggercheck, makezero, nilnesserr — #1767-#1770) stacked on the same branch. Each later PR's diff includes the earlier ones' lines until they merge; merge in order #1767 → #1768 → #1769 → #1770 and each will shrink to its own single line.
