### PR TITLE
chore(lint): enable contextcheck in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     # golangci-lint's implicit `default: standard` set. They are named here so
     # the config states what it enforces rather than inheriting it, and so a
     # future `default: none` cannot silently drop them.
+    - contextcheck
     - durationcheck
     - errcheck
     - errorlint
@@ -72,6 +73,21 @@ linters:
       - path: (^integration/|^ci/|_test\.go$|_test_utils\.go$)
         linters:
           - gosec
+      # The p2p comm layer (sessions, stream handlers, and the multiplexed/simple
+      # websocket connections) deliberately manages resources - cached streams,
+      # sub-connections, and sessions - whose lifecycles are independent of, and
+      # routinely longer than, any single call's context: a background per-session
+      # cleanup ticker and per-stream reader goroutine, a shutdown path that must
+      # run to completion regardless of the (already-cancelling) context that
+      # triggered it, and connections cached and reused across many calls. See
+      # platform/view/services/comm/host/websocket/ws/context_detachment_test.go,
+      # which regression-tests this decoupling directly. NewMsgConn's nil-ctx
+      # fallback (io/msgconn.go) is the same defensive-default idiom used
+      # elsewhere in the codebase. 24 of the 43 contextcheck findings measured
+      # when enabling the linter came from this cluster.
+      - path: ^platform/view/services/comm/(master\.go|p2p\.go|pingpong_test\.go|sessions_test_utils\.go|sig_exchange_test_utils\.go|test_utils\.go|io/msgconn\.go|host/websocket/ws/(multiplexed_provider(_test)?\.go|simple_provider(_test)?\.go|mtls_enforcement_test\.go))$
+        linters:
+          - contextcheck
 formatters:
   enable:
     - gci

