### PR TITLE
fix(deps): drop invalid applies-to from dependabot ignore rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,15 +45,13 @@ updates:
     ignore:
       # Fabric, Fabric-x, and IBM's crypto libs are updated by hand on a
       # regular cadence instead -- see "Dependency Management" in
-      # docs/dev/development.md. `applies-to: version-updates` (the default
-      # is both) keeps Dependabot's security-update path active, so a GHSA
-      # against any of them still opens a PR outside the weekly schedule.
+      # docs/dev/development.md. This also suppresses Dependabot's
+      # security-update PRs for these deps, not just the weekly ones -- a
+      # GHSA still surfaces as a Dependabot alert, just without an
+      # auto-generated PR, so a hit still needs a manual bump.
       - dependency-name: "github.com/hyperledger/fabric*"
-        applies-to: version-updates
       - dependency-name: "github.com/IBM/idemix"
-        applies-to: version-updates
       - dependency-name: "github.com/IBM/mathlib"
-        applies-to: version-updates
 
   # Actions are pinned to SHAs, so without this they never move at all.
   - package-ecosystem: github-actions

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -372,9 +372,11 @@ These track the Fabric/Fabric-x network binaries and the crypto stack, and bumpi
 often needs matching non-dependency changes across modules, so they're updated by hand
 with `gomate.sh update` on a regular cadence instead of arriving as unreviewed weekly noise.
 
-The exclusion only applies to version updates: it's scoped with `applies-to: version-updates`,
-so Dependabot's security-update path stays active and still opens a PR if a GHSA lands
-against any of them.
+Dependabot's `ignore` suppresses both the weekly version-update PRs and the
+auto-generated security-update PRs for these deps -- there's no config to scope it to
+one or the other. A GHSA against any of them still shows up as a Dependabot alert (the
+repo's Security tab), it just won't arrive as a ready-made PR; treat that alert the
+same as a routine bump and patch it by hand.
 
 ## Write Your Own Integration Test
 


### PR DESCRIPTION
PR #1781 introduced a misconfiguration in dependabot without noticing. This PR fixes it.