### PR TITLE
chore(lint): enable unconvert in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,7 @@ linters:
     - testifylint
     - thelper
     - tparallel
+    - unconvert
     - unused
     - usestdlibvars
   settings:

--- a/integration/nwo/fabric/packager/ccmetadata/validators.go
+++ b/integration/nwo/fabric/packager/ccmetadata/validators.go
@@ -151,7 +151,7 @@ func couchdbIndexFileValidator(fileName string, fileBytes []byte) error {
 // isJSON tests a string to determine if it can be parsed as valid JSON
 func isJSON(s []byte) (bool, map[string]any) {
 	var js map[string]any
-	return json.Unmarshal([]byte(s), &js) == nil, js
+	return json.Unmarshal(s, &js) == nil, js
 }
 
 func validateIndexJSON(indexDefinition map[string]any) error {

--- a/pkg/utils/compose/compose.go
+++ b/pkg/utils/compose/compose.go
@@ -26,7 +26,7 @@ func CreateCompositeKey(sb *strings.Builder, objectType string, attributes ...st
 	}
 	sb.WriteString(compositeKeyNamespace)
 	sb.WriteString(objectType)
-	sb.WriteRune(rune(minUnicodeRuneValue))
+	sb.WriteRune(minUnicodeRuneValue)
 	for _, att := range attributes {
 		if err := validateCompositeKeyAttribute(att); err != nil {
 			return "", err

--- a/platform/common/core/generic/vault/inspector_test.go
+++ b/platform/common/core/generic/vault/inspector_test.go
@@ -76,7 +76,7 @@ func TestInspectorGetStateMetadata(t *testing.T) {
 
 	got, err := i.GetStateMetadata("ns", "k1")
 	require.NoError(t, err)
-	require.Equal(t, driver.Metadata(meta), got)
+	require.Equal(t, meta, got)
 
 	missing, err := i.GetStateMetadata("ns", "absent")
 	require.NoError(t, err)

--- a/platform/fabric/core/generic/committer/endorsertx.go
+++ b/platform/fabric/core/generic/committer/endorsertx.go
@@ -60,7 +60,7 @@ func MapFinalityEvent(ctx context.Context, block *common.BlockMetadata, txNum dr
 	}
 
 	validationFlags := ValidationFlags(block.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER])
-	if uint64(txNum) >= uint64(len(validationFlags)) {
+	if txNum >= uint64(len(validationFlags)) {
 		return 0, nil, errors.Errorf("transaction number [%d] out of range for validation flags of length [%d]", txNum, len(validationFlags))
 	}
 

--- a/platform/fabric/core/generic/config/service_test.go
+++ b/platform/fabric/core/generic/config/service_test.go
@@ -142,7 +142,7 @@ func TestChannelHelpers(t *testing.T) {
 	t.Parallel()
 	ch := &cfg.Channel{}
 	// default values
-	require.Equal(t, time.Duration(5*time.Minute), ch.DiscoveryDefaultTTLS())
+	require.Equal(t, 5*time.Minute, ch.DiscoveryDefaultTTLS())
 	require.Equal(t, 1, ch.CommitParallelism())
 	require.Equal(t, 1*time.Second, ch.CommitterPollingTimeout())
 	require.Equal(t, 10*time.Second, ch.DeliverySleepAfterFailure())
@@ -152,7 +152,7 @@ func TestChannelHelpers(t *testing.T) {
 	require.Equal(t, 1, ch.DeliveryBufferSize())
 	require.Equal(t, 20*time.Second, ch.DiscoveryTimeout())
 	require.Equal(t, 3, ch.CommitterFinalityNumRetries())
-	require.Equal(t, time.Duration(100*time.Millisecond), ch.CommitterFinalityUnknownTXTimeout())
+	require.Equal(t, 100*time.Millisecond, ch.CommitterFinalityUnknownTXTimeout())
 	require.Equal(t, time.Minute, ch.FinalityForPartiesWaitTimeout())
 
 	// test PollingTimeout clamping

--- a/platform/fabric/core/generic/events/listenermanager_test.go
+++ b/platform/fabric/core/generic/events/listenermanager_test.go
@@ -119,7 +119,7 @@ func TestRemoveEventListenerAfterListenerAlreadyInvoked(t *testing.T) {
 		},
 	}
 	err := manager.onBlock(context.Background(), &common.Block{
-		Header:   &common.BlockHeader{Number: uint64(testBlockNumber)},
+		Header:   &common.BlockHeader{Number: testBlockNumber},
 		Data:     &common.BlockData{Data: [][]byte{[]byte("tx-1")}},
 		Metadata: &common.BlockMetadata{},
 	})
@@ -160,7 +160,7 @@ func TestOnBlockInvokesTransientAndPermanentListenersAndCachesEvent(t *testing.T
 	}
 
 	err := manager.onBlock(context.Background(), &common.Block{
-		Header:   &common.BlockHeader{Number: uint64(testBlockNumber)},
+		Header:   &common.BlockHeader{Number: testBlockNumber},
 		Data:     &common.BlockData{Data: [][]byte{[]byte("tx-1")}},
 		Metadata: &common.BlockMetadata{},
 	})
@@ -214,7 +214,7 @@ func TestNewBlockCallbackReturnsErrorWhenBlockProcessingFails(t *testing.T) {
 	}
 
 	stop, err := manager.newBlockCallback()(context.Background(), &common.Block{
-		Header:   &common.BlockHeader{Number: uint64(testBlockNumber)},
+		Header:   &common.BlockHeader{Number: testBlockNumber},
 		Data:     &common.BlockData{Data: [][]byte{[]byte("tx-1")}},
 		Metadata: &common.BlockMetadata{},
 	})
@@ -234,7 +234,7 @@ func TestNewBlockCallbackWithParallelProcessingDoesNotBubbleErrors(t *testing.T)
 	}
 
 	stop, err := manager.newBlockCallback()(context.Background(), &common.Block{
-		Header:   &common.BlockHeader{Number: uint64(testBlockNumber)},
+		Header:   &common.BlockHeader{Number: testBlockNumber},
 		Data:     &common.BlockData{Data: [][]byte{[]byte("tx-1")}},
 		Metadata: &common.BlockMetadata{},
 	})
@@ -275,7 +275,7 @@ func TestParallelBlockMapperMapReturnsError(t *testing.T) {
 	}
 
 	_, err := mapper.Map(context.Background(), &common.Block{
-		Header:   &common.BlockHeader{Number: uint64(testBlockNumber)},
+		Header:   &common.BlockHeader{Number: testBlockNumber},
 		Data:     &common.BlockData{Data: [][]byte{[]byte("tx-1")}},
 		Metadata: &common.BlockMetadata{},
 	})

--- a/platform/fabric/core/generic/ordering/bft.go
+++ b/platform/fabric/core/generic/ordering/bft.go
@@ -92,7 +92,7 @@ func (o *BFTBroadcaster) Broadcast(ctx context.Context, env *common2.Envelope) e
 	}
 
 	n := len(orderers)
-	f := (int(n) - 1) / 3
+	f := (n - 1) / 3
 	threshold := int(math.Ceil((float64(n) + float64(f) + 1) / 2.0))
 
 	for i := range retries {

--- a/platform/fabric/core/generic/rwset/handler_loader_test.go
+++ b/platform/fabric/core/generic/rwset/handler_loader_test.go
@@ -35,7 +35,7 @@ func TestEndorserTransactionHandlerLoad(t *testing.T) {
 		require.NoError(t, err)
 		require.Same(t, expectedRWS, rws)
 		_, txID, rwset := inspector.NewRWSetFromBytesArgsForCall(0)
-		require.Equal(t, cdriver.TxID(chdr.TxId), txID)
+		require.Equal(t, chdr.TxId, txID)
 		require.Equal(t, results, rwset)
 		require.Equal(t, chdr.TxId, tx.ID())
 		require.Equal(t, "test-network", tx.Network())
@@ -169,7 +169,7 @@ func TestLoaderGetRWSetFromEvn(t *testing.T) {
 			nil,
 			nil,
 		)
-		_, _, err := loader.GetRWSetFromEvn(t.Context(), cdriver.TxID(chdr.TxId))
+		_, _, err := loader.GetRWSetFromEvn(t.Context(), chdr.TxId)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "header type not supported")
 	})
@@ -186,7 +186,7 @@ func TestLoaderGetRWSetFromEvn(t *testing.T) {
 			nil,
 			nil,
 		)
-		_, _, err := loader.GetRWSetFromEvn(t.Context(), cdriver.TxID(chdr.TxId))
+		_, _, err := loader.GetRWSetFromEvn(t.Context(), chdr.TxId)
 		require.ErrorContains(t, err, "channel mismatch, expected [channel], got [mychannel]")
 	})
 
@@ -212,7 +212,7 @@ func TestLoaderGetRWSetFromEvn(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		rws, tx, err := loader.GetRWSetFromEvn(t.Context(), cdriver.TxID(chdr.TxId))
+		rws, tx, err := loader.GetRWSetFromEvn(t.Context(), chdr.TxId)
 		require.NoError(t, err)
 		require.Same(t, expectedRWS, rws)
 		require.Same(t, expectedTx, tx)
@@ -330,7 +330,7 @@ func TestLoaderGetInspectingRWSetFromEvn(t *testing.T) {
 		t.Parallel()
 		env, _, chdr, _, _, _ := buildTestEnvelope(t, cb.HeaderType_CONFIG, []byte("rwset"))
 		loader := NewLoader("network", "channel", nil, nil, nil, &rwsetmock.RWSetInspector{})
-		_, _, err := loader.GetInspectingRWSetFromEvn(t.Context(), cdriver.TxID(chdr.TxId), mustMarshalProto(t, env))
+		_, _, err := loader.GetInspectingRWSetFromEvn(t.Context(), chdr.TxId, mustMarshalProto(t, env))
 		require.Error(t, err)
 		require.ErrorContains(t, err, "failed unpacking envelope")
 	})
@@ -348,7 +348,7 @@ func TestLoaderGetInspectingRWSetFromEvn(t *testing.T) {
 			nil,
 			inspector,
 		)
-		_, _, err := loader.GetInspectingRWSetFromEvn(t.Context(), cdriver.TxID(chdr.TxId), mustMarshalProto(t, env))
+		_, _, err := loader.GetInspectingRWSetFromEvn(t.Context(), chdr.TxId, mustMarshalProto(t, env))
 		require.ErrorContains(t, err, "inspect-failed")
 	})
 
