### PR TITLE
chore(lint): enable testifylint in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,7 @@ linters:
     - rowserrcheck
     - recvcheck
     - staticcheck
+    - testifylint
     - thelper
     - tparallel
     - unused

--- a/integration/nwo/fabric/network/update_test.go
+++ b/integration/nwo/fabric/network/update_test.go
@@ -87,7 +87,7 @@ func TestNextChaincodeCarriesEverythingWhenNoOptionApplies(t *testing.T) { //nol
 	require.Empty(t, next.Chaincode.PackageFile)
 
 	require.Equal(t, "fsc-cc/iou:latest", next.Chaincode.Image, "Image must survive")
-	require.Equal(t, `{"Args":["init"]}`, next.Chaincode.Ctor, "Ctor must survive")
+	require.JSONEq(t, `{"Args":["init"]}`, next.Chaincode.Ctor, "Ctor must survive")
 	require.True(t, next.Chaincode.InitRequired, "InitRequired must survive")
 	require.Empty(t, next.Chaincode.Lang, "Lang must survive")
 	require.Empty(t, next.Chaincode.Path, "Path must survive")

--- a/integration/nwo/fabric/topology/namespace_test.go
+++ b/integration/nwo/fabric/topology/namespace_test.go
@@ -46,7 +46,7 @@ func TestAddNamespaceDefaults(t *testing.T) { //nolint:paralleltest
 	require.True(t, cc.Chaincode.IsCCaaS())
 	require.Empty(t, cc.Chaincode.Path)
 
-	require.Equal(t, `{"Args":["init"]}`, cc.Chaincode.Ctor)
+	require.JSONEq(t, `{"Args":["init"]}`, cc.Chaincode.Ctor)
 	require.True(t, cc.Chaincode.InitRequired)
 
 	require.Equal(t, []string{"Org1_peer_0"}, cc.Peers)
@@ -110,7 +110,7 @@ func TestWithCtorEnablesInit(t *testing.T) { //nolint:paralleltest
 	ns := top.AddNamespace("ns", Unanimity("Org1"),
 		WithContainerImage("fsc-cc/events:latest"),
 		WithCtor(`{"Args":["init","x"]}`))
-	require.Equal(t, `{"Args":["init","x"]}`, ns.cc.Chaincode.Ctor)
+	require.JSONEq(t, `{"Args":["init","x"]}`, ns.cc.Chaincode.Ctor)
 	require.True(t, ns.cc.Chaincode.InitRequired)
 }
 
@@ -127,7 +127,7 @@ func TestOptionsAreOrderIndependent(t *testing.T) { //nolint:paralleltest
 		WithCtor(`{"Args":["init"]}`))
 
 	require.Equal(t, *imageFirst.cc, *ctorFirst.cc)
-	require.Equal(t, `{"Args":["init"]}`, ctorFirst.cc.Chaincode.Ctor)
+	require.JSONEq(t, `{"Args":["init"]}`, ctorFirst.cc.Chaincode.Ctor)
 	require.True(t, ctorFirst.cc.Chaincode.InitRequired)
 }
 
@@ -150,7 +150,7 @@ func TestWithCtorSurvivesLegacyChaincode(t *testing.T) { //nolint:paralleltest
 	ns := top.AddNamespace("asset_transfer", Unanimity("Org1"),
 		WithLegacyChaincode(StateQueryChaincodePath),
 		WithCtor(`{"Args":["init"]}`))
-	require.Equal(t, `{"Args":["init"]}`, ns.cc.Chaincode.Ctor)
+	require.JSONEq(t, `{"Args":["init"]}`, ns.cc.Chaincode.Ctor)
 	require.True(t, ns.cc.Chaincode.InitRequired,
 		"a legacy namespace with an explicit ctor must still require init")
 }

--- a/platform/common/utils/deferred/holder_test.go
+++ b/platform/common/utils/deferred/holder_test.go
@@ -8,7 +8,6 @@ package deferred_test
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -31,7 +30,7 @@ func TestGetBeforeFirstUpdate(t *testing.T) {
 	require.Nil(t, v)
 	require.True(t, errors.Is(err, deferred.ErrNotLoaded),
 		"error must be matchable with errors.Is, got [%v]", err)
-	require.True(t, strings.Contains(err.Error(), "mychannel"),
+	require.Contains(t, err.Error(), "mychannel",
 		"error must name the channel, got [%v]", err)
 }
 
@@ -333,9 +332,9 @@ func TestWaitForValueTimeoutReportsNotLoaded(t *testing.T) {
 	require.Nil(t, v)
 	require.True(t, errors.Is(err, deferred.ErrNotLoaded),
 		"a timed-out wait must report ErrNotLoaded, got [%v]", err)
-	require.True(t, strings.Contains(err.Error(), "mychannel"),
+	require.Contains(t, err.Error(), "mychannel",
 		"error must name the subject, got [%v]", err)
-	require.True(t, strings.Contains(err.Error(), context.DeadlineExceeded.Error()),
+	require.Contains(t, err.Error(), context.DeadlineExceeded.Error(),
 		"error must still show the deadline-exceeded cause, got [%v]", err)
 }
 
@@ -355,9 +354,9 @@ func TestWaitForValueContextCancelled(t *testing.T) {
 	require.Nil(t, v)
 	require.True(t, errors.Is(err, deferred.ErrNotLoaded),
 		"a cancelled wait must report ErrNotLoaded, got [%v]", err)
-	require.True(t, strings.Contains(err.Error(), "mychannel"),
+	require.Contains(t, err.Error(), "mychannel",
 		"error must name the subject, got [%v]", err)
-	require.True(t, strings.Contains(err.Error(), context.Canceled.Error()),
+	require.Contains(t, err.Error(), context.Canceled.Error(),
 		"error must still show the cancellation cause, got [%v]", err)
 }
 

--- a/platform/common/utils/utils_test.go
+++ b/platform/common/utils/utils_test.go
@@ -111,7 +111,7 @@ func TestIgnoreErrorWithOneArg(t *testing.T) {
 func TestZero(t *testing.T) {
 	t.Parallel()
 	require.Equal(t, 0, Zero[int]())
-	require.Equal(t, "", Zero[string]())
+	require.Empty(t, Zero[string]())
 	require.Nil(t, Zero[*int]())
 }
 

--- a/platform/fabric/core/config_test.go
+++ b/platform/fabric/core/config_test.go
@@ -55,7 +55,7 @@ fabric:
 	cfg, err := NewConfig(p)
 	require.NoError(t, err)
 	assert.Empty(t, cfg.Names())
-	assert.Equal(t, "", cfg.DefaultName())
+	assert.Empty(t, cfg.DefaultName())
 }
 
 func TestAddNetwork_IntoEmptyConfig(t *testing.T) {

--- a/platform/fabric/core/generic/chaincode/discovery_test.go
+++ b/platform/fabric/core/generic/chaincode/discovery_test.go
@@ -131,7 +131,7 @@ func TestToDiscoveredPeersUntrustedCADropped(t *testing.T) {
 	peers, err := discoverPeers(t, fix, newPeerFixture(t, "Org1MSP", "evil:7051", []byte("forged")))
 	require.Error(t, err, "a response whose only peer fails validation must not succeed")
 	require.Empty(t, peers)
-	require.True(t, strings.Contains(err.Error(), "validation"),
+	require.Contains(t, err.Error(), "validation",
 		"error must attribute the empty result to validation, got [%v]", err)
 }
 

--- a/platform/fabric/core/generic/committer/committer_test.go
+++ b/platform/fabric/core/generic/committer/committer_test.go
@@ -320,7 +320,7 @@ func TestAddDeleteListenerAndNotifyFinality(t *testing.T) {
 	}
 
 	c.deleteListener("tx10", ch)
-	require.Len(t, c.listeners["tx10"], 0)
+	require.Empty(t, c.listeners["tx10"])
 }
 
 func TestIsFinalForKnownStatuses(t *testing.T) {
@@ -754,7 +754,7 @@ func TestCommitTxs(t *testing.T) {
 			&common.BlockMetadata{},
 		)
 		require.NoError(t, err)
-		require.Len(t, c.events, 0)
+		require.Empty(t, c.events)
 	})
 
 	t.Run("handler error is returned", func(t *testing.T) {

--- a/platform/fabric/core/generic/membership/membership_test.go
+++ b/platform/fabric/core/generic/membership/membership_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package membership
 
 import (
-	"strings"
 	"testing"
 	"time"
 
@@ -118,7 +117,7 @@ func TestAccessorsBeforeFirstUpdate(t *testing.T) {
 
 			require.Error(t, err)
 			require.ErrorIs(t, err, driver.ErrNotInitialized)
-			require.True(t, strings.Contains(err.Error(), "mychannel"),
+			require.Contains(t, err.Error(), "mychannel",
 				"error should name the channel, got [%v]", err)
 		})
 	}
@@ -301,9 +300,9 @@ func TestTLSRootCertsByMSPIDWithoutApplicationConfig(t *testing.T) {
 	certs, err := s.TLSRootCertsByMSPID("Org1MSP")
 	require.Error(t, err)
 	require.Nil(t, certs)
-	require.True(t, strings.Contains(err.Error(), "mychannel"),
+	require.Contains(t, err.Error(), "mychannel",
 		"error must name the channel, got [%v]", err)
-	require.True(t, strings.Contains(err.Error(), "application config does not exist"),
+	require.Contains(t, err.Error(), "application config does not exist",
 		"error must be specific to the missing application section, got [%v]", err)
 }
 
@@ -393,9 +392,9 @@ func TestTLSRootCertsByMSPIDUnknownMSPNamesTheMSP(t *testing.T) {
 	certs, err := tlsRootCertsByMSPID(ac, "NoSuchMSP", "mychannel")
 	require.Error(t, err)
 	require.Nil(t, certs)
-	require.True(t, strings.Contains(err.Error(), "NoSuchMSP"),
+	require.Contains(t, err.Error(), "NoSuchMSP",
 		"error must name the MSP, got [%v]", err)
-	require.True(t, strings.Contains(err.Error(), "mychannel"),
+	require.Contains(t, err.Error(), "mychannel",
 		"error must name the channel, got [%v]", err)
 }
 
@@ -467,7 +466,7 @@ func TestConfigWaitReleasedByUpdate(t *testing.T) {
 		// require.Error would not tell them apart, since both are errors.
 		require.NotErrorIs(t, err, driver.ErrNotInitialized,
 			"error must come from the installed configuration, not from never having waited for it, got [%v]", err)
-		require.True(t, strings.Contains(err.Error(), "application config does not exist"),
+		require.Contains(t, err.Error(), "application config does not exist",
 			"error must be the one produced by the seeded configuration, got [%v]", err)
 	case <-time.After(2 * time.Second):
 		t.Fatal("the update did not release the waiting accessor; it is sitting out its budget")
@@ -483,7 +482,7 @@ func TestConfigWaitTimesOut(t *testing.T) {
 
 	_, err := s.TLSRootCertsByMSPID("Org1MSP")
 	require.Error(t, err)
-	require.True(t, strings.Contains(err.Error(), "mychannel"),
+	require.Contains(t, err.Error(), "mychannel",
 		"error must name what it waited for, got [%v]", err)
 }
 
@@ -534,7 +533,7 @@ func TestMSPManagerConfigWaitTimesOut(t *testing.T) {
 
 	_, err := mgr.DeserializeIdentity(view.Identity("some-identity"))
 	require.Error(t, err)
-	require.True(t, strings.Contains(err.Error(), "mychannel"),
+	require.Contains(t, err.Error(), "mychannel",
 		"error must name what it waited for, got [%v]", err)
 }
 
@@ -561,7 +560,7 @@ func TestConfigWaitDoesNotWaitOnARejectedConfig(t *testing.T) {
 	require.ErrorIs(t, err, driver.ErrConfigRejected)
 	require.Less(t, elapsed, time.Second,
 		"a refused configuration must be reported immediately, not after the wait budget, took [%s]", elapsed)
-	require.True(t, strings.Contains(err.Error(), "mychannel"),
+	require.Contains(t, err.Error(), "mychannel",
 		"error must name the channel, got [%v]", err)
 }
 

--- a/platform/fabric/core/generic/ordering/cft_test.go
+++ b/platform/fabric/core/generic/ordering/cft_test.go
@@ -724,6 +724,6 @@ func TestCFTBroadcaster_ConnectionLifecycle(t *testing.T) {
 		err := b.Broadcast(t.Context(), &common.Envelope{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to send transaction to orderer")
-		require.Len(t, b.connections, 0, "no connections should be pooled after all failures")
+		require.Empty(t, b.connections, "no connections should be pooled after all failures")
 	})
 }

--- a/platform/fabric/services/endorser/transaction_test.go
+++ b/platform/fabric/services/endorser/transaction_test.go
@@ -155,7 +155,7 @@ func TestTransaction(t *testing.T) {
 
 	fakeTx.ProposalResponsesReturns([]driver.ProposalResponse{fakePR}, nil)
 	prs, _ := et.ProposalResponses()
-	require.Equal(t, 1, len(prs))
+	require.Len(t, prs, 1)
 
 	// ProposalResponses error
 	fakeTx.ProposalResponsesReturns(nil, fmt.Errorf("err"))

--- a/platform/fabric/services/state/flow_test.go
+++ b/platform/fabric/services/state/flow_test.go
@@ -341,7 +341,7 @@ func TestSendReceiveViewCall(t *testing.T) {
 		srv.coded = &mockCodec{
 			marshalRaw: []byte("send"),
 			unmarshalFn: func(raw []byte, v any) error {
-				require.Equal(t, []byte(`{"v":"ok"}`), raw)
+				require.JSONEq(t, `{"v":"ok"}`, string(raw))
 				target := v.(*struct {
 					V string `json:"v"`
 				})
@@ -622,7 +622,7 @@ func TestSendTransactionViewCallBranches(t *testing.T) {
 		}
 		_, err := NewSendTransactionView(tx, view.Identity("me")).Call(ctx)
 		require.NoError(t, err)
-		require.Len(t, ms.sent, 0)
+		require.Empty(t, ms.sent)
 	})
 
 	t.Run("bytes error", func(t *testing.T) {

--- a/platform/fabric/services/state/namespace_test.go
+++ b/platform/fabric/services/state/namespace_test.go
@@ -395,7 +395,7 @@ func TestContractAndSBEHandlers(t *testing.T) {
 
 		ep2, err := newStateEP(policy)
 		require.NoError(t, err)
-		require.Len(t, ep2.identities, 0)
+		require.Empty(t, ep2.identities)
 	})
 }
 

--- a/platform/view/services/comm/host/websocket/ws/stream_test.go
+++ b/platform/view/services/comm/host/websocket/ws/stream_test.go
@@ -135,7 +135,7 @@ func TestReader(t *testing.T) { //nolint:paralleltest
 	wg.Go(func() {
 		for _, in := range input {
 			read := &comm.ViewPacket{}
-			assert.NoError(t, r.ReadMsg(read))
+			assert.NoError(t, r.ReadMsg(read)) //nolint:testifylint // runs inside wg.Go and a loop; require.FailNow is unsafe outside the test goroutine
 			assert.True(t, proto.Equal(in, read))
 		}
 	})

--- a/platform/view/services/comm/session/random_test.go
+++ b/platform/view/services/comm/session/random_test.go
@@ -46,5 +46,5 @@ func TestGetRandomBytesZeroLen(t *testing.T) {
 	t.Parallel()
 	b, err := GetRandomBytes(0)
 	require.NoError(t, err)
-	require.Len(t, b, 0)
+	require.Empty(t, b)
 }

--- a/platform/view/services/comm/sig_exchange_test_utils.go
+++ b/platform/view/services/comm/sig_exchange_test_utils.go
@@ -112,7 +112,7 @@ func SignedSessionExchangeTestRound(t *testing.T, alice, bob *SignedExchangePart
 	// Alice: initiator.
 	wg.Go(func() {
 		session, err := alice.Node.NewSession("alice-view", "ctx-1", bob.Node.Address, []byte(bob.Node.ID))
-		if !assert.NoError(t, err) || !assert.NotNil(t, session) {
+		if !assert.NoError(t, err) || !assert.NotNil(t, session) { //nolint:testifylint // runs inside wg.Go; require.FailNow is unsafe outside the test goroutine
 			return
 		}
 		defer session.Close()
@@ -120,7 +120,7 @@ func SignedSessionExchangeTestRound(t *testing.T, alice, bob *SignedExchangePart
 		// Alice selects her own signer from the local identity carried by the
 		// session, not from any pre-captured key.
 		sig, err := alice.Sign(session.Info().LocalPKID, []byte(aliceMsg))
-		if !assert.NoError(t, err, "alice failed to sign") {
+		if !assert.NoError(t, err, "alice failed to sign") { //nolint:testifylint // runs inside wg.Go; require.FailNow is unsafe outside the test goroutine
 			return
 		}
 		assert.NotEmpty(t, session.Info().LocalPKID, "alice session carries no LocalPKID")
@@ -139,13 +139,13 @@ func SignedSessionExchangeTestRound(t *testing.T, alice, bob *SignedExchangePart
 				return
 			}
 			msg, err := utils.UnmarshalSignedMessage(rcv.Payload)
-			if !assert.NoError(t, err, "alice failed to decode reply") {
+			if !assert.NoError(t, err, "alice failed to decode reply") { //nolint:testifylint // runs inside wg.Go; require.FailNow is unsafe outside the test goroutine
 				return
 			}
 			assert.Equal(t, bobMsg, string(msg.Payload))
 			// Alice resolves Bob from the session info and verifies.
 			bobID, err := alice.verifyFromSession(session.Info(), msg)
-			if !assert.NoError(t, err) {
+			if !assert.NoError(t, err) { //nolint:testifylint // runs inside wg.Go; require.FailNow is unsafe outside the test goroutine
 				return
 			}
 			// Binding: the resolved identity's PKID matches what the session reported.

--- a/platform/view/services/comm/test_utils.go
+++ b/platform/view/services/comm/test_utils.go
@@ -40,10 +40,10 @@ func P2PLayerTestRound(t *testing.T, bootstrapNode, node *HostNode) {
 			SessionID:         "session",
 		}
 		err := bootstrapNode.sendTo(t.Context(), info, &ViewPacket{Payload: []byte("msg1")}, nil)
-		assert.NoError(t, err)
+		assert.NoError(t, err) //nolint:testifylint // runs inside wg.Go; require.FailNow is unsafe outside the test goroutine
 
 		err = bootstrapNode.sendTo(t.Context(), info, &ViewPacket{Payload: []byte("msg2")}, nil)
-		assert.NoError(t, err)
+		assert.NoError(t, err) //nolint:testifylint // runs inside wg.Go; require.FailNow is unsafe outside the test goroutine
 
 		msg := <-messages
 		assert.NotNil(t, msg)
@@ -84,18 +84,18 @@ func SessionsTestRound(t *testing.T, bootstrapNode, node *HostNode) {
 
 	wg.Go(func() {
 		session, err := bootstrapNode.NewSession("", "", node.Address, []byte(node.ID))
-		assert.NoError(t, err)
+		assert.NoError(t, err) //nolint:testifylint // runs inside wg.Go; require.FailNow is unsafe outside the test goroutine
 		assert.NotNil(t, session)
 
 		err = session.Send(ctx, []byte("ciao"))
-		assert.NoError(t, err)
+		assert.NoError(t, err) //nolint:testifylint // runs inside wg.Go; require.FailNow is unsafe outside the test goroutine
 
 		sessionMsgs := session.Receive()
 		msg := <-sessionMsgs
 		assert.Equal(t, []byte("ciaoback"), msg.Payload)
 
 		err = session.Send(ctx, []byte("ciao on session"))
-		assert.NoError(t, err)
+		assert.NoError(t, err) //nolint:testifylint // runs inside wg.Go; require.FailNow is unsafe outside the test goroutine
 
 		session.Close()
 	})
@@ -136,11 +136,11 @@ func SessionsForMPCTestRound(t *testing.T, bootstrapNode, node *HostNode) {
 
 	wg.Go(func() {
 		session, err := bootstrapNode.NewResponderSession("myawesomempcid", "", bootstrapNode.Address, []byte(node.ID), nil, nil)
-		assert.NoError(t, err)
+		assert.NoError(t, err) //nolint:testifylint // runs inside wg.Go; require.FailNow is unsafe outside the test goroutine
 		assert.NotNil(t, session)
 
 		err = session.Send(ctx, []byte("ciao"))
-		assert.NoError(t, err)
+		assert.NoError(t, err) //nolint:testifylint // runs inside wg.Go; require.FailNow is unsafe outside the test goroutine
 
 		sessionMsgs := session.Receive()
 		msg := <-sessionMsgs

--- a/platform/view/services/endpoint/service_extended_test.go
+++ b/platform/view/services/endpoint/service_extended_test.go
@@ -538,7 +538,7 @@ func TestResolverMethods(t *testing.T) {
 		}
 		assert.Equal(t, "localhost:8080", resolver.GetAddress(endpoint.P2PPort))
 		assert.Equal(t, "localhost:8081", resolver.GetAddress(endpoint.ViewPort))
-		assert.Equal(t, "", resolver.GetAddress(endpoint.ListenPort))
+		assert.Empty(t, resolver.GetAddress(endpoint.ListenPort))
 	})
 }
 

--- a/platform/view/services/id/ecdsa/ecdsa_test.go
+++ b/platform/view/services/id/ecdsa/ecdsa_test.go
@@ -30,7 +30,7 @@ func TestGetCurveHalfOrdersAt(t *testing.T) {
 
 	// P256 N = FFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551
 	// Half should be non-zero and greater than 0
-	require.True(t, halfOrder.Cmp(big.NewInt(0)) > 0)
+	require.Positive(t, halfOrder.Cmp(big.NewInt(0)))
 }
 
 func TestNewSigner(t *testing.T) {
@@ -260,7 +260,7 @@ func TestToLowS(t *testing.T) {
 	lowSig := toLowS(sk.PublicKey, sig)
 
 	// Must be updated to a value <= halfOrder
-	require.True(t, lowSig.S.Cmp(halfOrder) <= 0)
+	require.LessOrEqual(t, lowSig.S.Cmp(halfOrder), 0)
 	require.Equal(t, expectedS, lowSig.S)
 }
 

--- a/platform/view/services/id/provider_test.go
+++ b/platform/view/services/id/provider_test.go
@@ -64,7 +64,7 @@ func TestLoad(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, idProvider.Clients(), 1)
 	require.Equal(t, raw, []byte(idProvider.Clients()[0]))
-	require.Len(t, idProvider.Admins(), 0)
+	require.Empty(t, idProvider.Admins())
 }
 
 func TestNewProviderFailurePaths(t *testing.T) {

--- a/platform/view/services/storage/db/tablename_test.go
+++ b/platform/view/services/storage/db/tablename_test.go
@@ -431,7 +431,7 @@ func TestTableNameCreator_DefaultPrefix(t *testing.T) {
 		creator := NewTableNameCreator("")
 		formatter, err := creator.GetFormatter("")
 		require.NoError(t, err)
-		require.Equal(t, "", formatter.prefix)
+		require.Empty(t, formatter.prefix)
 	})
 
 	t.Run("non-empty default prefix", func(t *testing.T) {

--- a/platform/view/services/storage/driver/notifier/notifier_test.go
+++ b/platform/view/services/storage/driver/notifier/notifier_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
@@ -335,7 +336,10 @@ func TestNotifier_ConcurrentSubscribe(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			err := n.Subscribe(func(driver.Operation, map[driver.ColumnKey]string) {})
-			require.NoError(t, err)
+			// require.FailNow is unsafe from a goroutine other than the one
+			// running the test; assert here, the outer require.Len below
+			// still catches any subscription failure via listener count.
+			assert.NoError(t, err)
 		}()
 	}
 

--- a/platform/view/services/view/grpc/client/grpc_client_test.go
+++ b/platform/view/services/view/grpc/client/grpc_client_test.go
@@ -581,7 +581,7 @@ func TestLocalClient(t *testing.T) {
 	resStruct, err := lcStruct.CallView("fid", []byte("input"))
 	require.NoError(t, err)
 	expectedJSON, _ := json.Marshal(map[string]string{"status": "ok"})
-	require.Equal(t, expectedJSON, resStruct)
+	require.JSONEq(t, string(expectedJSON), string(resStruct.([]byte)))
 
 	// getTracer error
 	spErr := &fakeServiceProvider{tpErr: fmt.Errorf("tracer provider error")}

--- a/platform/view/services/view/grpc/server/view_test.go
+++ b/platform/view/services/view/grpc/server/view_test.go
@@ -216,8 +216,8 @@ func TestInstallViewHandler(t *testing.T) {
 
 	InstallViewHandler(vm, srv, tp)
 
-	require.Equal(t, 2, len(srv.processors))
-	require.Equal(t, 1, len(srv.streamers))
+	require.Len(t, srv.processors, 2)
+	require.Len(t, srv.streamers, 1)
 
 	// Each handler is invoked rather than only checked for non-nil: asserting
 	// NotNil alone still passes if the registrations are swapped.
@@ -263,7 +263,7 @@ func TestInstallViewHandler(t *testing.T) {
 		marshaller,
 	))
 	require.Equal(t, "stream_fid", vm.lastNewViewID)
-	require.Equal(t, 1, len(scs.sentMsgs))
+	require.Len(t, scs.sentMsgs, 1)
 }
 
 func TestInitiateView(t *testing.T) {
@@ -437,11 +437,11 @@ func TestStreamCallView(t *testing.T) {
 
 	require.Equal(t, 1, vm.newViewCallCount)
 	require.Equal(t, 1, vm.initiateContextCallCount)
-	require.Equal(t, 1, len(mockCtx.services))
+	require.Len(t, mockCtx.services, 1)
 	require.Equal(t, 1, marshaller.marshalCommandResponseCallCount)
 	require.Equal(t, sc.Command, marshaller.lastCommand)
 	require.Equal(t, []byte("test_result"), marshaller.lastCallViewResult(t))
-	require.Equal(t, 1, len(scs.sentMsgs))
+	require.Len(t, scs.sentMsgs, 1)
 }
 
 func TestStreamCallView_Error(t *testing.T) {

--- a/platform/view/services/view/web/web_test.go
+++ b/platform/view/services/view/web/web_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
@@ -95,7 +96,7 @@ func TestViewHandler(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	expectedJSON, _ := json.Marshal(map[string]string{"foo": "bar"})
-	require.Equal(t, expectedJSON, resp.(*protos.CommandResponse_CallViewResponse).CallViewResponse.Result)
+	require.JSONEq(t, string(expectedJSON), string(resp.(*protos.CommandResponse_CallViewResponse).CallViewResponse.Result))
 
 	// StreamCallView error path without real websocket
 	w := httptest.NewRecorder()
@@ -167,7 +168,9 @@ func TestClientStreamCallView(t *testing.T) {
 		cErr := newViewClient(vmErr, ip, tp)
 		tsErr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			err := cErr.StreamCallView("fid", w, r)
-			require.ErrorContains(t, err, "new view error")
+			// require.FailNow is unsafe from an http.Handler goroutine; this
+			// is the handler's last statement, so assert changes nothing.
+			assert.ErrorContains(t, err, "new view error")
 		}))
 		t.Cleanup(tsErr.Close)
 		wsErr, resp, _ := websocket.DefaultDialer.Dial("ws"+tsErr.URL[4:], nil)
@@ -186,7 +189,9 @@ func TestClientStreamCallView(t *testing.T) {
 		cErr := newViewClient(vmErr, ip, tp)
 		tsErr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			err := cErr.StreamCallView("fid", w, r)
-			require.ErrorContains(t, err, "init context error")
+			// require.FailNow is unsafe from an http.Handler goroutine; this
+			// is the handler's last statement, so assert changes nothing.
+			assert.ErrorContains(t, err, "init context error")
 		}))
 		t.Cleanup(tsErr.Close)
 		wsErr, resp, _ := websocket.DefaultDialer.Dial("ws"+tsErr.URL[4:], nil)
@@ -205,7 +210,9 @@ func TestClientStreamCallView(t *testing.T) {
 		cErr := newViewClient(vmErr, ip, tp)
 		tsErr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			err := cErr.StreamCallView("fid", w, r)
-			require.ErrorContains(t, err, "run view error")
+			// require.FailNow is unsafe from an http.Handler goroutine; this
+			// is the handler's last statement, so assert changes nothing.
+			assert.ErrorContains(t, err, "run view error")
 		}))
 		t.Cleanup(tsErr.Close)
 		wsErr, resp, _ := websocket.DefaultDialer.Dial("ws"+tsErr.URL[4:], nil)
@@ -224,7 +231,9 @@ func TestClientStreamCallView(t *testing.T) {
 		cErr := newViewClient(vmErr, ip, tp)
 		tsErr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			err := cErr.StreamCallView("fid", w, r)
-			require.ErrorContains(t, err, "registering stream command server")
+			// require.FailNow is unsafe from an http.Handler goroutine; this
+			// is the handler's last statement, so assert changes nothing.
+			assert.ErrorContains(t, err, "registering stream command server")
 		}))
 		t.Cleanup(tsErr.Close)
 		wsErr, resp, _ := websocket.DefaultDialer.Dial("ws"+tsErr.URL[4:], nil)
@@ -257,7 +266,7 @@ func TestClientStreamCallView(t *testing.T) {
 		var outStruct server2.Output
 		_ = json.Unmarshal(respMsg, &outStruct)
 		expectedJSON, _ := json.Marshal(map[string]string{"status": "ok"})
-		require.Equal(t, expectedJSON, outStruct.Raw)
+		require.JSONEq(t, string(expectedJSON), string(outStruct.Raw))
 	})
 
 	t.Run("Non-mutable context error", func(t *testing.T) {
@@ -266,7 +275,9 @@ func TestClientStreamCallView(t *testing.T) {
 		cNonMutable := newViewClient(vmNonMutable, ip, tp)
 		tsNonMutable := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			err := cNonMutable.StreamCallView("fid", w, r)
-			require.ErrorContains(t, err, "expected a mutable context")
+			// require.FailNow is unsafe from an http.Handler goroutine; this
+			// is the handler's last statement, so assert changes nothing.
+			assert.ErrorContains(t, err, "expected a mutable context")
 		}))
 		t.Cleanup(tsNonMutable.Close)
 		wsNM, resp, _ := websocket.DefaultDialer.Dial("ws"+tsNonMutable.URL[4:], nil)


### PR DESCRIPTION
`testifylint` flags `testify` assertions that could use a more specific assert/require call (`assert.Contains` instead of `assert.True(strings.Contains(...))`), or that use `require` unsafely (inside a goroutine or an `http.Handler`).

Part of #1755.

### Scoping

61 findings: 56 in the root module, 5 in `integration` (0 in the other two modules).

| Rule | Count | What it flags |
|---|---|---|
| contains | 15 | `assert.True(strings.Contains(...))` → `Contains` |
| require-error | 12 | a failed error check that should stop the test (`require`) |
| empty | 11 | `Equal(t, "", x)` / `Len(t, x, 0)` → `Empty` |
| encoded-compare | 9 | raw JSON byte/string equality → `require.JSONEq` (5 of these in `integration`) |
| len | 6 | `Equal(t, n, len(x))` → `Len` |
| go-require | 6 | `require` used unsafely (inside a goroutine or an `http.Handler`) |
| negative-positive | 1 | `True(x > 0)` → `require.Positive` |
| compares | 1 | `True(x <= 0)` → `require.LessOrEqual` |

43 findings (`contains`, `empty`, `encoded-compare`, `len`, `negative-positive`, `compares`) were auto-fixed by `make lint-auto-fix` and reviewed hunk by hunk, with two hand-fixes on top: removed now-unused `strings` imports left behind in `holder_test.go` and `membership_test.go` once their `strings.Contains(...)` assertions became `Contains` matchers, and added an explicit `[]byte` type assertion in `grpc_client_test.go` where the auto-fixed `require.JSONEq` call compared an `any`-typed result against a string parameter, which didn't compile.

The remaining 18 findings needed manual judgment. 6 `go-require` findings (1 in `notifier_test.go`, 5 in `web_test.go`) flagged genuinely unsafe `require` usage inside a `go func(){}()` goroutine or an `http.HandlerFunc` closure — converted to `assert` in all 6 cases, since each is the last statement in its goroutine/handler body, so nothing that must run afterward is skipped. The other 12 (`require-error`, in `test_utils.go`, `sig_exchange_test_utils.go`, `stream_test.go`) are false positives: they sit inside `wg.Go(func(){...})` closures (`sync.WaitGroup.Go`, Go 1.24+) that `testifylint`'s goroutine detector doesn't recognize — converting them to `require` would reintroduce the exact unsafe-`require` problem the `go-require` rule exists to catch. Suppressed individually with a `//nolint:testifylint` comment explaining that reasoning, matching the pattern already documented for `verifyFromSession` in `sig_exchange_test_utils.go`.

### Verification

`go build ./...` and `go vet ./...` (root and `integration/`) exit 0. `go test` passes for every touched package, including `notifier_test.go`'s `ConcurrentSubscribe` case under `-race`. `make checks` exits 0.

### Note for reviewers

This branch is independent — rooted directly on current `main`, not stacked on any other PR in this series.
