### PR TITLE
build(deps): exclude Fabric and IBM crypto deps from Dependabot versi…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,18 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # Fabric, Fabric-x, and IBM's crypto libs are updated by hand on a
+      # regular cadence instead -- see "Dependency Management" in
+      # docs/dev/development.md. `applies-to: version-updates` (the default
+      # is both) keeps Dependabot's security-update path active, so a GHSA
+      # against any of them still opens a PR outside the weekly schedule.
+      - dependency-name: "github.com/hyperledger/fabric*"
+        applies-to: version-updates
+      - dependency-name: "github.com/IBM/idemix"
+        applies-to: version-updates
+      - dependency-name: "github.com/IBM/mathlib"
+        applies-to: version-updates
 
   # Actions are pinned to SHAs, so without this they never move at all.
   - package-ecosystem: github-actions

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -364,6 +364,18 @@ Be careful with updating all dependencies at once. This may easily break somethi
 Note that `gomate.sh tidy` can also be invoked via `make tidy`. 
 After updating, run `make tidy` and `make checks` to verify the result.
 
+### Fabric and IBM crypto dependencies
+
+[`dependabot.yml`](../../.github/dependabot.yml) excludes `github.com/hyperledger/fabric*`,
+`github.com/IBM/idemix`, and `github.com/IBM/mathlib` from the weekly version-update PRs.
+These track the Fabric/Fabric-x network binaries and the crypto stack, and bumping them
+often needs matching non-dependency changes across modules, so they're updated by hand
+with `gomate.sh update` on a regular cadence instead of arriving as unreviewed weekly noise.
+
+The exclusion only applies to version updates: it's scoped with `applies-to: version-updates`,
+so Dependabot's security-update path stays active and still opens a PR if a GHSA lands
+against any of them.
+
 ## Write Your Own Integration Test
 
 Creating a new integration test is straightforward.


### PR DESCRIPTION
Fabric, Fabric-x, and IBM's crypto libs (`idemix`, `mathlib`) get bumped by hand on a regular cadence rather than through the weekly Dependabot batch — version changes there often need matching non-dependency changes across modules, so a routine version-update PR for them is more noise than help.

This adds ignore entries for `github.com/hyperledger/fabric*`, `github.com/IBM/idemix`, and `github.com/IBM/mathlib`, scoped with `applies-to: version-updates`. That scoping matters: Dependabot's ignore normally silences both version updates and security updates for a match, but pinning it to version-updates leaves the security path alone, so a GHSA against any of these still opens a PR outside the weekly schedule.

Documented the policy in `docs/dev/development.md` under "Dependency Management," next to the `gomate.sh update` instructions used for the manual bumps.