### PR TITLE
chore(lint): enable bodyclose in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     # golangci-lint's implicit `default: standard` set. They are named here so
     # the config states what it enforces rather than inheriting it, and so a
     # future `default: none` cannot silently drop them.
+    - bodyclose
     - durationcheck
     - errcheck
     - errorlint

--- a/integration/nwo/common/builder.go
+++ b/integration/nwo/common/builder.go
@@ -34,6 +34,7 @@ func (c *BuilderClient) Build(path string) string {
 
 	resp, err := http.Get(fmt.Sprintf("http://%s/%s", c.ServerAddress, path))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/platform/view/services/comm/host/websocket/dynamic_ca_test.go
+++ b/platform/view/services/comm/host/websocket/dynamic_ca_test.go
@@ -163,7 +163,10 @@ func TestDynamicCA(t *testing.T) {
 	url := fmt.Sprintf("wss://%s/p2p", serverAddr)
 
 	dialer := &gorilla_websocket.Dialer{TLSClientConfig: clientTLSConfig}
-	_, _, err = dialer.DialContext(t.Context(), url, nil)
+	_, resp, err := dialer.DialContext(t.Context(), url, nil)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
 	require.Error(t, err, "should fail as client cert is not trusted")
 
 	// 2. Add client cert to EndpointService (runtime change)

--- a/platform/view/services/comm/host/websocket/ws/large_message_test.go
+++ b/platform/view/services/comm/host/websocket/ws/large_message_test.go
@@ -96,8 +96,9 @@ func TestValidBoundaryMessage(t *testing.T) {
 
 	dialer := gorilla_websocket.Dialer{TLSClientConfig: clientTLSConfig}
 	u := fmt.Sprintf("wss://%s/p2p", srvEndpoint)
-	conn, _, err := dialer.Dial(u, nil)
+	conn, resp, err := dialer.Dial(u, nil)
 	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
 	defer func() { _ = conn.Close() }()
 
 	// Send meta
@@ -174,8 +175,9 @@ func TestMultipleMessagesOrderAndContent(t *testing.T) {
 
 	dialer := gorilla_websocket.Dialer{TLSClientConfig: clientTLSConfig}
 	u := fmt.Sprintf("wss://%s/p2p", srvEndpoint)
-	conn, _, err := dialer.Dial(u, nil)
+	conn, resp, err := dialer.Dial(u, nil)
 	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
 	defer func() { _ = conn.Close() }()
 
 	// Send meta

--- a/platform/view/services/comm/host/websocket/ws/mtls_enforcement_test.go
+++ b/platform/view/services/comm/host/websocket/ws/mtls_enforcement_test.go
@@ -50,8 +50,9 @@ func TestMTLSStrictness(t *testing.T) {
 	t.Run("Valid mTLS - Connection Accepted", func(t *testing.T) {
 		t.Parallel()
 		dialer := websocket.Dialer{TLSClientConfig: clientTLSConfig}
-		conn, _, err := dialer.Dial(url, nil)
+		conn, resp, err := dialer.Dial(url, nil)
 		require.NoError(t, err)
+		_ = resp.Body.Close()
 		_ = conn.Close()
 	})
 
@@ -63,7 +64,10 @@ func TestMTLSStrictness(t *testing.T) {
 			ServerName: "localhost",
 		}
 		dialer := websocket.Dialer{TLSClientConfig: invalidClientConfig}
-		_, _, err := dialer.Dial(url, nil)
+		_, resp, err := dialer.Dial(url, nil)
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
 		assert.Error(t, err, "Websocket dial should have failed without client certificate")
 	})
 
@@ -73,7 +77,10 @@ func TestMTLSStrictness(t *testing.T) {
 		_, untrustedClientConfig, _ := testMutualTLSConfigs(t, false)
 
 		dialer := websocket.Dialer{TLSClientConfig: untrustedClientConfig}
-		_, _, err := dialer.Dial(url, nil)
+		_, resp, err := dialer.Dial(url, nil)
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
 		assert.Error(t, err, "Websocket dial should have failed with untrusted client certificate")
 	})
 

--- a/platform/view/services/comm/host/websocket/ws/reproduction_test.go
+++ b/platform/view/services/comm/host/websocket/ws/reproduction_test.go
@@ -50,8 +50,9 @@ func TestAttack_SpoofPeerID(t *testing.T) { //nolint:paralleltest
 		TLSClientConfig: clientTLSConfig,
 	}
 	u := fmt.Sprintf("wss://%s/p2p", srvEndpoint)
-	conn, _, err := dialer.Dial(u, nil)
+	conn, resp, err := dialer.Dial(u, nil)
 	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
 	defer func() { _ = conn.Close() }()
 
 	// Send meta message claiming to be Alice
@@ -103,8 +104,9 @@ func TestAttack_HijackSessionID(t *testing.T) { //nolint:paralleltest
 		TLSClientConfig: clientTLSConfig,
 	}
 	u := fmt.Sprintf("wss://%s/p2p", srvEndpoint)
-	conn, _, err := dialer.Dial(u, nil)
+	conn, resp, err := dialer.Dial(u, nil)
 	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
 	defer func() { _ = conn.Close() }()
 
 	// Charlie connects legitimately

--- a/platform/view/services/comm/host/websocket/ws/simple_provider_test.go
+++ b/platform/view/services/comm/host/websocket/ws/simple_provider_test.go
@@ -71,8 +71,9 @@ func TestSimpleProvider_Security(t *testing.T) { //nolint:paralleltest
 					TLSClientConfig: clientTLSConfig,
 				}
 				u := fmt.Sprintf("wss://%s/p2p", srvEndpoint)
-				conn, _, err := dialer.Dial(u, nil)
+				conn, resp, err := dialer.Dial(u, nil)
 				require.NoError(t, err)
+				defer func() { _ = resp.Body.Close() }()
 				defer func() { _ = conn.Close() }()
 
 				meta := StreamMeta{

--- a/platform/view/services/view/web/web_test.go
+++ b/platform/view/services/view/web/web_test.go
@@ -142,8 +142,9 @@ func TestClientStreamCallView(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	wsURL := "ws" + ts.URL[4:]
-	ws, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	ws, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
 	t.Cleanup(func() { _ = ws.Close() })
 
 	// Send input payload conforming to server.Input format
@@ -169,7 +170,10 @@ func TestClientStreamCallView(t *testing.T) {
 			require.ErrorContains(t, err, "new view error")
 		}))
 		t.Cleanup(tsErr.Close)
-		wsErr, _, _ := websocket.DefaultDialer.Dial("ws"+tsErr.URL[4:], nil)
+		wsErr, resp, _ := websocket.DefaultDialer.Dial("ws"+tsErr.URL[4:], nil)
+		if resp != nil {
+			t.Cleanup(func() { _ = resp.Body.Close() })
+		}
 		if wsErr != nil {
 			t.Cleanup(func() { _ = wsErr.Close() })
 			_ = wsErr.WriteMessage(websocket.TextMessage, inputMsg)
@@ -185,7 +189,10 @@ func TestClientStreamCallView(t *testing.T) {
 			require.ErrorContains(t, err, "init context error")
 		}))
 		t.Cleanup(tsErr.Close)
-		wsErr, _, _ := websocket.DefaultDialer.Dial("ws"+tsErr.URL[4:], nil)
+		wsErr, resp, _ := websocket.DefaultDialer.Dial("ws"+tsErr.URL[4:], nil)
+		if resp != nil {
+			t.Cleanup(func() { _ = resp.Body.Close() })
+		}
 		if wsErr != nil {
 			t.Cleanup(func() { _ = wsErr.Close() })
 			_ = wsErr.WriteMessage(websocket.TextMessage, inputMsg)
@@ -201,7 +208,10 @@ func TestClientStreamCallView(t *testing.T) {
 			require.ErrorContains(t, err, "run view error")
 		}))
 		t.Cleanup(tsErr.Close)
