### PR TITLE
chore(lint): enable predeclared in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - misspell
     - nilnesserr
     - paralleltest
+    - predeclared
     - staticcheck
     - thelper
     - tparallel

--- a/integration/nwo/fabric/network/network_support.go
+++ b/integration/nwo/fabric/network/network_support.go
@@ -1540,7 +1540,7 @@ func (n *Network) GenerateOrdererConfig(o *topology.Orderer) {
 	t, err := template.New("orderer").Funcs(template.FuncMap{
 		"Orderer":    func() *topology.Orderer { return o },
 		"ToLower":    func(s string) string { return strings.ToLower(s) },
-		"ReplaceAll": func(s, old, new string) string { return strings.ReplaceAll(s, old, new) },
+		"ReplaceAll": func(s, old, replacement string) string { return strings.ReplaceAll(s, old, replacement) },
 		"TLSEnabled": func() bool { return tlsEnabled },
 	}).Parse(n.Templates.OrdererTemplate())
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -1567,7 +1567,7 @@ func (n *Network) GenerateCoreConfig(p *topology.Peer) {
 			"Orderer":                   func() *topology.Orderer { return n.Orderers[0] },
 			"PeerLocalExtraIdentityDir": func(p *topology.Peer, id string) string { return n.PeerLocalExtraIdentityDir(p, id) },
 			"ToLower":                   func(s string) string { return strings.ToLower(s) },
-			"ReplaceAll":                func(s, old, new string) string { return strings.ReplaceAll(s, old, new) },
+			"ReplaceAll":                func(s, old, replacement string) string { return strings.ReplaceAll(s, old, replacement) },
 		}).Parse(coreTemplate)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -1619,7 +1619,7 @@ func (n *Network) RenderFSCFabricExtension(p *topology.Peer) (string, error) {
 		"Orderers":                  func() []*topology.Orderer { return n.Orderers },
 		"PeerLocalExtraIdentityDir": func(p *topology.Peer, id string) string { return n.PeerLocalExtraIdentityDir(p, id) },
 		"ToLower":                   func(s string) string { return strings.ToLower(s) },
-		"ReplaceAll":                func(s, old, new string) string { return strings.ReplaceAll(s, old, new) },
+		"ReplaceAll":                func(s, old, replacement string) string { return strings.ReplaceAll(s, old, replacement) },
 		"Peers":                     func() []*topology.Peer { return refPeers },
 		"OrdererAddress":            func(o *topology.Orderer, portName api.PortName) string { return n.OrdererAddress(o, portName) },
 		"PeerAddress":               func(o *topology.Peer, portName api.PortName) string { return n.PeerAddress(o, portName) },

--- a/integration/nwo/fsc/fsc.go
+++ b/integration/nwo/fsc/fsc.go
@@ -580,7 +580,7 @@ func (p *Platform) GenerateCoreConfig(peer *node2.Replica) {
 		"Topology":     func() *Topology { return p.Topology },
 		"Extensions":   func() []string { return extensions },
 		"ToLower":      func(s string) string { return strings.ToLower(s) },
-		"ReplaceAll":   func(s, old, new string) string { return strings.ReplaceAll(s, old, new) },
+		"ReplaceAll":   func(s, old, replacement string) string { return strings.ReplaceAll(s, old, replacement) },
 		"Persistences": func() map[driver.PersistenceName]node2.PersistenceOpts { return persistences },
 		"Resolvers":    func() []*Resolver { return resolvers },
 		"WebEnabled":   func() bool { return p.Topology.WebEnabled },

--- a/platform/fabric/core/generic/delivery/random.go
+++ b/platform/fabric/core/generic/delivery/random.go
@@ -27,16 +27,16 @@ const (
 	NonceSize = 24
 )
 
-// GetRandomBytes returns len random looking bytes
-func GetRandomBytes(len int) ([]byte, error) {
-	key := make([]byte, len)
+// GetRandomBytes returns n random looking bytes
+func GetRandomBytes(n int) ([]byte, error) {
+	key := make([]byte, n)
 
-	n, err := rand.Read(key)
+	read, err := rand.Read(key)
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting random bytes")
 	}
-	if n != len {
-		return nil, errors.Errorf("failed to get [%d] bytes", len)
+	if read != n {
+		return nil, errors.Errorf("failed to get [%d] bytes", n)
 	}
 
 	return key, nil

--- a/platform/fabric/core/generic/fabricutils/utils.go
+++ b/platform/fabric/core/generic/fabricutils/utils.go
@@ -177,8 +177,8 @@ func CreateEndorserTX(signer SerializableSigner, proposal driver.Proposal, resps
 	}
 
 	// serialize the chaincode action payload
-	cap := &peer.ChaincodeActionPayload{ChaincodeProposalPayload: propPayloadBytes, Action: cea}
-	capBytes, err := protoutil.GetBytesChaincodeActionPayload(cap)
+	actionPayload := &peer.ChaincodeActionPayload{ChaincodeProposalPayload: propPayloadBytes, Action: cea}
+	capBytes, err := protoutil.GetBytesChaincodeActionPayload(actionPayload)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/platform/fabric/core/generic/ledger/version/util_test.go
+++ b/platform/fabric/core/generic/ledger/version/util_test.go
@@ -43,12 +43,12 @@ func TestDecodingAppendedValues(t *testing.T) {
 		appendedValues = append(appendedValues, encodeOrderPreservingVarUint64(uint64(i))...)
 	}
 
-	len := 0
+	consumed := 0
 	value := uint64(0)
 	var err error
 	for i := range 1000 {
-		appendedValues = appendedValues[len:]
-		value, len, err = decodeOrderPreservingVarUint64(appendedValues)
+		appendedValues = appendedValues[consumed:]
+		value, consumed, err = decodeOrderPreservingVarUint64(appendedValues)
 		require.NoError(t, err, "Error via calling DecodeOrderPreservingVarUint64")
 		require.Equalf(t, value, uint64(i), "expected value = [%d], decode value = [%d]", i, value)
 	}

--- a/platform/fabric/core/generic/ordering/client_test.go
+++ b/platform/fabric/core/generic/ordering/client_test.go
@@ -65,7 +65,7 @@ func (m *mockBroadcast) CloseSend() error {
 	return nil
 }
 
-func (m *mockBroadcast) getCalls() (send, recv, close int) {
+func (m *mockBroadcast) getCalls() (send, recv, closeCalls int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.sendCalls, m.recvCalls, m.closeCalls

--- a/platform/fabric/core/generic/rwset/envelope.go
+++ b/platform/fabric/core/generic/rwset/envelope.go
@@ -75,12 +75,12 @@ func UnpackEnvelopeFromPayloadAndCHHeader(networkID string, payl *common.Payload
 		return nil, err
 	}
 
-	cap, err := protoutil.UnmarshalChaincodeActionPayload(tx.Actions[0].Payload)
+	actionPayload, err := protoutil.UnmarshalChaincodeActionPayload(tx.Actions[0].Payload)
 	if err != nil {
 		logger.Errorf("VSCC error: GetChaincodeActionPayload failed, err %s", err)
 		return nil, err
 	}
-	cpp, err := protoutil.UnmarshalChaincodeProposalPayload(cap.ChaincodeProposalPayload)
+	cpp, err := protoutil.UnmarshalChaincodeProposalPayload(actionPayload.ChaincodeProposalPayload)
 	if err != nil {
 		logger.Errorf("VSCC error: GetChaincodeProposalPayload failed, err %s", err)
 		return nil, err
@@ -91,7 +91,7 @@ func UnpackEnvelopeFromPayloadAndCHHeader(networkID string, payl *common.Payload
 		return nil, err
 	}
 
-	pRespPayload, err := protoutil.UnmarshalProposalResponsePayload(cap.Action.ProposalResponsePayload)
+	pRespPayload, err := protoutil.UnmarshalProposalResponsePayload(actionPayload.Action.ProposalResponsePayload)
 	if err != nil {
 		err = errors.Errorf("GetProposalResponsePayload error %s", err)
 		return nil, err
@@ -112,10 +112,10 @@ func UnpackEnvelopeFromPayloadAndCHHeader(networkID string, payl *common.Payload
 	}
 
 	var proposalResponses []*peer.ProposalResponse
-	for _, endorsement := range cap.Action.Endorsements {
+	for _, endorsement := range actionPayload.Action.Endorsements {
 		proposalResponses = append(proposalResponses,
 			&peer.ProposalResponse{
-				Payload:     cap.Action.ProposalResponsePayload,
+				Payload:     actionPayload.Action.ProposalResponsePayload,
 				Endorsement: endorsement,
 			})
 	}

--- a/platform/fabric/core/generic/transaction/envelope.go
+++ b/platform/fabric/core/generic/transaction/envelope.go
@@ -163,11 +163,11 @@ func UnpackEnvelopePayload(payloadRaw []byte) (*UnpackedEnvelope, int32, error) 
 	if len(tx.Actions) == 0 {
 		return nil, chdr.Type, errors.Errorf("VSCC error: transaction has no actions")
 	}
-	cap, err := protoutil.UnmarshalChaincodeActionPayload(tx.Actions[0].Payload)
+	actionPayload, err := protoutil.UnmarshalChaincodeActionPayload(tx.Actions[0].Payload)
 	if err != nil {
 		return nil, chdr.Type, errors.Wrap(err, "VSCC error: GetChaincodeActionPayload failed")
 	}
-	cpp, err := protoutil.UnmarshalChaincodeProposalPayload(cap.ChaincodeProposalPayload)
+	cpp, err := protoutil.UnmarshalChaincodeProposalPayload(actionPayload.ChaincodeProposalPayload)
 	if err != nil {
 		return nil, chdr.Type, errors.Wrap(err, "VSCC error: GetChaincodeProposalPayload failed")
 	}
@@ -188,10 +188,10 @@ func UnpackEnvelopePayload(payloadRaw []byte) (*UnpackedEnvelope, int32, error) 
 		return nil, chdr.Type, errors.Errorf("chaincode invocation spec did not contain chaincode id")
 	}
 
-	if cap.Action == nil {
+	if actionPayload.Action == nil {
 		return nil, chdr.Type, errors.Errorf("VSCC error: chaincode action payload has no action")
 	}
-	pRespPayload, err := protoutil.UnmarshalProposalResponsePayload(cap.Action.ProposalResponsePayload)
+	pRespPayload, err := protoutil.UnmarshalProposalResponsePayload(actionPayload.Action.ProposalResponsePayload)
 	if err != nil {
 		return nil, chdr.Type, errors.Wrap(err, "failed to unmarshal proposal response payload")
 	}
@@ -209,18 +209,18 @@ func UnpackEnvelopePayload(payloadRaw []byte) (*UnpackedEnvelope, int32, error) 
 		"len(payl.Header.SignatureHeader) [%d] - "+
 		"len(payl.Data) [%d] - "+
 		"len(tx.Actions[0].Payload) [%d] - "+
-		"len(cap.ChaincodeProposalPayload) [%d] - "+
+		"len(actionPayload.ChaincodeProposalPayload) [%d] - "+
 		"len(cpp.Input) [%d] - "+
-		"len(cap.Action.ProposalResponsePayload) [%d] - "+
+		"len(actionPayload.Action.ProposalResponsePayload) [%d] - "+
 		"len(pRespPayload.Extension) [%d]",
 		len(payloadRaw),
 		len(payl.Header.ChannelHeader),
 		len(payl.Header.SignatureHeader),
 		len(payl.Data),
 		len(tx.Actions[0].Payload),
-		len(cap.ChaincodeProposalPayload),
+		len(actionPayload.ChaincodeProposalPayload),
 		len(cpp.Input),
-		len(cap.Action.ProposalResponsePayload),
+		len(actionPayload.Action.ProposalResponsePayload),
 		len(pRespPayload.Extension),
 	)
 
@@ -230,10 +230,10 @@ func UnpackEnvelopePayload(payloadRaw []byte) (*UnpackedEnvelope, int32, error) 
 	}
 
 	var proposalResponses []*peer.ProposalResponse
-	for _, endorsement := range cap.Action.Endorsements {
+	for _, endorsement := range actionPayload.Action.Endorsements {
 		proposalResponses = append(proposalResponses,
 			&peer.ProposalResponse{
-				Payload:     cap.Action.ProposalResponsePayload,
+				Payload:     actionPayload.Action.ProposalResponsePayload,
 				Endorsement: endorsement,
 			})
 	}

--- a/platform/fabric/core/generic/transaction/envelope_test.go
+++ b/platform/fabric/core/generic/transaction/envelope_test.go
@@ -75,7 +75,7 @@ func createEnvelopeWithArgs(tb testing.TB, args [][]byte) *common.Envelope {
 	cppBytes, err := proto.Marshal(cpp)
 	require.NoError(tb, err)
 
-	cap := &peer.ChaincodeActionPayload{
+	actionPayload := &peer.ChaincodeActionPayload{
 		ChaincodeProposalPayload: cppBytes,
 		Action: &peer.ChaincodeEndorsedAction{
 			ProposalResponsePayload: prpBytes,
@@ -84,7 +84,7 @@ func createEnvelopeWithArgs(tb testing.TB, args [][]byte) *common.Envelope {
 			},
 		},
 	}
-	capBytes, err := proto.Marshal(cap)
+	capBytes, err := proto.Marshal(actionPayload)
 	require.NoError(tb, err)
 
 	txAction := &peer.TransactionAction{

--- a/platform/fabric/core/protoutil/proputils.go
+++ b/platform/fabric/core/protoutil/proputils.go
@@ -28,11 +28,11 @@ func GetBytesChaincodeProposalPayload(cpp *peer.ChaincodeProposalPayload) ([]byt
 
 // GetBytesChaincodeActionPayload get the bytes of ChaincodeActionPayload from
 // the message
-func GetBytesChaincodeActionPayload(cap *peer.ChaincodeActionPayload) ([]byte, error) {
-	if cap == nil {
+func GetBytesChaincodeActionPayload(actionPayload *peer.ChaincodeActionPayload) ([]byte, error) {
+	if actionPayload == nil {
 		return nil, errors.New("error marshaling ChaincodeActionPayload: proto: Marshal called with nil")
 	}
-	capBytes, err := Marshal(cap)
+	capBytes, err := Marshal(actionPayload)
 	return capBytes, errors.Wrap(err, "error marshaling ChaincodeActionPayload")
 }
 

--- a/platform/view/services/comm/random.go
+++ b/platform/view/services/comm/random.go
@@ -27,11 +27,11 @@ const (
 	NonceSize = 24
 )
 
-// GetRandomBytes returns len random looking bytes
-func GetRandomBytes(len int) ([]byte, error) {
-	key := make([]byte, len)
+// GetRandomBytes returns n random looking bytes
+func GetRandomBytes(n int) ([]byte, error) {
+	key := make([]byte, n)
 
-	// TODO: rand could fill less bytes then len
+	// TODO: rand could fill less bytes then n
 	_, err := rand.Read(key)
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting random bytes")

--- a/platform/view/services/comm/session/random.go
+++ b/platform/view/services/comm/session/random.go
@@ -27,11 +27,11 @@ const (
 	NonceSize = 24
 )
 
-// GetRandomBytes returns len random looking bytes
-func GetRandomBytes(len int) ([]byte, error) {
-	key := make([]byte, len)
+// GetRandomBytes returns n random looking bytes
+func GetRandomBytes(n int) ([]byte, error) {
+	key := make([]byte, n)
 
-	// TODO: rand could fill less bytes then len
+	// TODO: rand could fill less bytes then n
 	_, err := rand.Read(key)
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting random bytes")


### PR DESCRIPTION
`predeclared` flags identifiers that shadow Go's predeclared names (`len`, `cap`, `new`, `close`, ...).

Part of #1755.

### Scoping

14 findings: 10 in the root module and 4 in the integration module (a separate Go module). All flagged identifiers were unexported parameters or locals — no exported fields, methods, or types — so each was renamed at its declaration and every use site. No behavior change.

### Verification

`make checks` exits 0 across all four modules.

### Note for reviewers

This branch is independent — rooted directly on current `main`, not stacked on any other wave-3 PR. It should merge cleanly regardless of the order the other wave-3 PRs land in.
