### PR TITLE
chore(lint): enable usestdlibvars in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,7 @@ linters:
     - thelper
     - tparallel
     - unused
+    - usestdlibvars
   settings:
     goheader:
       # Two header forms are accepted: the SPDX form used by code written for

--- a/platform/view/services/view/web/web_test.go
+++ b/platform/view/services/view/web/web_test.go
@@ -30,7 +30,7 @@ func TestDispatcher(t *testing.T) {
 	d := newDispatcher(h)
 
 	// vc is nil
-	req, _ := http.NewRequest("PUT", "/v1/Views/fid", nil)
+	req, _ := http.NewRequest(http.MethodPut, "/v1/Views/fid", nil)
 	req.SetPathValue("View", "fid")
 	reqctx := &server2.ReqContext{
 		Req:   req,
@@ -75,7 +75,7 @@ func TestViewHandler(t *testing.T) {
 	vh := &viewHandler{c: c}
 
 	// CallView success: byte slice
-	req, _ := http.NewRequest("PUT", "/v1/Views/fid", nil)
+	req, _ := http.NewRequest(http.MethodPut, "/v1/Views/fid", nil)
 	reqctx := &server2.ReqContext{Req: req}
 	resp, err := vh.CallView(reqctx, "fid", []byte("input"))
 	require.NoError(t, err)

--- a/platform/view/services/web/server/middleware/chain_test.go
+++ b/platform/view/services/web/server/middleware/chain_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Chain", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		req = httptest.NewRequest("GET", "/", nil)
+		req = httptest.NewRequest(http.MethodGet, "/", nil)
 		resp = httptest.NewRecorder()
 	})
 

--- a/platform/view/services/web/server/middleware/request_id_test.go
+++ b/platform/view/services/web/server/middleware/request_id_test.go
@@ -34,7 +34,7 @@ var _ = Describe("WithRequestID", func() {
 		)
 		chain = requestID(handler)
 
-		req = httptest.NewRequest("GET", "/", nil)
+		req = httptest.NewRequest(http.MethodGet, "/", nil)
 		resp = httptest.NewRecorder()
 	})
 

--- a/platform/view/services/web/server/middleware/require_cert_test.go
+++ b/platform/view/services/web/server/middleware/require_cert_test.go
@@ -33,7 +33,7 @@ var _ = Describe("RequireCert", func() {
 		requireCert = middleware2.RequireCert()
 		chain = requireCert(handler)
 
-		req = httptest.NewRequest("GET", "https:///", nil)
+		req = httptest.NewRequest(http.MethodGet, "https:///", nil)
 		req.TLS.VerifiedChains = [][]*x509.Certificate{{
 			&x509.Certificate{},
 		}}


### PR DESCRIPTION
`usestdlibvars` flags literals with equivalent stdlib constants (HTTP methods, status codes, crypto/TLS versions).

Part of #1755.

### Scoping

Five findings, all in the root module: `"PUT"` and `"GET"` literals passed to `http.NewRequest` / `httptest.NewRequest` in test files, replaced with `http.MethodPut` / `http.MethodGet`. All five are genuine HTTP methods used to build real HTTP requests, not test fixture data, so no `//nolint` was needed. No behavior change — the constants are equal to the literals they replace.

### Verification

`make checks` exits 0 across all four modules.

### Note for reviewers

This branch is independent — rooted directly on current `main`, not stacked on any other wave-3 PR. It should merge cleanly regardless of the order the other wave-3 PRs land in.