@@ -356,7 +356,7 @@ func TestLoaderGetInspectingRWSetFromEvn(t *testing.T) {
 		t.Parallel()
 		env, _, chdr, _, _, _ := buildTestEnvelope(t, cb.HeaderType_ENDORSER_TRANSACTION, []byte("rwset"))
 		loader := NewLoader("network", "channel", nil, nil, nil, &rwsetmock.RWSetInspector{})
-		_, _, err := loader.GetInspectingRWSetFromEvn(t.Context(), cdriver.TxID(chdr.TxId), mustMarshalProto(t, env))
+		_, _, err := loader.GetInspectingRWSetFromEvn(t.Context(), chdr.TxId, mustMarshalProto(t, env))
 		require.ErrorContains(t, err, "channel mismatch, expected [channel], got [mychannel]")
 	})
 
@@ -375,7 +375,7 @@ func TestLoaderGetInspectingRWSetFromEvn(t *testing.T) {
 			nil,
 			inspector,
 		)
-		rws, tx, err := loader.GetInspectingRWSetFromEvn(t.Context(), cdriver.TxID(chdr.TxId), mustMarshalProto(t, env))
+		rws, tx, err := loader.GetInspectingRWSetFromEvn(t.Context(), chdr.TxId, mustMarshalProto(t, env))
 		require.NoError(t, err)
 		require.Same(t, expectedRWS, rws)
 		_, rwsetBytes, _ := inspector.InspectRWSetArgsForCall(0)