--- a/platform/common/core/generic/vault/vault.go
+++ b/platform/common/core/generic/vault/vault.go
@@ -208,7 +208,7 @@ func (db *Vault[V]) commitTXs(txs []txCommitIndex) []error {
 
 func (db *Vault[V]) commitRWs(ctx context.Context, inputs ...commitInput) error {
 	for _, input := range inputs {
-		db.logger.DebugfContext(input.ctx, "Begin update for tx [%d:%d][%s]", input.block, input.indexInBloc, input.txID)
+		db.logger.DebugfContext(input.ctx, "Begin update for tx [%d:%d][%s]", input.block, input.indexInBloc, input.txID) //nolint:contextcheck // deliberately logging against this tx's own originating context (for trace correlation), not commitRWs' batch-level ctx: this call batches transactions submitted by different, possibly-already-returned callers
 	}
 
 	db.logger.Debugf("extract txids from [%d] inputs", len(inputs))

--- a/platform/fabric/core/generic/committer/committer.go
+++ b/platform/fabric/core/generic/committer/committer.go
@@ -497,8 +497,8 @@ func (c *Committer) listenTo(ctx context.Context, txID string, timeout time.Dura
 			stop = true
 		case event := <-ch:
 			span.AddEvent("receive_channel_result")
-			span.AddLink(trace.LinkFromContext(event.Ctx))
-			c.logger.DebugfContext(event.Ctx, "Got an answer to finality of [%s]: [%s]", txID, event.Err)
+			span.AddLink(trace.LinkFromContext(event.Ctx))                                                //nolint:contextcheck // event.Ctx is the finality event's own originating context (from the block-commit pipeline that produced it), linked here only for trace correlation; listenTo's own ctx (used above for ctx.Done()) is unrelated to when/how the tx was actually committed
+			c.logger.DebugfContext(event.Ctx, "Got an answer to finality of [%s]: [%s]", txID, event.Err) //nolint:contextcheck // same as above: log against the event's originating context for correlation, not listenTo's ctx
 			timeout.Stop()
 			return event.Err
 		case <-timeout.C:

--- a/platform/fabric/core/generic/delivery/delivery.go
+++ b/platform/fabric/core/generic/delivery/delivery.go
@@ -186,7 +186,7 @@ func (d *Delivery) stopError() error {
 // cancelled. It blocks until then and returns the error that caused the
 // shutdown, or nil for a clean stop. A nil ctx is treated as
 // context.Background.
-func (d *Delivery) Run(ctx context.Context) error {
+func (d *Delivery) Run(ctx context.Context) error { //nolint:contextcheck // documented nil-ctx fallback above (nil is treated as context.Background), not an ignored inherited context
 	logger.Debugf("Running delivery service [%d]", ctr.Add(1))
 	if ctx == nil {
 		ctx = context.Background()
@@ -293,7 +293,7 @@ func (d *Delivery) runReceiver(ctx context.Context, ch chan<- blockResponse) {
 				switch r := resp.Type.(type) {
 				case *pb.DeliverResponse_Block:
 					span.SetAttributes(tracing.String(messageTypeLabel, block))
-					if !d.handleBlockResponse(deliveryCtx, span, r, ch, waitTime) {
+					if !d.handleBlockResponse(deliveryCtx, span, r, ch, waitTime) { //nolint:contextcheck // deliveryCtx is a fresh root span per block-delivery attempt (context.Background(), see above), by design: block traces are independent per-attempt spans, not children of one span spanning the receiver's whole reconnect-loop lifetime
 						if dfCancel != nil {
 							dfCancel()
 						}

--- a/platform/fabric/core/generic/ordering/bft.go
+++ b/platform/fabric/core/generic/ordering/bft.go
@@ -187,7 +187,7 @@ func (o *BFTBroadcaster) getConnection(ctx context.Context, to *grpc.ConnectionC
 
 	select {
 	case <-state.slots:
-		return o.createConnectionWithSlot(to, state)
+		return o.createConnectionWithSlot(to, state) //nolint:contextcheck // pooled connection: its stream must use a connection-scoped context, not this request's (see comment in createConnection)
 	default:
 	}
 
@@ -195,7 +195,7 @@ func (o *BFTBroadcaster) getConnection(ctx context.Context, to *grpc.ConnectionC
 	case connection := <-state.pool:
 		return connection, nil
 	case <-state.slots:
-		return o.createConnectionWithSlot(to, state)
+		return o.createConnectionWithSlot(to, state) //nolint:contextcheck // same as above: pooled connection outlives this request
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}

--- a/platform/fabric/core/generic/ordering/cft.go
+++ b/platform/fabric/core/generic/ordering/cft.go
@@ -139,7 +139,7 @@ func (o *CFTBroadcaster) getConnection(ctx context.Context) (*Connection, error)
 
 			// Get the broadcast stream to receive a reply of Acknowledgement for each common.Envelope in order, indicating success or type of failure.
 			// Notice that this stream is shared, therefore its context must be something different from the context of the current broadcast request
-			stream, err := oClient.Broadcast(context.Background())
+			stream, err := oClient.Broadcast(context.Background()) //nolint:contextcheck // documented above: this stream is shared across broadcasts, so it deliberately does not use the current request's context
 			if err != nil {
 				client.Close()
 				return nil, errors.Wrapf(err, "failed creating orderer stream for %s", to.Address)

--- a/platform/fabric/core/generic/ordering/ordering.go
+++ b/platform/fabric/core/generic/ordering/ordering.go
@@ -105,7 +105,7 @@ func NewService(
 	return s
 }
 
-func (o *Service) Broadcast(ctx context.Context, blob any) error {
+func (o *Service) Broadcast(ctx context.Context, blob any) error { //nolint:contextcheck // documented nil-ctx fallback below (nil is treated as context.Background), not an ignored inherited context
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/platform/fabric/core/generic/rwset/loader.go
+++ b/platform/fabric/core/generic/rwset/loader.go
@@ -107,7 +107,7 @@ func (c *Loader) GetRWSetFromETx(ctx context.Context, txID driver2.TxID) (driver
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "cannot load etx [%s]", txID)
 	}
-	tx, err := c.TransactionManager.NewTransactionFromBytes(context.TODO(), c.Channel, raw)
+	tx, err := c.TransactionManager.NewTransactionFromBytes(ctx, c.Channel, raw)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/platform/fabric/services/state/flow_test.go
+++ b/platform/fabric/services/state/flow_test.go
@@ -38,8 +38,8 @@ func (m *mockSession) Send(_ context.Context, payload []byte) error {
 	return nil
 }
 
-func (m *mockSession) SendError(_ context.Context, payload []byte) error {
-	return m.Send(context.Background(), payload)
+func (m *mockSession) SendError(ctx context.Context, payload []byte) error {
+	return m.Send(ctx, payload)
 }
 
 func (m *mockSession) Receive() <-chan *view.Message { return m.recv }

--- a/platform/fabricx/core/channel/config/monitor.go
+++ b/platform/fabricx/core/channel/config/monitor.go
@@ -114,7 +114,7 @@ func NewChannelConfigMonitor(
 }
 
 // Start begins monitoring for configuration changes
-func (s *ChannelConfigMonitor) Start(ctx context.Context) error {
+func (s *ChannelConfigMonitor) Start(ctx context.Context) error { //nolint:contextcheck // documented nil-ctx fallback below (nil is treated as context.Background), not an ignored inherited context
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/platform/view/services/storage/driver/sql/postgres/test_utils.go
+++ b/platform/view/services/storage/driver/sql/postgres/test_utils.go
@@ -249,7 +249,7 @@ func StartPostgres(ctx context.Context, c *ContainerConfig, logger Logger) (func
 	}
 
 	// define our close function that is returned to the caller
-	closeFunc := func() {
+	closeFunc := func() { //nolint:contextcheck // documented below: a fresh context is used deliberately since the provided ctx may already be cancelled by the time t.Cleanup runs this
 		// we use a fresh context here as the provided ctx may be canceled already.
 		// this is particularly the case if ctx is provided by a test harness and closeFunc is called via t.Cleanup.
 		cctx := context.Background()

--- a/platform/view/services/view/manager.go
+++ b/platform/view/services/view/manager.go
@@ -276,7 +276,7 @@ func (cm *Manager) NewResponderContext(ctx context.Context, contextID string, se
 		return c, false, nil
 	}
 	if ok {
-		logger.DebugfContext(viewContext.Context(), "[%s] No new context to respond, reuse [contextID:%s]\n", me, contextID)
+		logger.DebugfContext(viewContext.Context(), "[%s] No new context to respond, reuse [contextID:%s]\n", me, contextID) //nolint:contextcheck // deliberately logging against the reused, longer-lived viewContext being returned, not this call's transient ctx
 		return viewContext, false, nil
 	}
 
@@ -297,7 +297,7 @@ func (cm *Manager) NewResponderContext(ctx context.Context, contextID string, se
 	cm.contexts[contextID] = c
 	cm.metrics.Contexts.Set(float64(len(cm.contexts)))
 
-	context.AfterFunc(c.Context(), func() {
+	context.AfterFunc(c.Context(), func() { //nolint:contextcheck // deliberately watching the new child context c's own lifetime (the tracked view context), not this call's ctx, to know when to evict the map entry
 		cm.DeleteContext(contextID)
 	})
 

--- a/platform/view/services/view/p2p/service.go
+++ b/platform/view/services/view/p2p/service.go
@@ -159,7 +159,7 @@ func (s *Service) respond(ctx context.Context, responder view.View, id view.Iden
 	// WithCancel resources once this responder is done (see getOrCreateContext).
 	defer cleanup()
 
-	logger.DebugfContext(viewCtx.Context(), "[%s] Respond [from:%s], [sessionID:%s], [contextID:%s](%v), [view:%s]", id, msg.FromEndpoint, msg.SessionID, msg.ContextID, isNew, logging.Identifier(responder))
+	logger.DebugfContext(viewCtx.Context(), "[%s] Respond [from:%s], [sessionID:%s], [contextID:%s](%v), [view:%s]", id, msg.FromEndpoint, msg.SessionID, msg.ContextID, isNew, logging.Identifier(responder)) //nolint:contextcheck // deliberately logging against the responder's own view context (the merged ctx documented in getOrCreateContext), not this func's ctx param
 
 	// if a new context has been created to run the responder,
 	// then dispose the context when not needed anymore
@@ -170,10 +170,10 @@ func (s *Service) respond(ctx context.Context, responder view.View, id view.Iden
 	// run view
 	_, err = s.runner.RunView(viewCtx, responder)
 	if err != nil {
-		logger.DebugfContext(viewCtx.Context(), "[%s] Respond Failure [from:%s], [sessionID:%s], [contextID:%s] [%s]\n", id, msg.FromEndpoint, msg.SessionID, msg.ContextID, err)
+		logger.DebugfContext(viewCtx.Context(), "[%s] Respond Failure [from:%s], [sessionID:%s], [contextID:%s] [%s]\n", id, msg.FromEndpoint, msg.SessionID, msg.ContextID, err) //nolint:contextcheck // same as above: logging against the responder's own view context, not this func's ctx param
 
 		// Keep error reporting uncancellable while preserving values from the responder context.
-		if serr := viewCtx.Session().SendError(context.WithoutCancel(viewCtx.Context()), []byte(err.Error())); serr != nil {
+		if serr := viewCtx.Session().SendError(context.WithoutCancel(viewCtx.Context()), []byte(err.Error())); serr != nil { //nolint:contextcheck // documented above: error reporting is deliberately made uncancellable via WithoutCancel
 			logger.Error(serr.Error())
 		}
 	}
@@ -215,7 +215,7 @@ func (s *Service) getOrCreateContext(ctx context.Context, me view.Identity, msg 
 		cancel()
 	}
 
-	viewCtx, isNew, err = s.viewManager.NewResponderContext(
+	viewCtx, isNew, err = s.viewManager.NewResponderContext( //nolint:contextcheck // documented above: mergedCtx deliberately merges msg.Ctx with this func's ctx (via context.AfterFunc), rather than passing ctx directly
 		mergedCtx,
 		msg.ContextID,
 		responderSession,


### PR DESCRIPTION
`contextcheck` flags a function that receives a `context.Context` but doesn't pass it through to a call that itself takes one — instead using `context.Background()`/`context.TODO()`, a nested detached context, or (missed) propagation.

Part of #1755.

### Scoping

43 findings, all in the root module. 2 were genuine bugs (a stray `context.TODO()` and an unused-`ctx` test double) and are threaded through with no behavior change. The other 41 are deliberate context detachment — background work, pooled connections/streams, and trace-correlation logging that must outlive or not derive from the call that happens to trigger them — and are suppressed with a reason.

- 24 findings in the p2p comm layer (cached/pooled websocket sub-connections, streams, and sessions whose lifecycle is independent of any single call, regression-tested by `context_detachment_test.go`) share one config exclusion in `.golangci.yml` rather than 24 scattered `//nolint`s.
- 17 findings elsewhere (nil-ctx fallbacks, trace-link/log correlation against a different originating context, shared broadcast/delivery streams, uncancellable error reporting) get individual `//nolint:contextcheck` comments, each naming the specific reason.

No deferred or ambiguous findings — every site traced back to an already-latent, often already-documented design rationale.

### Verification

`make checks` exits 0 across all four modules.

### Note for reviewers

This branch is independent — rooted directly on current `main`, not stacked on any other wave-4 PR. It should merge cleanly regardless of the order the other wave-4 PRs land in.
