### PR TITLE
chore(lint): enable errorlint in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     # future `default: none` cannot silently drop them.
     - durationcheck
     - errcheck
+    - errorlint
     - goheader
     - gosec
     - govet

--- a/integration/fabric/atsachaincode/chaincode/asset_transfer.go
+++ b/integration/fabric/atsachaincode/chaincode/asset_transfer.go
@@ -66,7 +66,7 @@ func (s *SmartContract) CreateAsset(ctx contractapi.TransactionContextInterface,
 	// In this scenario, client is only authorized to read/write private data from its own peer.
 	clientOrgID, err := getClientOrgID(ctx, true)
 	if err != nil {
-		return fmt.Errorf("failed to get verified OrgID: %v", err)
+		return errors.Wrapf(err, "failed to get verified OrgID")
 	}
 
 	asset := Asset{
@@ -77,25 +77,25 @@ func (s *SmartContract) CreateAsset(ctx contractapi.TransactionContextInterface,
 	}
 	assetBytes, err := json.Marshal(asset)
 	if err != nil {
-		return fmt.Errorf("failed to create asset JSON: %v", err)
+		return errors.Wrapf(err, "failed to create asset JSON")
 	}
 
 	err = ctx.GetStub().PutState(asset.ID, assetBytes)
 	if err != nil {
-		return fmt.Errorf("failed to put asset in public data: %v", err)
+		return errors.Wrapf(err, "failed to put asset in public data")
 	}
 
 	// Set the endorsement policy such that an owner org peer is required to endorse future updates
 	err = setAssetStateBasedEndorsement(ctx, asset.ID, clientOrgID)
 	if err != nil {
-		return fmt.Errorf("failed setting state based endorsement for owner: %v", err)
+		return errors.Wrapf(err, "failed setting state based endorsement for owner")
 	}
 
 	// Persist private immutable asset properties to owner's private data collection
 	collection := buildCollectionName(clientOrgID)
 	err = ctx.GetStub().PutPrivateData(collection, asset.ID, immutablePropertiesJSON)
 	if err != nil {
-		return fmt.Errorf("failed to put Asset private details: %v", err)
+		return errors.Wrapf(err, "failed to put Asset private details")
 	}
 
 	return nil
@@ -107,13 +107,13 @@ func (s *SmartContract) ChangePublicDescription(ctx contractapi.TransactionConte
 	fmt.Println("get client org id")
 	clientOrgID, err := getClientOrgID(ctx, false)
 	if err != nil {
-		return fmt.Errorf("failed to get verified OrgID: %v", err)
+		return errors.Wrapf(err, "failed to get verified OrgID")
 	}
 
 	fmt.Println("read asset")
 	asset, err := s.ReadAsset(ctx, assetID)
 	if err != nil {
-		return fmt.Errorf("failed to get asset: %v", err)
+		return errors.Wrapf(err, "failed to get asset")
 	}
 
 	fmt.Println("check org")
@@ -126,7 +126,7 @@ func (s *SmartContract) ChangePublicDescription(ctx contractapi.TransactionConte
 	asset.PublicDescription = newDescription
 	updatedAssetJSON, err := json.Marshal(asset)
 	if err != nil {
-		return fmt.Errorf("failed to marshal asset: %v", err)
+		return errors.Wrapf(err, "failed to marshal asset")
 	}
 
 	return ctx.GetStub().PutState(assetID, updatedAssetJSON)
@@ -141,7 +141,7 @@ func (s *SmartContract) AgreeToSell(ctx contractapi.TransactionContextInterface,
 
 	clientOrgID, err := getClientOrgID(ctx, true)
 	if err != nil {
-		return fmt.Errorf("failed to get verified OrgID: %v", err)
+		return errors.Wrapf(err, "failed to get verified OrgID")
 	}
 
 	// Verify that this clientOrgId actually owns the asset.
@@ -162,12 +162,12 @@ func agreeToPrice(ctx contractapi.TransactionContextInterface, assetID, priceTyp
 	// In this scenario, client is only authorized to read/write private data from its own peer.
 	clientOrgID, err := getClientOrgID(ctx, true)
 	if err != nil {
-		return fmt.Errorf("failed to get verified OrgID: %v", err)
+		return errors.Wrapf(err, "failed to get verified OrgID")
 	}
 
 	transMap, err := ctx.GetStub().GetTransient()
 	if err != nil {
-		return fmt.Errorf("error getting transient: %v", err)
+		return errors.Wrapf(err, "error getting transient")
 	}
 
 	// Asset price must be retrieved from the transient field as they are private
@@ -182,14 +182,14 @@ func agreeToPrice(ctx contractapi.TransactionContextInterface, assetID, priceTyp
 	// to avoid collisions between private asset properties, sell price, and buy price
 	assetPriceKey, err := ctx.GetStub().CreateCompositeKey(priceType, []string{assetID})
 	if err != nil {
-		return fmt.Errorf("failed to create composite key: %v", err)
+		return errors.Wrapf(err, "failed to create composite key")
 	}
 
 	// The Price hash will be verified later, therefore always pass and persist price bytes as is,
 	// so that there is no risk of nondeterministic marshaling.
 	err = ctx.GetStub().PutPrivateData(collection, assetPriceKey, price)
 	if err != nil {
-		return fmt.Errorf("failed to put asset bid: %v", err)
+		return errors.Wrapf(err, "failed to put asset bid")
 	}
 
 	return nil
@@ -200,7 +200,7 @@ func agreeToPrice(ctx contractapi.TransactionContextInterface, assetID, priceTyp
 func (s *SmartContract) VerifyAssetProperties(ctx contractapi.TransactionContextInterface, assetID string) (bool, error) {
 	transMap, err := ctx.GetStub().GetTransient()
 	if err != nil {
-		return false, fmt.Errorf("error getting transient: %v", err)
+		return false, errors.Wrapf(err, "error getting transient")
 	}
 
 	// / Asset properties must be retrieved from the transient field as they are private
@@ -211,13 +211,13 @@ func (s *SmartContract) VerifyAssetProperties(ctx contractapi.TransactionContext
 
 	asset, err := s.ReadAsset(ctx, assetID)
 	if err != nil {
-		return false, fmt.Errorf("failed to get asset: %v", err)
+		return false, errors.Wrapf(err, "failed to get asset")
 	}
 
 	collectionOwner := buildCollectionName(asset.OwnerOrg)
 	immutablePropertiesOnChainHash, err := ctx.GetStub().GetPrivateDataHash(collectionOwner, assetID)
 	if err != nil {
-		return false, fmt.Errorf("failed to read asset private properties hash from seller's collection: %v", err)
+		return false, errors.Wrapf(err, "failed to read asset private properties hash from seller's collection")
 	}
 	if immutablePropertiesOnChainHash == nil {
 		return false, fmt.Errorf("asset private properties hash does not exist: %s", assetID)
@@ -243,12 +243,12 @@ func (s *SmartContract) VerifyAssetProperties(ctx contractapi.TransactionContext
 func (s *SmartContract) TransferAsset(ctx contractapi.TransactionContextInterface, assetID, buyerOrgID string) error {
 	clientOrgID, err := getClientOrgID(ctx, false)
 	if err != nil {
-		return fmt.Errorf("failed to get verified OrgID: %v", err)
+		return errors.Wrapf(err, "failed to get verified OrgID")
 	}
 
 	transMap, err := ctx.GetStub().GetTransient()
 	if err != nil {
-		return fmt.Errorf("error getting transient data: %v", err)
+		return errors.Wrapf(err, "error getting transient data")
 	}
 
 	immutablePropertiesJSON, ok := transMap["asset_properties"]
@@ -264,22 +264,22 @@ func (s *SmartContract) TransferAsset(ctx contractapi.TransactionContextInterfac
 	var agreement Agreement
 	err = json.Unmarshal(priceJSON, &agreement)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal price JSON: %v", err)
+		return errors.Wrapf(err, "failed to unmarshal price JSON")
 	}
 
 	asset, err := s.ReadAsset(ctx, assetID)
 	if err != nil {
-		return fmt.Errorf("failed to get asset: %v", err)
+		return errors.Wrapf(err, "failed to get asset")
 	}
 
 	err = verifyTransferConditions(ctx, asset, immutablePropertiesJSON, clientOrgID, buyerOrgID, priceJSON)
 	if err != nil {
-		return fmt.Errorf("failed transfer verification: %v", err)
+		return errors.Wrapf(err, "failed transfer verification")
 	}
 
 	err = transferAssetState(ctx, asset, immutablePropertiesJSON, clientOrgID, buyerOrgID, agreement.Price)
 	if err != nil {
-		return fmt.Errorf("failed asset transfer: %v", err)
+		return errors.Wrapf(err, "failed asset transfer")
 	}
 
 	return nil
@@ -304,7 +304,7 @@ func verifyTransferConditions(ctx contractapi.TransactionContextInterface,
 	collectionSeller := buildCollectionName(clientOrgID)
 	immutablePropertiesOnChainHash, err := ctx.GetStub().GetPrivateDataHash(collectionSeller, asset.ID)
 	if err != nil {
-		return fmt.Errorf("failed to read asset private properties hash from seller's collection: %v", err)
+		return errors.Wrapf(err, "failed to read asset private properties hash from seller's collection")
 	}
 	if immutablePropertiesOnChainHash == nil {
 		return fmt.Errorf("asset private properties hash does not exist: %s", asset.ID)
@@ -328,11 +328,11 @@ func verifyTransferConditions(ctx contractapi.TransactionContextInterface,
 	// Get sellers asking price
 	assetForSaleKey, err := ctx.GetStub().CreateCompositeKey(typeAssetForSale, []string{asset.ID})
 	if err != nil {
-		return fmt.Errorf("failed to create composite key: %v", err)
+		return errors.Wrapf(err, "failed to create composite key")
 	}
 	sellerPriceHash, err := ctx.GetStub().GetPrivateDataHash(collectionSeller, assetForSaleKey)
 	if err != nil {
-		return fmt.Errorf("failed to get seller price hash: %v", err)
+		return errors.Wrapf(err, "failed to get seller price hash")
 	}
 	if sellerPriceHash == nil {
 		return fmt.Errorf("seller price for %s does not exist", asset.ID)
@@ -342,11 +342,11 @@ func verifyTransferConditions(ctx contractapi.TransactionContextInterface,
 	collectionBuyer := buildCollectionName(buyerOrgID)
 	assetBidKey, err := ctx.GetStub().CreateCompositeKey(typeAssetBid, []string{asset.ID})
 	if err != nil {
-		return fmt.Errorf("failed to create composite key: %v", err)
+		return errors.Wrapf(err, "failed to create composite key")
 	}
 	buyerPriceHash, err := ctx.GetStub().GetPrivateDataHash(collectionBuyer, assetBidKey)
 	if err != nil {
-		return fmt.Errorf("failed to get buyer price hash: %v", err)
+		return errors.Wrapf(err, "failed to get buyer price hash")
 	}
 	if buyerPriceHash == nil {
 		return fmt.Errorf("buyer price for %s does not exist", asset.ID)
@@ -409,21 +409,21 @@ func updateAssetState(ctx contractapi.TransactionContextInterface, asset *Asset)
 		return err
 	}
 	if err := ctx.GetStub().PutState(asset.ID, updatedAsset); err != nil {
-		return fmt.Errorf("failed to write asset for buyer: %v", err)
+		return errors.Wrapf(err, "failed to write asset for buyer")
 	}
 	if err := setAssetStateBasedEndorsement(ctx, asset.ID, asset.OwnerOrg); err != nil {
-		return fmt.Errorf("failed setting state based endorsement for new owner: %v", err)
+		return errors.Wrapf(err, "failed setting state based endorsement for new owner")
 	}
 	return nil
 }
 
 func updatePrivateDataCollections(ctx contractapi.TransactionContextInterface, assetID string, data []byte, collectionSeller, collectionBuyer string) error {
 	if err := ctx.GetStub().DelPrivateData(collectionSeller, assetID); err != nil {
-		return fmt.Errorf("failed to delete Asset private details from seller: %v", err)
+		return errors.Wrapf(err, "failed to delete Asset private details from seller")
 	}
 
 	if err := ctx.GetStub().PutPrivateData(collectionBuyer, assetID, data); err != nil {
-		return fmt.Errorf("failed to put Asset private properties for buyer: %v", err)
+		return errors.Wrapf(err, "failed to put Asset private properties for buyer")
 	}
 	return nil
 }
@@ -431,18 +431,18 @@ func updatePrivateDataCollections(ctx contractapi.TransactionContextInterface, a
 func deleteAssetPrices(ctx contractapi.TransactionContextInterface, assetID, collectionSeller, collectionBuyer string) error {
 	assetPriceKey, err := ctx.GetStub().CreateCompositeKey(typeAssetForSale, []string{assetID})
 	if err != nil {
-		return fmt.Errorf("failed to create composite key for seller: %v", err)
+		return errors.Wrapf(err, "failed to create composite key for seller")
 	}
 	if err := ctx.GetStub().DelPrivateData(collectionSeller, assetPriceKey); err != nil {
-		return fmt.Errorf("failed to delete asset price from implicit private data collection for seller: %v", err)
+		return errors.Wrapf(err, "failed to delete asset price from implicit private data collection for seller")
 	}
 
 	assetPriceKey, err = ctx.GetStub().CreateCompositeKey(typeAssetBid, []string{assetID})
 	if err != nil {
-		return fmt.Errorf("failed to create composite key for buyer: %v", err)
+		return errors.Wrapf(err, "failed to create composite key for buyer")
 	}
 	if err := ctx.GetStub().DelPrivateData(collectionBuyer, assetPriceKey); err != nil {
-		return fmt.Errorf("failed to delete asset price from implicit private data collection for buyer: %v", err)
+		return errors.Wrapf(err, "failed to delete asset price from implicit private data collection for buyer")
 	}
 	return nil
 }
@@ -450,12 +450,12 @@ func deleteAssetPrices(ctx contractapi.TransactionContextInterface, assetID, col
 func recordReceipts(ctx contractapi.TransactionContextInterface, assetID, collectionSeller, collectionBuyer string, price int) error {
 	receiptBuyKey, err := ctx.GetStub().CreateCompositeKey(typeAssetBuyReceipt, []string{assetID, ctx.GetStub().GetTxID()})
 	if err != nil {
-		return fmt.Errorf("failed to create composite key for receipt: %v", err)
+		return errors.Wrapf(err, "failed to create composite key for receipt")
 	}
 
 	txTimestamp, err := ctx.GetStub().GetTxTimestamp()
 	if err != nil {
-		return fmt.Errorf("failed to create timestamp for receipt: %v", err)
+		return errors.Wrapf(err, "failed to create timestamp for receipt")
 	}
 
 	if err := txTimestamp.CheckValid(); err != nil {
@@ -469,22 +469,22 @@ func recordReceipts(ctx contractapi.TransactionContextInterface, assetID, collec
 	}
 	receipt, err := json.Marshal(assetReceipt)
 	if err != nil {
-		return fmt.Errorf("failed to marshal receipt: %v", err)
+		return errors.Wrapf(err, "failed to marshal receipt")
 	}
 
 	err = ctx.GetStub().PutPrivateData(collectionBuyer, receiptBuyKey, receipt)
 	if err != nil {
-		return fmt.Errorf("failed to put private asset receipt for buyer: %v", err)
+		return errors.Wrapf(err, "failed to put private asset receipt for buyer")
 	}
 
 	receiptSaleKey, err := ctx.GetStub().CreateCompositeKey(typeAssetSaleReceipt, []string{ctx.GetStub().GetTxID(), assetID})
 	if err != nil {
-		return fmt.Errorf("failed to create composite key for receipt: %v", err)
+		return errors.Wrapf(err, "failed to create composite key for receipt")
 	}
 
 	err = ctx.GetStub().PutPrivateData(collectionSeller, receiptSaleKey, receipt)
 	if err != nil {
-		return fmt.Errorf("failed to put private asset receipt for seller: %v", err)
+		return errors.Wrapf(err, "failed to put private asset receipt for seller")
 	}
 
 	return nil
@@ -498,7 +498,7 @@ func recordReceipts(ctx contractapi.TransactionContextInterface, assetID, collec
 func getClientOrgID(ctx contractapi.TransactionContextInterface, verifyOrg bool) (string, error) {
 	clientOrgID, err := ctx.GetClientIdentity().GetMSPID()
 	if err != nil {
-		return "", fmt.Errorf("failed getting client's orgID: %v", err)
+		return "", errors.Wrapf(err, "failed getting client's orgID")
 	}
 
 	if verifyOrg {
@@ -515,7 +515,7 @@ func getClientOrgID(ctx contractapi.TransactionContextInterface, verifyOrg bool)
 func verifyClientOrgMatchesPeerOrg(clientOrgID string) error {
 	peerOrgID, err := shim.GetMSPID()
 	if err != nil {
-		return fmt.Errorf("failed getting peer's orgID: %v", err)
+		return errors.Wrapf(err, "failed getting peer's orgID")
 	}
 
 	if clientOrgID != peerOrgID {
@@ -538,15 +538,15 @@ func setAssetStateBasedEndorsement(ctx contractapi.TransactionContextInterface, 
 	fmt.Printf("orgToEndorse [%s]\n", orgToEndorse)
 	err = endorsementPolicy.AddOrgs(statebased.RoleTypePeer, orgToEndorse)
 	if err != nil {
-		return fmt.Errorf("failed to add org to endorsement policy: %v", err)
+		return errors.Wrapf(err, "failed to add org to endorsement policy")
 	}
 	policy, err := endorsementPolicy.Policy()
 	if err != nil {
-		return fmt.Errorf("failed to create endorsement policy bytes from org: %v", err)
+		return errors.Wrapf(err, "failed to create endorsement policy bytes from org")
 	}
 	err = ctx.GetStub().SetStateValidationParameter(assetID, policy)
 	if err != nil {
-		return fmt.Errorf("failed to set validation parameter on asset: %v", err)
+		return errors.Wrapf(err, "failed to set validation parameter on asset")
 	}
 
 	return nil
@@ -559,7 +559,7 @@ func buildCollectionName(clientOrgID string) string {
 func getClientImplicitCollectionName(ctx contractapi.TransactionContextInterface) (string, error) {
 	clientOrgID, err := getClientOrgID(ctx, true)
 	if err != nil {
-		return "", fmt.Errorf("failed to get verified OrgID: %v", err)
+		return "", errors.Wrapf(err, "failed to get verified OrgID")
 	}
 
 	err = verifyClientOrgMatchesPeerOrg(clientOrgID)

--- a/integration/fabric/atsachaincode/chaincode/asset_transfer_queries.go
+++ b/integration/fabric/atsachaincode/chaincode/asset_transfer_queries.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hyperledger/fabric-contract-api-go/v2/contractapi"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
 )
 
@@ -37,7 +38,7 @@ func (s *SmartContract) ReadAsset(ctx contractapi.TransactionContextInterface, a
 	// Since only public data is accessed in this function, no access control is required
 	assetJSON, err := ctx.GetStub().GetState(assetID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read from world state: %v", err)
+		return nil, errors.Wrapf(err, "failed to read from world state")
 	}
 	if assetJSON == nil {
 		return nil, fmt.Errorf("%s does not exist", assetID)
@@ -61,7 +62,7 @@ func (s *SmartContract) GetAssetPrivateProperties(ctx contractapi.TransactionCon
 
 	immutableProperties, err := ctx.GetStub().GetPrivateData(collection, assetID)
 	if err != nil {
-		return "", fmt.Errorf("failed to read asset private properties from client org's collection: %v", err)
+		return "", errors.Wrapf(err, "failed to read asset private properties from client org's collection")
 	}
 	if immutableProperties == nil {
 		return "", fmt.Errorf("asset private details does not exist in client org's collection: %s", assetID)
@@ -89,12 +90,12 @@ func getAssetPrice(ctx contractapi.TransactionContextInterface, assetID, priceTy
 
 	assetPriceKey, err := ctx.GetStub().CreateCompositeKey(priceType, []string{assetID})
 	if err != nil {
-		return "", fmt.Errorf("failed to create composite key: %v", err)
+		return "", errors.Wrapf(err, "failed to create composite key")
 	}
 
 	price, err := ctx.GetStub().GetPrivateData(collection, assetPriceKey)
 	if err != nil {
-		return "", fmt.Errorf("failed to read asset price from implicit private data collection: %v", err)
+		return "", errors.Wrapf(err, "failed to read asset price from implicit private data collection")
 	}
 	if price == nil {
 		return "", fmt.Errorf("asset price does not exist: %s", assetID)
@@ -122,7 +123,7 @@ func queryAgreementsByType(ctx contractapi.TransactionContextInterface, agreeTyp
 	// Query for any object type starting with `agreeType`
 	agreementsIterator, err := ctx.GetStub().GetPrivateDataByPartialCompositeKey(collection, agreeType, []string{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to read from private data collection: %v", err)
+		return nil, errors.Wrapf(err, "failed to read from private data collection")
 	}
 	defer utils.IgnoreErrorFunc(agreementsIterator.Close)
 

--- a/integration/nwo/fabric/packager/external/platform.go
+++ b/integration/nwo/fabric/packager/external/platform.go
@@ -98,10 +98,10 @@ func (p *Platform) GetDeploymentPayload(codepath string, replacer replacer.Func)
 
 	path, raw := replacer("connection.json", "connection.json")
 	if err := WriteBytesToPackage(raw, path, tw); err != nil {
-		return nil, fmt.Errorf("error writing connection.json to tar: %s", err)
+		return nil, errors.Wrapf(err, "error writing connection.json to tar")
 	}
 	if err != nil {
-		return nil, fmt.Errorf("error writing connection.json to tar: %s", err)
+		return nil, errors.Wrapf(err, "error writing connection.json to tar")
 	}
 
 	err = tw.Close()
@@ -133,12 +133,12 @@ func WriteBytesToPackage(raw []byte, packagepath string, tw *tar.Writer) error {
 
 	err := tw.WriteHeader(header)
 	if err != nil {
-		return fmt.Errorf("failed to write header for %s", err)
+		return errors.Wrapf(err, "failed to write header")
 	}
 
 	_, err = io.Copy(tw, bytes.NewBuffer(raw))
 	if err != nil {
-		return fmt.Errorf("failed to write as %s: %s", packagepath, err)
+		return errors.Wrapf(err, "failed to write as %s", packagepath)
 	}
 
 	return nil

--- a/integration/nwo/fabric/packager/golang/list.go
+++ b/integration/nwo/fabric/packager/golang/list.go
@@ -9,6 +9,7 @@ package golang
 import (
 	"context"
 	"encoding/json"
+	errors2 "errors"
 	"io"
 	"os"
 	"os/exec"
@@ -99,7 +100,7 @@ func gopathDependencyPackageInfo(goos, goarch, pkg string) ([]PackageInfo, error
 }
 
 func wrapExitErr(err error, message string) error {
-	if ee, ok := err.(*exec.ExitError); ok {
+	if ee, ok := errors2.AsType[*exec.ExitError](err); ok {
 		return errors.Wrapf(err, message+" with: %s", strings.TrimRight(string(ee.Stderr), "\n\r\t"))
 	}
 	return errors.Wrap(err, message)

--- a/integration/nwo/fabric/packager/golang/writer.go
+++ b/integration/nwo/fabric/packager/golang/writer.go
@@ -10,11 +10,11 @@ import (
 	"archive/tar"
 	"bufio"
 	"bytes"
-	"fmt"
 	"io"
 	"os"
 	"time"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
 )
 
@@ -22,18 +22,18 @@ import (
 func WriteBytesToPackage(raw []byte, localpath, packagepath string, tw *tar.Writer) error {
 	fd, err := os.Open(localpath)
 	if err != nil {
-		return fmt.Errorf("%s: %s", localpath, err)
+		return errors.Wrapf(err, "%s", localpath)
 	}
 	defer utils.IgnoreErrorFunc(fd.Close)
 
 	fi, err := fd.Stat()
 	if err != nil {
-		return fmt.Errorf("%s: %s", localpath, err)
+		return errors.Wrapf(err, "%s", localpath)
 	}
 
 	header, err := tar.FileInfoHeader(fi, localpath)
 	if err != nil {
-		return fmt.Errorf("failed calculating FileInfoHeader: %s", err)
+		return errors.Wrapf(err, "failed calculating FileInfoHeader")
 	}
 
 	// Take the variance out of the tar by using zero time and fixed uid/gid.
@@ -51,12 +51,12 @@ func WriteBytesToPackage(raw []byte, localpath, packagepath string, tw *tar.Writ
 
 	err = tw.WriteHeader(header)
 	if err != nil {
-		return fmt.Errorf("failed to write header for %s: %s", localpath, err)
+		return errors.Wrapf(err, "failed to write header for %s", localpath)
 	}
 
 	_, err = io.Copy(tw, bytes.NewBuffer(raw))
 	if err != nil {
-		return fmt.Errorf("failed to write %s as %s: %s", localpath, packagepath, err)
+		return errors.Wrapf(err, "failed to write %s as %s", localpath, packagepath)
 	}
 
 	return nil
@@ -66,18 +66,18 @@ func WriteBytesToPackage(raw []byte, localpath, packagepath string, tw *tar.Writ
 func WriteFileToPackage(localpath, packagepath string, tw *tar.Writer) error {
 	fd, err := os.Open(localpath)
 	if err != nil {
-		return fmt.Errorf("%s: %s", localpath, err)
+		return errors.Wrapf(err, "%s", localpath)
 	}
 	defer utils.IgnoreErrorFunc(fd.Close)
 
 	fi, err := fd.Stat()
 	if err != nil {
-		return fmt.Errorf("%s: %s", localpath, err)
+		return errors.Wrapf(err, "%s", localpath)
 	}
 
 	header, err := tar.FileInfoHeader(fi, localpath)
 	if err != nil {
-		return fmt.Errorf("failed calculating FileInfoHeader: %s", err)
+		return errors.Wrapf(err, "failed calculating FileInfoHeader")
 	}
 
 	// Take the variance out of the tar by using zero time and fixed uid/gid.
@@ -94,13 +94,13 @@ func WriteFileToPackage(localpath, packagepath string, tw *tar.Writer) error {
 
 	err = tw.WriteHeader(header)
 	if err != nil {
-		return fmt.Errorf("failed to write header for %s: %s", localpath, err)
+		return errors.Wrapf(err, "failed to write header for %s", localpath)
 	}
 
 	is := bufio.NewReader(fd)
 	_, err = io.Copy(tw, is)
 	if err != nil {
-		return fmt.Errorf("failed to write %s as %s: %s", localpath, packagepath, err)
+		return errors.Wrapf(err, "failed to write %s as %s", localpath, packagepath)
 	}
 
 	return nil

--- a/integration/nwo/fabric/packager/golang/writer_test.go
+++ b/integration/nwo/fabric/packager/golang/writer_test.go
@@ -67,7 +67,7 @@ func TestWriteBytesToPackage(t *testing.T) {
 	b := make([]byte, 5)
 	n, err := tr.Read(b)
 	require.Equal(t, 5, n)
-	require.True(t, err == nil || err == io.EOF, "Error reading file from the archive") // go1.10 returns io.EOF
+	require.True(t, err == nil || errors.Is(err, io.EOF), "Error reading file from the archive") // go1.10 returns io.EOF
 	require.Equal(t, filecontent, string(b), "file content from archive does not equal original content")
 
 	t.Run("non existent file", func(t *testing.T) {
@@ -139,7 +139,7 @@ func TestWriteFileToPackage(t *testing.T) {
 	b := make([]byte, 5)
 	n, err := tr.Read(b)
 	require.Equal(t, 5, n)
-	require.True(t, err == nil || err == io.EOF, "Error reading file from the archive") // go1.10 returns io.EOF
+	require.True(t, err == nil || errors.Is(err, io.EOF), "Error reading file from the archive") // go1.10 returns io.EOF
 	require.Equal(t, filecontent, string(b), "file content from archive does not equal original content")
 
 	t.Run("non existent file", func(t *testing.T) {

--- a/platform/common/utils/collections/iterators/stream.go
+++ b/platform/common/utils/collections/iterators/stream.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package iterators
 
 import (
+	"errors"
 	"io"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
@@ -28,7 +29,7 @@ type streamIterator[T any] struct {
 func (it *streamIterator[T]) Next() (T, error) {
 	if n, err := it.cli.Recv(); err == nil {
 		return n, nil
-	} else if err == io.EOF {
+	} else if errors.Is(err, io.EOF) {
 		return utils.Zero[T](), nil
 	} else {
 		return utils.Zero[T](), err

--- a/platform/common/utils/dig/dig.go
+++ b/platform/common/utils/dig/dig.go
@@ -8,12 +8,13 @@ package utils
 
 import (
 	"bytes"
-	"errors"
+	errors2 "errors"
 	"fmt"
 	"runtime/debug"
 
 	"go.uber.org/dig"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services"
 )
 
@@ -36,7 +37,7 @@ func Register[T any](c invoker) error {
 	})
 	if err != nil {
 		debug.PrintStack()
-		return fmt.Errorf("failed registering type %T: %+v", *new(T), err)
+		return errors.Wrapf(err, "failed registering type %T", *new(T))
 	}
 	return nil
 }
@@ -46,7 +47,7 @@ func ProvideAll(c *dig.Container, constructors ...any) error {
 	for i, constructor := range constructors {
 		errs[i] = c.Provide(constructor)
 	}
-	return errors.Join(errs...)
+	return errors2.Join(errs...)
 }
 
 func Identity[T any]() func(T) T {

--- a/platform/fabric/core/generic/membership/channelconfig/orderer.go
+++ b/platform/fabric/core/generic/membership/channelconfig/orderer.go
@@ -226,7 +226,7 @@ func (oc *OrdererConfig) validateBatchTimeout() error {
 	var err error
 	oc.batchTimeout, err = time.ParseDuration(oc.protos.BatchTimeout.Timeout)
 	if err != nil {
-		return fmt.Errorf("attempted to set the batch timeout to a invalid value: %s", err)
+		return errors.Wrapf(err, "attempted to set the batch timeout to a invalid value")
 	}
 	if oc.batchTimeout <= 0 {
 		return fmt.Errorf("attempted to set the batch timeout to a non-positive value: %s", oc.batchTimeout)

--- a/platform/fabric/core/generic/membership/channelconfig/util.go
+++ b/platform/fabric/core/generic/membership/channelconfig/util.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package channelconfig
 
 import (
-	"fmt"
 	"math"
 	"os"
 
@@ -317,13 +316,13 @@ func MarshalEtcdRaftMetadata(md *etcdraft.ConfigMetadata) ([]byte, error) {
 		// path where they are persisted locally, then load these files to memory.
 		clientCert, err := os.ReadFile(string(c.GetClientTlsCert()))
 		if err != nil {
-			return nil, fmt.Errorf("cannot load client cert for consenter %s:%d: %s", c.GetHost(), c.GetPort(), err)
+			return nil, errors.Wrapf(err, "cannot load client cert for consenter %s:%d", c.GetHost(), c.GetPort())
 		}
 		c.ClientTlsCert = clientCert
 
 		serverCert, err := os.ReadFile(string(c.GetServerTlsCert()))
 		if err != nil {
-			return nil, fmt.Errorf("cannot load server cert for consenter %s:%d: %s", c.GetHost(), c.GetPort(), err)
+			return nil, errors.Wrapf(err, "cannot load server cert for consenter %s:%d", c.GetHost(), c.GetPort())
 		}
 		c.ServerTlsCert = serverCert
 	}

--- a/platform/fabric/core/msp/mspimplsetup.go
+++ b/platform/fabric/core/msp/mspimplsetup.go
@@ -26,13 +26,13 @@ func (msp *bccspmsp) getCertifiersIdentifier(certRaw []byte) ([]byte, error) {
 	// 1. check that certificate is registered in msp.rootCerts or msp.intermediateCerts
 	cert, err := msp.getCertFromPem(certRaw)
 	if err != nil {
-		return nil, fmt.Errorf("failed getting certificate for [%v]: [%s]", certRaw, err)
+		return nil, errors.Wrapf(err, "failed getting certificate for [%v]", certRaw)
 	}
 
 	// 2. Sanitize it to ensure like for like comparison
 	cert, err = msp.sanitizeCert(cert)
 	if err != nil {
-		return nil, fmt.Errorf("sanitizeCert failed %s", err)
+		return nil, errors.Wrapf(err, "sanitizeCert failed")
 	}
 
 	found := false
@@ -67,14 +67,14 @@ func (msp *bccspmsp) getCertifiersIdentifier(certRaw []byte) ([]byte, error) {
 	} else {
 		chain, err = msp.getValidationChain(cert, true)
 		if err != nil {
-			return nil, fmt.Errorf("failed computing validation chain for [%v]. [%s]", cert, err)
+			return nil, errors.Wrapf(err, "failed computing validation chain for [%v]", cert)
 		}
 	}
 
 	// 4. compute the hash of the certification path
 	certifiersIdentifier, err = msp.getCertificationChainIdentifierFromChain(chain)
 	if err != nil {
-		return nil, fmt.Errorf("failed computing Certifiers Identifier for [%v]. [%s]", certRaw, err)
+		return nil, errors.Wrapf(err, "failed computing Certifiers Identifier for [%v]", certRaw)
 	}
 
 	return certifiersIdentifier, nil

--- a/platform/fabric/services/db/driver/sql/common/vault.go
+++ b/platform/fabric/services/db/driver/sql/common/vault.go
@@ -447,7 +447,7 @@ func (db *vaultReader) GetStateMetadata(ctx context.Context, namespace driver.Na
 	var m []byte
 	var kversion driver.RawVersion
 	err = row.Scan(&m, &kversion)
-	if err != nil && err == sql.ErrNoRows {
+	if err != nil && errors2.Is(err, sql.ErrNoRows) {
 		return nil, nil, nil
 	}
 	if err != nil {

--- a/platform/view/services/grpc/server_test.go
+++ b/platform/view/services/grpc/server_test.go
@@ -94,7 +94,7 @@ func (ess *emptyServiceServer) EmptyCall(context.Context, *testpb.Empty) (*testp
 func (esss *emptyServiceServer) EmptyStream(stream testpb.EmptyService_EmptyStreamServer) error {
 	for {
 		_, err := stream.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {
@@ -152,7 +152,7 @@ func invokeEmptyStream(address string, dialOptions ...grpc.DialOption) (*testpb.
 	go func() {
 		for {
 			in, err := stream.Recv()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				close(waitc)
 				return
 			}
@@ -170,7 +170,7 @@ func invokeEmptyStream(address string, dialOptions ...grpc.DialOption) (*testpb.
 	// the server side has already terminated. Whether or not we get an error
 	// depends on timing.
 	err = stream.Send(&testpb.Empty{})
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, errors.Errorf("stream send failed: %s", err)
 	}
 

--- a/platform/view/services/storage/driver/sql/sqlite/errormapper.go
+++ b/platform/view/services/storage/driver/sql/sqlite/errormapper.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package sqlite
 
 import (
+	errors2 "errors"
+
 	"modernc.org/sqlite"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
@@ -22,8 +24,8 @@ var errorMap = map[int]error{
 type ErrorMapper struct{}
 
 func (m *ErrorMapper) WrapError(err error) error {
-	pgErr, ok := err.(*sqlite.Error)
-	if !ok {
+	var pgErr *sqlite.Error
+	if !errors2.As(err, &pgErr) {
 		return err
 	}
 	mappedErr, ok := errorMap[pgErr.Code()]


### PR DESCRIPTION
`errorlint` flags error handling that breaks under wrapping: rendering an error with `%s`/`%v` instead of wrapping it, comparing an error directly to a sentinel instead of `errors.Is`, or asserting an error's type instead of `errors.As`.

Part of #1755.

### Scoping

86 findings, and unlike every other linter in this series the distribution is inverted: 17 in the root module and 69 in `integration`, roughly three quarters of those in the `atsachaincode` demo chaincode. Three classes of finding:

- 77 format-verb findings, where an error was rendered with `%s` or `%v` instead of being wrapped. Fixed with `errors.Wrapf` from `pkg/utils/errors` rather than the `fmt.Errorf("%w")` that `errorlint`'s own auto-fix proposes, because this project forbids `fmt.Errorf`. No new `fmt.Errorf` was introduced; 77 were removed.
- 7 sentinel comparisons (`err == io.EOF`, `err == sql.ErrNoRows`) converted to `errors.Is`. These change behavior in that a wrapped sentinel now matches, which is the intended semantic for tar reads, gRPC streams, and `database/sql`.
- 2 type assertions converted to unwrap-aware forms: `packager/golang/list.go`'s `wrapExitErr` and `sqlite/errormapper.go`'s `WrapError`.

The `atsachaincode` files are converted to the project error package rather than left on `fmt.Errorf`: they already import third-party Fabric packages, so they aren't self-contained standard-library samples.

Introducing `errors.As` also required the Go 1.27 modernization that `go fix` reports (`errors.AsType[*exec.ExitError]`) in `packager/golang/list.go`, without which `make checks` fails on its go-fix half.

### Verification

`make checks` exits 0 across all four modules.

### Note for reviewers

This branch is independent — rooted directly on current `main`, not stacked on any other wave-3 PR. It should merge cleanly regardless of the order the other wave-3 PRs land in.
