### PR TITLE
chore(lint): enable nilerr in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
     - makezero
     - loggercheck
     - misspell
+    - nilerr
     - nilnesserr
     - paralleltest
     - rowserrcheck

--- a/integration/fabric/events/views/events.go
+++ b/integration/fabric/events/views/events.go
@@ -44,9 +44,10 @@ func (c *EventsView) Call(viewCtx view.Context) (any, error) {
 	callBack := func(event *chaincode.Event) (bool, error) {
 		logger.Debugf("Chaincode Event Received in callback %s", event.EventName)
 		if event.Err != nil {
+			logger.Debugf("chaincode event callback received error [%s]", event.Err)
 			eventError = event.Err
 			wg.Done()
-			return true, nil
+			return true, nil //nolint:nilerr // event.Err is captured in eventError for the test's own assertions below; the callback's error return only makes the listener goroutine log it (see RegisterChaincodeEvents), so returning it here would just duplicate that log, not change test behaviour.
 		}
 
 		if event.EventName == c.EventName {

--- a/platform/fabric/sdk/dig/sdk.go
+++ b/platform/fabric/sdk/dig/sdk.go
@@ -170,7 +170,11 @@ func registerProcessorsForDrivers(in struct {
 
 	for _, d := range in.Drivers {
 		logger.Infof("trying to install for driver: %s", d.Name)
-		if c, err := in.CoreConfig.Config(in.CoreConfig.DefaultName()); err != nil || c.Driver != d.Name {
+		c, err := in.CoreConfig.Config(in.CoreConfig.DefaultName())
+		if err != nil {
+			return e.Wrapf(err, "failed getting config for default fabric network")
+		}
+		if c.Driver != d.Name {
 			logger.Infof("Skipping registration of default network, because its driver is %s. We are registering %s", c.Driver, d.Name)
 			return nil
 		}

--- a/platform/fabricx/core/vault/vault.go
+++ b/platform/fabricx/core/vault/vault.go
@@ -432,12 +432,23 @@ func (r *rwSetWrapper) GetStateMetadata(namespace cdriver.Namespace, key cdriver
 	// value, key by its sha256 digest, and return the stored {fieldMappingKey: mapping}
 	// so getFieldMapping finds meta[fieldMappingKey] exactly as on Fabric.
 	committed, err := r.v.queryService.GetState(namespace, key)
-	if err != nil || committed == nil || len(committed.Raw) == 0 {
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed getting committed state for namespace=%s, key=%s", namespace, key)
+	}
+	if committed == nil || len(committed.Raw) == 0 {
 		return nil, nil
 	}
 	digest := sha256.Sum256(committed.Raw)
+	// GetFieldMapping returns an error both on a genuine failure and on a miss (the
+	// underlying KVS read returns no row and unmarshalling the empty result fails) -
+	// see the comment on mds.GetFieldMapping. Callers must treat any error here as "no
+	// mapping", matching mds.LoadTransient's identical miss behaviour.
 	fm, err := r.v.mds.GetFieldMapping(context.Background(), string(namespace), string(key), digest[:])
-	if err != nil || len(fm) == 0 {
+	if err != nil {
+		logger.Debugf("no field mapping for namespace=%s, key=%s: %s", namespace, key, err)
+		return nil, nil
+	}
+	if len(fm) == 0 {
 		return nil, nil
 	}
 	return cdriver.Metadata(fm), nil

--- a/platform/view/services/config/config_util.go
+++ b/platform/view/services/config/config_util.go
@@ -55,7 +55,7 @@ func byteSizeDecodeHook(f, t reflect.Kind, data any) (any, error) {
 	if re.MatchString(raw) {
 		size, err := strconv.ParseUint(re.ReplaceAllString(raw, "${size}"), 0, 64)
 		if err != nil {
-			return data, nil
+			return data, errors.Wrapf(err, "invalid byte size value '%s'", raw)
 		}
 		unit := re.ReplaceAllString(raw, "${unit}")
 		switch strings.ToLower(unit) {


### PR DESCRIPTION
`nilerr` flags `if err != nil { return nil }` — checking an error but returning `nil` (or another nil-valued error) instead of propagating it.

Part of #1755.

### Scoping

Five findings: three real bugs fixed, two deliberate swallows (each now logged, one also carrying `//nolint:nilerr`).

- `platform/fabric/sdk/dig/sdk.go:175` — real bug: a config-lookup error for the default network's driver was conflated with a driver-name mismatch and silently ignored, which would have nil-pointer-dereferenced on `c.Driver` had the error path ever fired. Split the error check out and return it wrapped with `errors.Wrapf`.
- `platform/fabricx/core/vault/vault.go:436` — real bug: a genuine `queryService.GetState` RPC/network error was conflated with "no committed value" and silently swallowed. Split it out and return it wrapped with `errors.Wrapf`.
- `platform/fabricx/core/vault/vault.go:441` — deliberate: `mds.GetFieldMapping` is documented to return an error on both a genuine failure and an ordinary miss (see its comment in `platform/fabric/core/generic/transaction/services.go`), so callers must treat any error as "no mapping". Documented that reasoning in a comment at the call site and added a debug log line that wasn't there before — logging `err` in the block is enough for `nilerr` to stop reporting, so no `//nolint` is needed here.
- `platform/view/services/config/config_util.go:58` — real bug: `byteSizeDecodeHook` already returns a hard "overflows uint32" error a few lines below for a related overflow case; the `ParseUint` failure a few lines above (uint64 overflow before the shift) was silently deferred to the default decoder instead of being reported the same way. Now returns the error wrapped with `errors.Wrapf`.
- `integration/fabric/events/views/events.go:49` — deliberate: this test callback captures `event.Err` into the outer `eventError` variable for the test's own assertions; the callback's own error return only triggers a log line in the listener goroutine (`RegisterChaincodeEvents`) and has no bearing on the test outcome. Added a debug log line for the error and `//nolint:nilerr` with that reasoning.

### Verification

`make checks` exits 0 across all four modules.

### Note for reviewers

This branch is independent — rooted directly on current `main`, not stacked on any other wave-3 PR. It should merge cleanly regardless of the order the other wave-3 PRs land in.