-		wsErr, _, _ := websocket.DefaultDialer.Dial("ws"+tsErr.URL[4:], nil)
+		wsErr, resp, _ := websocket.DefaultDialer.Dial("ws"+tsErr.URL[4:], nil)
+		if resp != nil {
+			t.Cleanup(func() { _ = resp.Body.Close() })
+		}
 		if wsErr != nil {
 			t.Cleanup(func() { _ = wsErr.Close() })
 			_ = wsErr.WriteMessage(websocket.TextMessage, inputMsg)
@@ -217,7 +227,10 @@ func TestClientStreamCallView(t *testing.T) {
 			require.ErrorContains(t, err, "registering stream command server")
 		}))
 		t.Cleanup(tsErr.Close)
-		wsErr, _, _ := websocket.DefaultDialer.Dial("ws"+tsErr.URL[4:], nil)
+		wsErr, resp, _ := websocket.DefaultDialer.Dial("ws"+tsErr.URL[4:], nil)
+		if resp != nil {
+			t.Cleanup(func() { _ = resp.Body.Close() })
+		}
 		if wsErr != nil {
 			t.Cleanup(func() { _ = wsErr.Close() })
 			_ = wsErr.WriteMessage(websocket.TextMessage, inputMsg)
@@ -232,7 +245,10 @@ func TestClientStreamCallView(t *testing.T) {
 			_ = cStruct.StreamCallView("fid", w, r)
 		}))
 		t.Cleanup(tsStruct.Close)
