### PR TITLE
chore(lint): enable spancheck in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - misspell
     - nilnesserr
     - paralleltest
+    - spancheck
     - staticcheck
     - thelper
     - tparallel

--- a/platform/fabric/core/generic/delivery/delivery_test.go
+++ b/platform/fabric/core/generic/delivery/delivery_test.go
@@ -293,8 +293,8 @@ func TestHandleBlockResponse(t *testing.T) {
 
 	newSpan := func(t *testing.T) trace.Span {
 		t.Helper()
-		_, span := noop.NewTracerProvider().Tracer("test").Start(t.Context(), "span")
-		return span
+		_, span := noop.NewTracerProvider().Tracer("test").Start(t.Context(), "span") //nolint:spancheck // handleBlockResponse's callers own ending the span (see delivery.go); this is a noop span used only as a test fixture.
+		return span                                                                   //nolint:spancheck // same as above
 	}
 
 	t.Run("nil block is rejected, not dereferenced", func(t *testing.T) {

--- a/platform/view/services/comm/host/websocket/ws/multiplexed_provider.go
+++ b/platform/view/services/comm/host/websocket/ws/multiplexed_provider.go
@@ -394,7 +394,7 @@ func (c *multiplexedServerConn) newServerSubConn(newStreamCallback func(pStream 
 	if err != nil {
 		logger.Debugf("failed to unmarshal span context: %v", err)
 	}
-	ctx, span := c.tracer.Start(trace.ContextWithRemoteSpanContext(context.Background(), spanContext), "IncomingViewInvocation", tracing.WithAttributes(
+	ctx, span := c.tracer.Start(trace.ContextWithRemoteSpanContext(context.Background(), spanContext), "IncomingViewInvocation", tracing.WithAttributes( //nolint:spancheck // span is handed off to subConnWithSpan, whose Close() ends it (see below)
 		tracing.String(contextIDLabel, defaultContextIDLabel)))
 
 	sc := c.newSubConn(mm.ID)
@@ -409,7 +409,7 @@ func (c *multiplexedServerConn) newServerSubConn(newStreamCallback func(pStream 
 		ContextID:         meta.ContextID,
 		SessionID:         meta.SessionID,
 	}))
-}
+} //nolint:spancheck // span is handed off to subConnWithSpan, whose Close() ends it
 
 type multiplexedBaseConn struct {
 	writeMu sync.Mutex

--- a/platform/view/services/tracing/tracer.go
+++ b/platform/view/services/tracing/tracer.go
@@ -27,8 +27,11 @@ type tracer struct {
 	duration   metrics.Histogram
 }
 
+// Start returns the span to the caller, who owns ending it (span.End wraps
+// backingSpan.End, see span.go), so the missing-End findings here are false
+// positives.
 func (t *tracer) Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-	newCtx, backingSpan := t.backingTracer.Start(ctx, spanName, append(opts, WithAttributes(String(namespaceLabel, t.namespace)))...)
+	newCtx, backingSpan := t.backingTracer.Start(ctx, spanName, append(opts, WithAttributes(String(namespaceLabel, t.namespace)))...) //nolint:spancheck // caller owns ending the span, see comment above
 
-	return newCtx, newSpan(backingSpan, t.labelNames, t.operations, t.duration, opts...)
+	return newCtx, newSpan(backingSpan, t.labelNames, t.operations, t.duration, opts...) //nolint:spancheck // caller owns ending the span, see comment above
 }

--- a/platform/view/services/view/context.go
+++ b/platform/view/services/view/context.go
@@ -250,7 +250,7 @@ func (c *Context) StartSpan(name string, opts ...trace.SpanStartOption) trace.Sp
 
 // StartSpanFrom creates a new child span from the passed context.
 func (c *Context) StartSpanFrom(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-	return c.tracer.Start(ctx, name, opts...)
+	return c.tracer.Start(ctx, name, opts...) //nolint:spancheck // span is returned to the caller, who owns ending it (see e.g. platform/view/services/view/view.go's `defer span.End()` after calling this)
 }
 
 // ID returns the identifier of this context.


### PR DESCRIPTION
`spancheck` flags an OpenTelemetry span that's created but never ended (`span.End()`), or an error that's returned without being recorded on the span.

Part of #1755.

### Scoping

Seven findings, all in the root module, all missing-`End` false positives — every flagged span is deliberately handed off to a caller or wrapper that ends it, not leaked.

- `platform/fabric/core/generic/delivery/delivery_test.go:296-297` — test helper `newSpan` creates a noop span mirroring `handleBlockResponse`'s real contract (`delivery.go`), where callers own ending the span. Suppressed.
- `platform/view/services/comm/host/websocket/ws/multiplexed_provider.go:397,412` — the span is wrapped in `subConnWithSpan`, whose `Close()` calls `span.End()`. Suppressed.
- `platform/view/services/tracing/tracer.go:31,33` — `tracer.Start` returns the span to its caller; `span.End` (`span.go`) wraps `backingSpan.End`. Suppressed.
- `platform/view/services/view/context.go:253` — `Context.StartSpanFrom` returns the span to its caller (e.g. `view.go` calls `defer span.End()` right after). Suppressed.

No genuine span leak among the seven; all are trivial "factory hands span to owner" shapes that `spancheck`'s dataflow analysis can't see across function/struct boundaries. Each `//nolint:spancheck` names why.

### Verification

`make checks` exits 0 across all four modules.

### Note for reviewers

This branch is independent — rooted directly on current `main`, not stacked on any other wave-3 PR. It should merge cleanly regardless of the order the other wave-3 PRs land in.
