### PR TITLE
chore(lint): enable rowserrcheck in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - misspell
     - nilnesserr
     - paralleltest
+    - rowserrcheck
     - staticcheck
     - thelper
     - tparallel

--- a/platform/view/services/storage/driver/sql/common/binding.go
+++ b/platform/view/services/storage/driver/sql/common/binding.go
@@ -75,6 +75,9 @@ func (db *BindingStore) HaveSameBinding(ctx context.Context, this, that view.Ide
 		}
 		longTermIds = append(longTermIds, longTerm)
 	}
+	if err := rows.Err(); err != nil {
+		return false, errors.Wrapf(err, "error iterating rows")
+	}
 	if len(longTermIds) != 2 {
 		return false, errors.Errorf("%d entries found instead of 2", len(longTermIds))
 	}

--- a/platform/view/services/storage/driver/sql/common/signerinfo.go
+++ b/platform/view/services/storage/driver/sql/common/signerinfo.go
@@ -66,6 +66,9 @@ func (db *SignerInfoStore) FilterExistingSigners(ctx context.Context, ids ...vie
 		}
 		existingSigners = append(existingSigners, inverseMap[idHash])
 	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrapf(err, "error iterating rows")
+	}
 	logger.DebugfContext(ctx, "Found %d out of %d signers", len(existingSigners), len(ids))
 	return existingSigners, nil
 }


### PR DESCRIPTION
`rowserrcheck` flags a `*sql.Rows` iteration loop that never checks `Rows.Err()` after `Next()` returns false — a mid-iteration failure (dropped connection, cancelled context, decode error) ends the loop the same way a clean finish does, so the caller can't tell the two apart.

Part of #1755.

### Scoping

Two findings, both in `platform/view/services/storage/driver/sql/common`: `BindingStore.HaveSameBinding` and `SignerInfoStore.FilterExistingSigners` iterated `*sql.Rows` without checking `rows.Err()` afterward. Added the missing check after each loop, wrapped with `pkg/utils/errors` to match the surrounding error style.

### Verification

`make checks` exits 0 across all four modules.

### Note for reviewers

This branch is independent — rooted directly on current `main`, not stacked on any other wave-3 PR. It should merge cleanly regardless of the order the other wave-3 PRs land in.
