### PR TITLE
chore(ci): harden workflow token permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,6 +26,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -2,6 +2,9 @@ name: Git Checks
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   block-fixup:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-pr-review.yaml
+++ b/.github/workflows/on-pr-review.yaml
@@ -9,7 +9,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  checks: write
 
 jobs:
   on-pr-review:

--- a/.github/workflows/on-pr-update.yaml
+++ b/.github/workflows/on-pr-update.yaml
@@ -14,7 +14,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  checks: write
 
 jobs:
   on-pr-update:

--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -16,7 +16,6 @@ on:
 permissions:
   pull-requests: write
   contents: read
-  checks: write
 
 jobs:
   on-pr-open:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # One entry per `make unit-tests` module, on its own runner.
   utest:


### PR DESCRIPTION
## Summary
Addresses the OpenSSF Scorecard Token-Permissions findings (currently scoring 0):
- `codeql-analysis.yml`, `git.yml`, and `tests.yml` had no top-level `permissions` block. Scorecard flags this because a job added later without explicit permissions would silently inherit the repo/org default token scope instead of least privilege. Added `permissions: contents: read` at the top level of each (job-level overrides in `codeql-analysis.yml` are unchanged).
- `on-pr.yaml`, `on-pr-update.yaml`, and `on-pr-review.yaml` granted top-level `checks: write`. None of the bot scripts these workflows run (`bot-on-pr-open.js`, `bot-on-pr-update.js`, `bot-on-pr-review.js`) call the GitHub Checks API — `helpers/checks.js` is local DCO/GPG/merge-conflict validation, unrelated to that token scope. Removed the unused permission.