### PR TITLE
chore(lint): enable recvcheck in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - misspell
     - nilnesserr
     - paralleltest
+    - recvcheck
     - staticcheck
     - thelper
     - tparallel

--- a/platform/fabric/core/generic/membership/channelconfig/capabilities/application.go
+++ b/platform/fabric/core/generic/membership/channelconfig/capabilities/application.go
@@ -89,7 +89,7 @@ func (ap *ApplicationProvider) PrivateChannelData() bool {
 
 // CollectionUpgrade returns true if this channel is configured to allow updates to
 // existing collection or add new collections through chaincode upgrade (as introduced in v1.2)
-func (ap ApplicationProvider) CollectionUpgrade() bool {
+func (ap *ApplicationProvider) CollectionUpgrade() bool {
 	return ap.v12 || ap.v13 || ap.v142 || ap.v20 || ap.v25
 }
 


### PR DESCRIPTION
`recvcheck` flags a type whose methods mix pointer and value receivers.

Part of #1755.

### Scoping

`recvcheck` reported one finding: `ApplicationProvider` (`platform/fabric/core/generic/membership/channelconfig/capabilities/application.go`) used a pointer receiver on every method except `CollectionUpgrade`, which used a value receiver. `ApplicationProvider` is only ever constructed and used through `*ApplicationProvider` — `NewApplicationProvider` returns a pointer, assigned to the `ApplicationCapabilities` interface in `channelconfig/application.go` — and is never copied or stored by value, so the value receiver was an inconsistency rather than a deliberate value-type design. Changed `CollectionUpgrade` to a pointer receiver to match the rest of the type.

### Verification

`make checks` exits 0 across all four modules.

### Note for reviewers

This branch is independent — rooted directly on current `main`, not stacked on any other wave-3 PR. It should merge cleanly regardless of the order the other wave-3 PRs land in.
