### PR TITLE
chore(lint): enable nilnesserr in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
     - makezero
     - loggercheck
     - misspell
+    - nilnesserr
     - paralleltest
     - staticcheck
     - thelper


### PR DESCRIPTION
`nilnesserr` flags an `if err != nil` block that returns a *different*, nil-valued error variable — a shadowing or copy-paste slip that silently swallows the real error.

Part of #1755.

### Scoping

Measured at zero findings across all four modules. No code change; enabled as a regression guard.

### Verification

`make checks` exits 0 across all four modules — re-measured against current
`main` (including #1739's new test files) before opening this PR.

### Note for reviewers

This is one of four independent single-line commits (durationcheck, loggercheck, makezero, nilnesserr — #1767-#1770) stacked on the same branch. Each later PR's diff includes the earlier ones' lines until they merge; merge in order #1767 → #1768 → #1769 → #1770 and each will shrink to its own single line.