-		wsStruct, _, _ := websocket.DefaultDialer.Dial("ws"+tsStruct.URL[4:], nil)
+		wsStruct, resp, _ := websocket.DefaultDialer.Dial("ws"+tsStruct.URL[4:], nil)
+		if resp != nil {
+			t.Cleanup(func() { _ = resp.Body.Close() })
+		}
 		require.NotNil(t, wsStruct)
 		t.Cleanup(func() { _ = wsStruct.Close() })
 		_ = wsStruct.WriteMessage(websocket.TextMessage, inputMsg)
@@ -253,7 +269,10 @@ func TestClientStreamCallView(t *testing.T) {
 			require.ErrorContains(t, err, "expected a mutable context")
 		}))
 		t.Cleanup(tsNonMutable.Close)
-		wsNM, _, _ := websocket.DefaultDialer.Dial("ws"+tsNonMutable.URL[4:], nil)
+		wsNM, resp, _ := websocket.DefaultDialer.Dial("ws"+tsNonMutable.URL[4:], nil)
+		if resp != nil {
+			t.Cleanup(func() { _ = resp.Body.Close() })
+		}
 		if wsNM != nil {
 			t.Cleanup(func() { _ = wsNM.Close() })
 			_ = wsNM.WriteMessage(websocket.TextMessage, inputMsg)

--- a/platform/view/services/web/client/wsclient.go
+++ b/platform/view/services/web/client/wsclient.go
@@ -26,11 +26,12 @@ const maxMessageSize = 10 * 1024 * 1024
 
 func OpenWSClientConn(url string, config *tls.Config) (*websocket.Conn, error) {
 	dialer := &websocket.Dialer{TLSClientConfig: config}
-	ws, _, err := dialer.Dial(url, nil)
+	ws, resp, err := dialer.Dial(url, nil)
 	if err != nil {
 		logger.Errorf("Failed to establish websocket connection to [%s]: %s", url, err.Error())
 		return nil, err
 	}
+	_ = resp.Body.Close()
 	ws.SetReadLimit(maxMessageSize)
 	return ws, nil
 }


### PR DESCRIPTION
`bodyclose` flags an `*http.Response` whose `Body` is never closed — a connection/file-descriptor leak.

Part of #1755.

### Scoping

18 findings: 17 in the root module and 1 in the integration module. 16 of the 18 were in test files (gorilla/websocket dialer calls whose HTTP handshake response was discarded); 2 were in production code (`platform/view/services/web/client/wsclient.go` and `integration/nwo/common/builder.go`). None were inside a loop. Each fix closes the previously-leaked response body immediately after the existing error check, using `defer` where the call happens once per function/subtest and an explicit close where the error path is expected and the response may still be non-nil.

### Verification

`make checks` exits 0 across all four modules.

### Note for reviewers

This branch is independent — rooted directly on current `main`, not stacked on any other wave-4 PR. It should merge cleanly regardless of the order the other wave-4 PRs land in.