--- a/platform/fabric/services/state/certification_test.go
+++ b/platform/fabric/services/state/certification_test.go
@@ -85,8 +85,8 @@ func TestResolveCertifierUsesRegistered(t *testing.T) {
 func newCertifierNamespace(t *testing.T, ns, key string, committed []byte, mapping map[string][]byte) *Namespace {
 	t.Helper()
 	tx, rwset, driverTx := newTestStateTransaction(ns)
-	require.NoError(t, rwset.SetState(cdriver.Namespace(ns), cdriver.PKey(key), committed))
-	require.NoError(t, rwset.AddReadAt(cdriver.Namespace(ns), key, nil))
+	require.NoError(t, rwset.SetState(ns, key, committed))
+	require.NoError(t, rwset.AddReadAt(ns, key, nil))
 	if mapping != nil {
 		fmKey, err := fieldMappingKey(ns, key)
 		require.NoError(t, err)

--- a/platform/fabric/services/state/common_test.go
+++ b/platform/fabric/services/state/common_test.go
@@ -70,7 +70,7 @@ func (t *testRWSet) Clear(ns cdriver.Namespace) error {
 
 func (t *testRWSet) AddReadAt(ns cdriver.Namespace, key string, _ cdriver.RawVersion) error {
 	v, _ := t.GetState(ns, key)
-	t.reads[ns] = append(t.reads[ns], testRead{key: cdriver.PKey(key), value: cloneRaw(v)})
+	t.reads[ns] = append(t.reads[ns], testRead{key: key, value: cloneRaw(v)})
 	return nil
 }
 

--- a/platform/fabric/services/state/namespace_errors_test.go
+++ b/platform/fabric/services/state/namespace_errors_test.go
@@ -14,8 +14,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	cdriver "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 )
 
 const errNS = "assetns"
@@ -47,7 +45,7 @@ func requirePanicsContaining(tb testing.TB, want string, f func()) {
 // seedRead registers a read entry for key with the given raw value.
 func seedRead(tb testing.TB, rwset *testRWSet, key string, raw []byte) {
 	tb.Helper()
-	require.NoError(tb, rwset.SetState(errNS, cdriver.PKey(key), raw))
+	require.NoError(tb, rwset.SetState(errNS, key, raw))
 	rwset.writes[errNS] = nil // keep the write list clean; we only want a read
 	require.NoError(tb, rwset.AddReadAt(errNS, key, nil))
 }
@@ -505,7 +503,7 @@ func TestNamespaceAddOutputEmbeddingStateDerivesInnerID(t *testing.T) {
 	require.Equal(t, 1, tx.NumOutputs())
 	key, _, err := rwset.GetWriteAt(errNS, 0)
 	require.NoError(t, err)
-	require.Equal(t, "inner-id", string(key))
+	require.Equal(t, "inner-id", key)
 }
 
 type embeddingHouse struct {

--- a/platform/fabric/transaction.go
+++ b/platform/fabric/transaction.go
@@ -407,7 +407,7 @@ func (t *TransactionManager) NewTransaction(opts ...TransactionOption) (*Transac
 		return nil, err
 	}
 
-	tx, err := t.fns.fns.TransactionManager().NewTransaction(options.Ctx, driver.TransactionType(options.TransactionType), options.Creator, options.Nonce, options.TxID, ch.Name(), options.RawRequest)
+	tx, err := t.fns.fns.TransactionManager().NewTransaction(options.Ctx, options.TransactionType, options.Creator, options.Nonce, options.TxID, ch.Name(), options.RawRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/fabricx/core/transaction/transaction.go
+++ b/platform/fabricx/core/transaction/transaction.go
@@ -542,7 +542,7 @@ func (t *Transaction) persistFieldMappings() error {
 		if err != nil {
 			continue
 		}
-		writeVal, err := t.rwset.GetState(cdriver.Namespace(ns), cdriver.PKey(key), cdriver.FromIntermediate)
+		writeVal, err := t.rwset.GetState(ns, key, cdriver.FromIntermediate)
 		if err != nil || len(writeVal) == 0 {
 			logger.Warnf("no write value for field-mapping [%s:%s]; skipping persist", ns, key)
 			continue

--- a/platform/fabricx/core/transaction/transaction_test.go
+++ b/platform/fabricx/core/transaction/transaction_test.go
@@ -401,7 +401,7 @@ func TestStoreTransientPersistsFieldMappings(t *testing.T) {
 	require.Equal(t, 1, fakeRWSet.GetStateCallCount())
 	gotNs, gotKey, gotOpts := fakeRWSet.GetStateArgsForCall(0)
 	require.Equal(t, commondriver.Namespace("asset_transfer"), gotNs)
-	require.Equal(t, commondriver.PKey(origKey), gotKey)
+	require.Equal(t, origKey, gotKey)
 	require.Equal(t, []commondriver.GetStateOpt{commondriver.FromIntermediate}, gotOpts)
 }
 
@@ -745,11 +745,11 @@ func TestTransactionSetRWSet(t *testing.T) {
 			require.Equal(t, tc.expectedFromBytesCalls, fakeVault.NewRWSetFromBytesCallCount())
 			if tc.expectedNewRWSetCalls == 1 {
 				_, gotTxID := fakeVault.NewRWSetArgsForCall(0)
-				require.Equal(t, commondriver.TxID(tc.tx.TTxID), gotTxID)
+				require.Equal(t, tc.tx.TTxID, gotTxID)
 			}
 			if tc.expectedFromBytesCalls == 1 {
 				_, gotTxID, gotBytes := fakeVault.NewRWSetFromBytesArgsForCall(0)
-				require.Equal(t, commondriver.TxID(tc.tx.TTxID), gotTxID)
+				require.Equal(t, tc.tx.TTxID, gotTxID)
 				require.Equal(t, tc.expectedFromBytesArg, gotBytes)
 			}
 			require.Same(t, fakeRWSet, tc.tx.RWS())

--- a/platform/fabricx/core/vault/nsversion_test.go
+++ b/platform/fabricx/core/vault/nsversion_test.go
@@ -26,7 +26,7 @@ func nsVersionOf(t *testing.T, raw []byte, ns driver.Namespace) uint64 {
 	var tx applicationpb.Tx
 	require.NoError(t, proto.Unmarshal(raw, &tx))
 	for _, txNs := range tx.GetNamespaces() {
-		if txNs.GetNsId() == string(ns) {
+		if txNs.GetNsId() == ns {
 			return txNs.GetNsVersion()
 		}
 	}
@@ -143,7 +143,7 @@ func TestRWSet_NamespaceVersionResolvedOncePerNamespace(t *testing.T) {
 
 	before := qs.getStatesCount.Load()
 	for i := range 5 {
-		require.NoError(t, rws.SetState("ns1", driver.PKey(string(rune('a'+i))), []byte("val")))
+		require.NoError(t, rws.SetState("ns1", string(rune('a'+i)), []byte("val")))
 	}
 	require.Equal(t, before+1, qs.getStatesCount.Load(),
 		"only the first touch of a namespace resolves its version")
@@ -287,7 +287,7 @@ func TestRWSet_ConcurrentFirstTouchPinsSingleVersion(t *testing.T) {
 	var eg errgroup.Group
 	for g := range 16 {
 		eg.Go(func() error {
-			return rws.SetState("ns1", driver.PKey(string(rune('a'+g))), []byte("value"))
+			return rws.SetState("ns1", string(rune('a'+g)), []byte("value"))
 		})
 	}
 	require.NoError(t, eg.Wait())

--- a/platform/fabricx/core/vault/vault.go
+++ b/platform/fabricx/core/vault/vault.go
@@ -215,7 +215,7 @@ func (r *rwSetWrapper) IsValid() error {
 		}
 	}
 	for ns := range nsVersionsCopy {
-		addKey(metaNamespace, cdriver.PKey(ns))
+		addKey(metaNamespace, ns)
 	}
 
 	// A namespace with no keys makes the query service reject the whole batch.
@@ -232,7 +232,7 @@ func (r *rwSetWrapper) IsValid() error {
 
 	states, err := r.v.queryService.GetStates(query)
 	if err != nil {
-		return errors.Wrapf(err, "failed to validate rwset for tx %s", string(r.txID))
+		return errors.Wrapf(err, "failed to validate rwset for tx %s", r.txID)
 	}
 
 	for ns, reads := range readsCopy {
@@ -250,7 +250,7 @@ func (r *rwSetWrapper) IsValid() error {
 	}
 
 	for ns, pinnedVersion := range nsVersionsCopy {
-		current, found := states[metaNamespace][cdriver.PKey(ns)]
+		current, found := states[metaNamespace][ns]
 		// An unregistered namespace was pinned at version 0; it stays valid only while it
 		// remains unregistered.
 		currentVersion := MarshalVersion(0)
@@ -270,12 +270,12 @@ func (r *rwSetWrapper) IsValid() error {
 // been serialized.
 func (v *Vault) namespaceVersion(ns cdriver.Namespace) (cdriver.RawVersion, error) {
 	states, err := v.queryService.GetStates(map[cdriver.Namespace][]cdriver.PKey{
-		metaNamespace: {cdriver.PKey(ns)},
+		metaNamespace: {ns},
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to query %s version for namespace %s", metaNamespace, ns)
 	}
-	if state, ok := states[metaNamespace][cdriver.PKey(ns)]; ok {
+	if state, ok := states[metaNamespace][ns]; ok {
 		return state.Version, nil
 	}
 	return MarshalVersion(0), nil
@@ -443,7 +443,7 @@ func (r *rwSetWrapper) GetStateMetadata(namespace cdriver.Namespace, key cdriver
 	// underlying KVS read returns no row and unmarshalling the empty result fails) -
 	// see the comment on mds.GetFieldMapping. Callers must treat any error here as "no
 	// mapping", matching mds.LoadTransient's identical miss behaviour.
-	fm, err := r.v.mds.GetFieldMapping(context.Background(), string(namespace), string(key), digest[:])
+	fm, err := r.v.mds.GetFieldMapping(context.Background(), namespace, key, digest[:])
 	if err != nil {
 		logger.Debugf("no field mapping for namespace=%s, key=%s: %s", namespace, key, err)
 		return nil, nil
@@ -583,7 +583,7 @@ func (r *rwSetWrapper) Bytes() ([]byte, error) {
 	if r.cachedBytes == nil {
 		// Marshal rejects a namespace missing from nsVersions, which would mean a code path
 		// mutated the RWSet without pinning a version for it.
-		raw, err := r.v.marshaller.Marshal(string(r.txID), r.rws, r.nsVersions)
+		raw, err := r.v.marshaller.Marshal(r.txID, r.rws, r.nsVersions)
 		if err != nil {
 			return nil, err
 		}
@@ -702,9 +702,7 @@ func (v *Vault) Status(ctx context.Context, txID cdriver.TxID) (fdriver.Validati
 // ("not final yet"). The result preserves the order of the input txIDs.
 func (v *Vault) Statuses(ctx context.Context, txIDs ...cdriver.TxID) ([]cdriver.TxValidationStatus[fdriver.ValidationCode], error) {
 	ids := make([]string, len(txIDs))
-	for i, txID := range txIDs {
-		ids[i] = string(txID)
-	}
+	copy(ids, txIDs)
 
 	codes, err := v.queryService.GetTransactionStatuses(ids)
 	if err != nil {
@@ -714,7 +712,7 @@ func (v *Vault) Statuses(ctx context.Context, txIDs ...cdriver.TxID) ([]cdriver.
 	statuses := make([]cdriver.TxValidationStatus[fdriver.ValidationCode], len(txIDs))
 	for i, txID := range txIDs {
 		code := fdriver.Unknown // omitted from the batched result => not final yet
-		if statusCode, ok := codes[string(txID)]; ok {
+		if statusCode, ok := codes[txID]; ok {
 			code = v.mapStatusToValidationCode(statusCode)
 		}
 		statuses[i] = cdriver.TxValidationStatus[fdriver.ValidationCode]{

--- a/platform/fabricx/core/vault/vault_test.go
+++ b/platform/fabricx/core/vault/vault_test.go
@@ -61,14 +61,14 @@ func TestVaultX_GetStateMetadataServesStoreOnMiss(t *testing.T) {
 	stored := fdriver.TransientMap{fmKey: []byte(`{"_root_":"cHJlaW1hZ2U="}`)}
 
 	qs := newMockQueryService()
-	qs.setState("asset_transfer", driver.PKey(origKey), committed, 1)
+	qs.setState("asset_transfer", origKey, committed, 1)
 	mds := &mockMDS{fieldMappings: map[string]fdriver.TransientMap{string(digest[:]): stored}}
 
 	v := vault.NewVault(qs, mds)
 	rws, err := v.NewRWSet(context.Background(), "tx1")
 	require.NoError(t, err)
 
-	meta, err := rws.GetStateMetadata("asset_transfer", driver.PKey(origKey), driver.FromBoth)
+	meta, err := rws.GetStateMetadata("asset_transfer", origKey, driver.FromBoth)
 	require.NoError(t, err)
 	require.Equal(t, stored[fmKey], meta[fmKey])
 }

--- a/platform/view/services/comm/host/websocket/host_timeout_test.go
+++ b/platform/view/services/comm/host/websocket/host_timeout_test.go
@@ -31,7 +31,7 @@ func TestHostStartupTimeout(t *testing.T) { //nolint:paralleltest
 
 	// Create a mock config with invalid address
 	cfg := &mockConfig{
-		listenAddress: host2.PeerIPAddress(invalidAddress),
+		listenAddress: invalidAddress,
 	}
 
 	// Create a host with the invalid address
@@ -63,7 +63,7 @@ func TestHostStartupReadinessTimeout(t *testing.T) { //nolint:paralleltest
 
 	// Create a mock config
 	cfg := &mockConfig{
-		listenAddress: host2.PeerIPAddress(addr),
+		listenAddress: addr,
 	}
 
 	// Create a host

--- a/platform/view/services/comm/host/websocket/ws/reproduction_test.go
+++ b/platform/view/services/comm/host/websocket/ws/reproduction_test.go
@@ -131,7 +131,7 @@ func TestAttack_HijackSessionID(t *testing.T) { //nolint:paralleltest
 	}
 
 	// Verify that the RemotePeerID of the stream is indeed Charlie
-	assert.Equal(t, string(charlieID), srvStream.RemotePeerID())
+	assert.Equal(t, charlieID, srvStream.RemotePeerID())
 
 	// Note: In a full system, P2PNode uses internalSessionID = SessionID + "." + hash(FromPKID).
 	// Since FromPKID is verified by the host (Charlie), Charlie's internal session ID

--- a/platform/view/services/grpc/client_test.go
+++ b/platform/view/services/grpc/client_test.go
@@ -500,7 +500,7 @@ func TestSetServerRootCAs(t *testing.T) {
 
 	// good root cert
 	t.Log("running good config")
-	err = client.SetServerRootCAs([][]byte{[]byte(testCerts.caPEM)})
+	err = client.SetServerRootCAs([][]byte{testCerts.caPEM})
 	require.NoError(t, err)
 	// now connection should succeed again
 	conn, err = client.NewConnection(address)

--- a/platform/view/services/grpc/logging/server.go
+++ b/platform/view/services/grpc/logging/server.go
@@ -40,7 +40,7 @@ func (l LevelerFunc) PayloadLevel(ctx context.Context, fullMethod string) zapcor
 }
 
 // DefaultPayloadLevel is default level to use when logging payloads
-const DefaultPayloadLevel = zapcore.Level(zapcore.DebugLevel - 1)
+const DefaultPayloadLevel = zapcore.DebugLevel - 1
 
 type options struct {
 	Leveler

--- a/platform/view/services/grpc/tlsconfig_internal_test.go
+++ b/platform/view/services/grpc/tlsconfig_internal_test.go
@@ -102,8 +102,8 @@ func TestTLSConfig(t *testing.T) {
 		check: func(t *testing.T, cfg *tls.Config) {
 			t.Helper()
 			require.NotEmpty(t, cfg.CipherSuites)
-			require.NotContains(t, cfg.CipherSuites, uint16(tls.TLS_RSA_WITH_AES_128_GCM_SHA256))
-			require.NotContains(t, cfg.CipherSuites, uint16(tls.TLS_RSA_WITH_AES_256_GCM_SHA384))
+			require.NotContains(t, cfg.CipherSuites, tls.TLS_RSA_WITH_AES_128_GCM_SHA256)
+			require.NotContains(t, cfg.CipherSuites, tls.TLS_RSA_WITH_AES_256_GCM_SHA384)
 			require.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
 		},
 	}, {

--- a/platform/view/services/storage/driver/field_test.go
+++ b/platform/view/services/storage/driver/field_test.go
@@ -18,7 +18,7 @@ func TestFieldNameValidate(t *testing.T) {
 	t.Parallel()
 
 	for _, name := range []driver.FieldName{"pos", "tx_id", "col_id", "_x", "a1"} {
-		require.NoError(t, driver.FieldName(name).Validate(), name)
+		require.NoError(t, name.Validate(), name)
 	}
 }
 

--- a/platform/view/services/storage/driver/notifier/persistence_test.go
+++ b/platform/view/services/storage/driver/notifier/persistence_test.go
@@ -392,7 +392,7 @@ func TestUnversionedPersistenceNotifier_GetState(t *testing.T) {
 
 	ctx := context.Background()
 	mockKVS := &mock.KeyValueStore{}
-	expectedValue := driver2.RawValue([]byte("value1"))
+	expectedValue := []byte("value1")
 	mockKVS.GetStateReturns(expectedValue, nil)
 
 	upn := NewUnversioned(mockKVS)

--- a/platform/view/services/storage/driver/sql/common/unversioned_test.go
+++ b/platform/view/services/storage/driver/sql/common/unversioned_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	. "github.com/onsi/gomega"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
 	common2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
 )
 
@@ -46,7 +45,7 @@ func TestGetState(t *testing.T) { //nolint:paralleltest
 
 	Expect(mock.ExpectationsWereMet()).To(Succeed())
 	Expect(err).ToNot(HaveOccurred())
-	Expect(result).To(Equal(driver.UnversionedValue(value)))
+	Expect(result).To(Equal(value))
 }
 
 func TestGetState_QueryError(t *testing.T) { //nolint:paralleltest

--- a/platform/view/services/storage/kvs/keys.go
+++ b/platform/view/services/storage/kvs/keys.go
@@ -27,7 +27,7 @@ func CreateCompositeKey(objectType string, attributes []string) (string, error) 
 	var sb strings.Builder
 	sb.WriteString(compositeKeyNamespace)
 	sb.WriteString(objectType)
-	sb.WriteRune(rune(minUnicodeRuneValue))
+	sb.WriteRune(minUnicodeRuneValue)
 	for _, att := range attributes {
 		if err := validateCompositeKeyAttribute(att); err != nil {
 			return "", err

--- a/platform/view/services/tracing/utils.go
+++ b/platform/view/services/tracing/utils.go
@@ -36,15 +36,15 @@ func UnmarshalContext(data []byte) (trace.SpanContext, error) {
 
 	traceState, err := trace.ParseTraceState(sc.TraceState)
 	if err != nil {
-		return trace.SpanContext{}, errors.Wrapf(err, "failed unmarshalling trace state from [%s]", string(sc.TraceState))
+		return trace.SpanContext{}, errors.Wrapf(err, "failed unmarshalling trace state from [%s]", sc.TraceState)
 	}
 	spanID, err := trace.SpanIDFromHex(sc.SpanID)
 	if err != nil {
-		return trace.SpanContext{}, errors.Wrapf(err, "failed unmarshalling span ID from [%s]", string(sc.SpanID))
+		return trace.SpanContext{}, errors.Wrapf(err, "failed unmarshalling span ID from [%s]", sc.SpanID)
 	}
 	traceID, err := trace.TraceIDFromHex(sc.TraceID)
 	if err != nil {
-		return trace.SpanContext{}, errors.Wrapf(err, "failed unmarshalling trace ID from [%s]", string(sc.TraceID))
+		return trace.SpanContext{}, errors.Wrapf(err, "failed unmarshalling trace ID from [%s]", sc.TraceID)
 	}
 
 	return trace.NewSpanContext(trace.SpanContextConfig{

--- a/platform/view/services/view/context.go
+++ b/platform/view/services/view/context.go
@@ -85,7 +85,7 @@ func NewContextFactory(
 		identityProvider: identityProvider,
 		registry:         registry,
 		tracer: tracerProvider.Tracer("calls", tracing.WithMetricsOpts(tracing.MetricsOpts{
-			LabelNames: []string{string(SuccessLabel), string(ViewLabel), string(InitiatorViewLabel)},
+			LabelNames: []string{SuccessLabel, ViewLabel, InitiatorViewLabel},
 		})),
 		metrics:              metrics,
 		localIdentityChecker: localIdentityChecker,


### PR DESCRIPTION
`unconvert` flags a type conversion where the value already has the target type — e.g. `int(x)` where `x` is already `int`.

Part of #1755.

### Scoping

56 findings: 55 in the root module and 1 in `integration` (the other two modules had none). Every finding was a genuinely redundant conversion with no behavior change, for one of two reasons. Most of the codebase's domain identifiers (`TxNum`, `BlockNum`, `Namespace`, `PKey`, `TxID`, `RawValue`, `PeerID`, `PeerIPAddress`, `LabelName`) are declared as true Go type aliases (`type X = Y`), so converting across them is identical to converting a type to itself. The remainder — notably `FieldName` (`type FieldName string`) and the `driver.TransactionType` underlying the `TransactionType` alias — are genuinely defined types, not aliases; those deletions are safe for a different reason, namely that the conversion was a self-conversion of a value already carrying that exact named type. None of the four watch-for cases (pinning an untyped constant into an interface, crossing a type alias/named type, generics, or a deliberate width assertion) applied, so no `//nolint` was needed — all 56 conversions were deleted outright.

Removing two of the conversions turned a manual element-by-element slice copy in `Vault.Statuses` (fabricx) into two slices of the same underlying type; replaced the loop with `copy()` to satisfy staticcheck's S1001, which the change surfaced.

### Verification

`make checks` exits 0 across all four modules.

### Note for reviewers

This branch is independent — rooted directly on current `main`, not stacked on any other PR in this series.
