### PR TITLE
chore(lint): enable revive in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     - nilnesserr
     - paralleltest
     - predeclared
+    - revive
     - spancheck
     - rowserrcheck
     - recvcheck
@@ -64,6 +65,42 @@ linters:
         # reachable past 2^32 blocks. Revisit if the vault gains a 64-bit
         # version format.
         - G115
+    revive:
+      # `exported` and `package-comments` are deliberately omitted from this
+      # rule list, not suppressed after the fact: golangci-lint runs only the
+      # rules named here, so leaving these two out of the list IS how they are
+      # disabled. Both are public-API documentation work, not a lint-commit
+      # fix: `exported` measured 3672 findings (3672 distinct exported symbols
+      # needing a doc comment) and `package-comments` measured 268 findings
+      # (268 distinct packages missing a package doc comment); the union of
+      # packages needing either fix is 273. That documentation effort is
+      # tracked as a follow-up rather than done here.
+      severity: warning
+      confidence: 0.8
+      rules:
+        # Correctness / maintainability
+        - name: unreachable-code
+        - name: redefines-builtin-id
+        - name: var-naming
+        - name: receiver-naming
+        - name: error-naming
+        - name: error-strings
+        - name: errorf
+        - name: indent-error-flow
+        - name: superfluous-else
+        - name: early-return
+        - name: unnecessary-stmt
+        # API / code quality
+        - name: bare-return
+        - name: bool-literal-in-expr
+        - name: confusing-naming
+        - name: confusing-results
+        - name: modifies-parameter
+        - name: string-of-int
+        - name: time-naming
+        - name: unexported-return
+        - name: unused-parameter
+        - name: unused-receiver
   exclusions:
     paths:
       # nwo writes generated node commands here during integration tests; the
@@ -92,6 +129,21 @@ linters:
       - path: ^platform/view/services/comm/(master\.go|p2p\.go|pingpong_test\.go|sessions_test_utils\.go|sig_exchange_test_utils\.go|test_utils\.go|io/msgconn\.go|host/websocket/ws/(multiplexed_provider(_test)?\.go|simple_provider(_test)?\.go|mtls_enforcement_test\.go))$
         linters:
           - contextcheck
+      # unexported-return findings are deferred rather than fixed here, for the
+      # same reason exported/package-comments are omitted above: each finding is
+      # a public-API design decision (export the concrete type, or return an
+      # already-exported interface instead), not a lint-commit-sized fix, and a
+      # constructor returning an unexported concrete type that satisfies an
+      # exported interface is itself a common, deliberate Go idiom for hiding
+      # implementation details, not a bug. 121 findings across 68 files were
+      # measured when enabling the rule in the root module, plus 9 more across
+      # 7 files in the integration module and 2 more in the libp2p comm-host
+      # module; that redesign work is tracked as a follow-up rather than done
+      # here.
+      - path: ^(pkg/utils/retry\.go|integration/nwo/common/runner/buffer\.go|integration/nwo/fabric/platform\.go|integration/nwo/fabric/topology/idemix\.go|integration/nwo/fabric/topology/topology\.go|integration/nwo/monitoring/platform\.go|integration/reporting/jaeger/client\.go|integration/reporting/prometheus/client\.go|platform/view/services/comm/host/libp2p/config\.go|platform/view/services/comm/host/libp2p/provider\.go|platform/common/core/generic/committer/listenermgr\.go|platform/common/services/logging/types\.go|platform/common/utils/cache/lru\.go|platform/common/utils/cache/map\.go|platform/common/utils/cache/secondcache/second_chance\.go|platform/common/utils/cache/timeout\.go|platform/common/utils/lazy/getter\.go|platform/common/utils/lazy/holder\.go|platform/common/utils/lazy/provider\.go|platform/fabric/core/generic/channelprovider\.go|platform/fabric/core/generic/committer/depresolver\.go|platform/fabric/core/generic/driver/identity/msp\.go|platform/fabric/core/generic/endpoint/endpoint\.go|platform/fabric/core/generic/finality/committerflm\.go|platform/fabric/core/generic/finality/deliveryflm\.go|platform/fabric/core/generic/id/provider\.go|platform/fabric/core/generic/msp/service\.go|platform/fabric/core/generic/msp/x509/ecdsa\.go|platform/fabric/core/generic/rwset/handler\.go|platform/fabric/core/generic/rwset/processor\.go|platform/fabric/core/generic/services/grpc\.go|platform/fabric/core/generic/transaction/services\.go|platform/fabric/core/generic/transaction/transaction\.go|platform/fabric/core/generic/vault/vault\.go|platform/fabric/services/chaincode/endorse\.go|platform/fabric/services/chaincode/invoke\.go|platform/fabric/services/chaincode/query\.go|platform/fabric/services/crypto/provider\.go|platform/fabric/services/endorser/endorsement_proposal\.go|platform/fabric/services/endorser/endorsement\.go|platform/fabric/services/endorser/finality\.go|platform/fabric/services/endorser/ordering\.go|platform/fabric/services/state/flow\.go|platform/fabric/services/state/namespace\.go|platform/fabric/services/state/transaction\.go|platform/fabric/services/state/vault/vault\.go|platform/fabric/services/storage/endorsetx/store\.go|platform/fabric/services/storage/envelope/store\.go|platform/fabric/services/storage/metadata/store\.go|platform/fabricx/core/channel/provider\.go|platform/fabricx/core/committer/txhandler\.go|platform/fabricx/core/ledger/ledger\.go|platform/fabricx/core/transaction/manager\.go|platform/view/sdk/dig/container\.go|platform/view/sdk/vfsdk/container\.go|platform/view/services/comm/config\.go|platform/view/services/comm/host/websocket/config\.go|platform/view/services/comm/host/websocket/host\.go|platform/view/services/comm/host/websocket/provider\.go|platform/view/services/comm/host/websocket/routing/servicediscovery\.go|platform/view/services/comm/host/websocket/ws/stream\.go|platform/view/services/comm/session/json\.go|platform/view/services/metrics/operations/logger\.go|platform/view/services/metrics/operations/metrics\.go|platform/view/services/storage/db/tablename\.go|platform/view/services/storage/driver/pagination/keyset\.go|platform/view/services/storage/driver/pagination/none\.go|platform/view/services/storage/driver/pagination/offset\.go|platform/view/services/storage/driver/sql/common/utils\.go|platform/view/services/storage/driver/sql/postgres/notifier\.go|platform/view/services/storage/driver/sql/postgres/sanitizer\.go|platform/view/services/storage/driver/sql/postgres/test_utils\.go|platform/view/services/storage/driver/sql/sqlite/retrywritedb\.go|platform/view/services/storage/driver/sql/sqlite/sanitizer\.go|platform/view/services/tracing/span\.go|platform/view/services/view/grpc/client/client\.go|platform/view/services/view/grpc/client/si/ecdsa\.go)$
+        linters:
+          - revive
+        text: unexported-return
 formatters:
   enable:
     - gci

--- a/integration/benchmark/grpc/baseline_bench_test.go
+++ b/integration/benchmark/grpc/baseline_bench_test.go
@@ -73,7 +73,7 @@ func init() {
 
 // makeSelfSignedCert generates a localhost self-signed cert using ECDSA P-256.
 // It returns the tls.Certificate and the PEM-encoded cert for the client root pool.
-func makeSelfSignedCert() ([]byte, []byte, error) {
+func makeSelfSignedCert() (skPEM, crtPEM []byte, err error) {
 	// 1. generate ECDSA private key
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -121,7 +121,7 @@ type serverImpl struct {
 	workload view.View
 }
 
-func (s *serverImpl) ProcessCommand(ctx context.Context, command *protos.SignedCommand) (*protos.SignedCommandResponse, error) {
+func (s *serverImpl) ProcessCommand(_ context.Context, _ *protos.SignedCommand) (*protos.SignedCommandResponse, error) {
 	resp, err := s.workload.Call(nil)
 	if err != nil {
 		return nil, err
@@ -133,7 +133,7 @@ func (s *serverImpl) ProcessCommand(ctx context.Context, command *protos.SignedC
 	return &protos.SignedCommandResponse{}, nil
 }
 
-func (s *serverImpl) StreamCommand(g grpc.BidiStreamingServer[protos.SignedCommand, protos.SignedCommandResponse]) error {
+func (*serverImpl) StreamCommand(_ grpc.BidiStreamingServer[protos.SignedCommand, protos.SignedCommandResponse]) error {
 	panic("Not needed")
 }
 

--- a/integration/benchmark/grpc/remote/server/main.go
+++ b/integration/benchmark/grpc/remote/server/main.go
@@ -76,7 +76,7 @@ func main() {
 
 // makeSelfSignedCert generates a localhost self-signed cert using ECDSA P-256.
 // It returns the tls.Certificate and the PEM-encoded cert for the client root pool.
-func makeSelfSignedCert() ([]byte, []byte, error) {
+func makeSelfSignedCert() (skPEM, crtPEM []byte, err error) {
 	// 1. generate ECDSA private key
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -122,7 +122,7 @@ type BenchmarkService struct {
 	remote.UnimplementedBenchmarkServiceServer
 }
 
-func (b *BenchmarkService) Process(ctx context.Context, in *remote.Request) (*remote.Response, error) {
+func (*BenchmarkService) Process(ctx context.Context, in *remote.Request) (*remote.Response, error) {
 	p, ok := workloadProcessors[in.Workload]
 	if !ok {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid workload: %v", in.Workload)

--- a/integration/benchmark/grpc/remote/workload/noop.go
+++ b/integration/benchmark/grpc/remote/workload/noop.go
@@ -15,7 +15,7 @@ import (
 const NOOP = "noop"
 
 func CreateClientFuncNoop(_ *grpc.ClientConn) ClientFunc {
-	return func(ctx context.Context) error {
+	return func(_ context.Context) error {
 		return nil
 	}
 }

--- a/integration/benchmark/mocks.go
+++ b/integration/benchmark/mocks.go
@@ -34,11 +34,11 @@ func (m *MockIdentityProvider) DefaultIdentity() view.Identity {
 	return m.DefaultSigner
 }
 
-func (m *MockIdentityProvider) Admins() []view.Identity {
+func (*MockIdentityProvider) Admins() []view.Identity {
 	panic("implement me")
 }
 
-func (m *MockIdentityProvider) Clients() []view.Identity {
+func (*MockIdentityProvider) Clients() []view.Identity {
 	panic("implement me")
 }
 
@@ -46,7 +46,7 @@ type MockSignerProvider struct {
 	DefaultSigner sig.Signer
 }
 
-func (m *MockSignerProvider) GetSigner(identity view.Identity) (sig.Signer, error) {
+func (m *MockSignerProvider) GetSigner(_ view.Identity) (sig.Signer, error) {
 	return m.DefaultSigner, nil
 }
 
@@ -55,17 +55,17 @@ type MockViewManager struct {
 	Identity    view.Identity
 }
 
-func (m *MockViewManager) NewView(id string, in []byte) (view.View, error) {
+func (m *MockViewManager) NewView(_ string, _ []byte) (view.View, error) {
 	return m.Constructor(), nil
 }
 
-func (m *MockViewManager) InitiateView(ctx context.Context, view view.View) (any, error) {
+func (*MockViewManager) InitiateView(_ context.Context, view view.View) (any, error) {
 	return view.Call(nil)
 }
 
-func (m *MockViewManager) InitiateContext(ctx context.Context, view view.View) (view.Context, error) {
+func (*MockViewManager) InitiateContext(_ context.Context, _ view.View) (view.Context, error) {
 	panic("implement me")
 }
 
-func (m *MockViewManager) DeleteContext(contextID string) {
+func (*MockViewManager) DeleteContext(_ string) {
 }

--- a/integration/benchmark/views/cpu_bench.go
+++ b/integration/benchmark/views/cpu_bench.go
@@ -20,7 +20,7 @@ type CPUView struct {
 	params CPUParams
 }
 
-func (q *CPUView) Call(viewCtx view.Context) (any, error) {
+func (q *CPUView) Call(_ view.Context) (any, error) {
 	k := doWork(q.params.N)
 	_ = k
 	return "OK", nil
@@ -37,7 +37,7 @@ func doWork(n int) uint64 {
 
 type CPUViewFactory struct{}
 
-func (c *CPUViewFactory) NewView(in []byte) (view.View, error) {
+func (*CPUViewFactory) NewView(in []byte) (view.View, error) {
 	f := &CPUView{}
 	if err := json.Unmarshal(in, &f.params); err != nil {
 		return nil, err

--- a/integration/benchmark/views/noop_bench.go
+++ b/integration/benchmark/views/noop_bench.go
@@ -12,12 +12,12 @@ import (
 
 type NoopView struct{}
 
-func (q *NoopView) Call(viewCtx view.Context) (any, error) {
+func (*NoopView) Call(_ view.Context) (any, error) {
 	return "OK", nil
 }
 
 type NoopViewFactory struct{}
 
-func (c *NoopViewFactory) NewView(_ []byte) (view.View, error) {
+func (*NoopViewFactory) NewView(_ []byte) (view.View, error) {
 	return &NoopView{}, nil
 }

--- a/integration/benchmark/views/signer_bench.go
+++ b/integration/benchmark/views/signer_bench.go
@@ -30,7 +30,7 @@ type ECDSASignView struct {
 
 var msgBytes = []byte("hello, world")
 
-func (q *ECDSASignView) Call(viewCtx view.Context) (any, error) {
+func (q *ECDSASignView) Call(_ view.Context) (any, error) {
 	hash := sha256.Sum256(msgBytes)
 
 	sig, err := ecdsa.SignASN1(q.r, q.pr, hash[:])
@@ -43,7 +43,7 @@ func (q *ECDSASignView) Call(viewCtx view.Context) (any, error) {
 
 type ECDSASignViewFactory struct{}
 
-func (c *ECDSASignViewFactory) NewView(in []byte) (view.View, error) {
+func (*ECDSASignViewFactory) NewView(in []byte) (view.View, error) {
 	f := &ECDSASignView{}
 	if err := json.Unmarshal(in, &f.params); err != nil {
 		return nil, err

--- a/integration/fabric/atsa/views/accept.go
+++ b/integration/fabric/atsa/views/accept.go
@@ -16,7 +16,7 @@ import (
 
 type AcceptAssetView struct{}
 
-func (a *AcceptAssetView) Call(viewCtx view.Context) (any, error) {
+func (*AcceptAssetView) Call(viewCtx view.Context) (any, error) {
 	// As a first step, the owner responds to the request to exchange recipient identities.
 	id, err := state.RespondRequestRecipientIdentity(viewCtx)
 	assert.NoError(err, "failed to respond to identity request")

--- a/integration/fabric/atsa/views/agree.go
+++ b/integration/fabric/atsa/views/agree.go
@@ -75,7 +75,7 @@ func (a *AgreeToSellView) Call(viewCtx view.Context) (any, error) {
 
 type AgreeToSellViewFactory struct{}
 
-func (a *AgreeToSellViewFactory) NewView(in []byte) (view.View, error) {
+func (*AgreeToSellViewFactory) NewView(in []byte) (view.View, error) {
 	f := &AgreeToSellView{AgreeToSell: &AgreeToSell{}}
 	err := json.Unmarshal(in, f.AgreeToSell)
 	assert.NoError(err, "failed unmarshalling input")
@@ -120,7 +120,7 @@ func (a *AgreeToBuyView) Call(viewCtx view.Context) (any, error) {
 
 type AgreeToBuyViewFactory struct{}
 
-func (a *AgreeToBuyViewFactory) NewView(in []byte) (view.View, error) {
+func (*AgreeToBuyViewFactory) NewView(in []byte) (view.View, error) {
 	f := &AgreeToBuyView{AgreeToBuy: &AgreeToBuy{}}
 	err := json.Unmarshal(in, f.AgreeToBuy)
 	assert.NoError(err, "failed unmarshalling input")

--- a/integration/fabric/atsa/views/approver.go
+++ b/integration/fabric/atsa/views/approver.go
@@ -15,7 +15,7 @@ import (
 
 type ApproverView struct{}
 
-func (a *ApproverView) Call(viewCtx view.Context) (any, error) {
+func (*ApproverView) Call(viewCtx view.Context) (any, error) {
 	// When a business party runs the CollectEndorsementsView, at some point, this party sends the assembled transaction
 	// to the approver. Therefore, the approver waits to receive the transaction.
 	tx, err := state.ReceiveTransaction(viewCtx)

--- a/integration/fabric/atsa/views/issue.go
+++ b/integration/fabric/atsa/views/issue.go
@@ -70,7 +70,7 @@ func (f *IssueView) Call(viewCtx view.Context) (any, error) {
 
 type IssueViewFactory struct{}
 
-func (p *IssueViewFactory) NewView(in []byte) (view.View, error) {
+func (*IssueViewFactory) NewView(in []byte) (view.View, error) {
 	f := &IssueView{Issue: &Issue{}}
 	err := json.Unmarshal(in, f.Issue)
 	assert.NoError(err, "failed unmarshalling input")

--- a/integration/fabric/atsa/views/transfer.go
+++ b/integration/fabric/atsa/views/transfer.go
@@ -18,9 +18,11 @@ import (
 )
 
 type Transfer struct {
+	//nolint:revive // var-naming: renaming this exported struct field is an API break; see follow-up
 	AgreementId string
-	AssetId     string
-	Recipient   view.Identity
+	//nolint:revive // var-naming: renaming this exported struct field is an API break; see follow-up
+	AssetId   string
+	Recipient view.Identity
 
 	Approver view.Identity
 }
@@ -81,7 +83,7 @@ func (f *TransferView) Call(viewCtx view.Context) (any, error) {
 
 type TransferViewFactory struct{}
 
-func (p *TransferViewFactory) NewView(in []byte) (view.View, error) {
+func (*TransferViewFactory) NewView(in []byte) (view.View, error) {
 	f := &TransferView{Transfer: &Transfer{}}
 	err := json.Unmarshal(in, f.Transfer)
 	assert.NoError(err, "failed unmarshalling input")
@@ -90,7 +92,7 @@ func (p *TransferViewFactory) NewView(in []byte) (view.View, error) {
 
 type TransferResponderView struct{}
 
-func (t *TransferResponderView) Call(viewCtx view.Context) (any, error) {
+func (*TransferResponderView) Call(viewCtx view.Context) (any, error) {
 	// First, respond to a request for an identity
 	id, err := state.RespondRequestRecipientIdentity(viewCtx)
 	assert.NoError(err, "failed to respond to identity request")

--- a/integration/fabric/atsachaincode/chaincode/asset_transfer.go
+++ b/integration/fabric/atsachaincode/chaincode/asset_transfer.go
@@ -50,7 +50,7 @@ type receipt struct {
 }
 
 // CreateAsset creates an asset and sets it as owned by the client's org
-func (s *SmartContract) CreateAsset(ctx contractapi.TransactionContextInterface, assetID, publicDescription string) error {
+func (*SmartContract) CreateAsset(ctx contractapi.TransactionContextInterface, assetID, publicDescription string) error {
 	transientMap, err := ctx.GetStub().GetTransient()
 	if err != nil {
 		return errors.WithMessagef(err, "error getting transient: %v", err)
@@ -153,7 +153,7 @@ func (s *SmartContract) AgreeToSell(ctx contractapi.TransactionContextInterface,
 }
 
 // AgreeToBuy adds buyer's bid price to buyer's implicit private data collection
-func (s *SmartContract) AgreeToBuy(ctx contractapi.TransactionContextInterface, assetID string) error {
+func (*SmartContract) AgreeToBuy(ctx contractapi.TransactionContextInterface, assetID string) error {
 	return agreeToPrice(ctx, assetID, typeAssetBid)
 }
 

--- a/integration/fabric/atsachaincode/chaincode/asset_transfer_queries.go
+++ b/integration/fabric/atsachaincode/chaincode/asset_transfer_queries.go
@@ -22,7 +22,8 @@ import (
 
 // QueryResult structure used for handling result of query
 type QueryResult struct {
-	Record    *Asset
+	Record *Asset
+	//nolint:revive // var-naming: renaming this exported struct field is an API break; see follow-up
 	TxId      string    `json:"txId"`
 	Timestamp time.Time `json:"timestamp"`
 }
@@ -34,7 +35,7 @@ type Agreement struct {
 }
 
 // ReadAsset returns the public asset data
-func (s *SmartContract) ReadAsset(ctx contractapi.TransactionContextInterface, assetID string) (*Asset, error) {
+func (*SmartContract) ReadAsset(ctx contractapi.TransactionContextInterface, assetID string) (*Asset, error) {
 	// Since only public data is accessed in this function, no access control is required
 	assetJSON, err := ctx.GetStub().GetState(assetID)
 	if err != nil {
@@ -53,7 +54,7 @@ func (s *SmartContract) ReadAsset(ctx contractapi.TransactionContextInterface, a
 }
 
 // GetAssetPrivateProperties returns the immutable asset properties from owner's private data collection
-func (s *SmartContract) GetAssetPrivateProperties(ctx contractapi.TransactionContextInterface, assetID string) (string, error) {
+func (*SmartContract) GetAssetPrivateProperties(ctx contractapi.TransactionContextInterface, assetID string) (string, error) {
 	// In this scenario, client is only authorized to read/write private data from its own peer.
 	collection, err := getClientImplicitCollectionName(ctx)
 	if err != nil {
@@ -72,12 +73,12 @@ func (s *SmartContract) GetAssetPrivateProperties(ctx contractapi.TransactionCon
 }
 
 // GetAssetSalesPrice returns the sales price
-func (s *SmartContract) GetAssetSalesPrice(ctx contractapi.TransactionContextInterface, assetID string) (string, error) {
+func (*SmartContract) GetAssetSalesPrice(ctx contractapi.TransactionContextInterface, assetID string) (string, error) {
 	return getAssetPrice(ctx, assetID, typeAssetForSale)
 }
 
 // GetAssetBidPrice returns the bid price
-func (s *SmartContract) GetAssetBidPrice(ctx contractapi.TransactionContextInterface, assetID string) (string, error) {
+func (*SmartContract) GetAssetBidPrice(ctx contractapi.TransactionContextInterface, assetID string) (string, error) {
 	return getAssetPrice(ctx, assetID, typeAssetBid)
 }
 
@@ -105,12 +106,12 @@ func getAssetPrice(ctx contractapi.TransactionContextInterface, assetID, priceTy
 }
 
 // QueryAssetSaleAgreements returns all of an organization's proposed sales
-func (s *SmartContract) QueryAssetSaleAgreements(ctx contractapi.TransactionContextInterface) ([]Agreement, error) {
+func (*SmartContract) QueryAssetSaleAgreements(ctx contractapi.TransactionContextInterface) ([]Agreement, error) {
 	return queryAgreementsByType(ctx, typeAssetForSale)
 }
 
 // QueryAssetBuyAgreements returns all of an organization's proposed bids
-func (s *SmartContract) QueryAssetBuyAgreements(ctx contractapi.TransactionContextInterface) ([]Agreement, error) {
+func (*SmartContract) QueryAssetBuyAgreements(ctx contractapi.TransactionContextInterface) ([]Agreement, error) {
 	return queryAgreementsByType(ctx, typeAssetBid)
 }
 
@@ -147,7 +148,7 @@ func queryAgreementsByType(ctx contractapi.TransactionContextInterface, agreeTyp
 }
 
 // QueryAssetHistory returns the chain of custody for a asset since issuance
-func (s *SmartContract) QueryAssetHistory(ctx contractapi.TransactionContextInterface, assetID string) ([]QueryResult, error) {
+func (*SmartContract) QueryAssetHistory(ctx contractapi.TransactionContextInterface, assetID string) ([]QueryResult, error) {
 	resultsIterator, err := ctx.GetStub().GetHistoryForKey(assetID)
 	if err != nil {
 		return nil, err

--- a/integration/fabric/atsachaincode/views/assets.go
+++ b/integration/fabric/atsachaincode/views/assets.go
@@ -43,7 +43,7 @@ func (c *CreateAssetView) Call(viewCtx view.Context) (any, error) {
 
 type CreateAssetViewFactory struct{}
 
-func (c *CreateAssetViewFactory) NewView(in []byte) (view.View, error) {
+func (*CreateAssetViewFactory) NewView(in []byte) (view.View, error) {
 	f := &CreateAssetView{CreateAsset: &CreateAsset{}}
 	err := json.Unmarshal(in, f.CreateAsset)
 	assert.NoError(err, "failed unmarshalling input")
@@ -69,7 +69,7 @@ func (r *ReadAssetView) Call(viewCtx view.Context) (any, error) {
 
 type ReadAssetViewFactory struct{}
 
-func (p *ReadAssetViewFactory) NewView(in []byte) (view.View, error) {
+func (*ReadAssetViewFactory) NewView(in []byte) (view.View, error) {
 	f := &ReadAssetView{ReadAsset: &ReadAsset{}}
 	err := json.Unmarshal(in, f.ReadAsset)
 	assert.NoError(err, "failed unmarshalling input")
@@ -92,7 +92,7 @@ func (r *ReadAssetPrivatePropertiesView) Call(viewCtx view.Context) (any, error)
 
 type ReadAssetPrivatePropertiesViewFactory struct{}
 
-func (p *ReadAssetPrivatePropertiesViewFactory) NewView(in []byte) (view.View, error) {
+func (*ReadAssetPrivatePropertiesViewFactory) NewView(in []byte) (view.View, error) {
 	f := &ReadAssetPrivatePropertiesView{ReadAssetPrivateProperties: &ReadAssetPrivateProperties{}}
 	err := json.Unmarshal(in, f.ReadAssetPrivateProperties)
 	assert.NoError(err, "failed unmarshalling input")
@@ -123,7 +123,7 @@ func (r *ChangePublicDescriptionView) Call(viewCtx view.Context) (any, error) {
 
 type ChangePublicDescriptionViewFactory struct{}
 
-func (p *ChangePublicDescriptionViewFactory) NewView(in []byte) (view.View, error) {
+func (*ChangePublicDescriptionViewFactory) NewView(in []byte) (view.View, error) {
 	f := &ChangePublicDescriptionView{ChangePublicDescription: &ChangePublicDescription{}}
 	err := json.Unmarshal(in, f.ChangePublicDescription)
 	assert.NoError(err, "failed unmarshalling input")

--- a/integration/fabric/atsachaincode/views/buyer.go
+++ b/integration/fabric/atsachaincode/views/buyer.go
@@ -35,7 +35,7 @@ func (a *AgreeToBuyView) Call(viewCtx view.Context) (any, error) {
 
 type AgreeToBuyViewFactory struct{}
 
-func (p *AgreeToBuyViewFactory) NewView(in []byte) (view.View, error) {
+func (*AgreeToBuyViewFactory) NewView(in []byte) (view.View, error) {
 	f := &AgreeToBuyView{AssetPrice: &AssetPrice{}}
 	err := json.Unmarshal(in, f.AssetPrice)
 	assert.NoError(err, "failed unmarshalling input")

--- a/integration/fabric/atsachaincode/views/seller.go
+++ b/integration/fabric/atsachaincode/views/seller.go
@@ -38,7 +38,7 @@ func (a *AgreeToSellView) Call(viewCtx view.Context) (any, error) {
 
 type AgreeToSellViewFactory struct{}
 
-func (p *AgreeToSellViewFactory) NewView(in []byte) (view.View, error) {
+func (*AgreeToSellViewFactory) NewView(in []byte) (view.View, error) {
 	f := &AgreeToSellView{AssetPrice: &AssetPrice{}}
 	err := json.Unmarshal(in, f.AssetPrice)
 	assert.NoError(err, "failed unmarshalling input")
@@ -117,7 +117,7 @@ func (a *TransferView) Call(viewCtx view.Context) (any, error) {
 
 type TransferViewFactory struct{}
 
-func (p *TransferViewFactory) NewView(in []byte) (view.View, error) {
+func (*TransferViewFactory) NewView(in []byte) (view.View, error) {
 	f := &TransferView{Transfer: &Transfer{}}
 	err := json.Unmarshal(in, f.Transfer)
 	assert.NoError(err, "failed unmarshalling input")

--- a/integration/fabric/common/views/finality.go
+++ b/integration/fabric/common/views/finality.go
@@ -33,7 +33,7 @@ func (a *FinalityView) Call(viewCtx view.Context) (any, error) {
 
 type FinalityViewFactory struct{}
 
-func (c *FinalityViewFactory) NewView(in []byte) (view.View, error) {
+func (*FinalityViewFactory) NewView(in []byte) (view.View, error) {
 	f := &FinalityView{Finality: &Finality{}}
 	err := json.Unmarshal(in, f.Finality)
 	assert.NoError(err, "failed unmarshalling input")

--- a/integration/fabric/configupdate/views/configseq.go
+++ b/integration/fabric/configupdate/views/configseq.go
@@ -21,7 +21,7 @@ import (
 // started from.
 type ConfigSequenceView struct{}
 
-func (v *ConfigSequenceView) Call(viewCtx view.Context) (any, error) {
+func (*ConfigSequenceView) Call(viewCtx view.Context) (any, error) {
 	_, ch, err := fabric.GetDefaultChannel(viewCtx)
 	assert.NoError(err, "failed getting the default channel")
 
@@ -33,6 +33,6 @@ func (v *ConfigSequenceView) Call(viewCtx view.Context) (any, error) {
 
 type ConfigSequenceViewFactory struct{}
 
-func (f *ConfigSequenceViewFactory) NewView([]byte) (view.View, error) {
+func (*ConfigSequenceViewFactory) NewView([]byte) (view.View, error) {
 	return &ConfigSequenceView{}, nil
 }

--- a/integration/fabric/events/chaincode/events/events.go
+++ b/integration/fabric/events/chaincode/events/events.go
@@ -15,14 +15,14 @@ type SmartContract struct {
 	contractapi.Contract
 }
 
-func (s *SmartContract) InitLedger(ctx contractapi.TransactionContextInterface) {
+func (*SmartContract) InitLedger(_ contractapi.TransactionContextInterface) {
 	fmt.Println("Init Function Invoked")
 }
 
-func (s *SmartContract) CreateAsset(ctx contractapi.TransactionContextInterface) error {
+func (*SmartContract) CreateAsset(ctx contractapi.TransactionContextInterface) error {
 	return ctx.GetStub().SetEvent("CreateAsset", []byte("Invoked Create Asset Successfully"))
 }
 
-func (s *SmartContract) UpdateAsset(ctx contractapi.TransactionContextInterface) error {
+func (*SmartContract) UpdateAsset(ctx contractapi.TransactionContextInterface) error {
 	return ctx.GetStub().SetEvent("UpdateAsset", []byte("Invoked Update Asset Successfully"))
 }

--- a/integration/fabric/events/chaincode2/events/events.go
+++ b/integration/fabric/events/chaincode2/events/events.go
@@ -15,10 +15,10 @@ type SmartContract struct {
 	contractapi.Contract
 }
 
-func (s *SmartContract) InitLedger(ctx contractapi.TransactionContextInterface) {
+func (*SmartContract) InitLedger(_ contractapi.TransactionContextInterface) {
 	fmt.Println("Init Function Invoked")
 }
 
-func (s *SmartContract) CreateAsset(ctx contractapi.TransactionContextInterface) error {
+func (*SmartContract) CreateAsset(ctx contractapi.TransactionContextInterface) error {
 	return ctx.GetStub().SetEvent("CreateAsset", []byte("Invoked Create Asset Successfully From Upgraded Chaincode"))
 }

--- a/integration/fabric/events/views/events.go
+++ b/integration/fabric/events/views/events.go
@@ -96,7 +96,7 @@ func (c *EventsView) Call(viewCtx view.Context) (any, error) {
 
 type EventsViewFactory struct{}
 
-func (c *EventsViewFactory) NewView(in []byte) (view.View, error) {
+func (*EventsViewFactory) NewView(in []byte) (view.View, error) {
 	f := &EventsView{Events: &Events{}}
 	err := json.Unmarshal(in, f)
 	assert.NoError(err, "failed unmarshalling input")

--- a/integration/fabric/events/views/multipleEvents.go
+++ b/integration/fabric/events/views/multipleEvents.go
@@ -63,7 +63,7 @@ func (c *MultipleEventsView) Call(viewCtx view.Context) (any, error) {
 
 type MultipleEventsViewFactory struct{}
 
-func (c *MultipleEventsViewFactory) NewView(in []byte) (view.View, error) {
+func (*MultipleEventsViewFactory) NewView(in []byte) (view.View, error) {
 	f := &MultipleEventsView{MultipleEvents: &MultipleEvents{}}
 	err := json.Unmarshal(in, f)
 	assert.NoError(err, "failed unmarshalling input")

--- a/integration/fabric/events/views/multipleListeners.go
+++ b/integration/fabric/events/views/multipleListeners.go
@@ -148,7 +148,7 @@ func (c *MultipleListenersView) Call(viewCtx view.Context) (any, error) {
 
 type MultipleListenersViewFactory struct{}
 
-func (c *MultipleListenersViewFactory) NewView(in []byte) (view.View, error) {
+func (*MultipleListenersViewFactory) NewView(in []byte) (view.View, error) {
 	f := &MultipleListenersView{MultipleListeners: &MultipleListeners{}}
 	err := json.Unmarshal(in, f)
 	assert.NoError(err, "failed unmarshalling input")

--- a/integration/fabric/iou/views/approver.go
+++ b/integration/fabric/iou/views/approver.go
@@ -22,7 +22,7 @@ import (
 
 type ApproverView struct{}
 
-func (i *ApproverView) Call(viewCtx view.Context) (any, error) {
+func (*ApproverView) Call(viewCtx view.Context) (any, error) {
 	// When the borrower runs the CollectEndorsementsView, at some point, the borrower sends the assembled transaction
 	// to the approver. Therefore, the approver waits to receive the transaction.
 	tx, err := state.ReceiveTransaction(viewCtx)
@@ -111,7 +111,7 @@ func (i *ApproverView) Call(viewCtx view.Context) (any, error) {
 
 type ApproverInitView struct{}
 
-func (a *ApproverInitView) Call(viewCtx view.Context) (any, error) {
+func (*ApproverInitView) Call(viewCtx view.Context) (any, error) {
 	_, ch, err := fabric.GetDefaultChannel(viewCtx)
 	assert.NoError(err)
 	assert.NoError(ch.Committer().ProcessNamespace("iou"), "failed to setup namespace to process")
@@ -120,7 +120,7 @@ func (a *ApproverInitView) Call(viewCtx view.Context) (any, error) {
 
 type ApproverInitViewFactory struct{}
 
-func (c *ApproverInitViewFactory) NewView(in []byte) (view.View, error) {
+func (*ApproverInitViewFactory) NewView(_ []byte) (view.View, error) {
 	f := &ApproverInitView{}
 	return f, nil
 }

--- a/integration/fabric/iou/views/borrower.go
+++ b/integration/fabric/iou/views/borrower.go
@@ -88,7 +88,7 @@ func (i *CreateIOUView) Call(viewCtx view.Context) (any, error) {
 
 type CreateIOUViewFactory struct{}
 
-func (c *CreateIOUViewFactory) NewView(in []byte) (view.View, error) {
+func (*CreateIOUViewFactory) NewView(in []byte) (view.View, error) {
 	f := &CreateIOUView{}
 	err := json.Unmarshal(in, &f.Create)
 	assert.NoError(err)
@@ -161,7 +161,7 @@ func (u UpdateIOUView) Call(viewCtx view.Context) (any, error) {
 
 type UpdateIOUViewFactory struct{}
 
-func (c *UpdateIOUViewFactory) NewView(in []byte) (view.View, error) {
+func (*UpdateIOUViewFactory) NewView(in []byte) (view.View, error) {
 	f := &UpdateIOUView{}
 	err := json.Unmarshal(in, &f.Update)
 	assert.NoError(err)

--- a/integration/fabric/iou/views/lender.go
+++ b/integration/fabric/iou/views/lender.go
@@ -18,7 +18,7 @@ import (
 
 type CreateIOUResponderView struct{}
 
-func (i *CreateIOUResponderView) Call(viewCtx view.Context) (any, error) {
+func (*CreateIOUResponderView) Call(viewCtx view.Context) (any, error) {
 	// As a first step, the lender responds to the request to exchange recipient identities.
 	lender, borrower, err := state.RespondExchangeRecipientIdentities(viewCtx)
 	assert.NoError(err, "failed exchanging recipient identities")
@@ -67,7 +67,7 @@ func (i *CreateIOUResponderView) Call(viewCtx view.Context) (any, error) {
 
 type UpdateIOUResponderView struct{}
 
-func (i *UpdateIOUResponderView) Call(viewCtx view.Context) (any, error) {
+func (*UpdateIOUResponderView) Call(viewCtx view.Context) (any, error) {
 	// When the borrower runs the CollectEndorsementsView, at some point, the borrower sends the assembled transaction
 	// to the lender. Therefore, the lender waits to receive the transaction.
 	tx, err := state.ReceiveTransaction(viewCtx)

--- a/integration/fabric/iou/views/query.go
+++ b/integration/fabric/iou/views/query.go
@@ -33,7 +33,7 @@ func (q *QueryView) Call(viewCtx view.Context) (any, error) {
 
 type QueryViewFactory struct{}
 
-func (c *QueryViewFactory) NewView(in []byte) (view.View, error) {
+func (*QueryViewFactory) NewView(in []byte) (view.View, error) {
 	f := &QueryView{}
 	err := json.Unmarshal(in, &f.Query)
 	assert.NoError(err)

--- a/integration/fabric/runtimeconfig/views/inject.go
+++ b/integration/fabric/runtimeconfig/views/inject.go
@@ -84,7 +84,7 @@ func (v *InjectNetworkView) Call(viewCtx view.Context) (any, error) {
 
 type InjectNetworkViewFactory struct{}
 
-func (f *InjectNetworkViewFactory) NewView(in []byte) (view.View, error) {
+func (*InjectNetworkViewFactory) NewView(in []byte) (view.View, error) {
 	v := &InjectNetworkView{}
 	assert.NoError(json.Unmarshal(in, &v.InjectNetwork))
 	return v, nil

--- a/integration/fabric/stoprestart/initiator.go
+++ b/integration/fabric/stoprestart/initiator.go
@@ -53,6 +53,6 @@ func (p *Initiator) Call(viewCtx view.Context) (any, error) {
 
 type InitiatorViewFactory struct{}
 
-func (i *InitiatorViewFactory) NewView(in []byte) (view.View, error) {
+func (*InitiatorViewFactory) NewView(in []byte) (view.View, error) {
 	return &Initiator{in: in}, nil
 }

--- a/integration/fabric/stoprestart/responder.go
+++ b/integration/fabric/stoprestart/responder.go
@@ -16,7 +16,7 @@ import (
 
 type Responder struct{}
 
-func (p *Responder) Call(viewCtx view.Context) (any, error) {
+func (*Responder) Call(viewCtx view.Context) (any, error) {
 	// Retrieve the session opened by the initiator
 	session := viewCtx.Session()
 

--- a/integration/fabric/twonets/views/ping.go
+++ b/integration/fabric/twonets/views/ping.go
@@ -22,7 +22,7 @@ import (
 
 type Ping struct{}
 
-func (p *Ping) Call(viewCtx view.Context) (any, error) {
+func (*Ping) Call(viewCtx view.Context) (any, error) {
 	// Retrieve responder identity
 	identityProvider, err := id.GetProvider(viewCtx)
 	assert.NoError(err, "failed getting identity provider")
@@ -58,6 +58,6 @@ func (p *Ping) Call(viewCtx view.Context) (any, error) {
 
 type PingFactory struct{}
 
-func (p *PingFactory) NewView(in []byte) (view.View, error) {
+func (*PingFactory) NewView(_ []byte) (view.View, error) {
 	return &Ping{}, nil
 }

--- a/integration/fabric/twonets/views/pong.go
+++ b/integration/fabric/twonets/views/pong.go
@@ -19,7 +19,7 @@ import (
 
 type Pong struct{}
 
-func (p *Pong) Call(viewCtx view.Context) (any, error) {
+func (*Pong) Call(viewCtx view.Context) (any, error) {
 	// Retrieve the session opened by the initiator
 	session := viewCtx.Session()
 

--- a/integration/fabricx/simple/views/approve.go
+++ b/integration/fabricx/simple/views/approve.go
@@ -17,7 +17,7 @@ import (
 
 type ApproveView struct{}
 
-func (i *ApproveView) Call(viewCtx view.Context) (any, error) {
+func (*ApproveView) Call(viewCtx view.Context) (any, error) {
 	logger.Infof("Approve View called! great")
 
 	tx, err := state.ReceiveTransaction(viewCtx)

--- a/integration/fabricx/simple/views/policies.go
+++ b/integration/fabricx/simple/views/policies.go
@@ -24,7 +24,7 @@ type NamespacePoliciesResult struct {
 // by namespace.
 type NamespacePoliciesView struct{}
 
-func (v *NamespacePoliciesView) Call(viewCtx view.Context) (any, error) {
+func (*NamespacePoliciesView) Call(viewCtx view.Context) (any, error) {
 	network, ch, err := fabric.GetDefaultChannel(viewCtx)
 	if err != nil {
 		return nil, err
@@ -50,6 +50,6 @@ func (v *NamespacePoliciesView) Call(viewCtx view.Context) (any, error) {
 
 type NamespacePoliciesViewFactory struct{}
 
-func (c *NamespacePoliciesViewFactory) NewView([]byte) (view.View, error) {
+func (*NamespacePoliciesViewFactory) NewView([]byte) (view.View, error) {
 	return &NamespacePoliciesView{}, nil
 }

--- a/integration/fabricx/simple/views/query.go
+++ b/integration/fabricx/simple/views/query.go
@@ -117,7 +117,7 @@ func getObjectsViaMultiGet(qs queryservice.QueryService, ns driver.Namespace, ke
 
 type QueryViewFactory struct{}
 
-func (c *QueryViewFactory) NewView(in []byte) (view.View, error) {
+func (*QueryViewFactory) NewView(in []byte) (view.View, error) {
 	f := &QueryView{}
 	if err := json.Unmarshal(in, &f.params); err != nil {
 		return nil, err

--- a/integration/fsc/pingpong/factory.go
+++ b/integration/fsc/pingpong/factory.go
@@ -17,7 +17,7 @@ import (
 type InitiatorViewFactory struct{}
 
 // NewView returns a new instance of the Initiator view
-func (i *InitiatorViewFactory) NewView(in []byte) (view.View, error) {
+func (*InitiatorViewFactory) NewView(in []byte) (view.View, error) {
 	initiator := &Initiator{}
 	if len(in) > 0 {
 		if err := json.Unmarshal(in, &initiator.Params); err != nil {

--- a/integration/fsc/pingpong/fake/factory.go
+++ b/integration/fsc/pingpong/fake/factory.go
@@ -17,7 +17,7 @@ import (
 type InitiatorViewFactory struct{}
 
 // NewView returns a new instance of the Initiator view
-func (i *InitiatorViewFactory) NewView(in []byte) (view.View, error) {
+func (*InitiatorViewFactory) NewView(in []byte) (view.View, error) {
 	initiator := &Initiator{Params: &Params{}}
 	if len(in) > 0 {
 		if err := json.Unmarshal(in, initiator.Params); err != nil {

--- a/integration/fsc/pingpong/fake/responder.go
+++ b/integration/fsc/pingpong/fake/responder.go
@@ -17,7 +17,7 @@ import (
 // Responder answers a single ping with a mock pong.
 type Responder struct{}
 
-func (p *Responder) Call(viewCtx view.Context) (any, error) {
+func (*Responder) Call(viewCtx view.Context) (any, error) {
 	// Retrieve the session opened by the initiator
 	session := viewCtx.Session()
 

--- a/integration/fsc/pingpong/fake/runner.go
+++ b/integration/fsc/pingpong/fake/runner.go
@@ -36,7 +36,7 @@ func (c *DelegatedContext) StartSpanFrom(context.Context, string, ...trace.SpanS
 	return c.Context(), noop.Span{}
 }
 
-func (c *DelegatedContext) StartSpan(string, ...trace.SpanStartOption) trace.Span {
+func (*DelegatedContext) StartSpan(string, ...trace.SpanStartOption) trace.Span {
 	return noop.Span{}
 }
 
@@ -81,7 +81,7 @@ func (c *DelegatedContext) OnError(callback func()) {
 	c.ViewCtx.OnError(callback)
 }
 
-func (c *DelegatedContext) GetSession(caller view.View, party view.Identity, boundToViews ...view.View) (view.Session, error) {
+func (c *DelegatedContext) GetSession(caller view.View, party view.Identity, _ ...view.View) (view.Session, error) {
 	for _, responder := range c.responders {
 		if responder.InitiatorView == caller && responder.ResponderID.Equal(party) {
 			responder.Lock.RLock()

--- a/integration/fsc/pingpong/responder.go
+++ b/integration/fsc/pingpong/responder.go
@@ -68,7 +68,7 @@ func pong(viewCtx view.Context, session view.Session) (string, error) {
 // Responder answers pings with pongs until the initiator signals that the protocol is over.
 type Responder struct{}
 
-func (p *Responder) Call(viewCtx view.Context) (any, error) {
+func (*Responder) Call(viewCtx view.Context) (any, error) {
 	session := viewCtx.Session()
 	if session == nil {
 		return nil, errors.New("no default session, the responder must be invoked by an initiator")

--- a/integration/fsc/pingpong/stream.go
+++ b/integration/fsc/pingpong/stream.go
@@ -14,7 +14,7 @@ import (
 
 type StreamerView struct{}
 
-func (s *StreamerView) Call(viewCtx view.Context) (any, error) {
+func (*StreamerView) Call(viewCtx view.Context) (any, error) {
 	stream := view2.GetStream(viewCtx)
 	assert.NoError(stream.Send("hello"), "failed to send hello")
 	var msg string
@@ -28,6 +28,6 @@ func (s *StreamerView) Call(viewCtx view.Context) (any, error) {
 type StreamerViewFactory struct{}
 
 // NewView returns a new instance of the Initiator view
-func (i *StreamerViewFactory) NewView(in []byte) (view.View, error) {
+func (*StreamerViewFactory) NewView(_ []byte) (view.View, error) {
 	return &StreamerView{}, nil
 }

--- a/integration/fsc/signedpingpong/factory.go
+++ b/integration/fsc/signedpingpong/factory.go
@@ -11,6 +11,6 @@ import "github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 // AliceInitiatorViewFactory creates AliceInitiator views.
 type AliceInitiatorViewFactory struct{}
 
-func (f *AliceInitiatorViewFactory) NewView(in []byte) (view.View, error) {
+func (*AliceInitiatorViewFactory) NewView(_ []byte) (view.View, error) {
 	return &AliceInitiator{}, nil
 }

--- a/integration/fsc/signedpingpong/initiator.go
+++ b/integration/fsc/signedpingpong/initiator.go
@@ -27,7 +27,7 @@ const (
 // Bob's signed reply using the endpoint and sig services.
 type AliceInitiator struct{}
 
-func (a *AliceInitiator) Call(viewCtx view.Context) (any, error) {
+func (*AliceInitiator) Call(viewCtx view.Context) (any, error) {
 	identityProvider, err := id.GetProvider(viewCtx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed getting identity provider")

--- a/integration/fsc/signedpingpong/responder.go
+++ b/integration/fsc/signedpingpong/responder.go
@@ -21,7 +21,7 @@ import (
 // its own signed message.
 type BobResponder struct{}
 
-func (b *BobResponder) Call(viewCtx view.Context) (any, error) {
+func (*BobResponder) Call(viewCtx view.Context) (any, error) {
 	session := viewCtx.Session()
 
 	sigSvc, err := sig.GetService(viewCtx)

--- a/integration/fsc/stoprestart/factory.go
+++ b/integration/fsc/stoprestart/factory.go
@@ -10,6 +10,6 @@ import "github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 
 type InitiatorViewFactory struct{}
 
-func (i *InitiatorViewFactory) NewView(in []byte) (view.View, error) {
+func (*InitiatorViewFactory) NewView(_ []byte) (view.View, error) {
 	return &Initiator{}, nil
 }

--- a/integration/fsc/stoprestart/initiator.go
+++ b/integration/fsc/stoprestart/initiator.go
@@ -22,7 +22,7 @@ var logger = logging.MustGetLogger()
 
 type Initiator struct{}
 
-func (p *Initiator) Call(viewCtx view.Context) (any, error) {
+func (*Initiator) Call(viewCtx view.Context) (any, error) {
 	// Retrieve responder identity
 	identityProvider, err := id.GetProvider(viewCtx)
 	assert.NoError(err, "failed getting identity provider")

--- a/integration/fsc/stoprestart/responder.go
+++ b/integration/fsc/stoprestart/responder.go
@@ -20,7 +20,7 @@ import (
 
 type Responder struct{}
 
-func (p *Responder) Call(viewCtx view.Context) (any, error) {
+func (*Responder) Call(viewCtx view.Context) (any, error) {
 	// Retrieve the session opened by the initiator
 	session := viewCtx.Session()
 

--- a/integration/integration.go
+++ b/integration/integration.go
@@ -258,7 +258,7 @@ func (i *Infrastructure) Stop() {
 	i.NWO.Stop()
 }
 
-func (i *Infrastructure) Serve() error {
+func (*Infrastructure) Serve() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -393,16 +393,16 @@ func (i *Infrastructure) storeAdditionalConfigurations() {
 	}
 }
 
-func failMe(message string, callerSkip ...int) {
+func failMe(message string, _ ...int) {
 	panic(message)
 }
 
 type fscDefaultPlatformFactory struct{}
 
-func (p *fscDefaultPlatformFactory) Name() string {
+func (*fscDefaultPlatformFactory) Name() string {
 	return "fsc"
 }
 
-func (p *fscDefaultPlatformFactory) New(registry api.Context, t api.Topology, builder api.Builder) api.Platform {
+func (*fscDefaultPlatformFactory) New(registry api.Context, t api.Topology, builder api.Builder) api.Platform {
 	return fsc.NewPlatform(registry, t, builder)
 }

--- a/integration/nwo/cmd/commands/artifactgen/cmd.go
+++ b/integration/nwo/cmd/commands/artifactgen/cmd.go
@@ -70,7 +70,7 @@ func NewCmd() *cobra.Command {
 }
 
 // gen read topology and generates artifacts
-func gen(args []string) error {
+func gen(_ []string) error {
 	if len(topologyFile) == 0 {
 		return errors.Errorf("expecting topology file path")
 	}

--- a/integration/nwo/cmd/commands/cryptogen/ca/ca.go
+++ b/integration/nwo/cmd/commands/cryptogen/ca/ca.go
@@ -376,7 +376,7 @@ func LoadCertificateECDSA(certPath string) (*x509.Certificate, error) {
 	var cert *x509.Certificate
 	var err error
 
-	walkFunc := func(path string, info os.FileInfo, err error) error {
+	walkFunc := func(path string, _ os.FileInfo, _ error) error {
 		if strings.HasSuffix(path, ".pem") {
 			rawCert, err := os.ReadFile(path)
 			if err != nil {

--- a/integration/nwo/cmd/commands/cryptogen/ca/ca_test.go
+++ b/integration/nwo/cmd/commands/cryptogen/ca/ca_test.go
@@ -104,8 +104,8 @@ func TestLoadCertificateECDSA_empty_DER_cert(t *testing.T) {
 	defer utils.IgnoreErrorWithOneArg(os.RemoveAll, testDir)
 
 	filename := filepath.Join(testDir, "empty.pem")
-	empty_cert := "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----"
-	err = os.WriteFile(filename, []byte(empty_cert), 0o644)
+	emptyCert := "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----"
+	err = os.WriteFile(filename, []byte(emptyCert), 0o644)
 	require.NoErrorf(t, err, "failed to create file %s", filename)
 
 	cert, err := ca.LoadCertificateECDSA(testDir)

--- a/integration/nwo/cmd/commands/cryptogen/cmd.go
+++ b/integration/nwo/cmd/commands/cryptogen/cmd.go
@@ -45,7 +45,7 @@ func newGenCmd() *cobra.Command {
 		Use:   "generate",
 		Short: "Gen crypto artifacts.",
 		Long:  `Generate crypto material.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			generate()
 			return nil
 		},
@@ -62,7 +62,7 @@ func newShowTemplateCmd() *cobra.Command {
 		Use:   "showtemplate",
 		Short: "Show the default configuration template",
 		Long:  `Show the default configuration template`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			fmt.Print(defaultConfig)
 			return nil
 		},

--- a/integration/nwo/cmd/commands/cryptogen/csp/csp.go
+++ b/integration/nwo/cmd/commands/cryptogen/csp/csp.go
@@ -28,7 +28,7 @@ import (
 func LoadPrivateKey(keystorePath string) (*ecdsa.PrivateKey, error) {
 	var priv *ecdsa.PrivateKey
 
-	walkFunc := func(path string, info os.FileInfo, pathErr error) error {
+	walkFunc := func(path string, _ os.FileInfo, _ error) error {
 		if !strings.HasSuffix(path, "_sk") {
 			return nil
 		}
@@ -114,7 +114,7 @@ func (e *ECDSASigner) Public() crypto.PublicKey {
 }
 
 // Sign signs the digest and ensures that signatures use the Low S value.
-func (e *ECDSASigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+func (e *ECDSASigner) Sign(rand io.Reader, digest []byte, _ crypto.SignerOpts) ([]byte, error) {
 	r, s, err := ecdsa.Sign(rand, e.PrivateKey, digest)
 	if err != nil {
 		return nil, err

--- a/integration/nwo/cmd/commands/hsm/disabled.go
+++ b/integration/nwo/cmd/commands/hsm/disabled.go
@@ -18,7 +18,7 @@ func NewCmd() *cobra.Command {
 		Use:   "hsm",
 		Short: "HSM related utils (not available; rebuild with -tags pkcs11).",
 		Long:  "HSM related utilities are not available in this build. Rebuild with: go build -tags pkcs11",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},
 	}

--- a/integration/nwo/cmd/commands/view/cmd.go
+++ b/integration/nwo/cmd/commands/view/cmd.go
@@ -47,7 +47,7 @@ func NewCmd() *cobra.Command {
 		Use:   "view",
 		Short: "Invoke a view.",
 		Long:  `Invoke a view.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			return invoke()
 		},
 	}

--- a/integration/nwo/cmd/fsccli/main_test.go
+++ b/integration/nwo/cmd/fsccli/main_test.go
@@ -29,7 +29,7 @@ func TestCompile(t *testing.T) {
 }
 
 func TestArtifactsGen(t *testing.T) { //nolint:paralleltest
-	RegisterFailHandler(func(message string, callerSkip ...int) {
+	RegisterFailHandler(func(message string, _ ...int) {
 		panic(message)
 	})
 

--- a/integration/nwo/common/docker/utils.go
+++ b/integration/nwo/common/docker/utils.go
@@ -228,7 +228,7 @@ func PortBindings(ports ...int) network.PortMap {
 	return m
 }
 
-func StartLogs(cli dcli.APIClient, containerID, loggerName string) error {
+func StartLogs(cli dcli.APIClient, containerID, _ string) error {
 	dockerLogger := logging.MustGetLogger()
 	reader, err := cli.ContainerLogs(context.TODO(), containerID, dcli.ContainerLogsOptions{
 		ShowStdout: true,

--- a/integration/nwo/fabric/ccaas/image.go
+++ b/integration/nwo/fabric/ccaas/image.go
@@ -21,10 +21,10 @@ type imageInspector func(image string) (bool, error)
 // EnsureImagePresent fails with an actionable message when ref is not present
 // locally. nwo never builds chaincode images; `make chaincode-images` does.
 func EnsureImagePresent(ref string) error {
-	return ensureImagePresent(ref, dockerImageInspector)
+	return ensureImagePresentWith(ref, dockerImageInspector)
 }
 
-func ensureImagePresent(ref string, inspect imageInspector) error {
+func ensureImagePresentWith(ref string, inspect imageInspector) error {
 	present, err := inspect(ref)
 	if err != nil {
 		return err

--- a/integration/nwo/fabric/ccaas/image_test.go
+++ b/integration/nwo/fabric/ccaas/image_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestEnsureImagePresentMissing(t *testing.T) { //nolint:paralleltest
-	err := ensureImagePresent("fsc-cc/base:latest",
+	err := ensureImagePresentWith("fsc-cc/base:latest",
 		func(string) (bool, error) { return false, nil })
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "fsc-cc/base:latest")
@@ -21,6 +21,6 @@ func TestEnsureImagePresentMissing(t *testing.T) { //nolint:paralleltest
 }
 
 func TestEnsureImagePresentFound(t *testing.T) { //nolint:paralleltest
-	require.NoError(t, ensureImagePresent("fsc-cc/base:latest",
+	require.NoError(t, ensureImagePresentWith("fsc-cc/base:latest",
 		func(string) (bool, error) { return true, nil }))
 }

--- a/integration/nwo/fabric/chaincode/base/main.go
+++ b/integration/nwo/fabric/chaincode/base/main.go
@@ -16,12 +16,12 @@ import (
 
 type Chaincode struct{}
 
-func (t *Chaincode) Init(stub shim.ChaincodeStubInterface) *pb.Response {
+func (*Chaincode) Init(_ shim.ChaincodeStubInterface) *pb.Response {
 	fmt.Println("Init...")
 	return shim.Success(nil)
 }
 
-func (t *Chaincode) Invoke(stub shim.ChaincodeStubInterface) *pb.Response {
+func (*Chaincode) Invoke(stub shim.ChaincodeStubInterface) *pb.Response {
 	function, params := stub.GetFunctionAndParameters()
 	fmt.Printf("Invoke function %s with params %v\n", function, params)
 	return shim.Success(nil)

--- a/integration/nwo/fabric/commands/cryptogen.go
+++ b/integration/nwo/fabric/commands/cryptogen.go
@@ -30,7 +30,7 @@ type Extend struct {
 	Input  string
 }
 
-func (c Extend) SessionName() string {
+func (Extend) SessionName() string {
 	return "cryptogen-extend"
 }
 

--- a/integration/nwo/fabric/commands/discover.go
+++ b/integration/nwo/fabric/commands/discover.go
@@ -49,7 +49,7 @@ type Config struct {
 	ClientKey  string
 }
 
-func (c Config) SessionName() string {
+func (Config) SessionName() string {
 	return "discover-config"
 }
 
@@ -85,7 +85,7 @@ type Endorsers struct {
 	ClientKey   string
 }
 
-func (e Endorsers) SessionName() string {
+func (Endorsers) SessionName() string {
 	return "discover-endorsers"
 }
 

--- a/integration/nwo/fabric/commands/peer.go
+++ b/integration/nwo/fabric/commands/peer.go
@@ -34,7 +34,7 @@ func (n NodeReset) SessionName() string {
 	return n.NetworkPrefix + "-peer-node-reset"
 }
 
-func (n NodeReset) Args() []string {
+func (NodeReset) Args() []string {
 	return []string{
 		"node", "reset",
 	}

--- a/integration/nwo/fabric/network/connprofile.go
+++ b/integration/nwo/fabric/network/connprofile.go
@@ -17,6 +17,7 @@ type Connection struct {
 }
 
 type AdminCredential struct {
+	//nolint:revive // var-naming: renaming this exported struct field is an API break; see follow-up
 	Id       string `json:"id"`
 	Password string `json:"password"`
 }
@@ -25,8 +26,9 @@ type Client struct {
 	AdminCredential      AdminCredential `json:"adminCredential"`
 	Organization         string          `json:"organization"`
 	EnableAuthentication bool            `json:"enableAuthentication"`
-	TlsEnable            bool            `json:"tlsEnable"`
-	Connection           Connection      `json:"connection"`
+	//nolint:revive // var-naming: renaming this exported struct field is an API break; see follow-up
+	TlsEnable  bool       `json:"tlsEnable"`
+	Connection Connection `json:"connection"`
 }
 
 type Organization struct {
@@ -43,15 +45,18 @@ type Peer struct {
 	GrpcOptions map[string]any `json:"grpcOptions"`
 }
 
+//nolint:revive // var-naming: renaming this exported type is an API break; see follow-up
 type HttpOptions struct {
 	Verify bool `json:"verify"`
 }
 
 type CertificationAuthority struct {
-	Url         string            `json:"url"`
-	CaName      string            `json:"caName"`
-	TLSCACerts  map[string]string `json:"tlsCACerts"`
-	HttpOptions HttpOptions       `json:"httpOptions"`
+	//nolint:revive // var-naming: renaming this exported struct field is an API break; see follow-up
+	Url        string            `json:"url"`
+	CaName     string            `json:"caName"`
+	TLSCACerts map[string]string `json:"tlsCACerts"`
+	//nolint:revive // var-naming: renaming this exported struct field is an API break; see follow-up
+	HttpOptions HttpOptions `json:"httpOptions"`
 }
 
 type ChannelPeer struct {

--- a/integration/nwo/fabric/network/network.go
+++ b/integration/nwo/fabric/network/network.go
@@ -210,7 +210,7 @@ func (n *Network) createChannelBlock(c *topology.Channel) common.Command {
 	}
 }
 
-func (n *Network) Load() {
+func (*Network) Load() {
 }
 
 func (n *Network) Members() []grouper.Member {

--- a/integration/nwo/fabric/network/resolver.go
+++ b/integration/nwo/fabric/network/resolver.go
@@ -40,23 +40,23 @@ func (n *Network) GenerateResolverMap() {
 	for _, peer := range n.Peers {
 		org := n.Organization(peer.Organization)
 
+		if peer.Type != topology.FSCPeer {
+			continue
+		}
+
 		var addresses map[api.PortName]string
 		var path string
-		if peer.Type == topology.FSCPeer {
-			if n.topology.NodeOUs {
-				switch peer.Role {
-				case "":
-					path = n.PeerUserLocalMSP(peer, peer.Name)
-				case "client":
-					path = n.PeerUserLocalMSP(peer, peer.Name)
-				default:
-					path = n.PeerLocalMSP(peer)
-				}
-			} else {
+		if n.topology.NodeOUs {
+			switch peer.Role {
+			case "":
 				path = n.PeerUserLocalMSP(peer, peer.Name)
+			case "client":
+				path = n.PeerUserLocalMSP(peer, peer.Name)
+			default:
+				path = n.PeerLocalMSP(peer)
 			}
 		} else {
-			continue
+			path = n.PeerUserLocalMSP(peer, peer.Name)
 		}
 
 		var aliases []string
@@ -82,31 +82,29 @@ func (n *Network) GenerateResolverMap() {
 }
 
 func (n *Network) ViewNodeLocalCertPath(peer *topology.Peer) string {
-	if n.topology.NodeOUs {
-		switch peer.Role {
-		case "":
-			return n.PeerUserLocalMSPIdentityCert(peer, peer.Name)
-		case "client":
-			return n.PeerUserLocalMSPIdentityCert(peer, peer.Name)
-		default:
-			return n.PeerLocalMSPIdentityCert(peer)
-		}
-	} else {
+	if !n.topology.NodeOUs {
+		return n.PeerLocalMSPIdentityCert(peer)
+	}
+	switch peer.Role {
+	case "":
+		return n.PeerUserLocalMSPIdentityCert(peer, peer.Name)
+	case "client":
+		return n.PeerUserLocalMSPIdentityCert(peer, peer.Name)
+	default:
 		return n.PeerLocalMSPIdentityCert(peer)
 	}
 }
 
 func (n *Network) ViewNodeLocalPrivateKeyPath(peer *topology.Peer) string {
-	if n.topology.NodeOUs {
-		switch peer.Role {
-		case "":
-			return n.PeerUserKey(peer, peer.Name)
-		case "client":
-			return n.PeerUserKey(peer, peer.Name)
-		default:
-			return n.PeerKey(peer)
-		}
-	} else {
+	if !n.topology.NodeOUs {
+		return n.PeerKey(peer)
+	}
+	switch peer.Role {
+	case "":
+		return n.PeerUserKey(peer, peer.Name)
+	case "client":
+		return n.PeerUserKey(peer, peer.Name)
+	default:
 		return n.PeerKey(peer)
 	}
 }

--- a/integration/nwo/fabric/packager/external/platform.go
+++ b/integration/nwo/fabric/packager/external/platform.go
@@ -27,7 +27,7 @@ var gzipCompressionLevel = gzip.DefaultCompression
 type Platform struct{}
 
 // Name returns the name of this platform.
-func (p *Platform) Name() string {
+func (*Platform) Name() string {
 	return "EXTERNAL"
 }
 
@@ -35,7 +35,7 @@ func (p *Platform) Name() string {
 // looks like go chainccode.
 //
 // NOTE: this is only used at the _client_ side by the peer CLI.
-func (p *Platform) ValidatePath(rawPath string) error {
+func (*Platform) ValidatePath(_ string) error {
 	return nil
 }
 
@@ -43,7 +43,7 @@ func (p *Platform) ValidatePath(rawPath string) error {
 // This should not impact legacy GOPATH chaincode.
 //
 // NOTE: this is only used at the _client_ side by the peer CLI.
-func (p *Platform) NormalizePath(rawPath string) (string, error) {
+func (*Platform) NormalizePath(rawPath string) (string, error) {
 	return rawPath, nil
 }
 
@@ -51,7 +51,7 @@ func (p *Platform) NormalizePath(rawPath string) (string, error) {
 //
 // NOTE: this code is used in some transaction validation paths but can be changed
 // post 2.0.
-func (p *Platform) ValidateCodePackage(code []byte) error {
+func (*Platform) ValidateCodePackage(code []byte) error {
 	is := bytes.NewReader(code)
 	gr, err := gzip.NewReader(is)
 	if err != nil {
@@ -88,7 +88,7 @@ func (p *Platform) ValidateCodePackage(code []byte) error {
 // required assets to build and run go chaincode.
 //
 // NOTE: this is only used at the _client_ side by the peer CLI.
-func (p *Platform) GetDeploymentPayload(codepath string, replacer replacer.Func) ([]byte, error) {
+func (*Platform) GetDeploymentPayload(_ string, replacer replacer.Func) ([]byte, error) {
 	payload := bytes.NewBuffer(nil)
 	gw, err := gzip.NewWriterLevel(payload, gzipCompressionLevel)
 	if err != nil {

--- a/integration/nwo/fabric/packager/golang/platform.go
+++ b/integration/nwo/fabric/packager/golang/platform.go
@@ -34,7 +34,7 @@ import (
 type Platform struct{}
 
 // Name returns the name of this platform.
-func (p *Platform) Name() string {
+func (*Platform) Name() string {
 	return pb.ChaincodeSpec_GOLANG.String()
 }
 
@@ -42,7 +42,7 @@ func (p *Platform) Name() string {
 // looks like go chainccode.
 //
 // NOTE: this is only used at the _client_ side by the peer CLI.
-func (p *Platform) ValidatePath(rawPath string) error {
+func (*Platform) ValidatePath(rawPath string) error {
 	_, err := DescribeCode(rawPath)
 	if err != nil {
 		return err
@@ -55,7 +55,7 @@ func (p *Platform) ValidatePath(rawPath string) error {
 // This should not impact legacy GOPATH chaincode.
 //
 // NOTE: this is only used at the _client_ side by the peer CLI.
-func (p *Platform) NormalizePath(rawPath string) (string, error) {
+func (*Platform) NormalizePath(rawPath string) (string, error) {
 	modInfo, err := moduleInfo(rawPath)
 	if err != nil {
 		return "", err
@@ -73,7 +73,7 @@ func (p *Platform) NormalizePath(rawPath string) (string, error) {
 //
 // NOTE: this code is used in some transaction validation paths but can be changed
 // post 2.0.
-func (p *Platform) ValidateCodePackage(code []byte) error {
+func (*Platform) ValidateCodePackage(code []byte) error {
 	is := bytes.NewReader(code)
 	gr, err := gzip.NewReader(is)
 	if err != nil {
@@ -107,7 +107,7 @@ func (p *Platform) ValidateCodePackage(code []byte) error {
 }
 
 // Directory constant copied from tar package.
-const c_ISDIR = 0o40000
+const cISDIR = 0o40000
 
 // Default compression to use for production. Test packages disable compression.
 var gzipCompressionLevel = gzip.DefaultCompression
@@ -116,7 +116,7 @@ var gzipCompressionLevel = gzip.DefaultCompression
 // required assets to build and run go chaincode.
 //
 // NOTE: this is only used at the _client_ side by the peer CLI.
-func (p *Platform) GetDeploymentPayload(codepath string, replacer replacer.Func) ([]byte, error) {
+func (*Platform) GetDeploymentPayload(codepath string, replacer replacer.Func) ([]byte, error) {
 	codeDescriptor, err := DescribeCode(codepath)
 	if err != nil {
 		return nil, err
@@ -161,7 +161,7 @@ func (p *Platform) GetDeploymentPayload(codepath string, replacer replacer.Func)
 		err := tw.WriteHeader(&tar.Header{
 			Typeflag: tar.TypeDir,
 			Name:     dirname + "/",
-			Mode:     c_ISDIR | 0o755,
+			Mode:     cISDIR | 0o755,
 			Uid:      500,
 			Gid:      500,
 		})

--- a/integration/nwo/fabric/platform.go
+++ b/integration/nwo/fabric/platform.go
@@ -98,11 +98,11 @@ func NewPlatformFactory() *platformFactory {
 	return &platformFactory{}
 }
 
-func (f platformFactory) Name() string {
+func (platformFactory) Name() string {
 	return "fabric"
 }
 
-func (f platformFactory) New(registry api.Context, t api.Topology, builder api.Builder) api.Platform {
+func (platformFactory) New(registry api.Context, t api.Topology, builder api.Builder) api.Platform {
 	return NewPlatform(registry, t, builder)
 }
 

--- a/integration/nwo/fabric/topology/ds.go
+++ b/integration/nwo/fabric/topology/ds.go
@@ -73,7 +73,8 @@ type Channel struct {
 type Orderer struct {
 	Name         string `yaml:"name,omitempty"`
 	Organization string `yaml:"organization,omitempty"`
-	Id           int    `yaml:"id,omitempty"`
+	//nolint:revive // var-naming: renaming this exported struct field would collide with the ID() method below; an API break either way; see follow-up
+	Id int `yaml:"id,omitempty"`
 }
 
 // ID provides a unique identifier for an orderer instance.

--- a/integration/nwo/fabric/topology/namespace_test.go
+++ b/integration/nwo/fabric/topology/namespace_test.go
@@ -196,7 +196,7 @@ type recordingT struct {
 	message string
 }
 
-func (r *recordingT) Helper() {}
+func (*recordingT) Helper() {}
 
 func (r *recordingT) Fatalf(format string, args ...any) {
 	r.failed = true

--- a/integration/nwo/fabric/topology/templates.go
+++ b/integration/nwo/fabric/topology/templates.go
@@ -28,7 +28,7 @@ func (t *Templates) CoreTemplate() string {
 	return DefaultCoreTemplate
 }
 
-func (t *Templates) FSCFabricExtensionTemplate() string {
+func (*Templates) FSCFabricExtensionTemplate() string {
 	return DefaultFSCFabricExtensionTemplate
 }
 

--- a/integration/nwo/fabricx/extensions/scv2/ext.go
+++ b/integration/nwo/fabricx/extensions/scv2/ext.go
@@ -73,7 +73,7 @@ func (e *Extension) GenerateArtifacts() {
 }
 
 // PostRun starts the sidecar container once the network is up.
-func (e *Extension) PostRun(load bool) {
+func (e *Extension) PostRun(_ bool) {
 	// TODO: we want to launch one SC per org
 	// run the docker container
 	e.launchContainer()

--- a/integration/nwo/fabricx/fxconfig/namespace.go
+++ b/integration/nwo/fabricx/fxconfig/namespace.go
@@ -106,7 +106,7 @@ func (n *NamespaceCommon) Env() []string {
 	return env
 }
 
-func (n *CreateNamespace) SessionName() string {
+func (*CreateNamespace) SessionName() string {
 	return fmt.Sprintf("%s-createnamespace", fxconfigCMD)
 }
 
@@ -127,7 +127,7 @@ func (n *UpdateNamespace) Args() []string {
 	}
 }
 
-func (n *UpdateNamespace) SessionName() string {
+func (*UpdateNamespace) SessionName() string {
 	return fmt.Sprintf("%s-updatenamespace", fxconfigCMD)
 }
 
@@ -136,7 +136,7 @@ type ListNamespaces struct {
 	TLSConfig   TLSConfig
 }
 
-func (n *ListNamespaces) Args() []string {
+func (*ListNamespaces) Args() []string {
 	return []string{"namespace", "list"}
 }
 
@@ -155,7 +155,7 @@ func (n *ListNamespaces) Env() []string {
 	return env
 }
 
-func (n *ListNamespaces) SessionName() string {
+func (*ListNamespaces) SessionName() string {
 	return fmt.Sprintf("%s-listnamespaces", fxconfigCMD)
 }
 

--- a/integration/nwo/fabricx/network/network.go
+++ b/integration/nwo/fabricx/network/network.go
@@ -96,7 +96,7 @@ func (n *Network) GenerateArtifacts() {
 	}
 }
 
-func (n *Network) Members() []grouper.Member {
+func (*Network) Members() []grouper.Member {
 	// note that we do not start any peers or orderers here
 	// the committer all-in-one image takes care of this
 	return grouper.Members{}

--- a/integration/nwo/fabricx/platform.go
+++ b/integration/nwo/fabricx/platform.go
@@ -52,7 +52,7 @@ func (f *ExtendedPlatformFactory) WithExtensions(exts ...ExtensionFactory) *Exte
 
 func NewPlatformFactory() *ExtendedPlatformFactory {
 	return NewFabricxPlatformFactory().WithExtensions(
-		func(platform *Platform, registry api.Context, t api.Topology, builder api.Builder) fabric_network.Extension {
+		func(platform *Platform, _ api.Context, t api.Topology, _ api.Builder) fabric_network.Extension {
 			fxTopo, ok := t.(*Topology)
 			if !ok {
 				panic(fmt.Sprintf("expected *fabricx.Topology, got %T", t))
@@ -149,7 +149,7 @@ func (p *Platform) Members() []grouper.Member {
 	return p.Network.Members()
 }
 
-func (p *Platform) DeleteVault(id string) {
+func (*Platform) DeleteVault(id string) {
 	logger.Warnf("Deleting vault for [%s]", id)
 }
 

--- a/integration/nwo/fsc/commands/cryptogen.go
+++ b/integration/nwo/fsc/commands/cryptogen.go
@@ -11,7 +11,7 @@ type Generate struct {
 	Output string
 }
 
-func (c Generate) SessionName() string {
+func (Generate) SessionName() string {
 	return "cryptogen-generate"
 }
 
@@ -29,7 +29,7 @@ type Extend struct {
 	Input  string
 }
 
-func (c Extend) SessionName() string {
+func (Extend) SessionName() string {
 	return "cryptogen-extend"
 }
 

--- a/integration/nwo/fsc/commands/node.go
+++ b/integration/nwo/fsc/commands/node.go
@@ -14,7 +14,7 @@ func (n NodeStart) SessionName() string {
 	return n.NodeID
 }
 
-func (n NodeStart) Args() []string {
+func (NodeStart) Args() []string {
 	return []string{
 		"node", "start",
 	}

--- a/integration/nwo/fsc/fake/another/sdk.go
+++ b/integration/nwo/fsc/fake/another/sdk.go
@@ -14,10 +14,10 @@ func NewSDK() *SDK {
 	return &SDK{}
 }
 
-func (d *SDK) Install() error {
+func (*SDK) Install() error {
 	panic("implement me")
 }
 
-func (d *SDK) Start(ctx context.Context) error {
+func (*SDK) Start(_ context.Context) error {
 	panic("implement me")
 }

--- a/integration/nwo/fsc/fake/sdk.go
+++ b/integration/nwo/fsc/fake/sdk.go
@@ -14,10 +14,10 @@ func NewSDK() *SDK {
 	return &SDK{}
 }
 
-func (d *SDK) Install() error {
+func (*SDK) Install() error {
 	panic("implement me")
 }
 
-func (d *SDK) Start(ctx context.Context) error {
+func (*SDK) Start(_ context.Context) error {
 	panic("implement me")
 }

--- a/integration/nwo/fsc/fsc.go
+++ b/integration/nwo/fsc/fsc.go
@@ -104,11 +104,11 @@ func NewPlatform(registry api.Context, t api.Topology, builderClient BuilderClie
 	return p
 }
 
-func (p *Platform) Name() string {
+func (*Platform) Name() string {
 	return TopologyName
 }
 
-func (p *Platform) Type() string {
+func (*Platform) Type() string {
 	return TopologyName
 }
 
@@ -219,10 +219,10 @@ func (p *Platform) setIdentities(address string, peer *node2.Replica) {
 	p.Context.SetViewIdentity(peer.Name, cert)
 }
 
-func (p *Platform) Load() {
+func (*Platform) Load() {
 }
 
-func (p *Platform) members(bootstrap bool) []grouper.Member {
+func (p *Platform) membersFiltered(bootstrap bool) []grouper.Member {
 	members := grouper.Members{}
 	for _, node := range p.Peers {
 		if node.Bootstrap == bootstrap {
@@ -233,7 +233,7 @@ func (p *Platform) members(bootstrap bool) []grouper.Member {
 }
 
 func (p *Platform) Members() []grouper.Member {
-	return append(p.members(true), p.members(false)...)
+	return append(p.membersFiltered(true), p.membersFiltered(false)...)
 }
 
 func (p *Platform) PreRun() {
@@ -647,11 +647,11 @@ func sqliteName(prefix node2.PersistenceKey) driver.PersistenceName {
 }
 
 func (p *Platform) BootstrapViewNodeGroupRunner() ifrit.Runner {
-	return grouper.NewParallel(syscall.SIGTERM, p.members(true))
+	return grouper.NewParallel(syscall.SIGTERM, p.membersFiltered(true))
 }
 
 func (p *Platform) FSCNodeGroupRunner() ifrit.Runner {
-	return grouper.NewParallel(syscall.SIGTERM, p.members(false))
+	return grouper.NewParallel(syscall.SIGTERM, p.membersFiltered(false))
 }
 
 func (p *Platform) FSCNodeRunner(node *node2.Replica, env ...string) *runner2.Runner {
@@ -769,14 +769,14 @@ func (p *Platform) NodeConfigPath(peer *node2.Replica) string {
 	return filepath.Join(p.NodeDir(peer), "core.yaml")
 }
 
-func (p *Platform) NodeCmdDir(peer *node2.Replica) string {
+func (*Platform) NodeCmdDir(peer *node2.Replica) string {
 	wd, err := os.Getwd()
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
 	return filepath.Join(wd, "out", "cmd", peer.Name)
 }
 
-func (p *Platform) NodeCmdPackage(peer *node2.Replica) string {
+func (*Platform) NodeCmdPackage(peer *node2.Replica) string {
 	wd, err := os.Getwd()
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "Failed to get working directory: %s", err)
 
@@ -842,7 +842,7 @@ func (p *Platform) BootstrapNode(me *node2.Peer) string {
 	return ""
 }
 
-func (p *Platform) ClientAuthRequired() bool {
+func (*Platform) ClientAuthRequired() bool {
 	return false
 }
 
@@ -955,7 +955,7 @@ func (p *Platform) PeerHost(peer *node2.Replica) string {
 	return p.Context.HostByPeerID("fsc", peer.ID())
 }
 
-func (p *Platform) GetReplicas(peer *node2.Peer) []*node2.Replica {
+func (*Platform) GetReplicas(peer *node2.Peer) []*node2.Replica {
 	uniqueNames := peer.ReplicaUniqueNames()
 	replicas := make([]*node2.Replica, len(uniqueNames))
 	for i, uniqueName := range uniqueNames {

--- a/integration/nwo/fsc/fsc_test.go
+++ b/integration/nwo/fsc/fsc_test.go
@@ -29,11 +29,11 @@ func NewDummySDK() *DummySDK {
 	return &DummySDK{}
 }
 
-func (d *DummySDK) Install() error {
+func (*DummySDK) Install() error {
 	panic("implement me")
 }
 
-func (d *DummySDK) Start(ctx context.Context) error {
+func (*DummySDK) Start(_ context.Context) error {
 	panic("implement me")
 }
 

--- a/integration/nwo/fsc/node/fake/sdk1/sdk.go
+++ b/integration/nwo/fsc/node/fake/sdk1/sdk.go
@@ -10,10 +10,10 @@ import "context"
 
 type DummySDK struct{}
 
-func (d *DummySDK) Install() error {
+func (*DummySDK) Install() error {
 	panic("implement me")
 }
 
-func (d *DummySDK) Start(ctx context.Context) error {
+func (*DummySDK) Start(_ context.Context) error {
 	panic("implement me")
 }

--- a/integration/nwo/fsc/node/fake/sdk2/sdk.go
+++ b/integration/nwo/fsc/node/fake/sdk2/sdk.go
@@ -10,10 +10,10 @@ import "context"
 
 type DummySDK struct{}
 
-func (d *DummySDK) Install() error {
+func (*DummySDK) Install() error {
 	panic("implement me")
 }
 
-func (d *DummySDK) Start(ctx context.Context) error {
+func (*DummySDK) Start(_ context.Context) error {
 	panic("implement me")
 }

--- a/integration/nwo/fsc/node/fake/sdk3/sdk.go
+++ b/integration/nwo/fsc/node/fake/sdk3/sdk.go
@@ -10,10 +10,10 @@ import "context"
 
 type DummySDK struct{}
 
-func (d *DummySDK) Install() error {
+func (*DummySDK) Install() error {
 	panic("implement me")
 }
 
-func (d *DummySDK) Start(ctx context.Context) error {
+func (*DummySDK) Start(_ context.Context) error {
 	panic("implement me")
 }

--- a/integration/nwo/fsc/node/node.go
+++ b/integration/nwo/fsc/node/node.go
@@ -178,6 +178,7 @@ func (o *Options) AddAlias(alias string) {
 type Option func(*Options) error
 
 type FactoryEntry struct {
+	//nolint:revive // var-naming: renaming this exported struct field is an API break; see follow-up
 	Id   string
 	Type string
 }
@@ -188,6 +189,7 @@ type ResponderEntry struct {
 }
 
 type SDKEntry struct {
+	//nolint:revive // var-naming: renaming this exported struct field is an API break; see follow-up
 	Id   string
 	Type string
 }

--- a/integration/nwo/fsc/topology.go
+++ b/integration/nwo/fsc/topology.go
@@ -111,7 +111,7 @@ func (t *Topology) AddNodeByName(name string) *node.Node {
 	return t.addNode(n)
 }
 
-func (t *Topology) NewTemplate(name string) *node.Node {
+func (*Topology) NewTemplate(name string) *node.Node {
 	n := node.NewNode(name)
 	return n
 }

--- a/integration/nwo/monitoring/platform.go
+++ b/integration/nwo/monitoring/platform.go
@@ -38,11 +38,11 @@ func NewPlatformFactory() *platformFactory {
 	return &platformFactory{}
 }
 
-func (f platformFactory) Name() string {
+func (platformFactory) Name() string {
 	return TopologyName
 }
 
-func (f platformFactory) New(registry api.Context, t api.Topology, builder api.Builder) api.Platform {
+func (platformFactory) New(registry api.Context, t api.Topology, _ api.Builder) api.Platform {
 	return New(registry, t.(*Topology))
 }
 
@@ -89,7 +89,7 @@ func (p *Platform) Type() string {
 	return p.topology.Type()
 }
 
-func (p *Platform) GenerateConfigTree() {
+func (*Platform) GenerateConfigTree() {
 }
 
 func (p *Platform) GenerateArtifacts() {
@@ -99,10 +99,10 @@ func (p *Platform) GenerateArtifacts() {
 	}
 }
 
-func (p *Platform) Load() {
+func (*Platform) Load() {
 }
 
-func (p *Platform) Members() []grouper.Member {
+func (*Platform) Members() []grouper.Member {
 	return nil
 }
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -21,12 +21,12 @@ import (
 
 type mockFSCNode struct{}
 
-func (m *mockFSCNode) ID() string                        { return "test-id" }
-func (m *mockFSCNode) Start() error                      { return nil }
-func (m *mockFSCNode) Stop()                             {}
-func (m *mockFSCNode) InstallSDK(p pkgnode.SDK) error    { return nil }
-func (m *mockFSCNode) GetService(v any) (any, error)     { return nil, nil }
-func (m *mockFSCNode) RegisterService(service any) error { return nil }
+func (*mockFSCNode) ID() string                     { return "test-id" }
+func (*mockFSCNode) Start() error                   { return nil }
+func (*mockFSCNode) Stop()                          {}
+func (*mockFSCNode) InstallSDK(_ pkgnode.SDK) error { return nil }
+func (*mockFSCNode) GetService(_ any) (any, error)  { return nil, nil }
+func (*mockFSCNode) RegisterService(_ any) error    { return nil }
 
 func writeCoreYAML(t *testing.T) string {
 	t.Helper()

--- a/node/start/start_test.go
+++ b/node/start/start_test.go
@@ -22,9 +22,9 @@ type mockStartNode struct {
 	ch       chan error
 }
 
-func (m *mockStartNode) ID() string             { return "test-id" }
+func (*mockStartNode) ID() string               { return "test-id" }
 func (m *mockStartNode) Start() error           { return m.startErr }
-func (m *mockStartNode) Stop()                  {}
+func (*mockStartNode) Stop()                    {}
 func (m *mockStartNode) Callback() chan<- error { return m.ch }
 
 func newMockStartNode(startErr error) *mockStartNode {

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -59,8 +59,8 @@ func (m *mockSDKWithPostStart) PostStart(_ context.Context) error {
 // panicSDK panics during Install to test panic recovery.
 type panicSDK struct{}
 
-func (p *panicSDK) Install() error                { panic("test panic") }
-func (p *panicSDK) Start(_ context.Context) error { return nil }
+func (*panicSDK) Install() error                { panic("test panic") }
+func (*panicSDK) Start(_ context.Context) error { return nil }
 
 func newTestNode() *Node {
 	return &Node{

--- a/pkg/runner/batch.go
+++ b/pkg/runner/batch.go
@@ -152,6 +152,7 @@ func NewBatchExecutor[I, O any](
 	return &batchExecutor[I, O]{batcher: newBatcher(ctx, executor, capacity, timeout)}
 }
 
+//nolint:revive // confusing-naming: batchExecutor and serialExecutor both implement the exported BatchExecutor interface; renaming Execute is an API break; see follow-up
 func (r *batchExecutor[I, O]) Execute(input I) (O, error) {
 	o, err := r.call(input)
 	if err != nil {

--- a/pkg/runner/batch_test.go
+++ b/pkg/runner/batch_test.go
@@ -25,7 +25,7 @@ func TestBatchRunner(t *testing.T) {
 	t.Parallel()
 
 	ctr := &atomic.Uint32{}
-	runner, m, locksObtained := newBatchRunner(t)
+	runner, m, locksObtained := newTestBatchRunner(t)
 
 	run(t, ctr, runner, 100)
 	require.Len(t, m, 100)
@@ -39,7 +39,7 @@ func TestBatchRunnerFewRequests(t *testing.T) {
 	t.Parallel()
 
 	ctr := &atomic.Uint32{}
-	runner, m, locksObtained := newBatchRunner(t)
+	runner, m, locksObtained := newTestBatchRunner(t)
 
 	run(t, ctr, runner, 1)
 
@@ -56,7 +56,7 @@ func TestBatchRunnerFewRequests(t *testing.T) {
 	require.LessOrEqual(t, l, 4)
 }
 
-func newBatchRunner(t *testing.T) (BatchRunner[int], map[string]string, *uint32) {
+func newTestBatchRunner(t *testing.T) (BatchRunner[int], map[string]string, *uint32) {
 	t.Helper()
 	var locksObtained uint32
 	m := make(map[string]string)

--- a/pkg/runner/serial.go
+++ b/pkg/runner/serial.go
@@ -30,6 +30,7 @@ type serialExecutor[I any, O any] struct {
 	executor ExecuteFunc[I, Output[O]]
 }
 
+//nolint:revive // confusing-naming: serialExecutor and batchExecutor both implement the exported BatchExecutor interface; renaming Execute is an API break; see follow-up
 func (r *serialExecutor[I, O]) Execute(input I) (O, error) {
 	res := r.executor([]I{input})[0]
 	return res.Val, res.Err

--- a/pkg/utils/retry.go
+++ b/pkg/utils/retry.go
@@ -35,12 +35,12 @@ func NewTypedRetryRunner[V any](maxTimes int, delay time.Duration, expBackoff bo
 func (r *typedRetryRunner[V]) Run(runner func() (V, error)) (V, error) {
 	var result V
 	err := r.retryRunner.Run(func() error {
-		if v, e := runner(); e != nil {
+		v, e := runner()
+		if e != nil {
 			return e
-		} else {
-			result = v
-			return nil
 		}
+		result = v
+		return nil
 	})
 	return result, err
 }

--- a/platform/common/core/generic/committer/finality_test.go
+++ b/platform/common/core/generic/committer/finality_test.go
@@ -161,7 +161,7 @@ func TestFinalityManager_Dispatch_PanicRecovery(t *testing.T) {
 	}
 	require.NoError(t, manager.AddListener("txID", listener))
 
-	listener.On("OnStatus", event.TxID, event.ValidationCode, event.ValidationMessage).Once().Run(func(args mock.Arguments) {
+	listener.On("OnStatus", event.TxID, event.ValidationCode, event.ValidationMessage).Once().Run(func(_ mock.Arguments) {
 		panic("listener panic")
 	})
 	require.NotPanics(t, func() {

--- a/platform/common/core/generic/vault/fake/qe.go
+++ b/platform/common/core/generic/vault/fake/qe.go
@@ -42,13 +42,13 @@ func (qe QE) GetState(_ context.Context, _ driver.Namespace, pkey driver.PKey) (
 	}, nil
 }
 
-func (qe QE) Done() error {
+func (QE) Done() error {
 	return nil
 }
 
 type TxStatusStore struct{}
 
-func (m TxStatusStore) GetTxStatus(_ context.Context, txID driver.TxID) (*driver.TxStatus, error) {
+func (TxStatusStore) GetTxStatus(_ context.Context, txID driver.TxID) (*driver.TxStatus, error) {
 	return &driver.TxStatus{TxID: txID, Code: 1}, nil
 }
 

--- a/platform/common/core/generic/vault/inspector.go
+++ b/platform/common/core/generic/vault/inspector.go
@@ -15,19 +15,19 @@ type Inspector struct {
 	Rws ReadWriteSet
 }
 
-func (i *Inspector) IsValid() error {
+func (*Inspector) IsValid() error {
 	return nil
 }
 
-func (i *Inspector) IsClosed() bool {
+func (*Inspector) IsClosed() bool {
 	return false
 }
 
-func (i *Inspector) SetState(driver.Namespace, driver.PKey, driver.RawValue) error {
+func (*Inspector) SetState(driver.Namespace, driver.PKey, driver.RawValue) error {
 	panic("programming error: the rwset inspector is read-only")
 }
 
-func (i *Inspector) AddReadAt(ns driver.Namespace, key string, version Version) error {
+func (*Inspector) AddReadAt(_ driver.Namespace, _ string, _ Version) error {
 	panic("programming error: the rwset inspector is read-only")
 }
 
@@ -35,11 +35,11 @@ func (i *Inspector) GetState(namespace driver.Namespace, key driver.PKey, _ ...d
 	return i.Rws.WriteSet.Get(namespace, key), nil
 }
 
-func (i *Inspector) GetDirectState(driver.Namespace, driver.PKey) ([]byte, error) {
+func (*Inspector) GetDirectState(driver.Namespace, driver.PKey) ([]byte, error) {
 	panic("programming error: no access to query executor")
 }
 
-func (i *Inspector) DeleteState(driver.Namespace, driver.PKey) error {
+func (*Inspector) DeleteState(driver.Namespace, driver.PKey) error {
 	panic("programming error: the rwset inspector is read-only")
 }
 
@@ -47,11 +47,11 @@ func (i *Inspector) GetStateMetadata(namespace driver.Namespace, key driver.PKey
 	return i.Rws.MetaWriteSet.Get(namespace, key), nil
 }
 
-func (i *Inspector) SetStateMetadata(driver.Namespace, driver.PKey, driver.Metadata) error {
+func (*Inspector) SetStateMetadata(driver.Namespace, driver.PKey, driver.Metadata) error {
 	panic("programming error: the rwset inspector is read-only")
 }
 
-func (i *Inspector) SetStateMetadatas(ns driver.Namespace, kvs map[driver.PKey]driver.VaultMetadataValue) map[driver.PKey]error {
+func (*Inspector) SetStateMetadatas(_ driver.Namespace, _ map[driver.PKey]driver.VaultMetadataValue) map[driver.PKey]error {
 	panic("programming error: the rwset inspector is read-only")
 }
 
@@ -112,21 +112,21 @@ func (i *Inspector) Namespaces() []driver.Namespace {
 	return namespaces
 }
 
-func (i *Inspector) AppendRWSet(driver.RawValue, ...driver.Namespace) error {
+func (*Inspector) AppendRWSet(driver.RawValue, ...driver.Namespace) error {
 	panic("programming error: the rwset inspector is read-only")
 }
 
-func (i *Inspector) Bytes() ([]byte, error) {
+func (*Inspector) Bytes() ([]byte, error) {
 	panic("programming error: unexpected call")
 }
 
-func (i *Inspector) Equals(other any, nss ...driver.Namespace) error {
+func (*Inspector) Equals(_ any, _ ...driver.Namespace) error {
 	panic("programming error: unexpected call")
 }
 
-func (i *Inspector) Done() {
+func (*Inspector) Done() {
 }
 
-func (i *Inspector) Clear(driver.Namespace) error {
+func (*Inspector) Clear(driver.Namespace) error {
 	panic("programming error: unexpected call")
 }

--- a/platform/common/core/generic/vault/interceptor_test.go
+++ b/platform/common/core/generic/vault/interceptor_test.go
@@ -24,7 +24,7 @@ func TestConcurrency(t *testing.T) {
 	qe := fake.NewQE()
 	idsr := fake.TxStatusStore{}
 
-	i := newInterceptor(logging.MustGetLogger(), context.Background(), EmptyRWSet(), qe, idsr, "1")
+	i := newVaultInterceptor(logging.MustGetLogger(), context.Background(), EmptyRWSet(), qe, idsr, "1")
 	s, err := i.GetState("ns", "key")
 	require.NoError(t, err)
 	require.Equal(t, qe.State.Raw, s, "with no opts, getstate should return the FromStorage value (query executor)")
@@ -69,7 +69,7 @@ func TestAddReadAt(t *testing.T) {
 	t.Parallel()
 	qe := fake.QE{}
 	idsr := fake.TxStatusStore{}
-	i := newInterceptor(logging.MustGetLogger(), context.Background(), EmptyRWSet(), qe, idsr, "1")
+	i := newVaultInterceptor(logging.MustGetLogger(), context.Background(), EmptyRWSet(), qe, idsr, "1")
 
 	require.NoError(t, i.AddReadAt("ns", "key", []byte("version")))
 	require.Len(t, i.RWs().Reads, 1)
@@ -82,11 +82,11 @@ type failingQE struct {
 	doneErr bool
 }
 
-func (q failingQE) GetStateMetadata(context.Context, driver.Namespace, driver.PKey) (driver.Metadata, driver.RawVersion, error) {
+func (failingQE) GetStateMetadata(context.Context, driver.Namespace, driver.PKey) (driver.Metadata, driver.RawVersion, error) {
 	return nil, nil, errors.New("query executor unavailable")
 }
 
-func (q failingQE) GetState(context.Context, driver.Namespace, driver.PKey) (*driver.VaultRead, error) {
+func (failingQE) GetState(context.Context, driver.Namespace, driver.PKey) (*driver.VaultRead, error) {
 	return nil, errors.New("query executor unavailable")
 }
 
@@ -101,28 +101,28 @@ func (q failingQE) Done() error {
 // the version-comparison branches are reachable.
 type staleQE struct{}
 
-func (q staleQE) GetStateMetadata(context.Context, driver.Namespace, driver.PKey) (driver.Metadata, driver.RawVersion, error) {
+func (staleQE) GetStateMetadata(context.Context, driver.Namespace, driver.PKey) (driver.Metadata, driver.RawVersion, error) {
 	return map[string][]byte{"md": []byte("meta")}, []byte("stale-version"), nil
 }
 
-func (q staleQE) GetState(_ context.Context, _ driver.Namespace, pkey driver.PKey) (*driver.VaultRead, error) {
+func (staleQE) GetState(_ context.Context, _ driver.Namespace, pkey driver.PKey) (*driver.VaultRead, error) {
 	return &driver.VaultRead{Key: pkey, Raw: []byte("raw"), Version: []byte("stale-version")}, nil
 }
 
-func (q staleQE) Done() error { return nil }
+func (staleQE) Done() error { return nil }
 
 // nilStateQE reports a key that is absent from storage.
 type nilStateQE struct{}
 
-func (q nilStateQE) GetStateMetadata(context.Context, driver.Namespace, driver.PKey) (driver.Metadata, driver.RawVersion, error) {
+func (nilStateQE) GetStateMetadata(context.Context, driver.Namespace, driver.PKey) (driver.Metadata, driver.RawVersion, error) {
 	return nil, nil, nil
 }
 
-func (q nilStateQE) GetState(context.Context, driver.Namespace, driver.PKey) (*driver.VaultRead, error) {
+func (nilStateQE) GetState(context.Context, driver.Namespace, driver.PKey) (*driver.VaultRead, error) {
 	return nil, nil
 }
 
-func (q nilStateQE) Done() error { return nil }
+func (nilStateQE) Done() error { return nil }
 
 func newTestInterceptor(qe VersionedQueryExecutor) *Interceptor[ValidationCode] {
 	return NewInterceptor[ValidationCode](

--- a/platform/common/core/generic/vault/mapper.go
+++ b/platform/common/core/generic/vault/mapper.go
@@ -22,7 +22,7 @@ type rwSetMapper struct {
 	vb     VersionBuilder
 }
 
-func (m *rwSetMapper) mapTxIDs(inputs []commitInput) []driver.TxID {
+func (*rwSetMapper) mapTxIDs(inputs []commitInput) []driver.TxID {
 	txIDs := make([]driver.TxID, len(inputs))
 	for i, input := range inputs {
 		txIDs[i] = input.txID

--- a/platform/common/core/generic/vault/vault.go
+++ b/platform/common/core/generic/vault/vault.go
@@ -240,13 +240,13 @@ func (db *Vault[V]) SetDiscarded(ctx context.Context, txID driver.TxID, message 
 func (db *Vault[V]) NewRWSet(ctx context.Context, txID driver.TxID) (api2.RWSet, error) {
 	db.logger.Debugf("NewRWSet[%s]", txID)
 
-	return db.newRWSet(ctx, txID, EmptyRWSet(), driver.LevelDefault)
+	return db.buildRWSet(ctx, txID, EmptyRWSet(), driver.LevelDefault)
 }
 
 func (db *Vault[V]) NewRWSetWithIsolationLevel(ctx context.Context, txID driver.TxID, isolationLevel driver.IsolationLevel) (api2.RWSet, error) {
 	db.logger.Debugf("NewRWSet[%s]", txID)
 
-	return db.newRWSet(ctx, txID, EmptyRWSet(), isolationLevel)
+	return db.buildRWSet(ctx, txID, EmptyRWSet(), isolationLevel)
 }
 
 func (db *Vault[V]) NewRWSetFromBytes(ctx context.Context, txID driver.TxID, rwsetBytes []byte) (driver.RWSet, error) {
@@ -256,10 +256,10 @@ func (db *Vault[V]) NewRWSetFromBytes(ctx context.Context, txID driver.TxID, rws
 		return nil, errors.Wrapf(err, "failed populating tx [%s]", txID)
 	}
 
-	return db.newRWSet(ctx, txID, rwSet, driver.LevelDefault)
+	return db.buildRWSet(ctx, txID, rwSet, driver.LevelDefault)
 }
 
-func (db *Vault[V]) newRWSet(ctx context.Context, txID driver.TxID, rws ReadWriteSet, isolationLevel driver.IsolationLevel) (driver.RWSet, error) {
+func (db *Vault[V]) buildRWSet(ctx context.Context, txID driver.TxID, rws ReadWriteSet, isolationLevel driver.IsolationLevel) (driver.RWSet, error) {
 	qe, err := db.vaultStore.NewTxLockVaultReader(ctx, txID, isolationLevel)
 	if err != nil {
 		return nil, err

--- a/platform/common/core/generic/vault/vault_test.go
+++ b/platform/common/core/generic/vault/vault_test.go
@@ -33,13 +33,13 @@ func (p *testArtifactProvider) RemoveNils(items []driver2.VaultRead) []driver2.V
 	return p.removeNils(items)
 }
 
-func (p *testArtifactProvider) NewCachedVault(ddb driver.VaultStore) (*Vault[ValidationCode], error) {
+func (*testArtifactProvider) NewCachedVault(ddb driver.VaultStore) (*Vault[ValidationCode], error) {
 	vaultLogger := logging.MustGetLogger()
 	return New[ValidationCode](
 		vaultLogger,
 		vault2.NewCachedVault(ddb, 100),
 		VCProvider,
-		newInterceptor,
+		newVaultInterceptor,
 		&populator{},
 		&disabled.Provider{},
 		&noop.TracerProvider{},
@@ -47,12 +47,12 @@ func (p *testArtifactProvider) NewCachedVault(ddb driver.VaultStore) (*Vault[Val
 	), nil
 }
 
-func (p *testArtifactProvider) NewNonCachedVault(ddb driver.VaultStore) (*Vault[ValidationCode], error) {
+func (*testArtifactProvider) NewNonCachedVault(ddb driver.VaultStore) (*Vault[ValidationCode], error) {
 	return New[ValidationCode](
 		logging.MustGetLogger(),
 		vault2.NewCachedVault(ddb, 0),
 		VCProvider,
-		newInterceptor,
+		newVaultInterceptor,
 		&populator{},
 		&disabled.Provider{},
 		&noop.TracerProvider{},
@@ -60,11 +60,11 @@ func (p *testArtifactProvider) NewNonCachedVault(ddb driver.VaultStore) (*Vault[
 	), nil
 }
 
-func (p *testArtifactProvider) NewMarshaller() Marshaller {
+func (*testArtifactProvider) NewMarshaller() Marshaller {
 	return &marshaller{}
 }
 
-func newInterceptor(
+func newVaultInterceptor(
 	logger Logger,
 	ctx context.Context,
 	rwSet ReadWriteSet,
@@ -99,11 +99,11 @@ func (p *populator) Populate(rwsetBytes []byte, namespaces ...driver2.Namespace)
 
 type marshaller struct{}
 
-func (m *marshaller) Marshal(txID string, rws *ReadWriteSet) ([]byte, error) {
+func (*marshaller) Marshal(_ string, rws *ReadWriteSet) ([]byte, error) {
 	return json.Marshal(rws)
 }
 
-func (m *marshaller) Append(destination *ReadWriteSet, raw []byte, nss ...string) error {
+func (*marshaller) Append(destination *ReadWriteSet, raw []byte, nss ...string) error {
 	source := &ReadWriteSet{}
 	err := json.Unmarshal(raw, source)
 	if err != nil {

--- a/platform/common/core/generic/vault/version.go
+++ b/platform/common/core/generic/vault/version.go
@@ -18,13 +18,13 @@ var zeroVersion = []byte{0, 0, 0, 0, 0, 0, 0, 0}
 
 type BlockTxIndexVersionComparator struct{}
 
-func (b *BlockTxIndexVersionComparator) Equal(a, c driver2.RawVersion) bool {
+func (*BlockTxIndexVersionComparator) Equal(a, c driver2.RawVersion) bool {
 	return Equal(a, c)
 }
 
 type BlockTxIndexVersionBuilder struct{}
 
-func (b *BlockTxIndexVersionBuilder) VersionedValues(_ *ReadWriteSet, _ driver2.Namespace, writes NamespaceWrites, block driver2.BlockNum, indexInBloc driver2.TxNum) (map[driver2.PKey]driver2.VaultValue, error) {
+func (*BlockTxIndexVersionBuilder) VersionedValues(_ *ReadWriteSet, _ driver2.Namespace, writes NamespaceWrites, block driver2.BlockNum, indexInBloc driver2.TxNum) (map[driver2.PKey]driver2.VaultValue, error) {
 	vals := make(map[driver2.PKey]driver2.VaultValue, len(writes))
 	for pkey, val := range writes {
 		vals[pkey] = driver2.VaultValue{Raw: val, Version: BlockTxIndexToBytes(block, indexInBloc)}
@@ -32,7 +32,7 @@ func (b *BlockTxIndexVersionBuilder) VersionedValues(_ *ReadWriteSet, _ driver2.
 	return vals, nil
 }
 
-func (b *BlockTxIndexVersionBuilder) VersionedMetaValues(rws *ReadWriteSet, ns driver2.Namespace, writes KeyedMetaWrites, block driver2.BlockNum, indexInBloc driver2.TxNum) (map[driver2.PKey]driver2.VaultMetadataValue, error) {
+func (*BlockTxIndexVersionBuilder) VersionedMetaValues(_ *ReadWriteSet, _ driver2.Namespace, writes KeyedMetaWrites, block driver2.BlockNum, indexInBloc driver2.TxNum) (map[driver2.PKey]driver2.VaultMetadataValue, error) {
 	vals := make(map[driver2.PKey]driver2.VaultMetadataValue, len(writes))
 	for pkey, val := range writes {
 		vals[pkey] = driver2.VaultMetadataValue{Metadata: val, Version: BlockTxIndexToBytes(block, indexInBloc)}
@@ -42,7 +42,7 @@ func (b *BlockTxIndexVersionBuilder) VersionedMetaValues(rws *ReadWriteSet, ns d
 
 type BlockTxIndexVersionMarshaller struct{}
 
-func (m BlockTxIndexVersionMarshaller) FromBytes(data Version) (driver2.BlockNum, driver2.TxNum, error) {
+func (BlockTxIndexVersionMarshaller) FromBytes(data Version) (driver2.BlockNum, driver2.TxNum, error) {
 	if len(data) == 0 {
 		return 0, 0, nil
 	}
@@ -54,7 +54,7 @@ func (m BlockTxIndexVersionMarshaller) FromBytes(data Version) (driver2.BlockNum
 	return Block, TxNum, nil
 }
 
-func (m BlockTxIndexVersionMarshaller) ToBytes(bn driver2.BlockNum, txn driver2.TxNum) Version {
+func (BlockTxIndexVersionMarshaller) ToBytes(bn driver2.BlockNum, txn driver2.TxNum) Version {
 	return BlockTxIndexToBytes(bn, txn)
 }
 

--- a/platform/common/sdk/dig/sdk.go
+++ b/platform/common/sdk/dig/sdk.go
@@ -45,14 +45,14 @@ type BaseSDK struct {
 	cfg driver.ConfigService
 }
 
-func (s *BaseSDK) Install() error { return nil }
+func (*BaseSDK) Install() error { return nil }
 
-func (s *BaseSDK) Start(context.Context) error { return nil }
+func (*BaseSDK) Start(context.Context) error { return nil }
 
 func (s *BaseSDK) ConfigService() driver.ConfigService { return s.cfg }
 
 func (s *BaseSDK) Container() Container { return s.c }
 
-func (s *BaseSDK) PostStart(context.Context) error { return nil }
+func (*BaseSDK) PostStart(context.Context) error { return nil }
 
-func (s *BaseSDK) Stop() error { return nil }
+func (*BaseSDK) Stop() error { return nil }

--- a/platform/common/services/logging/config.go
+++ b/platform/common/services/logging/config.go
@@ -78,7 +78,7 @@ func Init(c Config) {
 	configMutex.Unlock()
 
 	for _, f := range c.ContextLogFields {
-		registerContextLogField(f.Name, f.Key, true)
+		doRegisterContextLogField(f.Name, f.Key, true)
 	}
 }
 
@@ -130,10 +130,10 @@ var (
 // given field name, on every context-aware log call. Panics if name is already
 // registered.
 func RegisterContextLogField(name string, key any) {
-	registerContextLogField(name, key, false)
+	doRegisterContextLogField(name, key, false)
 }
 
-func registerContextLogField(name string, key any, overwrite bool) {
+func doRegisterContextLogField(name string, key any, overwrite bool) {
 	ctxFieldsMutex.Lock()
 	defer ctxFieldsMutex.Unlock()
 

--- a/platform/common/services/logging/logging_test_utils.go
+++ b/platform/common/services/logging/logging_test_utils.go
@@ -24,7 +24,7 @@ type (
 
 // Named returns an Option that names the logger under test.
 func Named(loggerName string) Option {
-	return func(r *floggingtest.RecordingCore, l *zap.Logger) *zap.Logger {
+	return func(_ *floggingtest.RecordingCore, l *zap.Logger) *zap.Logger {
 		return l.Named(loggerName)
 	}
 }

--- a/platform/common/services/logging/mock.go
+++ b/platform/common/services/logging/mock.go
@@ -24,68 +24,68 @@ func (m *MockLogger) Named(name string) Logger {
 	return m
 }
 
-func (m *MockLogger) Debug(args ...any) {
+func (*MockLogger) Debug(args ...any) {
 	fmt.Println("DEBUG:", fmt.Sprint(args...))
 }
 
-func (m *MockLogger) Debugf(format string, args ...any) {
+func (*MockLogger) Debugf(format string, args ...any) {
 	fmt.Printf("DEBUG: "+format+"\n", args...)
 }
 
-func (m *MockLogger) Error(args ...any) {
+func (*MockLogger) Error(args ...any) {
 	fmt.Println("ERROR:", fmt.Sprint(args...))
 }
 
-func (m *MockLogger) Errorf(format string, args ...any) {
+func (*MockLogger) Errorf(format string, args ...any) {
 	fmt.Printf("ERROR: "+format+"\n", args...)
 }
 
-func (m *MockLogger) Fatal(args ...any) {
+func (*MockLogger) Fatal(args ...any) {
 	fmt.Println("FATAL:", fmt.Sprint(args...))
 }
 
-func (m *MockLogger) Fatalf(format string, args ...any) {
+func (*MockLogger) Fatalf(format string, args ...any) {
 	fmt.Printf("FATAL: "+format+"\n", args...)
 }
 
-func (m *MockLogger) Info(args ...any) {
+func (*MockLogger) Info(args ...any) {
 	fmt.Println("INFO:", fmt.Sprint(args...))
 }
 
-func (m *MockLogger) Infof(format string, args ...any) {
+func (*MockLogger) Infof(format string, args ...any) {
 	fmt.Printf("INFO: "+format+"\n", args...)
 }
 
-func (m *MockLogger) Panic(args ...any) {
+func (*MockLogger) Panic(args ...any) {
 	fmt.Println("PANIC:", fmt.Sprint(args...))
 }
 
-func (m *MockLogger) Panicf(format string, args ...any) {
+func (*MockLogger) Panicf(format string, args ...any) {
 	fmt.Printf("PANIC: "+format+"\n", args...)
 }
 
-func (m *MockLogger) Warn(args ...any) {
+func (*MockLogger) Warn(args ...any) {
 	fmt.Println("WARN:", fmt.Sprint(args...))
 }
 
-func (m *MockLogger) Warnf(format string, args ...any) {
+func (*MockLogger) Warnf(format string, args ...any) {
 	fmt.Printf("WARN: "+format+"\n", args...)
 }
 
-func (m *MockLogger) IsEnabledFor(level zapcore.Level) bool {
+func (*MockLogger) IsEnabledFor(_ zapcore.Level) bool {
 	// Implement logic to check if the given log level is enabled
 	return true
 }
 
-func (m *MockLogger) Warnw(format string, args ...any) {
+func (*MockLogger) Warnw(format string, args ...any) {
 	fmt.Printf("WARN: "+format+"\n", args...)
 }
 
-func (m *MockLogger) Warningf(format string, args ...any) {
+func (*MockLogger) Warningf(format string, args ...any) {
 	fmt.Printf("WARNING: "+format+"\n", args...)
 }
 
-func (m *MockLogger) Errorw(format string, args ...any) {
+func (*MockLogger) Errorw(format string, args ...any) {
 	fmt.Printf("ERROR: "+format+"\n", args...)
 }
 
@@ -134,6 +134,6 @@ func (m *MockLogger) PanicwContext(_ context.Context, template string, args ...a
 	m.Panicf(template, args...)
 }
 
-func (m *MockLogger) Zap() *zap.Logger {
+func (*MockLogger) Zap() *zap.Logger {
 	return nil
 }

--- a/platform/common/services/logging/testlogger/logger_test.go
+++ b/platform/common/services/logging/testlogger/logger_test.go
@@ -55,7 +55,7 @@ func TestGetPackageName(t *testing.T) {
 
 type VersionInfoHandler struct{}
 
-func (h *VersionInfoHandler) sendResponseLikeMethod() (string, error) {
+func (*VersionInfoHandler) sendResponseLikeMethod() (string, error) {
 	return level2()
 }
 

--- a/platform/common/utils/cache/cache.go
+++ b/platform/common/utils/cache/cache.go
@@ -27,7 +27,7 @@ type rwLock interface {
 
 type noLock struct{}
 
-func (l *noLock) Lock()    {}
-func (l *noLock) Unlock()  {}
-func (l *noLock) RLock()   {}
-func (l *noLock) RUnlock() {}
+func (*noLock) Lock()    {}
+func (*noLock) Unlock()  {}
+func (*noLock) RLock()   {}
+func (*noLock) RUnlock() {}

--- a/platform/common/utils/cache/eviction.go
+++ b/platform/common/utils/cache/eviction.go
@@ -38,6 +38,7 @@ type EvictionPolicy[K comparable] interface {
 	Push(K)
 }
 
+//nolint:revive // confusing-naming: evictionCache and mapCache both implement the exported Map interface; renaming either is an API break; see follow-up
 func (c *evictionCache[K, V]) Get(key K) (V, bool) {
 	c.l.RLock()
 	defer c.l.RUnlock()
@@ -45,6 +46,7 @@ func (c *evictionCache[K, V]) Get(key K) (V, bool) {
 	return v, ok
 }
 
+//nolint:revive // confusing-naming: evictionCache and mapCache both implement the exported Map interface; renaming either is an API break; see follow-up
 func (c *evictionCache[K, V]) Put(key K, value V) {
 	c.l.Lock()
 	defer c.l.Unlock()
@@ -55,6 +57,7 @@ func (c *evictionCache[K, V]) Put(key K, value V) {
 	c.evictionPolicy.Push(key)
 }
 
+//nolint:revive // confusing-naming: evictionCache and mapCache both implement the exported Map interface; renaming either is an API break; see follow-up
 func (c *evictionCache[K, V]) Update(key K, f func(bool, V) (bool, V)) bool {
 	c.l.Lock()
 	defer c.l.Unlock()
@@ -71,6 +74,7 @@ func (c *evictionCache[K, V]) Update(key K, f func(bool, V) (bool, V)) bool {
 	return ok
 }
 
+//nolint:revive // confusing-naming: evictionCache and mapCache both implement the exported Map interface; renaming either is an API break; see follow-up
 func (c *evictionCache[K, V]) Delete(keys ...K) {
 	c.l.Lock()
 	defer c.l.Unlock()
@@ -79,6 +83,7 @@ func (c *evictionCache[K, V]) Delete(keys ...K) {
 	}
 }
 
+//nolint:revive // confusing-naming: evictionCache and mapCache both implement the exported Map interface; renaming either is an API break; see follow-up
 func (c *evictionCache[K, V]) Len() int {
 	c.l.RLock()
 	defer c.l.RUnlock()

--- a/platform/common/utils/cache/eviction_test.go
+++ b/platform/common/utils/cache/eviction_test.go
@@ -21,7 +21,7 @@ func (m *mockEvictionPolicy) Push(key string) {
 	m.pushedKeys = append(m.pushedKeys, key)
 }
 
-func (m *mockEvictionPolicy) String() string {
+func (*mockEvictionPolicy) String() string {
 	return "mockPolicy"
 }
 
@@ -46,7 +46,7 @@ func TestEvictionCache(t *testing.T) {
 	require.Equal(t, 1, c.Len())
 
 	// Test Update (existing key)
-	ok = c.Update("k1", func(exists bool, val string) (bool, string) {
+	ok = c.Update("k1", func(_ bool, _ string) (bool, string) {
 		return true, "v1-updated"
 	})
 	require.True(t, ok)
@@ -55,7 +55,7 @@ func TestEvictionCache(t *testing.T) {
 	require.Equal(t, "v1-updated", v)
 
 	// Test Update (delete key)
-	c.Update("k1", func(exists bool, val string) (bool, string) {
+	c.Update("k1", func(_ bool, _ string) (bool, string) {
 		return false, ""
 	})
 	_, ok = c.Get("k1")
@@ -64,7 +64,7 @@ func TestEvictionCache(t *testing.T) {
 
 	// Test Update (new key)
 	policy.pushedKeys = nil
-	ok = c.Update("k2", func(exists bool, val string) (bool, string) {
+	ok = c.Update("k2", func(_ bool, _ string) (bool, string) {
 		return true, "v2"
 	})
 	require.False(t, ok)

--- a/platform/common/utils/cache/map.go
+++ b/platform/common/utils/cache/map.go
@@ -20,6 +20,7 @@ type mapCache[K comparable, V any] struct {
 	l rwLock
 }
 
+//nolint:revive // confusing-naming: mapCache and evictionCache both implement the exported Map interface; renaming either is an API break; see follow-up
 func (c *mapCache[K, V]) Get(key K) (V, bool) {
 	c.l.RLock()
 	defer c.l.RUnlock()
@@ -27,12 +28,14 @@ func (c *mapCache[K, V]) Get(key K) (V, bool) {
 	return v, ok
 }
 
+//nolint:revive // confusing-naming: mapCache and evictionCache both implement the exported Map interface; renaming either is an API break; see follow-up
 func (c *mapCache[K, V]) Put(key K, value V) {
 	c.l.Lock()
 	defer c.l.Unlock()
 	c.m[key] = value
 }
 
+//nolint:revive // confusing-naming: mapCache and evictionCache both implement the exported Map interface; renaming either is an API break; see follow-up
 func (c *mapCache[K, V]) Delete(keys ...K) {
 	c.l.Lock()
 	defer c.l.Unlock()
@@ -41,6 +44,7 @@ func (c *mapCache[K, V]) Delete(keys ...K) {
 	}
 }
 
+//nolint:revive // confusing-naming: mapCache and evictionCache both implement the exported Map interface; renaming either is an API break; see follow-up
 func (c *mapCache[K, V]) Update(key K, f func(bool, V) (bool, V)) bool {
 	c.l.Lock()
 	defer c.l.Unlock()
@@ -54,6 +58,7 @@ func (c *mapCache[K, V]) Update(key K, f func(bool, V) (bool, V)) bool {
 	return ok
 }
 
+//nolint:revive // confusing-naming: mapCache and evictionCache both implement the exported Map interface; renaming either is an API break; see follow-up
 func (c *mapCache[K, V]) Len() int {
 	return len(c.m)
 }

--- a/platform/common/utils/cache/map_test.go
+++ b/platform/common/utils/cache/map_test.go
@@ -37,7 +37,7 @@ func TestMapCache(t *testing.T) {
 	require.Equal(t, "v1-updated", v)
 
 	// Test Update (delete key)
-	c.Update("k1", func(exists bool, val string) (bool, string) {
+	c.Update("k1", func(_ bool, _ string) (bool, string) {
 		return false, ""
 	})
 	_, ok = c.Get("k1")
@@ -45,7 +45,7 @@ func TestMapCache(t *testing.T) {
 	require.Equal(t, 0, c.Len())
 
 	// Test Update (new key)
-	ok = c.Update("k2", func(exists bool, val string) (bool, string) {
+	ok = c.Update("k2", func(exists bool, _ string) (bool, string) {
 		require.False(t, exists)
 		return true, "v2"
 	})

--- a/platform/common/utils/cache/secondcache/second_chance.go
+++ b/platform/common/utils/cache/secondcache/second_chance.go
@@ -60,10 +60,10 @@ func (cache *typedSecondChanceCache[T]) Get(key string) (T, bool) {
 	cache.rwlock.RLock()
 	defer cache.rwlock.RUnlock()
 
-	return cache.get(key)
+	return cache.getLocked(key)
 }
 
-func (cache *typedSecondChanceCache[T]) get(key string) (T, bool) {
+func (cache *typedSecondChanceCache[T]) getLocked(key string) (T, bool) {
 	item, ok := cache.table[key]
 	if !ok {
 		return zero[T](), false
@@ -78,7 +78,7 @@ func (cache *typedSecondChanceCache[T]) get(key string) (T, bool) {
 func (cache *typedSecondChanceCache[T]) GetOrLoad(key string, loader func() (T, error)) (T, bool, error) {
 	cache.rwlock.RLock()
 
-	if value, ok := cache.get(key); ok {
+	if value, ok := cache.getLocked(key); ok {
 		cache.rwlock.RUnlock()
 		return value, true, nil
 	}
@@ -87,7 +87,7 @@ func (cache *typedSecondChanceCache[T]) GetOrLoad(key string, loader func() (T, 
 	cache.rwlock.Lock()
 	defer cache.rwlock.Unlock()
 
-	if value, ok := cache.get(key); ok {
+	if value, ok := cache.getLocked(key); ok {
 		return value, true, nil
 	}
 
@@ -96,7 +96,7 @@ func (cache *typedSecondChanceCache[T]) GetOrLoad(key string, loader func() (T, 
 		return zero[T](), false, err
 	}
 
-	cache.add(key, value)
+	cache.addLocked(key, value)
 
 	return value, false, nil
 }
@@ -105,10 +105,10 @@ func (cache *typedSecondChanceCache[T]) Add(key string, value T) {
 	cache.rwlock.Lock()
 	defer cache.rwlock.Unlock()
 
-	cache.add(key, value)
+	cache.addLocked(key, value)
 }
 
-func (cache *typedSecondChanceCache[T]) add(key string, value T) {
+func (cache *typedSecondChanceCache[T]) addLocked(key string, value T) {
 	if old, ok := cache.table[key]; ok {
 		old.value = value
 		old.referenced.Store(1)
@@ -267,7 +267,7 @@ func (cache *secondChanceCacheBytes) Delete(key []byte) {
 	}
 }
 
-func (cache *secondChanceCacheBytes) key(k []byte) Slice {
+func (*secondChanceCacheBytes) key(k []byte) Slice {
 	// hash k using sha256
 	var key Slice
 	copy(key[:], k)

--- a/platform/common/utils/collections/iterators/empty.go
+++ b/platform/common/utils/collections/iterators/empty.go
@@ -13,6 +13,6 @@ func Empty[K any]() Iterator[K] { return &empty[K]{zero: utils.Zero[K]()} }
 
 type empty[K any] struct{ zero K }
 
-func (i *empty[K]) Close() {}
+func (*empty[K]) Close() {}
 
 func (i *empty[K]) Next() (K, error) { return i.zero, nil }

--- a/platform/common/utils/collections/iterators/flatten.go
+++ b/platform/common/utils/collections/iterators/flatten.go
@@ -28,23 +28,29 @@ type flattenedPointers[A any, B any] struct {
 	remaining   []B
 }
 
+//nolint:revive // confusing-naming: flattenedPointers, flattenedValues and mapped all implement the exported Iterator interface; renaming Next is an API break; see follow-up
 func (it *flattenedPointers[A, B]) Next() (B, error) {
 	if len(it.remaining) > 0 {
 		n := it.remaining[0]
 		it.remaining = it.remaining[1:]
 		return n, nil
-	} else if next, err := it.Iterator.Next(); err != nil {
-		return utils.Zero[B](), errors.Wrapf(err, "failed fetching")
-	} else if utils.IsNil(next) {
-		return utils.Zero[B](), nil
-	} else if next, err := it.transformer(next); err != nil {
-		return utils.Zero[B](), errors.Wrapf(err, "failed transforming")
-	} else if len(next) == 0 {
-		return utils.Zero[B](), nil
-	} else {
-		it.remaining = next[1:]
-		return next[0], nil
 	}
+	next, err := it.Iterator.Next()
+	if err != nil {
+		return utils.Zero[B](), errors.Wrapf(err, "failed fetching")
+	}
+	if utils.IsNil(next) {
+		return utils.Zero[B](), nil
+	}
+	transformed, err := it.transformer(next)
+	if err != nil {
+		return utils.Zero[B](), errors.Wrapf(err, "failed transforming")
+	}
+	if len(transformed) == 0 {
+		return utils.Zero[B](), nil
+	}
+	it.remaining = transformed[1:]
+	return transformed[0], nil
 }
 
 // FlattenValues behaves like [Flatten], but yields a pointer to each element of
@@ -59,21 +65,27 @@ type flattenedValues[A any, B any] struct {
 	remaining   []B
 }
 
+//nolint:revive // confusing-naming: flattenedPointers, flattenedValues and mapped all implement the exported Iterator interface; renaming Next is an API break; see follow-up
 func (it *flattenedValues[A, B]) Next() (*B, error) {
 	if len(it.remaining) > 0 {
 		n := it.remaining[0]
 		it.remaining = it.remaining[1:]
 		return &n, nil
-	} else if next, err := it.Iterator.Next(); err != nil {
-		return nil, errors.Wrapf(err, "failed fetching")
-	} else if utils.IsNil(next) {
-		return nil, nil
-	} else if next, err := it.transformer(next); err != nil {
-		return nil, errors.Wrapf(err, "failed transforming")
-	} else if len(next) == 0 {
-		return nil, nil
-	} else {
-		it.remaining = next[1:]
-		return &next[0], nil
 	}
+	next, err := it.Iterator.Next()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed fetching")
+	}
+	if utils.IsNil(next) {
+		return nil, nil
+	}
+	transformed, err := it.transformer(next)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed transforming")
+	}
+	if len(transformed) == 0 {
+		return nil, nil
+	}
+	it.remaining = transformed[1:]
+	return &transformed[0], nil
 }

--- a/platform/common/utils/collections/iterators/map.go
+++ b/platform/common/utils/collections/iterators/map.go
@@ -25,10 +25,11 @@ type mapped[A any, B any] struct {
 	transformer func(A) (B, error)
 }
 
+//nolint:revive // confusing-naming: mapped, flattenedPointers and flattenedValues all implement the exported Iterator interface; renaming Next is an API break; see follow-up
 func (it *mapped[A, B]) Next() (B, error) {
-	if next, err := it.Iterator.Next(); err != nil {
+	next, err := it.Iterator.Next()
+	if err != nil {
 		return utils.Zero[B](), err
-	} else {
-		return it.transformer(next)
 	}
+	return it.transformer(next)
 }

--- a/platform/common/utils/collections/iterators/reducers.go
+++ b/platform/common/utils/collections/iterators/reducers.go
@@ -23,8 +23,10 @@ type reducer[V any, S any] struct {
 	merge   ReduceFunc[V, S]
 }
 
+//nolint:revive // confusing-naming: reducer, setReducer, flatReducer and maxByReducer all implement the exported Reducer interface, and package func Reduce shares the name; renaming Produce is an API break; see follow-up
 func (r *reducer[V, S]) Produce() S { return r.initial }
 
+//nolint:revive // confusing-naming: reducer, setReducer, flatReducer and maxByReducer all implement the exported Reducer interface, and package func Reduce shares the name; renaming Reduce is an API break; see follow-up
 func (r *reducer[V, S]) Reduce(s S, v V) (S, error) { return r.merge(s, v) }
 
 // ToSet creates a reducer that collects the comparable elements of an Iterator into a Set
@@ -32,9 +34,11 @@ func ToSet[V comparable]() Reducer[*V, sets.Set[V]] { return &setReducer[V]{} }
 
 type setReducer[V comparable] struct{}
 
-func (r *setReducer[V]) Produce() sets.Set[V] { return sets.New[V]() }
+//nolint:revive // confusing-naming: reducer, setReducer, flatReducer and maxByReducer all implement the exported Reducer interface, and package func Reduce shares the name; renaming Produce is an API break; see follow-up
+func (*setReducer[V]) Produce() sets.Set[V] { return sets.New[V]() }
 
-func (r *setReducer[V]) Reduce(s sets.Set[V], v *V) (sets.Set[V], error) {
+//nolint:revive // confusing-naming: reducer, setReducer, flatReducer and maxByReducer all implement the exported Reducer interface, and package func Reduce shares the name; renaming Reduce is an API break; see follow-up
+func (*setReducer[V]) Reduce(s sets.Set[V], v *V) (sets.Set[V], error) {
 	s.Add(*v)
 	return s, nil
 }
@@ -44,9 +48,11 @@ func ToFlattened[V any]() Reducer[*[]V, []V] { return &flatReducer[V]{} }
 
 type flatReducer[V any] struct{}
 
-func (r *flatReducer[V]) Produce() []V { return []V{} }
+//nolint:revive // confusing-naming: reducer, setReducer, flatReducer and maxByReducer all implement the exported Reducer interface, and package func Reduce shares the name; renaming Produce is an API break; see follow-up
+func (*flatReducer[V]) Produce() []V { return []V{} }
 
-func (r *flatReducer[V]) Reduce(vs []V, v *[]V) ([]V, error) { return append(vs, *v...), nil }
+//nolint:revive // confusing-naming: reducer, setReducer, flatReducer and maxByReducer all implement the exported Reducer interface, and package func Reduce shares the name; renaming Reduce is an API break; see follow-up
+func (*flatReducer[V]) Reduce(vs []V, v *[]V) ([]V, error) { return append(vs, *v...), nil }
 
 // ToMaxBy returns a [Reducer] that selects the element with the greatest key, as
 // derived by fn. Ties keep the earlier element, and an empty [Iterator] reduces
@@ -64,8 +70,10 @@ type maxByReducer[V any, K cmp.Ordered] struct {
 	seen bool
 }
 
-func (r *maxByReducer[V, K]) Produce() V { return utils.Zero[V]() }
+//nolint:revive // confusing-naming: maxByReducer implements the exported Reducer interface; renaming Produce is an API break; see follow-up
+func (*maxByReducer[V, K]) Produce() V { return utils.Zero[V]() }
 
+//nolint:revive // confusing-naming: maxByReducer implements the exported Reducer interface; renaming Reduce is an API break; see follow-up
 func (r *maxByReducer[V, K]) Reduce(maxVal, v V) (V, error) {
 	currKey, err := r.fn(v)
 	if err != nil {

--- a/platform/common/utils/collections/iterators/stream.go
+++ b/platform/common/utils/collections/iterators/stream.go
@@ -27,13 +27,14 @@ type streamIterator[T any] struct {
 }
 
 func (it *streamIterator[T]) Next() (T, error) {
-	if n, err := it.cli.Recv(); err == nil {
+	n, err := it.cli.Recv()
+	if err == nil {
 		return n, nil
-	} else if errors.Is(err, io.EOF) {
-		return utils.Zero[T](), nil
-	} else {
-		return utils.Zero[T](), err
 	}
+	if errors.Is(err, io.EOF) {
+		return utils.Zero[T](), nil
+	}
+	return utils.Zero[T](), err
 }
 
 func (it *streamIterator[T]) Close() {

--- a/platform/common/utils/collections/iterators/utils.go
+++ b/platform/common/utils/collections/iterators/utils.go
@@ -75,6 +75,8 @@ func GetFirst[T any](vs Iterator[T]) (T, error) {
 }
 
 // Reduce reduces the elements of an iterator into an aggregated structure
+//
+//nolint:revive // confusing-naming: package func Reduce and the Reducer.Reduce method are both exported public API; renaming either is an API break; see follow-up
 func Reduce[V, S any](it Iterator[*V], reducer Reducer[*V, S]) (S, error) {
 	return ReduceValue(it, reducer.Produce(), reducer.Reduce)
 }

--- a/platform/common/utils/lazy/holder_test.go
+++ b/platform/common/utils/lazy/holder_test.go
@@ -76,7 +76,7 @@ func TestHolderBasic(t *testing.T) {
 		return 42, nil
 	}
 
-	h := NewHolder(provider, func(v int) error { return nil })
+	h := NewHolder(provider, func(_ int) error { return nil })
 
 	// Test Get
 	v, err := h.Get()
@@ -98,7 +98,7 @@ func TestHolderErrors(t *testing.T) {
 		return 0, errors.New("provider error")
 	}
 
-	h := NewHolder(provider, func(v int) error { return nil })
+	h := NewHolder(provider, func(_ int) error { return nil })
 
 	v, err := h.Get()
 	require.Error(t, err)

--- a/platform/common/utils/lazy/provider.go
+++ b/platform/common/utils/lazy/provider.go
@@ -41,7 +41,7 @@ type lazyProvider[I any, K comparable, V any] struct {
 	zero      V
 }
 
-func (v *lazyProvider[I, K, V]) Update(input I) (V, V, error) {
+func (v *lazyProvider[I, K, V]) Update(input I) (old, updated V, err error) {
 	key := v.keyMapper(input)
 
 	v.cacheLock.Lock()
@@ -62,7 +62,7 @@ func (v *lazyProvider[I, K, V]) Update(input I) (V, V, error) {
 
 func (v *lazyProvider[I, K, V]) Get(input I) (V, error) {
 	key := v.keyMapper(input)
-	if res, ok := v.peek(key); ok {
+	if res, ok := v.peekValue(key); ok {
 		return res, nil
 	}
 
@@ -86,10 +86,10 @@ func (v *lazyProvider[I, K, V]) Get(input I) (V, error) {
 }
 
 func (v *lazyProvider[I, K, V]) Peek(input I) (V, bool) {
-	return v.peek(v.keyMapper(input))
+	return v.peekValue(v.keyMapper(input))
 }
 
-func (v *lazyProvider[I, K, V]) peek(key K) (V, bool) {
+func (v *lazyProvider[I, K, V]) peekValue(key K) (V, bool) {
 	// Check cache
 	v.cacheLock.RLock()
 	defer v.cacheLock.RUnlock()

--- a/platform/fabric/chaincode_test.go
+++ b/platform/fabric/chaincode_test.go
@@ -46,7 +46,7 @@ type mockChaincode struct {
 	mcd *dummyChaincodeDiscover
 }
 
-func (m *mockChaincode) NewInvocation(function string, args ...any) driver.ChaincodeInvocation {
+func (m *mockChaincode) NewInvocation(_ string, _ ...any) driver.ChaincodeInvocation {
 	return m.mci
 }
 
@@ -54,11 +54,11 @@ func (m *mockChaincode) NewDiscover() driver.ChaincodeDiscover {
 	return m.mcd
 }
 
-func (m *mockChaincode) IsAvailable() (bool, error) {
+func (*mockChaincode) IsAvailable() (bool, error) {
 	return true, nil
 }
 
-func (m *mockChaincode) Version() (string, error) {
+func (*mockChaincode) Version() (string, error) {
 	return "v1", nil
 }
 
@@ -177,7 +177,7 @@ func (d *dummyChaincodeInvocation) Endorse() (driver.Envelope, error) {
 	return d.endorseResult, nil
 }
 
-func (d *dummyChaincodeInvocation) WithSignerIdentity(id view.Identity) driver.ChaincodeInvocation {
+func (d *dummyChaincodeInvocation) WithSignerIdentity(_ view.Identity) driver.ChaincodeInvocation {
 	d.withSignerIdentityCallCount++
 	return d
 }

--- a/platform/fabric/committer_test.go
+++ b/platform/fabric/committer_test.go
@@ -38,44 +38,44 @@ type mockCommitter struct {
 	CommitTXCount               int
 }
 
-func (m *mockCommitter) ProcessNamespace(nss ...driver2.Namespace) error {
+func (m *mockCommitter) ProcessNamespace(_ ...driver2.Namespace) error {
 	m.ProcessNamespaceCount++
 	return nil
 }
 
-func (m *mockCommitter) CommitTX(ctx context.Context, txid driver2.TxID, blockNum driver2.BlockNum, txNum driver2.TxNum, env *common.Envelope) error {
+func (m *mockCommitter) CommitTX(_ context.Context, _ driver2.TxID, _ driver2.BlockNum, _ driver2.TxNum, _ *common.Envelope) error {
 	m.CommitTXCount++
 	return nil
 }
 
-func (m *mockCommitter) Status(ctx context.Context, txID driver2.TxID) (driver.ValidationCode, string, error) {
+func (m *mockCommitter) Status(_ context.Context, txID driver2.TxID) (driver.ValidationCode, string, error) {
 	m.StatusCallCount++
 	m.StatusTxID = txID
 	return m.StatusValidation, m.StatusDeps, m.StatusErr
 }
 
-func (m *mockCommitter) DiscardTx(ctx context.Context, txID driver2.TxID, message string) error {
+func (m *mockCommitter) DiscardTx(_ context.Context, txID driver2.TxID, message string) error {
 	m.DiscardCallCount++
 	m.DiscardTxID = txID
 	m.DiscardMsg = message
 	return m.DiscardErr
 }
 
-func (m *mockCommitter) Start(ctx context.Context) error {
+func (*mockCommitter) Start(_ context.Context) error {
 	return nil
 }
 
-func (m *mockCommitter) AddFinalityListener(txID driver2.TxID, listener driver.FinalityListener) error {
+func (m *mockCommitter) AddFinalityListener(_ driver2.TxID, _ driver.FinalityListener) error {
 	m.AddFinalityListenerCount++
 	return nil
 }
 
-func (m *mockCommitter) RemoveFinalityListener(txID driver2.TxID, listener driver.FinalityListener) error {
+func (m *mockCommitter) RemoveFinalityListener(_ driver2.TxID, _ driver.FinalityListener) error {
 	m.RemoveFinalityListenerCount++
 	return nil
 }
 
-func (m *mockCommitter) AddTransactionFilter(tf driver.TransactionFilter) error {
+func (m *mockCommitter) AddTransactionFilter(_ driver.TransactionFilter) error {
 	m.AddTransactionFilterCount++
 	return nil
 }

--- a/platform/fabric/core/config_test.go
+++ b/platform/fabric/core/config_test.go
@@ -341,7 +341,7 @@ fabric:
 func TestFSNProvider_AddNetwork_RunsConfiguredValidators(t *testing.T) {
 	t.Parallel()
 	p := newTestProvider(t, baseYAML)
-	reject := NetworkConfigValidatorFunc(func(networkName string, configProvider ConfigProvider) error {
+	reject := NetworkConfigValidatorFunc(func(networkName string, _ ConfigProvider) error {
 		return errors.Errorf("network [%s] rejected by policy", networkName)
 	})
 	provider, err := NewFabricNetworkServiceProvider(p, nil, []NetworkConfigValidator{reject})

--- a/platform/fabric/core/generic/chaincode/chaincode_test.go
+++ b/platform/fabric/core/generic/chaincode/chaincode_test.go
@@ -52,9 +52,9 @@ type mockMSPIdentity struct {
 	mspID string
 }
 
-func (m *mockMSPIdentity) GetMSPIdentifier() string           { return m.mspID }
-func (m *mockMSPIdentity) Validate() error                    { return nil }
-func (m *mockMSPIdentity) Verify(message, sigma []byte) error { return nil }
+func (m *mockMSPIdentity) GetMSPIdentifier() string { return m.mspID }
+func (*mockMSPIdentity) Validate() error            { return nil }
+func (*mockMSPIdentity) Verify(_, _ []byte) error   { return nil }
 
 type chaincodeTestFixture struct {
 	Chaincode       *chaincode.Chaincode
@@ -829,7 +829,7 @@ func TestInvoke_EndorseQuerySubmit(t *testing.T) {
 		)
 
 		var callCount atomic.Int32
-		fix.EndorserClient.ProcessProposalCalls(func(ctx context.Context, prop *pb.SignedProposal, opts ...grpc.CallOption) (*pb.ProposalResponse, error) {
+		fix.EndorserClient.ProcessProposalCalls(func(_ context.Context, _ *pb.SignedProposal, _ ...grpc.CallOption) (*pb.ProposalResponse, error) {
 			payload := "payload1"
 			if callCount.Add(1) > 1 {
 				payload = "payload2"

--- a/platform/fabric/core/generic/chaincode/discovery.go
+++ b/platform/fabric/core/generic/chaincode/discovery.go
@@ -465,6 +465,6 @@ func (f *byMSPIDs) Filter(endorsers discovery.Endorsers) discovery.Endorsers {
 
 type noFilter struct{}
 
-func (f *noFilter) Filter(endorsers discovery.Endorsers) discovery.Endorsers {
+func (*noFilter) Filter(endorsers discovery.Endorsers) discovery.Endorsers {
 	return endorsers
 }

--- a/platform/fabric/core/generic/chaincode/invoke.go
+++ b/platform/fabric/core/generic/chaincode/invoke.go
@@ -62,7 +62,7 @@ func NewInvoke(chaincode *Chaincode, function string, args ...any) *Invoke {
 
 func (i *Invoke) Endorse() (driver.Envelope, error) {
 	for j := 0; j < i.NumRetries; j++ {
-		res, err := i.endorse()
+		res, err := i.doEndorse()
 		if err != nil {
 			if j+1 >= i.NumRetries {
 				return nil, err
@@ -75,7 +75,7 @@ func (i *Invoke) Endorse() (driver.Envelope, error) {
 	return nil, errors.Errorf("failed to perform endorse")
 }
 
-func (i *Invoke) endorse() (driver.Envelope, error) {
+func (i *Invoke) doEndorse() (driver.Envelope, error) {
 	_, prop, responses, signer, err := i.prepare(false)
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func (i *Invoke) endorse() (driver.Envelope, error) {
 
 func (i *Invoke) Query() ([]byte, error) {
 	for j := 0; j < i.NumRetries; j++ {
-		res, err := i.query()
+		res, err := i.doQuery()
 		if err != nil {
 			if j+1 >= i.NumRetries {
 				return nil, err
@@ -110,7 +110,7 @@ func (i *Invoke) Query() ([]byte, error) {
 	return nil, errors.Errorf("failed to perform query")
 }
 
-func (i *Invoke) query() ([]byte, error) {
+func (i *Invoke) doQuery() ([]byte, error) {
 	_, _, responses, _, err := i.prepare(!i.MatchEndorsementPolicy)
 	if err != nil {
 		return nil, err
@@ -150,7 +150,7 @@ func (i *Invoke) query() ([]byte, error) {
 
 func (i *Invoke) Submit() (string, []byte, error) {
 	for j := 0; j < i.NumRetries; j++ {
-		txID, res, err := i.submit()
+		txID, res, err := i.doSubmit()
 		if err != nil {
 			if j+1 >= i.NumRetries {
 				return "", nil, err
@@ -163,7 +163,7 @@ func (i *Invoke) Submit() (string, []byte, error) {
 	return "", nil, errors.Errorf("failed to perform submit")
 }
 
-func (i *Invoke) submit() (string, []byte, error) {
+func (i *Invoke) doSubmit() (string, []byte, error) {
 	txID, prop, responses, signer, err := i.prepare(false)
 	if err != nil {
 		return "", nil, err
@@ -505,7 +505,7 @@ func (i *Invoke) prepareArgs() ([][]byte, error) {
 	return args, nil
 }
 
-func (i *Invoke) toBytes(arg any) ([]byte, error) {
+func (*Invoke) toBytes(arg any) ([]byte, error) {
 	switch v := arg.(type) {
 	case []byte:
 		return v, nil
@@ -518,7 +518,7 @@ func (i *Invoke) toBytes(arg any) ([]byte, error) {
 	case uint64:
 		return []byte(strconv.FormatUint(v, 10)), nil
 	default:
-		return nil, errors.Errorf("arg type [%T] not recognized.", v)
+		return nil, errors.Errorf("arg type [%T] not recognized", v)
 	}
 }
 

--- a/platform/fabric/core/generic/channelprovider.go
+++ b/platform/fabric/core/generic/channelprovider.go
@@ -294,6 +294,6 @@ func (f *vaultDeliveryWrapper) GetLastTxID(ctx context.Context) (string, error) 
 	return tx.TxID, nil
 }
 
-func (f *vaultDeliveryWrapper) GetLastBlock(context.Context) (uint64, error) {
+func (*vaultDeliveryWrapper) GetLastBlock(context.Context) (uint64, error) {
 	return 0, driver.ErrNotImplemented
 }

--- a/platform/fabric/core/generic/committer/committer.go
+++ b/platform/fabric/core/generic/committer/committer.go
@@ -236,16 +236,15 @@ func (c *Committer) DiscardTx(ctx context.Context, txID, message string) error {
 	}
 	if vc == driver.Unknown {
 		// give it a second chance
-		if c.EnvelopeService.Exists(ctx, txID) {
-			if err := c.extractStoredEnvelopeToVault(ctx, txID); err != nil {
-				return errors.WithMessagef(err, "failed to extract stored envelope for [%s]", txID)
-			}
-		} else {
+		if !c.EnvelopeService.Exists(ctx, txID) {
 			c.logger.Debugf("Discarding transaction [%s] skipped, tx is unknown", txID)
 			if err := c.Vault.SetDiscarded(ctx, txID, message); err != nil {
 				c.logger.Errorf("failed setting tx discarded [%s] in vault: %s", txID, err)
 			}
 			return nil
+		}
+		if err := c.extractStoredEnvelopeToVault(ctx, txID); err != nil {
+			return errors.WithMessagef(err, "failed to extract stored envelope for [%s]", txID)
 		}
 	}
 
@@ -275,7 +274,7 @@ func (c *Committer) CommitTX(ctx context.Context, txID string, block driver.Bloc
 	case driver.Unknown:
 		return c.commitUnknown(ctx, txID, block, indexInBlock, envelope)
 	case driver.Busy:
-		return c.commit(ctx, txID, block, indexInBlock, envelope)
+		return c.commitBusyTx(ctx, txID, block, indexInBlock, envelope)
 	default:
 		return errors.Errorf("invalid status code [%d] for [%s]", vc, txID)
 	}
@@ -526,7 +525,7 @@ func (c *Committer) listenTo(ctx context.Context, txID string, timeout time.Dura
 	return errors.Errorf("failed to listen to transaction [%s] for timeout", txID)
 }
 
-func (c *Committer) commitConfig(ctx context.Context, txID driver2.TxID, blockNumber driver2.BlockNum, seq driver2.TxNum, envelope []byte) error {
+func (c *Committer) applyConfigCommit(ctx context.Context, txID driver2.TxID, blockNumber driver2.BlockNum, seq driver2.TxNum, envelope []byte) error {
 	c.logger.Debugf("[Channel: %s] commit config transaction number [bn:%d][seq:%d]", c.ChannelConfig.ID(), blockNumber, seq)
 
 	rws, err := c.Vault.NewRWSet(ctx, txID)
@@ -552,7 +551,7 @@ func (c *Committer) commitConfig(ctx context.Context, txID driver2.TxID, blockNu
 	return nil
 }
 
-func (c *Committer) commit(ctx context.Context, txID string, block, indexInBlock uint64, envelope *common.Envelope) error {
+func (c *Committer) commitBusyTx(ctx context.Context, txID string, block, indexInBlock uint64, envelope *common.Envelope) error {
 	// This is a normal transaction, validated by Fabric.
 	// Commit it cause Fabric says it is valid.
 	c.logger.DebugfContext(ctx, "[%s] committing", txID)
@@ -650,7 +649,7 @@ func (c *Committer) commitUnknown(ctx context.Context, txID string, block, index
 		return errors.WithMessagef(err, "failed to get rws from envelope [%s]", txID)
 	}
 	rws.Done()
-	return c.commit(ctx, txID, block, indexInBlock, envelope)
+	return c.commitBusyTx(ctx, txID, block, indexInBlock, envelope)
 }
 
 func (c *Committer) commitStoredEnvelope(ctx context.Context, txID string, block, indexInBlock uint64) error {
@@ -659,7 +658,7 @@ func (c *Committer) commitStoredEnvelope(ctx context.Context, txID string, block
 		return err
 	}
 	// commit
-	return c.commit(ctx, txID, block, indexInBlock, nil)
+	return c.commitBusyTx(ctx, txID, block, indexInBlock, nil)
 }
 
 func (c *Committer) fetchEnvelope(txID string) ([]byte, error) {

--- a/platform/fabric/core/generic/committer/committer_test.go
+++ b/platform/fabric/core/generic/committer/committer_test.go
@@ -954,7 +954,7 @@ func TestCommitAdditionalBranches(t *testing.T) {
 				},
 			},
 		}
-		err := c.commit(t.Context(), "tx-commit-parse", 1, 0, &common.Envelope{Payload: []byte("payload")})
+		err := c.commitBusyTx(t.Context(), "tx-commit-parse", 1, 0, &common.Envelope{Payload: []byte("payload")})
 		require.ErrorContains(t, err, "parse-failed")
 	})
 
@@ -982,7 +982,7 @@ func TestCommitAdditionalBranches(t *testing.T) {
 				},
 			},
 		}
-		err := c.commit(t.Context(), "tx-commit-match", 1, 0, &common.Envelope{Payload: []byte("payload")})
+		err := c.commitBusyTx(t.Context(), "tx-commit-match", 1, 0, &common.Envelope{Payload: []byte("payload")})
 		require.ErrorContains(t, err, "rwsets do not match")
 	})
 
@@ -1004,7 +1004,7 @@ func TestCommitAdditionalBranches(t *testing.T) {
 				},
 			},
 		}
-		err := c.commit(t.Context(), "tx-commit-store", 1, 0, &common.Envelope{Payload: []byte("payload")})
+		err := c.commitBusyTx(t.Context(), "tx-commit-store", 1, 0, &common.Envelope{Payload: []byte("payload")})
 		require.ErrorContains(t, err, "failed to store unknown envelope")
 	})
 
@@ -1029,7 +1029,7 @@ func TestCommitAdditionalBranches(t *testing.T) {
 				},
 			},
 		}
-		err := c.commit(t.Context(), "tx-commit-rws", 1, 0, &common.Envelope{Payload: []byte("payload")})
+		err := c.commitBusyTx(t.Context(), "tx-commit-rws", 1, 0, &common.Envelope{Payload: []byte("payload")})
 		require.ErrorContains(t, err, "failed to get rws from envelope")
 	})
 
@@ -1045,7 +1045,7 @@ func TestCommitAdditionalBranches(t *testing.T) {
 			},
 			Vault: &fake.Vault{},
 		}
-		err := c.commit(t.Context(), "tx-commit-post", 1, 0, nil)
+		err := c.commitBusyTx(t.Context(), "tx-commit-post", 1, 0, nil)
 		require.ErrorContains(t, err, "process-failed")
 	})
 
@@ -1063,7 +1063,7 @@ func TestCommitAdditionalBranches(t *testing.T) {
 				},
 			},
 		}
-		err := c.commit(t.Context(), "tx-commit-vault", 1, 0, nil)
+		err := c.commitBusyTx(t.Context(), "tx-commit-vault", 1, 0, nil)
 		require.ErrorContains(t, err, "vault-commit-failed")
 	})
 }

--- a/platform/fabric/core/generic/committer/config.go
+++ b/platform/fabric/core/generic/committer/config.go
@@ -172,7 +172,7 @@ func (c *Committer) CommitConfig(ctx context.Context, blockNumber driver.BlockNu
 	}
 
 	// when validation passes, we can commit the config transaction
-	if err := c.commitConfig(ctx, txID, blockNumber, sequence, raw); err != nil {
+	if err := c.applyConfigCommit(ctx, txID, blockNumber, sequence, raw); err != nil {
 		return errors.Wrapf(err, "failed committing configtx to the vault")
 	}
 

--- a/platform/fabric/core/generic/committer/config_test.go
+++ b/platform/fabric/core/generic/committer/config_test.go
@@ -154,9 +154,9 @@ func TestCommitConfig(t *testing.T) {
 	t.Run("membership update failure is returned as error, not a panic", func(t *testing.T) {
 		t.Parallel()
 		// CommitConfig checks Status once itself (must be Unknown to proceed
-		// past the "already committed" guard), then commitConfig->CommitTX
+		// past the "already committed" guard), then applyConfigCommit->CommitTX
 		// checks Status again internally (must be Busy to take the
-		// already-exercised c.commit()->CommitTxFn path instead of the
+		// already-exercised c.commitBusyTx()->CommitTxFn path instead of the
 		// unrelated commitUnknown() path). A stateful fake mirrors that.
 		var statusCalls int
 		c := &Committer{
@@ -211,7 +211,7 @@ func TestCommitConfigKeysOnTheConfigSequence(t *testing.T) {
 	// configtx_0 is already Valid, as it is on any node that has caught up with
 	// the channel's genesis block. For configtx_1 the status is consulted
 	// twice: CommitConfig's own "already committed" guard must see Unknown to
-	// proceed, then commitConfig -> Committer.CommitTX consults it again and
+	// proceed, then applyConfigCommit -> Committer.CommitTX consults it again and
 	// must see Busy, because Unknown there routes to commitUnknown() instead of
 	// the commit() path that calls CommitTxFn. The existing "membership update
 	// failure" sub-test documents the same mechanics.
@@ -381,7 +381,7 @@ func TestCommitConfigInternalSuccessPath(t *testing.T) {
 		},
 	}
 
-	err := c.commitConfig(t.Context(), "configtx_1", 8, 1, []byte("env"))
+	err := c.applyConfigCommit(t.Context(), "configtx_1", 8, 1, []byte("env"))
 	require.NoError(t, err)
 	require.True(t, committed)
 	require.GreaterOrEqual(t, rws.DoneCount, 1)
@@ -471,7 +471,7 @@ func TestCommitConfigInternalErrorPaths(t *testing.T) {
 				},
 			},
 		}
-		err := c.commitConfig(t.Context(), "configtx_2", 3, 2, []byte("env"))
+		err := c.applyConfigCommit(t.Context(), "configtx_2", 3, 2, []byte("env"))
 		require.ErrorContains(t, err, "cannot create rws for configtx")
 	})
 
@@ -490,7 +490,7 @@ func TestCommitConfigInternalErrorPaths(t *testing.T) {
 				},
 			},
 		}
-		err := c.commitConfig(t.Context(), "configtx_3", 3, 3, []byte("env"))
+		err := c.applyConfigCommit(t.Context(), "configtx_3", 3, 3, []byte("env"))
 		require.ErrorContains(t, err, "failed setting configtx state in rws")
 	})
 
@@ -517,7 +517,7 @@ func TestCommitConfigInternalErrorPaths(t *testing.T) {
 				ProcessByIDFn: func(context.Context, string, cdriver.TxID) error { return nil },
 			},
 		}
-		err := c.commitConfig(t.Context(), "configtx_4", 4, 4, []byte("env"))
+		err := c.applyConfigCommit(t.Context(), "configtx_4", 4, 4, []byte("env"))
 		require.ErrorContains(t, err, "failed committing configtx rws")
 	})
 }

--- a/platform/fabric/core/generic/committer/depresolver.go
+++ b/platform/fabric/core/generic/committer/depresolver.go
@@ -31,7 +31,7 @@ func NewSerialDependencyResolver() *serialDependencyResolver {
 	return &serialDependencyResolver{}
 }
 
-func (r *serialDependencyResolver) Resolve(txs []CommitTx) ParallelExecutable[SerialExecutable[CommitTx]] {
+func (*serialDependencyResolver) Resolve(txs []CommitTx) ParallelExecutable[SerialExecutable[CommitTx]] {
 	return ParallelExecutable[SerialExecutable[CommitTx]]{txs}
 }
 
@@ -43,7 +43,7 @@ func NewParallelDependencyResolver() *parallelDependencyResolver {
 	return &parallelDependencyResolver{}
 }
 
-func (r *parallelDependencyResolver) Resolve(txs []CommitTx) ParallelExecutable[SerialExecutable[CommitTx]] {
+func (*parallelDependencyResolver) Resolve(txs []CommitTx) ParallelExecutable[SerialExecutable[CommitTx]] {
 	s := make(ParallelExecutable[SerialExecutable[CommitTx]], len(txs))
 	for i, tx := range txs {
 		s[i] = SerialExecutable[CommitTx]{tx}

--- a/platform/fabric/core/generic/committer/endorsertx.go
+++ b/platform/fabric/core/generic/committer/endorsertx.go
@@ -26,25 +26,23 @@ func (c *Committer) HandleEndorserTransaction(ctx context.Context, block *common
 		return nil, err
 	}
 
-	switch pb.TxValidationCode(fabricValidationCode) {
-	case pb.TxValidationCode_VALID:
+	if pb.TxValidationCode(fabricValidationCode) == pb.TxValidationCode_VALID {
 		processed, err := c.CommitEndorserTransaction(ctx, event.TxID, tx.BlkNum, tx.TxNum, tx.Envelope, event)
-		if err != nil {
-			if errors.HasCause(err, ErrDiscardTX) {
-				// in this case, we will discard the transaction
-				event.ValidationCode = convertValidationCode(int32(pb.TxValidationCode_INVALID_OTHER_REASON))
-				event.ValidationMessage = err.Error()
-				break
+		if err == nil {
+			if !processed {
+				if err := c.GetChaincodeEvents(tx.Envelope, tx.BlkNum); err != nil {
+					return nil, errors.Wrapf(err, "failed to publish chaincode events [%s]", event.TxID)
+				}
 			}
+			c.logger.DebugfContext(ctx, "Processed transaction")
+			return event, nil
+		}
+		if !errors.HasCause(err, ErrDiscardTX) {
 			return nil, errors.Wrapf(err, "failed committing transaction [%s]", event.TxID)
 		}
-		if !processed {
-			if err := c.GetChaincodeEvents(tx.Envelope, tx.BlkNum); err != nil {
-				return nil, errors.Wrapf(err, "failed to publish chaincode events [%s]", event.TxID)
-			}
-		}
-		c.logger.DebugfContext(ctx, "Processed transaction")
-		return event, nil
+		// in this case, we will discard the transaction
+		event.ValidationCode = convertValidationCode(int32(pb.TxValidationCode_INVALID_OTHER_REASON))
+		event.ValidationMessage = err.Error()
 	}
 
 	if err := c.DiscardEndorserTransaction(ctx, event.TxID, tx.BlkNum, tx.Raw, event); err != nil {

--- a/platform/fabric/core/generic/committer/fake/fakes.go
+++ b/platform/fabric/core/generic/committer/fake/fakes.go
@@ -332,7 +332,7 @@ func (c *Counter) With(...string) metrics.Counter {
 	return c
 }
 
-func (c *Counter) Add(float64) {}
+func (*Counter) Add(float64) {}
 
 type Gauge struct{}
 
@@ -340,9 +340,9 @@ func (g *Gauge) With(...string) metrics.Gauge {
 	return g
 }
 
-func (g *Gauge) Add(float64) {}
+func (*Gauge) Add(float64) {}
 
-func (g *Gauge) Set(float64) {}
+func (*Gauge) Set(float64) {}
 
 type Histogram struct{}
 
@@ -350,19 +350,19 @@ func (h *Histogram) With(...string) metrics.Histogram {
 	return h
 }
 
-func (h *Histogram) Observe(float64) {}
+func (*Histogram) Observe(float64) {}
 
 type MetricsProvider struct{}
 
-func (p *MetricsProvider) NewCounter(metrics.CounterOpts) metrics.Counter {
+func (*MetricsProvider) NewCounter(metrics.CounterOpts) metrics.Counter {
 	return &Counter{}
 }
 
-func (p *MetricsProvider) NewGauge(metrics.GaugeOpts) metrics.Gauge {
+func (*MetricsProvider) NewGauge(metrics.GaugeOpts) metrics.Gauge {
 	return &Gauge{}
 }
 
-func (p *MetricsProvider) NewHistogram(metrics.HistogramOpts) metrics.Histogram {
+func (*MetricsProvider) NewHistogram(metrics.HistogramOpts) metrics.Histogram {
 	return &Histogram{}
 }
 
@@ -377,7 +377,7 @@ func (f *Filter) Accept(cdriver.TxID, []byte) (bool, error) {
 
 type FinalityListener struct{}
 
-func (l *FinalityListener) OnStatus(context.Context, cdriver.TxID, fdriver.ValidationCode, string) {
+func (*FinalityListener) OnStatus(context.Context, cdriver.TxID, fdriver.ValidationCode, string) {
 }
 
 type ListenerManager struct {
@@ -394,9 +394,9 @@ func (m *ListenerManager) RemoveListener(txID cdriver.TxID, _ cdriver.FinalityLi
 	m.RemovedTx = txID
 }
 
-func (m *ListenerManager) InvokeListeners(cdriver.FinalityEvent[fdriver.ValidationCode]) {}
+func (*ListenerManager) InvokeListeners(cdriver.FinalityEvent[fdriver.ValidationCode]) {}
 
-func (m *ListenerManager) TxIDs() []cdriver.TxID { return nil }
+func (*ListenerManager) TxIDs() []cdriver.TxID { return nil }
 
 type QueryExecutor struct {
 	cdriver.QueryExecutor

--- a/platform/fabric/core/generic/config/service.go
+++ b/platform/fabric/core/generic/config/service.go
@@ -178,7 +178,7 @@ func (s *Service) ClientKeepAliveConfig() *grpc.ClientKeepAliveConfig {
 	return c
 }
 
-func (s *Service) NewDefaultChannelConfig(name string) driver.ChannelConfig {
+func (*Service) NewDefaultChannelConfig(name string) driver.ChannelConfig {
 	return &Channel{
 		Name:       name,
 		Default:    false,

--- a/platform/fabric/core/generic/delivery/deliverclient_test.go
+++ b/platform/fabric/core/generic/delivery/deliverclient_test.go
@@ -28,8 +28,8 @@ type fakeDeliverFiltered struct {
 	pos       int
 }
 
-func (f *fakeDeliverFiltered) Send(*cb.Envelope) error { return nil }
-func (f *fakeDeliverFiltered) CloseSend() error        { return nil }
+func (*fakeDeliverFiltered) Send(*cb.Envelope) error { return nil }
+func (*fakeDeliverFiltered) CloseSend() error        { return nil }
 
 func (f *fakeDeliverFiltered) Recv() (*pb.DeliverResponse, error) {
 	if f.pos >= len(f.responses) {

--- a/platform/fabric/core/generic/delivery/delivery_test.go
+++ b/platform/fabric/core/generic/delivery/delivery_test.go
@@ -46,15 +46,15 @@ type mockLedger struct {
 	blockErr    error
 }
 
-func (m *mockLedger) GetLedgerInfo() (*driver.LedgerInfo, error) { return nil, nil }
-func (m *mockLedger) GetTransactionByID(txID string) (driver.ProcessedTransaction, error) {
+func (*mockLedger) GetLedgerInfo() (*driver.LedgerInfo, error) { return nil, nil }
+func (*mockLedger) GetTransactionByID(_ string) (driver.ProcessedTransaction, error) {
 	return nil, nil
 }
 
-func (m *mockLedger) GetBlockNumberByTxID(txID string) (uint64, error) {
+func (m *mockLedger) GetBlockNumberByTxID(_ string) (uint64, error) {
 	return m.blockNumber, m.blockErr
 }
-func (m *mockLedger) GetBlockByNumber(number uint64) (driver.Block, error) { return nil, nil }
+func (*mockLedger) GetBlockByNumber(_ uint64) (driver.Block, error) { return nil, nil }
 
 // --- Tests for random.go ---
 
@@ -439,7 +439,7 @@ func TestDeliveryLifecycle(t *testing.T) {
 		d := &Delivery{
 			bufferSize: 1,
 			stop:       make(chan struct{}),
-			callback: func(ctx context.Context, block *cb.Block) (bool, error) {
+			callback: func(_ context.Context, _ *cb.Block) (bool, error) {
 				return false, errors.New("callback error")
 			},
 		}
@@ -456,7 +456,7 @@ func TestDeliveryLifecycle(t *testing.T) {
 		d := &Delivery{
 			bufferSize: 1,
 			stop:       make(chan struct{}),
-			callback: func(ctx context.Context, block *cb.Block) (bool, error) {
+			callback: func(_ context.Context, _ *cb.Block) (bool, error) {
 				return true, nil
 			},
 		}
@@ -657,7 +657,7 @@ func TestRunReceiverResponses(t *testing.T) {
 		vault:         &mockVault{},
 		NetworkName:   "testNet",
 		channel:       "testChannel",
-		callback:      func(ctx context.Context, block *cb.Block) (bool, error) { return false, nil },
+		callback:      func(_ context.Context, _ *cb.Block) (bool, error) { return false, nil },
 		channelConfig: &mockChannelConfig{},
 		tracer:        noop.NewTracerProvider().Tracer("test"),
 		client:        &mockPeerClient{},

--- a/platform/fabric/core/generic/delivery/helpers_test.go
+++ b/platform/fabric/core/generic/delivery/helpers_test.go
@@ -36,11 +36,11 @@ type mockPeerClient struct {
 	cert       tls.Certificate
 }
 
-func (m *mockPeerClient) Address() string                                    { return m.addr }
-func (m *mockPeerClient) Certificate() tls.Certificate                       { return m.cert }
-func (m *mockPeerClient) Close()                                             {}
-func (m *mockPeerClient) EndorserClient() (pb.EndorserClient, error)         { return nil, nil }
-func (m *mockPeerClient) DiscoveryClient() (services.DiscoveryClient, error) { return nil, nil }
+func (m *mockPeerClient) Address() string                                  { return m.addr }
+func (m *mockPeerClient) Certificate() tls.Certificate                     { return m.cert }
+func (*mockPeerClient) Close()                                             {}
+func (*mockPeerClient) EndorserClient() (pb.EndorserClient, error)         { return nil, nil }
+func (*mockPeerClient) DiscoveryClient() (services.DiscoveryClient, error) { return nil, nil }
 
 // DeliverClient never returns a nil client with a nil error: a real peer client
 // cannot do that, and NewDeliver would dereference the nil interface and take
@@ -68,7 +68,7 @@ func (m *mockDeliverClientRPC) DeliverFiltered(_ context.Context, _ ...googlegrp
 	return m.filtered, m.filteredErr
 }
 
-func (m *mockDeliverClientRPC) DeliverWithPrivateData(_ context.Context, _ ...googlegrpc.CallOption) (pb.Deliver_DeliverWithPrivateDataClient, error) {
+func (*mockDeliverClientRPC) DeliverWithPrivateData(_ context.Context, _ ...googlegrpc.CallOption) (pb.Deliver_DeliverWithPrivateDataClient, error) {
 	return nil, nil
 }
 
@@ -92,7 +92,7 @@ func (m *mockSigningIdentity) Serialize() ([]byte, error) {
 	return []byte("serialized"), nil
 }
 
-func (m *mockSigningIdentity) Sign(msg []byte) ([]byte, error) {
+func (m *mockSigningIdentity) Sign(_ []byte) ([]byte, error) {
 	if m.signErr != nil {
 		return nil, m.signErr
 	}
@@ -219,13 +219,13 @@ type mockChannelConfig struct {
 	driver.ChannelConfig
 }
 
-func (m *mockChannelConfig) DeliverySleepAfterFailure() time.Duration { return 10 * time.Millisecond }
+func (*mockChannelConfig) DeliverySleepAfterFailure() time.Duration { return 10 * time.Millisecond }
 
-func (m *mockChannelConfig) CommitterWaitForEventTimeout() time.Duration {
+func (*mockChannelConfig) CommitterWaitForEventTimeout() time.Duration {
 	return 10 * time.Millisecond
 }
-func (m *mockChannelConfig) DeliveryBufferSize() int { return 1 }
-func (m *mockChannelConfig) ID() string              { return "testChannel" }
+func (*mockChannelConfig) DeliveryBufferSize() int { return 1 }
+func (*mockChannelConfig) ID() string              { return "testChannel" }
 
 // --- Transaction mocks ---
 
@@ -234,32 +234,32 @@ type mockTransactionManager struct {
 	err error
 }
 
-func (m *mockTransactionManager) ComputeTxID(*driver.TxIDComponents) string { return "" }
-func (m *mockTransactionManager) NewEnvelope() driver.Envelope              { return nil }
-func (m *mockTransactionManager) NewProposalResponseFromBytes([]byte) (driver.ProposalResponse, error) {
+func (*mockTransactionManager) ComputeTxID(*driver.TxIDComponents) string { return "" }
+func (*mockTransactionManager) NewEnvelope() driver.Envelope              { return nil }
+func (*mockTransactionManager) NewProposalResponseFromBytes([]byte) (driver.ProposalResponse, error) {
 	return nil, nil
 }
 
-func (m *mockTransactionManager) NewTransaction(context.Context, driver.TransactionType, view.Identity, []byte, string, string, []byte) (driver.Transaction, error) {
+func (*mockTransactionManager) NewTransaction(context.Context, driver.TransactionType, view.Identity, []byte, string, string, []byte) (driver.Transaction, error) {
 	return nil, nil
 }
 
-func (m *mockTransactionManager) NewTransactionFromBytes(context.Context, string, []byte) (driver.Transaction, error) {
+func (*mockTransactionManager) NewTransactionFromBytes(context.Context, string, []byte) (driver.Transaction, error) {
 	return nil, nil
 }
 
-func (m *mockTransactionManager) NewTransactionFromEnvelopeBytes(context.Context, string, []byte) (driver.Transaction, error) {
+func (*mockTransactionManager) NewTransactionFromEnvelopeBytes(context.Context, string, []byte) (driver.Transaction, error) {
 	return nil, nil
 }
 
-func (m *mockTransactionManager) AddTransactionFactory(driver.TransactionType, driver.TransactionFactory) {
+func (*mockTransactionManager) AddTransactionFactory(driver.TransactionType, driver.TransactionFactory) {
 }
 
-func (m *mockTransactionManager) NewProcessedTransactionFromEnvelopePayload([]byte) (driver.ProcessedTransaction, int32, error) {
+func (*mockTransactionManager) NewProcessedTransactionFromEnvelopePayload([]byte) (driver.ProcessedTransaction, int32, error) {
 	return nil, 0, nil
 }
 
-func (m *mockTransactionManager) NewProcessedTransaction([]byte) (driver.ProcessedTransaction, error) {
+func (*mockTransactionManager) NewProcessedTransaction([]byte) (driver.ProcessedTransaction, error) {
 	return nil, nil
 }
 
@@ -273,11 +273,11 @@ type mockProcessedTx struct {
 	env     []byte
 }
 
-func (m *mockProcessedTx) TxID() string          { return m.txID }
-func (m *mockProcessedTx) Results() []byte       { return m.results }
-func (m *mockProcessedTx) Envelope() []byte      { return m.env }
-func (m *mockProcessedTx) ValidationCode() int32 { return 0 }
-func (m *mockProcessedTx) IsValid() bool         { return true }
+func (m *mockProcessedTx) TxID() string        { return m.txID }
+func (m *mockProcessedTx) Results() []byte     { return m.results }
+func (m *mockProcessedTx) Envelope() []byte    { return m.env }
+func (*mockProcessedTx) ValidationCode() int32 { return 0 }
+func (*mockProcessedTx) IsValid() bool         { return true }
 
 // --- Test helpers ---
 

--- a/platform/fabric/core/generic/delivery/service.go
+++ b/platform/fabric/core/generic/delivery/service.go
@@ -134,10 +134,10 @@ func (c *Service) Stop() {
 	c.deliveryService.Stop(nil)
 }
 
-// scanBlock runs a throwaway Delivery over this channel, starting from the
+// runBlockScan runs a throwaway Delivery over this channel, starting from the
 // position implied by vault, and invokes callback for each block. It blocks
 // until the callback asks to stop, the callback fails, or ctx is cancelled.
-func (c *Service) scanBlock(ctx context.Context, vault Vault, callback driver.BlockCallback) error {
+func (c *Service) runBlockScan(ctx context.Context, vault Vault, callback driver.BlockCallback) error {
 	deliveryService, err := New(
 		c.NetworkName,
 		c.channelConfig,
@@ -161,13 +161,13 @@ func (c *Service) scanBlock(ctx context.Context, vault Vault, callback driver.Bl
 
 // ScanBlock delivers whole blocks to callback, starting from the genesis block.
 func (c *Service) ScanBlock(ctx context.Context, callback driver.BlockCallback) error {
-	return c.scanBlock(ctx, &fakeVault{}, callback)
+	return c.runBlockScan(ctx, &fakeVault{}, callback)
 }
 
 // ScanBlockFrom delivers whole blocks to callback, starting from the given
 // block number.
 func (c *Service) ScanBlockFrom(ctx context.Context, block driver.BlockNum, callback driver.BlockCallback) error {
-	return c.scanBlock(ctx, &fakeVault{block: block}, callback)
+	return c.runBlockScan(ctx, &fakeVault{block: block}, callback)
 }
 
 // Scan delivers the transactions committed after txID to callback, one at a
@@ -175,7 +175,7 @@ func (c *Service) ScanBlockFrom(ctx context.Context, block driver.BlockNum, call
 // configured to accept. Passing an empty txID starts from the genesis block.
 func (c *Service) Scan(ctx context.Context, txID string, callback driver.DeliveryCallback) error {
 	vault := &fakeVault{txID: txID}
-	return c.scanBlock(ctx, vault,
+	return c.runBlockScan(ctx, vault,
 		func(_ context.Context, block *common.Block) (bool, error) {
 			for i, tx := range block.Data.Data {
 				validationCode, err := validationCodeAt(block, i)
@@ -225,7 +225,7 @@ func (c *Service) Scan(ctx context.Context, txID string, callback driver.Deliver
 // instead of from a transaction ID.
 func (c *Service) ScanFromBlock(ctx context.Context, block driver.BlockNum, callback driver.DeliveryCallback) error {
 	vault := &fakeVault{block: block}
-	return c.scanBlock(ctx, vault,
+	return c.runBlockScan(ctx, vault,
 		func(_ context.Context, block *common.Block) (bool, error) {
 			for i, tx := range block.Data.Data {
 				validationCode, err := validationCodeAt(block, i)

--- a/platform/fabric/core/generic/delivery/service_test.go
+++ b/platform/fabric/core/generic/delivery/service_test.go
@@ -109,7 +109,7 @@ func TestServiceLifecycle(t *testing.T) {
 			&mockLedger{},
 			&mockVault{},
 			&mockTransactionManager{},
-			func(ctx context.Context, block *cb.Block) (bool, error) { return false, nil },
+			func(_ context.Context, _ *cb.Block) (bool, error) { return false, nil },
 			noop.NewTracerProvider(),
 			nil,
 			[]cb.HeaderType{cb.HeaderType_ENDORSER_TRANSACTION},
@@ -158,7 +158,7 @@ func TestScanBlockVariants(t *testing.T) {
 			Metadata: &cb.BlockMetadata{Metadata: [][]byte{nil, nil, {uint8(pb.TxValidationCode_VALID), uint8(pb.TxValidationCode_VALID)}}},
 		}}}
 
-		err := svc.Scan(ctx, "txid", func(tx driver.ProcessedTransaction) (bool, error) {
+		err := svc.Scan(ctx, "txid", func(_ driver.ProcessedTransaction) (bool, error) {
 			return false, errors.New("callback err")
 		})
 		require.ErrorContains(t, err, "callback err")
@@ -179,7 +179,7 @@ func TestScanBlockVariants(t *testing.T) {
 			Metadata: &cb.BlockMetadata{Metadata: [][]byte{nil, nil, {uint8(pb.TxValidationCode_VALID)}}},
 		}}}
 
-		err := svc.Scan(ctx, "txid", func(tx driver.ProcessedTransaction) (bool, error) {
+		err := svc.Scan(ctx, "txid", func(_ driver.ProcessedTransaction) (bool, error) {
 			return true, nil
 		})
 		require.NoError(t, err)
@@ -223,7 +223,7 @@ func TestScanBlockVariants(t *testing.T) {
 		cancel()
 		t.Cleanup(cancel)
 
-		err := svc.Scan(ctx, "tx1", func(tx driver.ProcessedTransaction) (bool, error) { return false, nil })
+		err := svc.Scan(ctx, "tx1", func(_ driver.ProcessedTransaction) (bool, error) { return false, nil })
 		if err != nil {
 			require.ErrorContains(t, err, "context done")
 		}
@@ -248,7 +248,7 @@ func TestScanBlockVariants(t *testing.T) {
 			Metadata: &cb.BlockMetadata{Metadata: [][]byte{nil, nil, {uint8(pb.TxValidationCode_VALID)}}},
 		}}}
 
-		err := svc.Scan(ctx, "tx1", func(tx driver.ProcessedTransaction) (bool, error) { return false, nil })
+		err := svc.Scan(ctx, "tx1", func(_ driver.ProcessedTransaction) (bool, error) { return false, nil })
 		require.ErrorContains(t, err, "error unmarshalling")
 	})
 
@@ -275,7 +275,7 @@ func TestScanBlockVariants(t *testing.T) {
 			Metadata: &cb.BlockMetadata{Metadata: [][]byte{nil, nil, {uint8(pb.TxValidationCode_VALID)}}},
 		}}}
 
-		err := svc.Scan(ctx, "tx1", func(tx driver.ProcessedTransaction) (bool, error) {
+		err := svc.Scan(ctx, "tx1", func(_ driver.ProcessedTransaction) (bool, error) {
 			close(processed)
 			return false, nil // return stop = false to reach the end of the loop
 		})
@@ -300,7 +300,7 @@ func TestScanBlockVariants(t *testing.T) {
 			Metadata: &cb.BlockMetadata{Metadata: [][]byte{nil, nil, {uint8(pb.TxValidationCode_VALID)}}},
 		}}}
 
-		err := svc.ScanFromBlock(ctx, 10, func(tx driver.ProcessedTransaction) (bool, error) {
+		err := svc.ScanFromBlock(ctx, 10, func(_ driver.ProcessedTransaction) (bool, error) {
 			return true, nil // return stop = true
 		})
 		require.NoError(t, err)
@@ -323,7 +323,7 @@ func TestScanBlockVariants(t *testing.T) {
 		}}}
 		recvChan <- &pb.DeliverResponse{Type: &pb.DeliverResponse_Status{Status: cb.Status_SUCCESS}}
 
-		err := svc.ScanFromBlock(ctx, 10, func(tx driver.ProcessedTransaction) (bool, error) {
+		err := svc.ScanFromBlock(ctx, 10, func(_ driver.ProcessedTransaction) (bool, error) {
 			return false, errors.New("callback error")
 		})
 		require.ErrorContains(t, err, "callback error")
@@ -349,7 +349,7 @@ func TestScanBlockVariants(t *testing.T) {
 			Metadata: &cb.BlockMetadata{Metadata: [][]byte{nil, nil, {uint8(pb.TxValidationCode_VALID), uint8(pb.TxValidationCode_VALID)}}},
 		}}}
 
-		err := svc.ScanFromBlock(ctx, 10, func(tx driver.ProcessedTransaction) (bool, error) {
+		err := svc.ScanFromBlock(ctx, 10, func(_ driver.ProcessedTransaction) (bool, error) {
 			return false, nil
 		})
 		require.ErrorContains(t, err, "tx mgr error")
@@ -369,7 +369,7 @@ func TestScanBlockVariants(t *testing.T) {
 			Metadata: &cb.BlockMetadata{Metadata: [][]byte{nil, nil, {uint8(pb.TxValidationCode_VALID)}}},
 		}}}
 
-		err := svc.ScanFromBlock(ctx, 10, func(tx driver.ProcessedTransaction) (bool, error) { return false, nil })
+		err := svc.ScanFromBlock(ctx, 10, func(_ driver.ProcessedTransaction) (bool, error) { return false, nil })
 		require.ErrorContains(t, err, "error unmarshalling Envelope")
 	})
 
@@ -387,7 +387,7 @@ func TestScanBlockVariants(t *testing.T) {
 			Metadata: &cb.BlockMetadata{Metadata: [][]byte{}},
 		}}}
 
-		err := svc.ScanFromBlock(ctx, 10, func(tx driver.ProcessedTransaction) (bool, error) { return false, nil })
+		err := svc.ScanFromBlock(ctx, 10, func(_ driver.ProcessedTransaction) (bool, error) { return false, nil })
 		require.ErrorContains(t, err, "metadata lacks transaction filter")
 	})
 
@@ -400,7 +400,7 @@ func TestScanBlockVariants(t *testing.T) {
 		// cancel synchronously so it fails when trying to sleep before reconnecting
 		cancel()
 
-		err := svc.ScanFromBlock(ctx, 10, func(tx driver.ProcessedTransaction) (bool, error) { return false, nil })
+		err := svc.ScanFromBlock(ctx, 10, func(_ driver.ProcessedTransaction) (bool, error) { return false, nil })
 		if err != nil {
 			require.ErrorContains(t, err, "context done")
 		}

--- a/platform/fabric/core/generic/discovery/client.go
+++ b/platform/fabric/core/generic/discovery/client.go
@@ -531,7 +531,7 @@ func (resp response) mapEndorsersOfChannel(ccRs *discovery.ChaincodeQueryResult,
 	return nil
 }
 
-func (resp response) createEndorsementDescriptor(desc *discovery.EndorsementDescriptor, channel string) (*endorsementDescriptor, error) {
+func (response) createEndorsementDescriptor(desc *discovery.EndorsementDescriptor, channel string) (*endorsementDescriptor, error) {
 	descriptor := &endorsementDescriptor{
 		layouts:           []map[string]int{},
 		endorsersByGroups: make(map[string][]*Peer),

--- a/platform/fabric/core/generic/discovery/client_test.go
+++ b/platform/fabric/core/generic/discovery/client_test.go
@@ -394,7 +394,7 @@ func computeSHA256(bytes []byte) []byte {
 
 func TestUnableToSign(t *testing.T) {
 	t.Parallel()
-	signer := func(msg []byte) ([]byte, error) {
+	signer := func(_ []byte) ([]byte, error) {
 		return nil, errors.New("not enough entropy")
 	}
 	failToConnect := func() (*grpc.ClientConn, error) {

--- a/platform/fabric/core/generic/discovery/selection.go
+++ b/platform/fabric/core/generic/discovery/selection.go
@@ -54,7 +54,7 @@ var (
 
 type noPriorities struct{}
 
-func (nc noPriorities) Compare(_, _ Peer) Priority {
+func (noPriorities) Compare(_, _ Peer) Priority {
 	return 0
 }
 

--- a/platform/fabric/core/generic/endpoint/pki.go
+++ b/platform/fabric/core/generic/endpoint/pki.go
@@ -19,7 +19,7 @@ import (
 
 type PublicKeyExtractor struct{}
 
-func (p PublicKeyExtractor) ExtractPublicKey(id view.Identity) (any, error) {
+func (PublicKeyExtractor) ExtractPublicKey(id view.Identity) (any, error) {
 	si := &msp.SerializedIdentity{}
 	err := proto.Unmarshal(id, si)
 	if err != nil {

--- a/platform/fabric/core/generic/endpoint/resolver.go
+++ b/platform/fabric/core/generic/endpoint/resolver.go
@@ -23,6 +23,7 @@ var logger = logging.MustGetLogger()
 
 type Resolver struct {
 	config.Resolver
+	//nolint:revive // var-naming: renaming this exported struct field is an API break; see follow-up
 	Id             []byte
 	RootID         view.Identity
 	IdentityGetter func() (view.Identity, []byte, error)

--- a/platform/fabric/core/generic/events/listenermanager.go
+++ b/platform/fabric/core/generic/events/listenermanager.go
@@ -87,7 +87,7 @@ func NewListenerManager[T EventInfo](
 	tracer trace.Tracer,
 	mapper EventInfoMapper[T],
 ) (*ListenerManager[T], error) {
-	return newListenerManager[T](ctx, logger, config, delivery, queryService, tracer, mapper, false)
+	return buildListenerManager[T](ctx, logger, config, delivery, queryService, tracer, mapper, false)
 }
 
 func NewSequentialListenerManager[T EventInfo](
@@ -99,10 +99,10 @@ func NewSequentialListenerManager[T EventInfo](
 	tracer trace.Tracer,
 	mapper EventInfoMapper[T],
 ) (*ListenerManager[T], error) {
-	return newListenerManager[T](ctx, logger, config, delivery, queryService, tracer, mapper, true)
+	return buildListenerManager[T](ctx, logger, config, delivery, queryService, tracer, mapper, true)
 }
 
-func newListenerManager[T EventInfo](
+func buildListenerManager[T EventInfo](
 	ctx context.Context,
 	logger logging.Logger,
 	config DeliveryListenerManagerConfig,

--- a/platform/fabric/core/generic/events/listenermanager_leak_test.go
+++ b/platform/fabric/core/generic/events/listenermanager_leak_test.go
@@ -31,7 +31,7 @@ func (d *blockingDelivery) ScanBlock(ctx context.Context, _ fabric.BlockCallback
 
 type nopQuery struct{}
 
-func (nopQuery) QueryByID(ctx context.Context, _ driver.BlockNum, _ map[EventID][]ListenerEntry[testEvent]) (<-chan []testEvent, error) {
+func (nopQuery) QueryByID(_ context.Context, _ driver.BlockNum, _ map[EventID][]ListenerEntry[testEvent]) (<-chan []testEvent, error) {
 	ch := make(chan []testEvent)
 	close(ch)
 	return ch, nil

--- a/platform/fabric/core/generic/events/listenermanager_test.go
+++ b/platform/fabric/core/generic/events/listenermanager_test.go
@@ -310,7 +310,7 @@ func newTestListener(id string) *testListener {
 
 // Namespace implements ListenerEntry and returns an empty namespace, meaning
 // the listener applies to all namespaces.
-func (l *testListener) Namespace() driver.Namespace {
+func (*testListener) Namespace() driver.Namespace {
 	return ""
 }
 
@@ -345,7 +345,7 @@ func (m staticMapper) MapTxData(_ context.Context, _ []byte, _ *common.BlockMeta
 }
 
 // MapProcessedTx satisfies the EventInfoMapper interface and always returns nil.
-func (m staticMapper) MapProcessedTx(_ *fabric.ProcessedTransaction) ([]testEvent, error) {
+func (staticMapper) MapProcessedTx(_ *fabric.ProcessedTransaction) ([]testEvent, error) {
 	return nil, nil
 }
 

--- a/platform/fabric/core/generic/fabricutils/fake/fakes.go
+++ b/platform/fabric/core/generic/fabricutils/fake/fakes.go
@@ -55,7 +55,7 @@ func (r *ProposalResponse) EndorserSignature() []byte { return r.EndorserSignatu
 func (r *ProposalResponse) Results() []byte           { return r.ResultsBytes }
 func (r *ProposalResponse) ResponseStatus() int32     { return r.Status }
 func (r *ProposalResponse) ResponseMessage() string   { return r.Message }
-func (r *ProposalResponse) Bytes() ([]byte, error)    { return nil, nil }
-func (r *ProposalResponse) VerifyEndorsement(driver.VerifierProvider) error {
+func (*ProposalResponse) Bytes() ([]byte, error)      { return nil, nil }
+func (*ProposalResponse) VerifyEndorsement(driver.VerifierProvider) error {
 	return nil
 }

--- a/platform/fabric/core/generic/finality/deliveryflm.go
+++ b/platform/fabric/core/generic/finality/deliveryflm.go
@@ -42,7 +42,7 @@ type deliveryListenerEntry struct {
 	l fabric.FinalityListener
 }
 
-func (e *deliveryListenerEntry) Namespace() driver2.Namespace {
+func (*deliveryListenerEntry) Namespace() driver2.Namespace {
 	return ""
 }
 
@@ -113,7 +113,7 @@ func (m *txInfoMapper) MapTxData(ctx context.Context, tx []byte, block *common.B
 	return txInfos, nil
 }
 
-func (m *txInfoMapper) MapProcessedTx(tx *fabric.ProcessedTransaction) ([]txInfo, error) {
+func (*txInfoMapper) MapProcessedTx(tx *fabric.ProcessedTransaction) ([]txInfo, error) {
 	status, message := committer.MapValidationCode(tx.ValidationCode())
 	return []txInfo{{
 		txID:    tx.TxID(),

--- a/platform/fabric/core/generic/finality/deliveryqs.go
+++ b/platform/fabric/core/generic/finality/deliveryqs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/events"
 )
 
+//nolint:revive // error-naming: renaming this exported error var to the ErrFoo form is an API break; see follow-up
 var TxNotFound = errors.New("tx not found")
 
 type DeliveryScanQueryByID[T events.EventInfo] struct {
@@ -29,11 +30,11 @@ func (q *DeliveryScanQueryByID[T]) QueryByID(ctx context.Context, lastBlock driv
 	txIDs := collections.Keys(evicted)
 	results := collections.NewSet(txIDs...)
 	ch := make(chan []T, len(txIDs))
-	go q.queryByID(ctx, results, ch, lastBlock)
+	go q.runQueryByID(ctx, results, ch, lastBlock)
 	return ch, nil
 }
 
-func (q *DeliveryScanQueryByID[T]) queryByID(ctx context.Context, results collections.Set[string], ch chan []T, lastBlock uint64) {
+func (q *DeliveryScanQueryByID[T]) runQueryByID(ctx context.Context, results collections.Set[string], ch chan []T, lastBlock uint64) {
 	defer close(ch)
 
 	startingBlock := max(1, lastBlock-10)

--- a/platform/fabric/core/generic/finality/fake/fakes.go
+++ b/platform/fabric/core/generic/finality/fake/fakes.go
@@ -26,12 +26,12 @@ type Committer struct {
 	mock.Mock
 }
 
-func (m *Committer) Start(ctx context.Context) error { return nil }
-func (m *Committer) ProcessNamespace(nss ...cdriver.Namespace) error {
+func (*Committer) Start(_ context.Context) error { return nil }
+func (*Committer) ProcessNamespace(_ ...cdriver.Namespace) error {
 	return nil
 }
-func (m *Committer) AddTransactionFilter(tf fdriver.TransactionFilter) error { return nil }
-func (m *Committer) Status(ctx context.Context, txID cdriver.TxID) (fdriver.ValidationCode, string, error) {
+func (*Committer) AddTransactionFilter(_ fdriver.TransactionFilter) error { return nil }
+func (*Committer) Status(_ context.Context, _ cdriver.TxID) (fdriver.ValidationCode, string, error) {
 	return 0, "", nil
 }
 
@@ -45,11 +45,11 @@ func (m *Committer) RemoveFinalityListener(txID string, listener fdriver.Finalit
 	return args.Error(0)
 }
 
-func (m *Committer) DiscardTx(ctx context.Context, txID cdriver.TxID, message string) error {
+func (*Committer) DiscardTx(_ context.Context, _ cdriver.TxID, _ string) error {
 	return nil
 }
 
-func (m *Committer) CommitTX(ctx context.Context, txID cdriver.TxID, block cdriver.BlockNum, indexInBlock cdriver.TxNum, envelope *common.Envelope) error {
+func (*Committer) CommitTX(_ context.Context, _ cdriver.TxID, _ cdriver.BlockNum, _ cdriver.TxNum, _ *common.Envelope) error {
 	return nil
 }
 
@@ -73,7 +73,7 @@ func (m *Channel) Ledger() fdriver.Ledger {
 	return args.Get(0).(fdriver.Ledger)
 }
 
-func (m *Channel) Name() string {
+func (*Channel) Name() string {
 	return "test"
 }
 
@@ -89,13 +89,13 @@ type Delivery struct {
 	mock.Mock
 }
 
-func (m *Delivery) Start(ctx context.Context) error { return nil }
+func (*Delivery) Start(_ context.Context) error { return nil }
 
-func (m *Delivery) ScanBlock(ctx context.Context, callback fdriver.BlockCallback) error {
+func (*Delivery) ScanBlock(_ context.Context, _ fdriver.BlockCallback) error {
 	return nil
 }
 
-func (m *Delivery) ScanBlockFrom(ctx context.Context, block fdriver.BlockNum, callback fdriver.BlockCallback) error {
+func (*Delivery) ScanBlockFrom(_ context.Context, _ fdriver.BlockNum, _ fdriver.BlockCallback) error {
 	return nil
 }
 
@@ -144,11 +144,11 @@ func (m *PeerClient) DeliverClient() (pb.DeliverClient, error) {
 	return args.Get(0).(pb.DeliverClient), args.Error(1)
 }
 
-func (m *PeerClient) EndorserClient() (pb.EndorserClient, error) {
+func (*PeerClient) EndorserClient() (pb.EndorserClient, error) {
 	return nil, nil
 }
 
-func (m *PeerClient) DiscoveryClient() (services.DiscoveryClient, error) {
+func (*PeerClient) DiscoveryClient() (services.DiscoveryClient, error) {
 	return nil, nil
 }
 
@@ -190,13 +190,13 @@ func (m *DeliverFilteredStream) Recv() (*pb.DeliverResponse, error) {
 	}
 	return args.Get(0).(*pb.DeliverResponse), args.Error(1)
 }
-func (m *DeliverFilteredStream) CloseSend() error             { return m.Called().Error(0) }
-func (m *DeliverFilteredStream) Header() (metadata.MD, error) { return nil, nil }
-func (m *DeliverFilteredStream) Trailer() metadata.MD         { return nil }
-func (m *DeliverFilteredStream) CloseRead() error             { return nil }
-func (m *DeliverFilteredStream) Context() context.Context     { return context.Background() }
-func (m *DeliverFilteredStream) SendMsg(m_ any) error         { return nil }
-func (m *DeliverFilteredStream) RecvMsg(m_ any) error         { return nil }
+func (m *DeliverFilteredStream) CloseSend() error           { return m.Called().Error(0) }
+func (*DeliverFilteredStream) Header() (metadata.MD, error) { return nil, nil }
+func (*DeliverFilteredStream) Trailer() metadata.MD         { return nil }
+func (*DeliverFilteredStream) CloseRead() error             { return nil }
+func (*DeliverFilteredStream) Context() context.Context     { return context.Background() }
+func (*DeliverFilteredStream) SendMsg(_ any) error          { return nil }
+func (*DeliverFilteredStream) RecvMsg(_ any) error          { return nil }
 
 type SigningIdentity struct {
 	mock.Mock

--- a/platform/fabric/core/generic/membership/channelconfig/applicationorg.go
+++ b/platform/fabric/core/generic/membership/channelconfig/applicationorg.go
@@ -67,6 +67,6 @@ func (aog *ApplicationOrgConfig) AnchorPeers() []*pb.AnchorPeer {
 	return aog.protos.AnchorPeers.AnchorPeers
 }
 
-func (aoc *ApplicationOrgConfig) Validate() error {
-	return aoc.OrganizationConfig.Validate()
+func (aog *ApplicationOrgConfig) Validate() error {
+	return aog.OrganizationConfig.Validate()
 }

--- a/platform/fabric/core/generic/membership/channelconfig/capabilities/application.go
+++ b/platform/fabric/core/generic/membership/channelconfig/capabilities/application.go
@@ -65,7 +65,7 @@ func NewApplicationProvider(capabilities map[string]*cb.Capability) *Application
 }
 
 // Type returns a descriptive string for logging purposes.
-func (ap *ApplicationProvider) Type() string {
+func (*ApplicationProvider) Type() string {
 	return applicationTypeName
 }
 
@@ -128,7 +128,7 @@ func (ap *ApplicationProvider) LifecycleV20() bool {
 }
 
 // MetadataLifecycle always returns false
-func (ap *ApplicationProvider) MetadataLifecycle() bool {
+func (*ApplicationProvider) MetadataLifecycle() bool {
 	return false
 }
 
@@ -150,7 +150,7 @@ func (ap *ApplicationProvider) PurgePvtData() bool {
 }
 
 // HasCapability returns true if the capability is supported by this binary.
-func (ap *ApplicationProvider) HasCapability(capability string) bool {
+func (*ApplicationProvider) HasCapability(capability string) bool {
 	switch capability {
 	// Add new capability names here
 	case ApplicationV1_1:

--- a/platform/fabric/core/generic/membership/channelconfig/capabilities/channel.go
+++ b/platform/fabric/core/generic/membership/channelconfig/capabilities/channel.go
@@ -59,12 +59,12 @@ func NewChannelProvider(capabilities map[string]*cb.Capability) *ChannelProvider
 }
 
 // Type returns a descriptive string for logging purposes.
-func (cp *ChannelProvider) Type() string {
+func (*ChannelProvider) Type() string {
 	return channelTypeName
 }
 
 // HasCapability returns true if the capability is supported by this binary.
-func (cp *ChannelProvider) HasCapability(capability string) bool {
+func (*ChannelProvider) HasCapability(capability string) bool {
 	switch capability {
 	// Add new capability names here
 	case ChannelV3_0:

--- a/platform/fabric/core/generic/membership/channelconfig/capabilities/orderer.go
+++ b/platform/fabric/core/generic/membership/channelconfig/capabilities/orderer.go
@@ -42,12 +42,12 @@ func NewOrdererProvider(capabilities map[string]*cb.Capability) *OrdererProvider
 }
 
 // Type returns a descriptive string for logging purposes.
-func (cp *OrdererProvider) Type() string {
+func (*OrdererProvider) Type() string {
 	return ordererTypeName
 }
 
 // HasCapability returns true if the capability is supported by this binary.
-func (cp *OrdererProvider) HasCapability(capability string) bool {
+func (*OrdererProvider) HasCapability(capability string) bool {
 	switch capability {
 	// Add new capability names here
 	case OrdererV1_1:

--- a/platform/fabric/core/generic/membership/channelconfig/msp.go
+++ b/platform/fabric/core/generic/membership/channelconfig/msp.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package channelconfig
 
 import (
-	"fmt"
-
 	"github.com/hyperledger/fabric-lib-go/bccsp"
 	mspprotos "github.com/hyperledger/fabric-protos-go-apiv2/msp"
 
@@ -69,7 +67,7 @@ func (bh *MSPConfigHandler) ProposeMSP(mspConfig *mspprotos.MSPConfig) (msp.MSP,
 			return nil, errors.WithMessage(err, "creating the MSP manager failed")
 		}
 	default:
-		return nil, errors.New(fmt.Sprintf("Setup error: unsupported msp type %d", mspConfig.Type))
+		return nil, errors.Errorf("Setup error: unsupported msp type %d", mspConfig.Type)
 	}
 
 	// set it up
@@ -83,7 +81,7 @@ func (bh *MSPConfigHandler) ProposeMSP(mspConfig *mspprotos.MSPConfig) (msp.MSP,
 
 	existingPendingMSPConfig, ok := bh.idMap[mspID]
 	if ok && !proto.Equal(existingPendingMSPConfig.mspConfig, mspConfig) {
-		return nil, errors.New(fmt.Sprintf("Attempted to define two different versions of MSP: %s", mspID))
+		return nil, errors.Errorf("Attempted to define two different versions of MSP: %s", mspID)
 	}
 
 	if !ok {

--- a/platform/fabric/core/generic/membership/channelconfig/orderer.go
+++ b/platform/fabric/core/generic/membership/channelconfig/orderer.go
@@ -114,8 +114,8 @@ func NewOrdererOrgConfig(orgName string, orgGroup *cb.ConfigGroup, mspConfigHand
 	return ooc, nil
 }
 
-func (ooc *OrdererOrgConfig) Validate() error {
-	return ooc.OrganizationConfig.Validate()
+func (oc *OrdererOrgConfig) Validate() error {
+	return oc.OrganizationConfig.Validate()
 }
 
 // NewOrdererConfig creates a new instance of the orderer config.

--- a/platform/fabric/core/generic/membership/channelconfig/util.go
+++ b/platform/fabric/core/generic/membership/channelconfig/util.go
@@ -331,9 +331,9 @@ func MarshalEtcdRaftMetadata(md *etcdraft.ConfigMetadata) ([]byte, error) {
 
 // MarshalBFTOptions serializes smartbft options.
 func MarshalBFTOptions(op *smartbft.Options) ([]byte, error) {
-	if copyMd, ok := proto.Clone(op).(*smartbft.Options); ok {
-		return proto.Marshal(copyMd)
-	} else {
+	copyMd, ok := proto.Clone(op).(*smartbft.Options)
+	if !ok {
 		return nil, errors.New("consenter options type mismatch")
 	}
+	return proto.Marshal(copyMd)
 }

--- a/platform/fabric/core/generic/membership/membership.go
+++ b/platform/fabric/core/generic/membership/membership.go
@@ -315,7 +315,7 @@ func (c *Service) MSPManager() driver.MSPManager {
 	return &mspManager{config: c.config, waitFor: c.configWait}
 }
 
-func (c *Service) CheckACL(signedProp driver.SignedProposal) error {
+func (*Service) CheckACL(_ driver.SignedProposal) error {
 	return driver.ErrNotImplemented
 }
 

--- a/platform/fabric/core/generic/membership/membership_test.go
+++ b/platform/fabric/core/generic/membership/membership_test.go
@@ -316,10 +316,10 @@ type fakeApplicationOrg struct {
 	msp   msp.MSP
 }
 
-func (f *fakeApplicationOrg) Name() string                  { return f.name }
-func (f *fakeApplicationOrg) MSPID() string                 { return f.mspID }
-func (f *fakeApplicationOrg) MSP() msp.MSP                  { return f.msp }
-func (f *fakeApplicationOrg) AnchorPeers() []*pb.AnchorPeer { return nil }
+func (f *fakeApplicationOrg) Name() string                { return f.name }
+func (f *fakeApplicationOrg) MSPID() string               { return f.mspID }
+func (f *fakeApplicationOrg) MSP() msp.MSP                { return f.msp }
+func (*fakeApplicationOrg) AnchorPeers() []*pb.AnchorPeer { return nil }
 
 // fakeApplication is a minimal channelconfig.Application double.
 type fakeApplication struct {

--- a/platform/fabric/core/generic/msp/idemix/cache_test.go
+++ b/platform/fabric/core/generic/msp/idemix/cache_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestIdentityCache(t *testing.T) { //nolint:paralleltest
 	var counter atomic.Int32
-	c := NewIdentityCache(func(opts *driver.IdentityOptions) (view.Identity, []byte, error) {
+	c := NewIdentityCache(func(_ *driver.IdentityOptions) (view.Identity, []byte, error) {
 		counter.Add(1)
 		return []byte("hello world"), []byte("audit"), nil
 	}, 100, nil, nil)
@@ -53,7 +53,7 @@ func TestIdentityCache(t *testing.T) { //nolint:paralleltest
 
 func TestIdentityCacheClose(t *testing.T) { //nolint:paralleltest
 	var counter atomic.Int32
-	c := NewIdentityCache(func(opts *driver.IdentityOptions) (view.Identity, []byte, error) {
+	c := NewIdentityCache(func(_ *driver.IdentityOptions) (view.Identity, []byte, error) {
 		counter.Add(1)
 		return []byte("hello world"), []byte("audit"), nil
 	}, 10, nil, nil)

--- a/platform/fabric/core/generic/msp/idemix/crypto_test.go
+++ b/platform/fabric/core/generic/msp/idemix/crypto_test.go
@@ -15,8 +15,8 @@ import (
 
 type dummyKVS struct{}
 
-func (d *dummyKVS) Put(key string, value any) error { return nil }
-func (d *dummyKVS) Get(key string, value any) error { return nil }
+func (*dummyKVS) Put(_ string, _ any) error { return nil }
+func (*dummyKVS) Get(_ string, _ any) error { return nil }
 
 func TestNewBCCSP(t *testing.T) { //nolint:paralleltest
 

--- a/platform/fabric/core/generic/msp/idemix/deserializer.go
+++ b/platform/fabric/core/generic/msp/idemix/deserializer.go
@@ -92,7 +92,7 @@ func (i *Deserializer) DeserializeVerifierAgainstNymEID(raw, nymEID []byte) (dri
 	}, nil
 }
 
-func (i *Deserializer) DeserializeSigner(raw []byte) (driver.Signer, error) {
+func (*Deserializer) DeserializeSigner(_ []byte) (driver.Signer, error) {
 	return nil, errors.New("not supported")
 }
 

--- a/platform/fabric/core/generic/msp/idemix/id.go
+++ b/platform/fabric/core/generic/msp/idemix/id.go
@@ -53,11 +53,11 @@ func NewMSPIdentityWithVerType(idemix *Idemix, nymPublicKey bccsp.Key, role *m.M
 	return id, nil
 }
 
-func (id *MSPIdentity) Anonymous() bool {
+func (*MSPIdentity) Anonymous() bool {
 	return true
 }
 
-func (id *MSPIdentity) ExpiresAt() time.Time {
+func (*MSPIdentity) ExpiresAt() time.Time {
 	// Idemix MSP currently does not use expiration dates or revocation,
 	// so we return the zero time to indicate this.
 	return time.Time{}
@@ -102,7 +102,7 @@ func (id *MSPIdentity) Verify(msg, sig []byte) error {
 	return err
 }
 
-func (id *MSPIdentity) SatisfiesPrincipal(principal *m.MSPPrincipal) error {
+func (*MSPIdentity) SatisfiesPrincipal(_ *m.MSPPrincipal) error {
 	return errors.Errorf("not supported")
 }
 
@@ -186,6 +186,7 @@ type MSPSigningIdentity struct {
 	Cred         []byte
 	UserKey      bccsp.Key `json:"-"`
 	NymKey       bccsp.Key `json:"-"`
+	//nolint:revive // var-naming: renaming this exported struct field is an API break; see follow-up
 	EnrollmentId string
 }
 

--- a/platform/fabric/core/generic/msp/idemix/id_test.go
+++ b/platform/fabric/core/generic/msp/idemix/id_test.go
@@ -43,10 +43,10 @@ func TestMSPIdentityMethods(t *testing.T) { //nolint:paralleltest
 	err := id.SatisfiesPrincipal(nil)
 	require.ErrorContains(t, err, "not supported")
 
-	sigId := &idemix.MSPSigningIdentity{
+	sigID := &idemix.MSPSigningIdentity{
 		MSPIdentity: id,
 	}
-	publicVersion := sigId.GetPublicVersion()
+	publicVersion := sigID.GetPublicVersion()
 	require.Equal(t, id, publicVersion)
 }
 

--- a/platform/fabric/core/generic/msp/idemix/provider_test.go
+++ b/platform/fabric/core/generic/msp/idemix/provider_test.go
@@ -420,9 +420,9 @@ func TestProvider_IdentityManagerMethods(t *testing.T) { //nolint:paralleltest
 	id, _, err := p.Identity(nil)
 	require.NoError(t, err)
 
-	sigId, err := p.DeserializeSigningIdentity(id)
+	sigID, err := p.DeserializeSigningIdentity(id)
 	require.NoError(t, err)
-	require.NotNil(t, sigId)
+	require.NotNil(t, sigID)
 
 	_, err = p.DeserializeVerifier(id)
 	require.NoError(t, err)

--- a/platform/fabric/core/generic/msp/service_internal_test.go
+++ b/platform/fabric/core/generic/msp/service_internal_test.go
@@ -33,10 +33,10 @@ type testConfig struct {
 	msps        []config.MSP
 }
 
-func (c *testConfig) NetworkName() string           { return c.networkName }
-func (c *testConfig) DefaultMSP() string            { return c.defaultMSP }
-func (c *testConfig) MSPs() ([]config.MSP, error)   { return c.msps, nil }
-func (c *testConfig) TranslatePath(p string) string { return p }
+func (c *testConfig) NetworkName() string         { return c.networkName }
+func (c *testConfig) DefaultMSP() string          { return c.defaultMSP }
+func (c *testConfig) MSPs() ([]config.MSP, error) { return c.msps, nil }
+func (*testConfig) TranslatePath(p string) string { return p }
 
 // loaderFunc turns a function into a driver.IdentityLoader.
 type loaderFunc func(manager driver.Manager, c config.MSP) error

--- a/platform/fabric/core/generic/msp/service_test.go
+++ b/platform/fabric/core/generic/msp/service_test.go
@@ -251,17 +251,17 @@ func TestService_SetDefaultIdentity(t *testing.T) {
 		_ = mspService.Load()
 
 		// Set initial identity
-		initialId := view.Identity("initial_id")
+		initialID := view.Identity("initial_id")
 		initialSid := &mock.SigningIdentity{}
-		mspService.SetDefaultIdentity("default_msp", initialId, initialSid)
+		mspService.SetDefaultIdentity("default_msp", initialID, initialSid)
 
 		// Try to set with non-matching id - should be no-op
-		newId := view.Identity("new_id")
+		newID := view.Identity("new_id")
 		newSid := &mock.SigningIdentity{}
-		mspService.SetDefaultIdentity("non_matching_msp", newId, newSid)
+		mspService.SetDefaultIdentity("non_matching_msp", newID, newSid)
 
 		// Verify identity remains unchanged
-		require.Equal(t, initialId, mspService.DefaultIdentity())
+		require.Equal(t, initialID, mspService.DefaultIdentity())
 		require.Equal(t, initialSid, mspService.DefaultSigningIdentity())
 	})
 }
@@ -290,31 +290,31 @@ func TestService_GetIdentityByID(t *testing.T) {
 	mspService, _, binderService, _ := setup(t)
 	id := view.Identity("id1")
 
-	require.NoError(t, mspService.AddMSP("apple", msp.BccspMSP, "enrollment1", func(opts *fdriver.IdentityOptions) (view.Identity, []byte, error) {
+	require.NoError(t, mspService.AddMSP("apple", msp.BccspMSP, "enrollment1", func(_ *fdriver.IdentityOptions) (view.Identity, []byte, error) {
 		return id, nil, nil
 	}))
 
 	t.Run("ByMSPName", func(t *testing.T) {
 		t.Parallel()
-		resId, err := mspService.GetIdentityByID("apple")
+		resID, err := mspService.GetIdentityByID("apple")
 		require.NoError(t, err)
-		require.Equal(t, id, resId)
+		require.Equal(t, id, resID)
 	})
 
 	t.Run("ByEnrollmentID", func(t *testing.T) {
 		t.Parallel()
-		resId, err := mspService.GetIdentityByID("enrollment1")
+		resID, err := mspService.GetIdentityByID("enrollment1")
 		require.NoError(t, err)
-		require.Equal(t, id, resId)
+		require.Equal(t, id, resID)
 	})
 
 	t.Run("ViaBinderService", func(t *testing.T) {
 		t.Parallel()
-		binderId := view.Identity("binder_id")
-		binderService.GetIdentityReturns(binderId, nil)
-		resId, err := mspService.GetIdentityByID("non_existent")
+		binderID := view.Identity("binder_id")
+		binderService.GetIdentityReturns(binderID, nil)
+		resID, err := mspService.GetIdentityByID("non_existent")
 		require.NoError(t, err)
-		require.Equal(t, binderId, resId)
+		require.Equal(t, binderID, resID)
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
@@ -331,22 +331,22 @@ func TestService_Identity(t *testing.T) {
 	t.Parallel()
 	mspService, _, _, _ := setup(t)
 	id := view.Identity("id1")
-	require.NoError(t, mspService.AddMSP("apple", msp.BccspMSP, "enrollment1", func(opts *fdriver.IdentityOptions) (view.Identity, []byte, error) {
+	require.NoError(t, mspService.AddMSP("apple", msp.BccspMSP, "enrollment1", func(_ *fdriver.IdentityOptions) (view.Identity, []byte, error) {
 		return id, nil, nil
 	}))
 
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
-		resId, err := mspService.Identity("apple")
+		resID, err := mspService.Identity("apple")
 		require.NoError(t, err)
-		require.Equal(t, id, resId)
+		require.Equal(t, id, resID)
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
 		t.Parallel()
-		resId, err := mspService.Identity("unknown")
+		resID, err := mspService.Identity("unknown")
 		require.Error(t, err)
-		require.Nil(t, resId)
+		require.Nil(t, resID)
 	})
 }
 
@@ -355,7 +355,7 @@ func TestService_GetIdentityInfoByIdentity_BCCSP(t *testing.T) {
 	mspService, _, _, _ := setup(t)
 	id := view.Identity("id1")
 
-	require.NoError(t, mspService.AddMSP("apple", msp.BccspMSP, "enrollment1", func(opts *fdriver.IdentityOptions) (view.Identity, []byte, error) {
+	require.NoError(t, mspService.AddMSP("apple", msp.BccspMSP, "enrollment1", func(_ *fdriver.IdentityOptions) (view.Identity, []byte, error) {
 		return id, nil, nil
 	}))
 
@@ -375,14 +375,14 @@ func TestService_GetIdentityInfoByIdentity_BCCSP(t *testing.T) {
 func TestService_GetIdentityInfoByIdentity_Idemix(t *testing.T) {
 	t.Parallel()
 	mspService, _, _, _ := setup(t)
-	idemixId := view.Identity("idemix_id")
-	require.NoError(t, mspService.AddMSP("orange", msp.IdemixMSP, "enrollment2", func(opts *fdriver.IdentityOptions) (view.Identity, []byte, error) {
-		return idemixId, nil, nil
+	idemixID := view.Identity("idemix_id")
+	require.NoError(t, mspService.AddMSP("orange", msp.IdemixMSP, "enrollment2", func(_ *fdriver.IdentityOptions) (view.Identity, []byte, error) {
+		return idemixID, nil, nil
 	}))
 
 	t.Run("Success", func(t *testing.T) {
 		t.Parallel()
-		info := mspService.GetIdentityInfoByIdentity(msp.IdemixMSP, idemixId)
+		info := mspService.GetIdentityInfoByIdentity(msp.IdemixMSP, idemixID)
 		require.NotNil(t, info)
 		require.Equal(t, "orange", info.ID)
 	})
@@ -399,40 +399,40 @@ func TestService_AnonymousIdentity(t *testing.T) {
 	t.Run("BindsDefaultViewIdentity", func(t *testing.T) {
 		t.Parallel()
 		mspService, _, binderService, _ := setup(t)
-		idemixId := view.Identity("idemix_id")
+		idemixID := view.Identity("idemix_id")
 
 		initialCount := binderService.BindCallCount()
 
-		require.NoError(t, mspService.AddMSP("idemix", msp.IdemixMSP, "idemix_enrollment", func(opts *fdriver.IdentityOptions) (view.Identity, []byte, error) {
-			return idemixId, nil, nil
+		require.NoError(t, mspService.AddMSP("idemix", msp.IdemixMSP, "idemix_enrollment", func(_ *fdriver.IdentityOptions) (view.Identity, []byte, error) {
+			return idemixID, nil, nil
 		}))
 
-		anonId, err := mspService.AnonymousIdentity()
+		anonID, err := mspService.AnonymousIdentity()
 		require.NoError(t, err)
-		require.Equal(t, idemixId, anonId)
+		require.Equal(t, idemixID, anonID)
 		require.Equal(t, initialCount+1, binderService.BindCallCount())
 	})
 
 	t.Run("IdentityNotFound", func(t *testing.T) {
 		t.Parallel()
 		mspService, _, _, _ := setup(t)
-		anonId, err := mspService.AnonymousIdentity()
+		anonID, err := mspService.AnonymousIdentity()
 		require.Error(t, err)
-		require.Nil(t, anonId)
+		require.Nil(t, anonID)
 	})
 
 	t.Run("BindFails", func(t *testing.T) {
 		t.Parallel()
 		mspService, _, binderService, _ := setup(t)
-		idemixId := view.Identity("idemix_id")
+		idemixID := view.Identity("idemix_id")
 		binderService.BindReturns(errors.New("bind failed"))
 
-		require.NoError(t, mspService.AddMSP("idemix", msp.IdemixMSP, "idemix_enrollment", func(opts *fdriver.IdentityOptions) (view.Identity, []byte, error) {
-			return idemixId, nil, nil
+		require.NoError(t, mspService.AddMSP("idemix", msp.IdemixMSP, "idemix_enrollment", func(_ *fdriver.IdentityOptions) (view.Identity, []byte, error) {
+			return idemixID, nil, nil
 		}))
 
-		anonId, err := mspService.AnonymousIdentity()
+		anonID, err := mspService.AnonymousIdentity()
 		require.Error(t, err)
-		require.Nil(t, anonId)
+		require.Nil(t, anonID)
 	})
 }

--- a/platform/fabric/core/generic/msp/x509/audit.go
+++ b/platform/fabric/core/generic/msp/x509/audit.go
@@ -9,6 +9,7 @@ package x509
 import "encoding/json"
 
 type AuditInfo struct {
+	//nolint:revive // var-naming: renaming this exported struct field is an API break; see follow-up
 	EnrollmentId     string
 	RevocationHandle []byte
 }

--- a/platform/fabric/core/generic/msp/x509/deserializer.go
+++ b/platform/fabric/core/generic/msp/x509/deserializer.go
@@ -20,7 +20,7 @@ import (
 
 type Deserializer struct{}
 
-func (i *Deserializer) DeserializeVerifier(raw []byte) (driver.Verifier, error) {
+func (*Deserializer) DeserializeVerifier(raw []byte) (driver.Verifier, error) {
 	si := &msp.SerializedIdentity{}
 	err := proto.Unmarshal(raw, si)
 	if err != nil {
@@ -38,11 +38,11 @@ func (i *Deserializer) DeserializeVerifier(raw []byte) (driver.Verifier, error) 
 	return NewVerifier(publicKey), nil
 }
 
-func (i *Deserializer) DeserializeSigner(raw []byte) (driver.Signer, error) {
+func (*Deserializer) DeserializeSigner(_ []byte) (driver.Signer, error) {
 	return nil, errors.New("not supported")
 }
 
-func (i *Deserializer) Info(raw, auditInfo []byte) (string, error) {
+func (*Deserializer) Info(raw, _ []byte) (string, error) {
 	si := &msp.SerializedIdentity{}
 	err := proto.Unmarshal(raw, si)
 	if err != nil {
@@ -55,6 +55,6 @@ func (i *Deserializer) Info(raw, auditInfo []byte) (string, error) {
 	return fmt.Sprintf("MSP.x509: [%s][%s][%s]", view.Identity(raw).UniqueID(), si.Mspid, cert.Subject.CommonName), nil
 }
 
-func (i *Deserializer) String() string {
+func (*Deserializer) String() string {
 	return "Generic X509 Verifier Deserializer"
 }

--- a/platform/fabric/core/generic/msp/x509/loader.go
+++ b/platform/fabric/core/generic/msp/x509/loader.go
@@ -27,7 +27,7 @@ var logger = logging.MustGetLogger()
 
 type IdentityLoader struct{}
 
-func (i *IdentityLoader) Load(manager driver.Manager, c config.MSP) error {
+func (*IdentityLoader) Load(manager driver.Manager, c config.MSP) error {
 	var bccspOpts *config.BCCSP
 	if c.Opts != nil {
 		logger.Debugf("Options [%v]", c.Opts)

--- a/platform/fabric/core/generic/msp/x509/pkcs11/disabled.go
+++ b/platform/fabric/core/generic/msp/x509/pkcs11/disabled.go
@@ -33,10 +33,10 @@ type PKCS11Opts struct {
 	SessionCacheSize uint           `yaml:"SessionCacheSize,omitempty"`
 }
 
-func NewProvider(opts any, ks bccsp.KeyStore, mapper func(ski []byte) []byte) (bccsp.BCCSP, error) {
+func NewProvider(_ any, _ bccsp.KeyStore, _ func(ski []byte) []byte) (bccsp.BCCSP, error) {
 	panic("pkcs11 not included in build. Use: go build -tags pkcs11")
 }
 
-func ToPKCS11OptsOpts(o any) *PKCS11Opts {
+func ToPKCS11OptsOpts(_ any) *PKCS11Opts {
 	panic("pkcs11 not included in build. Use: go build -tags pkcs11")
 }

--- a/platform/fabric/core/generic/msp/x509/provider.go
+++ b/platform/fabric/core/generic/msp/x509/provider.go
@@ -41,7 +41,7 @@ func NewProvider(mspConfigPath, keyStorePath, mspID string, signerService Signer
 // If the configuration path contains the secret key,
 // then the provider can generate also signatures, otherwise it cannot.
 func NewProviderWithBCCSPConfig(mspConfigPath, keyStorePath, mspID string, signerService SignerService, bccspConfig *config.BCCSP) (*Provider, error) {
-	p, err := newProvider(mspConfigPath, keyStorePath, mspID, signerService, bccspConfig)
+	p, err := buildProvider(mspConfigPath, keyStorePath, mspID, signerService, bccspConfig)
 	if err == nil {
 		return p, nil
 	}
@@ -58,7 +58,7 @@ func NewProviderWithBCCSPConfig(mspConfigPath, keyStorePath, mspID string, signe
 	return &Provider{id: idRaw, enrollmentID: enrollmentID}, nil
 }
 
-func newProvider(mspConfigPath, keyStorePath, mspID string, signerService SignerService, bccspConfig *config.BCCSP) (*Provider, error) {
+func buildProvider(mspConfigPath, keyStorePath, mspID string, signerService SignerService, bccspConfig *config.BCCSP) (*Provider, error) {
 	sID, err := GetSigningIdentity(mspConfigPath, keyStorePath, mspID, bccspConfig)
 	if err != nil {
 		return nil, err
@@ -85,7 +85,7 @@ func (p *Provider) IsRemote() bool {
 	return p.sID == nil
 }
 
-func (p *Provider) Identity(opts *driver.IdentityOptions) (view.Identity, []byte, error) {
+func (p *Provider) Identity(_ *driver.IdentityOptions) (view.Identity, []byte, error) {
 	revocationHandle, err := GetRevocationHandle(p.id)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed getting revocation handle")
@@ -119,7 +119,7 @@ func (p *Provider) EnrollmentID() string {
 // must not be treated as an authorization decision on its own - callers
 // must check the resulting identity against an explicit allow-list (e.g.
 // the configured Admins/Clients/DefaultIdentity) before trusting it.
-func (p *Provider) DeserializeVerifier(raw []byte) (driver.Verifier, error) {
+func (*Provider) DeserializeVerifier(raw []byte) (driver.Verifier, error) {
 	si := &msp.SerializedIdentity{}
 	err := proto.Unmarshal(raw, si)
 	if err != nil {
@@ -137,11 +137,11 @@ func (p *Provider) DeserializeVerifier(raw []byte) (driver.Verifier, error) {
 	return NewVerifier(publicKey), nil
 }
 
-func (p *Provider) DeserializeSigner(raw []byte) (driver.Signer, error) {
+func (*Provider) DeserializeSigner(_ []byte) (driver.Signer, error) {
 	return nil, errors.New("not supported")
 }
 
-func (p *Provider) Info(raw, auditInfo []byte) (string, error) {
+func (*Provider) Info(raw, _ []byte) (string, error) {
 	si := &msp.SerializedIdentity{}
 	err := proto.Unmarshal(raw, si)
 	if err != nil {

--- a/platform/fabric/core/generic/ordering/bft.go
+++ b/platform/fabric/core/generic/ordering/bft.go
@@ -272,7 +272,7 @@ func (o *BFTBroadcaster) releaseConnection(connection *Connection, to *grpc.Conn
 	}
 }
 
-func (o *BFTBroadcaster) releaseSlot(state *bftOrdererState) {
+func (*BFTBroadcaster) releaseSlot(state *bftOrdererState) {
 	select {
 	case state.slots <- struct{}{}:
 	default:

--- a/platform/fabric/core/generic/ordering/bft_test.go
+++ b/platform/fabric/core/generic/ordering/bft_test.go
@@ -39,7 +39,7 @@ func (f *fakeBroadcastStream) Recv() (*ab.BroadcastResponse, error) {
 	return &ab.BroadcastResponse{Status: f.status}, nil
 }
 
-func (f *fakeBroadcastStream) CloseSend() error { return nil }
+func (*fakeBroadcastStream) CloseSend() error { return nil }
 
 // fakeServices hands out orderer clients whose stream creation is instant, so
 // tests exercise the acquire/pool machinery without real network I/O.
@@ -553,7 +553,7 @@ func TestBFTBroadcaster_DiscardConnection(t *testing.T) {
 		},
 		{
 			name: "handles nil connection",
-			setupConn: func(t *testing.T, b *BFTBroadcaster) *Connection {
+			setupConn: func(t *testing.T, _ *BFTBroadcaster) *Connection {
 				t.Helper()
 				return nil
 			},

--- a/platform/fabric/core/generic/ordering/cft_test.go
+++ b/platform/fabric/core/generic/ordering/cft_test.go
@@ -111,7 +111,7 @@ func (f *fakeCFTStream) Recv() (*ab.BroadcastResponse, error) {
 	return &ab.BroadcastResponse{Status: f.status}, nil
 }
 
-func (f *fakeCFTStream) CloseSend() error {
+func (*fakeCFTStream) CloseSend() error {
 	return nil
 }
 

--- a/platform/fabric/core/generic/ordering/client_test.go
+++ b/platform/fabric/core/generic/ordering/client_test.go
@@ -82,11 +82,11 @@ func (m *mockClient) Address() string {
 	return m.address
 }
 
-func (m *mockClient) Certificate() tls.Certificate {
+func (*mockClient) Certificate() tls.Certificate {
 	return tls.Certificate{}
 }
 
-func (m *mockClient) OrdererClient() (ab.AtomicBroadcastClient, error) {
+func (*mockClient) OrdererClient() (ab.AtomicBroadcastClient, error) {
 	return nil, nil
 }
 
@@ -456,7 +456,7 @@ type blockingStream struct {
 	mu         sync.Mutex
 }
 
-func (b *blockingStream) Send(*common.Envelope) error { return nil }
+func (*blockingStream) Send(*common.Envelope) error { return nil }
 
 func (b *blockingStream) Recv() (*ab.BroadcastResponse, error) {
 	<-b.done

--- a/platform/fabric/core/generic/ordering/fake/config_service.go
+++ b/platform/fabric/core/generic/ordering/fake/config_service.go
@@ -34,7 +34,7 @@ func (c *ConfigService) BroadcastNumRetries() int {
 	return c.RetriesValue
 }
 
-func (c *ConfigService) BroadcastRetryInterval() time.Duration {
+func (*ConfigService) BroadcastRetryInterval() time.Duration {
 	return 0
 }
 

--- a/platform/fabric/core/generic/ordering/ordering.go
+++ b/platform/fabric/core/generic/ordering/ordering.go
@@ -164,17 +164,17 @@ func (o *Service) SetConsensusType(consensusType ConsensusType) error {
 	})
 }
 
-func (f *Service) Configure(consensusType string, orderers []*grpc.ConnectionConfig) error {
-	if err := f.SetConsensusType(consensusType); err != nil {
+func (o *Service) Configure(consensusType string, orderers []*grpc.ConnectionConfig) error {
+	if err := o.SetConsensusType(consensusType); err != nil {
 		return errors.WithMessagef(err, "failed to set consensus type from channel config")
 	}
-	if err := f.ConfigService.SetConfigOrderers(orderers); err != nil {
+	if err := o.ConfigService.SetConfigOrderers(orderers); err != nil {
 		return errors.WithMessagef(err, "failed to set orderers")
 	}
 	return nil
 }
 
-func (o *Service) createFabricEndorseTransactionEnvelope(tx Transaction) (*common2.Envelope, error) {
+func (*Service) createFabricEndorseTransactionEnvelope(tx Transaction) (*common2.Envelope, error) {
 	env, err := tx.Envelope()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed creating envelope for transaction [%s]", tx.ID())

--- a/platform/fabric/core/generic/ordering/ordering_test.go
+++ b/platform/fabric/core/generic/ordering/ordering_test.go
@@ -54,12 +54,12 @@ type mockEnvelope struct {
 }
 
 func (m *mockEnvelope) Bytes() ([]byte, error) { return m.bytes, m.bytesErr }
-func (m *mockEnvelope) FromBytes([]byte) error { return nil }
-func (m *mockEnvelope) Results() []byte        { return nil }
-func (m *mockEnvelope) TxID() string           { return "" }
-func (m *mockEnvelope) Nonce() []byte          { return nil }
-func (m *mockEnvelope) Creator() []byte        { return nil }
-func (m *mockEnvelope) String() string         { return "" }
+func (*mockEnvelope) FromBytes([]byte) error   { return nil }
+func (*mockEnvelope) Results() []byte          { return nil }
+func (*mockEnvelope) TxID() string             { return "" }
+func (*mockEnvelope) Nonce() []byte            { return nil }
+func (*mockEnvelope) Creator() []byte          { return nil }
+func (*mockEnvelope) String() string           { return "" }
 
 // mockTransactionWithEnvelope implements TransactionWithEnvelope for testing
 type mockTransactionWithEnvelope struct {
@@ -89,7 +89,7 @@ type mockBroadcaster struct {
 	env       *common.Envelope
 }
 
-func (m *mockBroadcaster) broadcast(ctx context.Context, env *common.Envelope) error {
+func (m *mockBroadcaster) broadcast(_ context.Context, env *common.Envelope) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.called = true
@@ -103,7 +103,7 @@ func (m *mockBroadcaster) broadcast(ctx context.Context, env *common.Envelope) e
 // arrives.
 func newTestService() *Service {
 	return NewService(
-		func(channelID string) (driver.EndorserTransactionService, error) {
+		func(_ string) (driver.EndorserTransactionService, error) {
 			return &mockEndorserTransactionService{}, nil
 		},
 		&mockSignerService{},
@@ -141,7 +141,7 @@ func requireNoBroadcaster(t *testing.T, s *Service) {
 func TestNewService(t *testing.T) {
 	t.Parallel()
 
-	getEndorserTxService := func(channelID string) (driver.EndorserTransactionService, error) {
+	getEndorserTxService := func(_ string) (driver.EndorserTransactionService, error) {
 		return &mockEndorserTransactionService{}, nil
 	}
 	sigService := &mockSignerService{}
@@ -225,7 +225,7 @@ func TestService_Configure(t *testing.T) {
 		t.Parallel()
 		configService := &fake.ConfigService{PoolSizeValue: 4, RetriesValue: 3, NetworkNameValue: "test-network"}
 		service := NewService(
-			func(channelID string) (driver.EndorserTransactionService, error) {
+			func(_ string) (driver.EndorserTransactionService, error) {
 				return &mockEndorserTransactionService{}, nil
 			},
 			&mockSignerService{},
@@ -345,7 +345,7 @@ func TestService_Broadcast(t *testing.T) {
 	t.Run("broadcast with invalid blob type", func(t *testing.T) {
 		t.Parallel()
 		service := newTestService()
-		setBroadcaster(t, service, func(ctx context.Context, env *common.Envelope) error { return nil })
+		setBroadcaster(t, service, func(_ context.Context, _ *common.Envelope) error { return nil })
 
 		err := service.Broadcast(t.Context(), "invalid type")
 		require.Error(t, err)
@@ -370,7 +370,7 @@ func TestService_Broadcast(t *testing.T) {
 	t.Run("broadcast with transaction envelope error", func(t *testing.T) {
 		t.Parallel()
 		service := newTestService()
-		setBroadcaster(t, service, func(ctx context.Context, env *common.Envelope) error { return nil })
+		setBroadcaster(t, service, func(_ context.Context, _ *common.Envelope) error { return nil })
 
 		tx := &mockTransaction{
 			id:          "tx1",
@@ -385,7 +385,7 @@ func TestService_Broadcast(t *testing.T) {
 	t.Run("broadcast with transaction bytes error", func(t *testing.T) {
 		t.Parallel()
 		service := newTestService()
-		setBroadcaster(t, service, func(ctx context.Context, env *common.Envelope) error { return nil })
+		setBroadcaster(t, service, func(_ context.Context, _ *common.Envelope) error { return nil })
 
 		tx := &mockTransaction{
 			id: "tx1",
@@ -402,7 +402,7 @@ func TestService_Broadcast(t *testing.T) {
 	t.Run("broadcast with invalid envelope bytes", func(t *testing.T) {
 		t.Parallel()
 		service := newTestService()
-		setBroadcaster(t, service, func(ctx context.Context, env *common.Envelope) error { return nil })
+		setBroadcaster(t, service, func(_ context.Context, _ *common.Envelope) error { return nil })
 
 		tx := &mockTransaction{
 			id: "tx1",

--- a/platform/fabric/core/generic/rwset/composite.go
+++ b/platform/fabric/core/generic/rwset/composite.go
@@ -34,13 +34,13 @@ func CreateCompositeKey(objectType string, attributes []string) (string, error) 
 	return ck.String(), nil
 }
 
-func CreateRangeKeysForPartialCompositeKey(objectType string, attributes []string) (string, string, error) {
+func CreateRangeKeysForPartialCompositeKey(objectType string, attributes []string) (startKey, endKey string, err error) {
 	partialCompositeKey, err := CreateCompositeKey(objectType, attributes)
 	if err != nil {
 		return "", "", err
 	}
-	startKey := partialCompositeKey
-	endKey := partialCompositeKey + string(maxUnicodeRuneValue)
+	startKey = partialCompositeKey
+	endKey = partialCompositeKey + string(maxUnicodeRuneValue)
 
 	return startKey, endKey, nil
 }

--- a/platform/fabric/core/generic/services/conn.go
+++ b/platform/fabric/core/generic/services/conn.go
@@ -116,7 +116,7 @@ func (c *ClientWrapper) Address() string {
 	return c.client.Address()
 }
 
-func (c *ClientWrapper) Close() {
+func (*ClientWrapper) Close() {
 	// Don't do anything
 }
 

--- a/platform/fabric/core/generic/transaction/manager.go
+++ b/platform/fabric/core/generic/transaction/manager.go
@@ -28,15 +28,15 @@ func NewManager() *Manager {
 	return &Manager{factories: map[driver.TransactionType]driver.TransactionFactory{}}
 }
 
-func (m *Manager) ComputeTxID(id *driver.TxIDComponents) string {
+func (*Manager) ComputeTxID(id *driver.TxIDComponents) string {
 	return ComputeTxID(id)
 }
 
-func (m *Manager) NewEnvelope() driver.Envelope {
+func (*Manager) NewEnvelope() driver.Envelope {
 	return NewEnvelope()
 }
 
-func (m *Manager) NewProposalResponseFromBytes(raw []byte) (driver.ProposalResponse, error) {
+func (*Manager) NewProposalResponseFromBytes(raw []byte) (driver.ProposalResponse, error) {
 	return NewProposalResponseFromBytes(raw)
 }
 
@@ -97,15 +97,15 @@ func (m *Manager) AddTransactionFactory(tt driver.TransactionType, factory drive
 	m.factories[tt] = factory
 }
 
-func (m *Manager) NewProcessedTransactionFromEnvelopePayload(envelopePayload []byte) (driver.ProcessedTransaction, int32, error) {
+func (*Manager) NewProcessedTransactionFromEnvelopePayload(envelopePayload []byte) (driver.ProcessedTransaction, int32, error) {
 	return NewProcessedTransactionFromEnvelopePayload(envelopePayload)
 }
 
-func (m *Manager) NewProcessedTransactionFromEnvelopeRaw(envelope []byte) (driver.ProcessedTransaction, error) {
+func (*Manager) NewProcessedTransactionFromEnvelopeRaw(envelope []byte) (driver.ProcessedTransaction, error) {
 	return NewProcessedTransactionFromEnvelopeRaw(envelope)
 }
 
-func (m *Manager) NewProcessedTransaction(pt []byte) (driver.ProcessedTransaction, error) {
+func (*Manager) NewProcessedTransaction(pt []byte) (driver.ProcessedTransaction, error) {
 	return NewProcessedTransaction(pt)
 }
 
@@ -119,7 +119,7 @@ func NewEndorserTransactionFactory(networkName string, channelProvider ChannelPr
 	return &EndorserTransactionFactory{networkName: networkName, channelProvider: channelProvider, sigService: sigService}
 }
 
-func (e *EndorserTransactionFactory) NewTransaction(ctx context.Context, channel string, nonce, creator []byte, txid string, rawRequest []byte) (driver.Transaction, error) {
+func (e *EndorserTransactionFactory) NewTransaction(ctx context.Context, channel string, nonce, creator []byte, txid string, _ []byte) (driver.Transaction, error) {
 	ch, err := e.channelProvider.Channel(channel)
 	if err != nil {
 		return nil, err

--- a/platform/fabric/core/generic/transaction/manager_test.go
+++ b/platform/fabric/core/generic/transaction/manager_test.go
@@ -55,10 +55,10 @@ func TestManager_NewTransactionFromBytes(t *testing.T) {
 	require.Error(t, err)
 
 	// Error when factory not found
-	validJson, err := json.Marshal(&transaction.SerializedTransaction{Type: driver.EndorserTransaction, Raw: []byte("raw tx")})
+	validJSON, err := json.Marshal(&transaction.SerializedTransaction{Type: driver.EndorserTransaction, Raw: []byte("raw tx")})
 	require.NoError(t, err)
 
-	_, err = m.NewTransactionFromBytes(ctx, "testchannel", validJson)
+	_, err = m.NewTransactionFromBytes(ctx, "testchannel", validJSON)
 	require.ErrorContains(t, err, "transaction type [3] not recognized")
 
 	// Add factory and test success
@@ -69,7 +69,7 @@ func TestManager_NewTransactionFromBytes(t *testing.T) {
 
 	m.AddTransactionFactory(driver.EndorserTransaction, mockFactory)
 
-	tx, err := m.NewTransactionFromBytes(ctx, "testchannel", validJson)
+	tx, err := m.NewTransactionFromBytes(ctx, "testchannel", validJSON)
 	require.NoError(t, err)
 	require.NotNil(t, tx)
 }

--- a/platform/fabric/core/generic/transaction/transaction.go
+++ b/platform/fabric/core/generic/transaction/transaction.go
@@ -82,7 +82,7 @@ type Transaction struct {
 	ctx              context.Context
 	channelProvider  ChannelProvider
 	sigService       driver.SignerService
-	rwset            driver.RWSet
+	rwSetHandle      driver.RWSet
 	channel          driver.Channel
 	signedProposal   *SignedProposal
 	proposalResponse *pb.ProposalResponse
@@ -317,21 +317,21 @@ func (t *Transaction) SetRWSet() error {
 		if err != nil {
 			return errors.WithMessagef(err, "failed to get rws from proposal response")
 		}
-		t.rwset, err = t.channel.Vault().NewRWSetFromBytes(t.ctx, t.ID(), results)
+		t.rwSetHandle, err = t.channel.Vault().NewRWSetFromBytes(t.ctx, t.ID(), results)
 		if err != nil {
 			return errors.WithMessagef(err, "failed to populate rws from proposal response")
 		}
 	case len(t.RWSet) != 0:
-		logger.DebugfContext(t.ctx, "populate rws from rwset")
+		logger.DebugfContext(t.ctx, "populate rws from rwSetHandle")
 		var err error
-		t.rwset, err = t.channel.Vault().NewRWSetFromBytes(t.ctx, t.ID(), t.RWSet)
+		t.rwSetHandle, err = t.channel.Vault().NewRWSetFromBytes(t.ctx, t.ID(), t.RWSet)
 		if err != nil {
 			return errors.WithMessagef(err, "failed to populate rws from existing rws")
 		}
 	default:
 		logger.DebugfContext(t.ctx, "populate rws from scratch")
 		var err error
-		t.rwset, err = t.channel.Vault().NewRWSet(t.ctx, t.ID())
+		t.rwSetHandle, err = t.channel.Vault().NewRWSet(t.ctx, t.ID())
 		if err != nil {
 			return errors.WithMessagef(err, "failed to create fresh rws")
 		}
@@ -341,37 +341,37 @@ func (t *Transaction) SetRWSet() error {
 }
 
 func (t *Transaction) RWS() driver.RWSet {
-	return t.rwset
+	return t.rwSetHandle
 }
 
 func (t *Transaction) Done() error {
-	if t.rwset != nil {
+	if t.rwSetHandle != nil {
 		// There is a simulation in progress:
 		// 1. terminate it
 		// 2. append it to the payload
-		t.rwset.Done()
+		t.rwSetHandle.Done()
 		var err error
-		t.RWSet, err = t.rwset.Bytes()
+		t.RWSet, err = t.rwSetHandle.Bytes()
 		if err != nil {
 			return errors.Wrapf(err, "failed marshalling rws")
 		}
-		logger.Debugf("terminated simulation with [%s][len:%d]", logging.Eval(t.rwset.Namespaces), len(t.RWSet))
+		logger.Debugf("terminated simulation with [%s][len:%d]", logging.Eval(t.rwSetHandle.Namespaces), len(t.RWSet))
 	}
 	return nil
 }
 
 func (t *Transaction) Close() {
-	logger.Debugf("closing transaction [%s,%v]", t.ID(), t.rwset != nil)
-	if t.rwset != nil {
-		t.rwset.Done()
-		t.rwset = nil
+	logger.Debugf("closing transaction [%s,%v]", t.ID(), t.rwSetHandle != nil)
+	if t.rwSetHandle != nil {
+		t.rwSetHandle.Done()
+		t.rwSetHandle = nil
 	}
 }
 
 func (t *Transaction) Raw() ([]byte, error) {
-	if t.rwset != nil {
+	if t.rwSetHandle != nil {
 		var err error
-		t.RWSet, err = t.rwset.Bytes()
+		t.RWSet, err = t.rwSetHandle.Bytes()
 		if err != nil {
 			return nil, err
 		}
@@ -380,13 +380,13 @@ func (t *Transaction) Raw() ([]byte, error) {
 }
 
 func (t *Transaction) GetRWSet() (driver.RWSet, error) {
-	if t.rwset == nil {
+	if t.rwSetHandle == nil {
 		err := t.SetRWSet()
 		if err != nil {
 			return nil, err
 		}
 	}
-	return t.rwset, nil
+	return t.rwSetHandle, nil
 }
 
 func (t *Transaction) Bytes() ([]byte, error) {
@@ -441,7 +441,7 @@ func (t *Transaction) EndorseWithIdentity(identity view.Identity) error {
 		if err != nil {
 			return errors.Wrapf(err, "failed getting proposal response")
 		}
-		err = t.appendProposalResponse(t.proposalResponse)
+		err = t.recordProposalResponse(t.proposalResponse)
 		if err != nil {
 			return errors.Wrapf(err, "failed appending proposal response")
 		}
@@ -476,7 +476,7 @@ func (t *Transaction) EndorseWithSigner(identity view.Identity, s driver.Signer)
 		if err != nil {
 			return errors.Wrapf(err, "failed getting proposal response")
 		}
-		err = t.appendProposalResponse(t.proposalResponse)
+		err = t.recordProposalResponse(t.proposalResponse)
 		if err != nil {
 			return errors.Wrapf(err, "failed appending proposal response")
 		}
@@ -527,11 +527,11 @@ func (t *Transaction) EndorseProposalResponseWithIdentity(identity view.Identity
 	if err != nil {
 		return err
 	}
-	return t.appendProposalResponse(t.proposalResponse)
+	return t.recordProposalResponse(t.proposalResponse)
 }
 
 func (t *Transaction) AppendProposalResponse(response driver.ProposalResponse) error {
-	return t.appendProposalResponse(response.(*ProposalResponse).pr)
+	return t.recordProposalResponse(response.(*ProposalResponse).pr)
 }
 
 func (t *Transaction) ProposalHasBeenEndorsedBy(party view.Identity) error {
@@ -625,7 +625,7 @@ func (t *Transaction) generateProposal(signer SerializableSigner) error {
 	return nil
 }
 
-func (t *Transaction) appendProposalResponse(response *pb.ProposalResponse) error {
+func (t *Transaction) recordProposalResponse(response *pb.ProposalResponse) error {
 	for _, r := range t.TProposalResponses {
 		if bytes.Equal(r.Endorsement.Endorser, response.Endorsement.Endorser) {
 			logger.Debugf("an endorsement from [%s] found, skip it", view.Identity(r.Endorsement.Endorser))
@@ -638,11 +638,11 @@ func (t *Transaction) appendProposalResponse(response *pb.ProposalResponse) erro
 }
 
 func (t *Transaction) getProposalResponse(signer SerializableSigner) (*pb.ProposalResponse, error) {
-	rwset, err := t.GetRWSet()
+	rwSetHandle, err := t.GetRWSet()
 	if err != nil {
 		return nil, err
 	}
-	pubSimResBytes, err := rwset.Bytes()
+	pubSimResBytes, err := rwSetHandle.Bytes()
 	if err != nil {
 		return nil, err
 	}

--- a/platform/fabric/core/generic/vault/vault.go
+++ b/platform/fabric/core/generic/vault/vault.go
@@ -120,7 +120,7 @@ type marshaller struct {
 	versionMarshaller vault.BlockTxIndexVersionMarshaller
 }
 
-func (m *marshaller) Marshal(txID string, rws *vault.ReadWriteSet) ([]byte, error) {
+func (m *marshaller) Marshal(_ string, rws *vault.ReadWriteSet) ([]byte, error) {
 	rwsb := rwsetutil.NewRWSetBuilder()
 
 	for ns, keyMap := range rws.Reads {

--- a/platform/fabric/core/generic/vault/vault_test.go
+++ b/platform/fabric/core/generic/vault/vault_test.go
@@ -30,15 +30,15 @@ func (p *artifactsProvider) RemoveNils(items []driver2.VaultRead) []driver2.Vaul
 	return p.removeNils(items)
 }
 
-func (p *artifactsProvider) NewCachedVault(ddb dbdriver.VaultStore) (*vault.Vault[fdriver.ValidationCode], error) {
+func (*artifactsProvider) NewCachedVault(ddb dbdriver.VaultStore) (*vault.Vault[fdriver.ValidationCode], error) {
 	return NewVault(vault2.NewCachedVault(ddb, 100), &disabled.Provider{}, &noop.TracerProvider{}), nil
 }
 
-func (p *artifactsProvider) NewNonCachedVault(ddb dbdriver.VaultStore) (*vault.Vault[fdriver.ValidationCode], error) {
+func (*artifactsProvider) NewNonCachedVault(ddb dbdriver.VaultStore) (*vault.Vault[fdriver.ValidationCode], error) {
 	return NewVault(vault2.NewCachedVault(ddb, 0), &disabled.Provider{}, &noop.TracerProvider{}), nil
 }
 
-func (p *artifactsProvider) NewMarshaller() vault.Marshaller {
+func (*artifactsProvider) NewMarshaller() vault.Marshaller {
 	return &marshaller{}
 }
 

--- a/platform/fabric/core/msp/cache/cache.go
+++ b/platform/fabric/core/msp/cache/cache.go
@@ -26,7 +26,7 @@ var mspLogger = logging.MustGetLogger("msp")
 func New(o msp.MSP) (msp.MSP, error) {
 	mspLogger.Debugf("Creating Cache-MSP instance")
 	if o == nil {
-		return nil, errors.Errorf("Invalid passed MSP. It must be different from nil.")
+		return nil, errors.Errorf("invalid passed MSP. It must be different from nil")
 	}
 
 	theMsp := &cachedMSP{MSP: o}

--- a/platform/fabric/core/msp/cache/cache_test.go
+++ b/platform/fabric/core/msp/cache/cache_test.go
@@ -25,7 +25,7 @@ func TestNewCacheMsp(t *testing.T) {
 	i, err := New(nil)
 	require.Error(t, err)
 	require.Nil(t, i)
-	require.Contains(t, err.Error(), "Invalid passed MSP. It must be different from nil.")
+	require.Contains(t, err.Error(), "invalid passed MSP. It must be different from nil")
 
 	i, err = New(&fake.MSP{})
 	require.NoError(t, err)
@@ -130,7 +130,7 @@ func TestDeserializeIdentity(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(100)
 	for i := range 100 {
-		go func(m msp.MSP, i int) {
+		go func(_ msp.MSP, i int) {
 			sIdentity := serializedIdentity
 			expectedIdentity := mockIdentity
 			defer wg.Done()
@@ -359,16 +359,16 @@ func TestCachedSigningIdentity_GetPublicVersion(t *testing.T) {
 	id, err := wrappedMSP.DeserializeIdentity(serializedIdentity)
 	require.NoError(t, err)
 
-	signingId, ok := id.(msp.SigningIdentity)
+	signingID, ok := id.(msp.SigningIdentity)
 	require.True(t, ok)
 
-	publicId := signingId.GetPublicVersion()
-	require.NotNil(t, publicId)
+	publicID := signingID.GetPublicVersion()
+	require.NotNil(t, publicID)
 
 	// Verify it's a cached identity
-	_, ok = publicId.(*cachedIdentity)
+	_, ok = publicID.(*cachedIdentity)
 	require.True(t, ok)
-	require.Equal(t, mockPublicIdentity, publicId.(*cachedIdentity).Identity)
+	require.Equal(t, mockPublicIdentity, publicID.(*cachedIdentity).Identity)
 
 	mockSigningIdentity.AssertExpectations(t)
 }
@@ -390,10 +390,10 @@ func TestCachedSigningIdentity_Sign(t *testing.T) {
 	id, err := wrappedMSP.DeserializeIdentity(serializedIdentity)
 	require.NoError(t, err)
 
-	signingId, ok := id.(msp.SigningIdentity)
+	signingID, ok := id.(msp.SigningIdentity)
 	require.True(t, ok)
 
-	res, err := signingId.Sign(msg)
+	res, err := signingID.Sign(msg)
 	require.NoError(t, err)
 	require.Equal(t, sig, res)
 

--- a/platform/fabric/core/msp/cert.go
+++ b/platform/fabric/core/msp/cert.go
@@ -58,8 +58,8 @@ type tbsCertificate struct {
 	Validity           validity
 	Subject            asn1.RawValue
 	PublicKey          publicKeyInfo
-	UniqueId           asn1.BitString   `asn1:"optional,tag:1"`
-	SubjectUniqueId    asn1.BitString   `asn1:"optional,tag:2"`
+	UniqueID           asn1.BitString   `asn1:"optional,tag:1"`
+	SubjectUniqueID    asn1.BitString   `asn1:"optional,tag:2"`
 	Extensions         []pkix.Extension `asn1:"optional,explicit,tag:3"`
 }
 

--- a/platform/fabric/core/msp/configbuilder.go
+++ b/platform/fabric/core/msp/configbuilder.go
@@ -399,11 +399,10 @@ func loadCertificateAt(dir, certificatePath, ouType string) []byte {
 
 	f := filepath.Join(dir, certificatePath)
 	raw, err := readFile(f)
-	if err != nil {
-		mspLogger.Warnf("Failed loading %s certificate at [%s]: [%s]", ouType, f, err)
-	} else {
+	if err == nil {
 		return raw
 	}
+	mspLogger.Warnf("Failed loading %s certificate at [%s]: [%s]", ouType, f, err)
 
 	return nil
 }

--- a/platform/fabric/core/msp/fake/msp.go
+++ b/platform/fabric/core/msp/fake/msp.go
@@ -19,7 +19,7 @@ type MSP struct {
 	tmock.Mock
 }
 
-func (m *MSP) IsWellFormed(_ *pmsp.SerializedIdentity) error {
+func (*MSP) IsWellFormed(_ *pmsp.SerializedIdentity) error {
 	return nil
 }
 
@@ -79,11 +79,11 @@ type Identity struct {
 	ID string
 }
 
-func (m *Identity) Anonymous() bool {
+func (*Identity) Anonymous() bool {
 	panic("implement me")
 }
 
-func (m *Identity) ExpiresAt() time.Time {
+func (*Identity) ExpiresAt() time.Time {
 	panic("implement me")
 }
 
@@ -104,7 +104,7 @@ func (*Identity) GetOrganizationalUnits() []*msp.OUIdentifier {
 	panic("implement me")
 }
 
-func (*Identity) Verify(msg, sig []byte) error {
+func (*Identity) Verify(_, _ []byte) error {
 	return nil
 }
 

--- a/platform/fabric/core/msp/identities.go
+++ b/platform/fabric/core/msp/identities.go
@@ -146,7 +146,7 @@ func (id *identity) GetOrganizationalUnits() []*OUIdentifier {
 }
 
 // Anonymous returns true if this identity provides anonymity
-func (id *identity) Anonymous() bool {
+func (*identity) Anonymous() bool {
 	return false
 }
 
@@ -157,8 +157,8 @@ func (id *identity) Anonymous() bool {
 func NewSerializedIdentity(mspID string, certPEM []byte) ([]byte, error) {
 	// We serialize identities by prepending the MSPID
 	// and appending the x509 cert in PEM format
-	sId := &msp.SerializedIdentity{Mspid: mspID, IdBytes: certPEM}
-	raw, err := proto.Marshal(sId)
+	sID := &msp.SerializedIdentity{Mspid: mspID, IdBytes: certPEM}
+	raw, err := proto.Marshal(sID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed serializing identity [%s][%X]", mspID, certPEM)
 	}
@@ -215,8 +215,8 @@ func (id *identity) Serialize() ([]byte, error) {
 	}
 
 	// We serialize identities by prepending the MSPID and appending the ASN.1 DER content of the cert
-	sId := &msp.SerializedIdentity{Mspid: id.id.Mspid, IdBytes: pemBytes}
-	idBytes, err := proto.Marshal(sId)
+	sID := &msp.SerializedIdentity{Mspid: id.id.Mspid, IdBytes: pemBytes}
+	idBytes, err := proto.Marshal(sID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not marshal a SerializedIdentity structure for identity %s", id.id)
 	}
@@ -224,7 +224,7 @@ func (id *identity) Serialize() ([]byte, error) {
 	return idBytes, nil
 }
 
-func (id *identity) getHashOpt(hashFamily string) (bccsp.HashOpts, error) {
+func (*identity) getHashOpt(hashFamily string) (bccsp.HashOpts, error) {
 	switch hashFamily {
 	case bccsp.SHA2:
 		return bccsp.GetHashOpt(bccsp.SHA256)
@@ -244,15 +244,15 @@ type signingidentity struct {
 
 func newSigningIdentity(cert *x509.Certificate, pk bccsp.Key, signer crypto.Signer, msp *bccspmsp) (SigningIdentity, error) {
 	// mspIdentityLogger.Infof("Creating signing identity instance for ID %s", id)
-	mspId, err := newIdentity(cert, pk, msp)
+	mspID, err := newIdentity(cert, pk, msp)
 	if err != nil {
 		return nil, err
 	}
 	return &signingidentity{
-		id:     mspId.(*identity).id,
-		cert:   mspId.(*identity).cert,
-		msp:    mspId.(*identity).msp,
-		pk:     mspId.(*identity).pk,
+		id:     mspID.(*identity).id,
+		cert:   mspID.(*identity).cert,
+		msp:    mspID.(*identity).msp,
+		pk:     mspID.(*identity).pk,
 		signer: signer,
 	}, nil
 }

--- a/platform/fabric/core/msp/identities_test.go
+++ b/platform/fabric/core/msp/identities_test.go
@@ -106,7 +106,7 @@ UdiVmT6jldSKIETZm+kszfkANWxzKZXcXg==
 func TestSignatureAlgorithms(t *testing.T) { //nolint:paralleltest
 	gt := gomega.NewGomegaWithT(t)
 
-	t.Run("Test ecdsa sign with digest and ed25519 sign with full message", func(t *testing.T) { //nolint:paralleltest
+	t.Run("Test ecdsa sign with digest and ed25519 sign with full message", func(_ *testing.T) { //nolint:paralleltest
 		bccspDefault := factory.GetDefault()
 		mspImpl, _ := newBccspMsp(MSPv3_0, bccspDefault)
 		mspImpl.(*bccspmsp).cryptoConfig = &msp.FabricCryptoConfig{
@@ -168,7 +168,7 @@ func TestSignatureAlgorithms(t *testing.T) { //nolint:paralleltest
 
 func TestIdentityValidation(t *testing.T) { //nolint:paralleltest
 	gt := gomega.NewGomegaWithT(t)
-	t.Run("Test MSPv3_0 ed2551 identity validation", func(t *testing.T) { //nolint:paralleltest
+	t.Run("Test MSPv3_0 ed2551 identity validation", func(_ *testing.T) { //nolint:paralleltest
 		bccspDefault := factory.GetDefault()
 		mspImpl, _ := newBccspMsp(MSPv1_4_3, bccspDefault)
 		cryptoConfig := &msp.FabricCryptoConfig{

--- a/platform/fabric/core/msp/msp.go
+++ b/platform/fabric/core/msp/msp.go
@@ -182,6 +182,7 @@ type IdentityIdentifier struct {
 	Mspid string
 
 	// The identifier for an identity within a provider
+	//nolint:revive // var-naming: renaming this exported struct field is an API break; see follow-up
 	Id string
 }
 

--- a/platform/fabric/core/msp/msp_test.go
+++ b/platform/fabric/core/msp/msp_test.go
@@ -175,7 +175,7 @@ type bccspNoKeyLookupKS struct {
 	bccsp.BCCSP
 }
 
-func (*bccspNoKeyLookupKS) GetKey(ski []byte) (k bccsp.Key, err error) {
+func (*bccspNoKeyLookupKS) GetKey(_ []byte) (k bccsp.Key, err error) {
 	return nil, errors.New("not found")
 }
 
@@ -466,13 +466,13 @@ func TestIsWellFormed(t *testing.T) { //nolint:paralleltest
 		return
 	}
 
-	sId := &msp.SerializedIdentity{}
-	err = proto.Unmarshal(serializedID, sId)
+	sID := &msp.SerializedIdentity{}
+	err = proto.Unmarshal(serializedID, sID)
 	require.NoError(t, err)
 
 	// An MSP Manager without any MSPs should not recognize the identity since
 	// not providers are registered
-	err = mspMgr.IsWellFormed(sId)
+	err = mspMgr.IsWellFormed(sID)
 	require.Error(t, err)
 	require.Equal(t, "no MSP provider recognizes the identity", err.Error())
 
@@ -480,44 +480,44 @@ func TestIsWellFormed(t *testing.T) { //nolint:paralleltest
 	err = mspMgr.Setup([]MSP{localMsp})
 	require.NoError(t, err)
 
-	err = localMsp.IsWellFormed(sId)
+	err = localMsp.IsWellFormed(sID)
 	require.NoError(t, err)
-	err = mspMgr.IsWellFormed(sId)
+	err = mspMgr.IsWellFormed(sID)
 	require.NoError(t, err)
 
-	bl, _ := pem.Decode(sId.IdBytes)
+	bl, _ := pem.Decode(sID.IdBytes)
 	require.Equal(t, "CERTIFICATE", bl.Type)
 
 	// Now, strip off the type from the PEM block. It should still be valid
 	bl.Type = ""
-	sId.IdBytes = pem.EncodeToMemory(bl)
+	sID.IdBytes = pem.EncodeToMemory(bl)
 
-	err = localMsp.IsWellFormed(sId)
+	err = localMsp.IsWellFormed(sID)
 	require.NoError(t, err)
 
 	// Now, corrupt the type of the PEM block.
 	// make sure it isn't considered well formed by both an MSP and an MSP Manager
 	bl.Type = "foo"
-	sId.IdBytes = pem.EncodeToMemory(bl)
-	err = localMsp.IsWellFormed(sId)
+	sID.IdBytes = pem.EncodeToMemory(bl)
+	err = localMsp.IsWellFormed(sID)
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "pem type is")
 	require.Contains(t, err.Error(), "should be 'CERTIFICATE' or missing")
 
-	err = mspMgr.IsWellFormed(sId)
+	err = mspMgr.IsWellFormed(sID)
 	require.Error(t, err)
 	require.Equal(t, "no MSP provider recognizes the identity", err.Error())
 
 	// Restore the identity to what it was
-	sId = &msp.SerializedIdentity{}
-	err = proto.Unmarshal(serializedID, sId)
+	sID = &msp.SerializedIdentity{}
+	err = proto.Unmarshal(serializedID, sID)
 	require.NoError(t, err)
 
 	// Append some trailing junk at the end
-	sId.IdBytes = append(sId.IdBytes, []byte{1, 2, 3}...)
+	sID.IdBytes = append(sID.IdBytes, []byte{1, 2, 3}...)
 	// And ensure it is deemed invalid
-	err = localMsp.IsWellFormed(sId)
+	err = localMsp.IsWellFormed(sID)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "for MSP SampleOrg has trailing bytes")
 
@@ -543,9 +543,9 @@ func TestIsWellFormed(t *testing.T) { //nolint:paralleltest
 	// Pour it back into the identity
 	rawCert, err := asn1.Marshal(newCert)
 	require.NoError(t, err)
-	sId.IdBytes = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rawCert})
+	sID.IdBytes = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rawCert})
 	// Ensure it is invalid now and the signature modification is detected
-	err = localMsp.IsWellFormed(sId)
+	err = localMsp.IsWellFormed(sID)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "for MSP SampleOrg has a non canonical signature")
 }

--- a/platform/fabric/core/msp/mspimpl.go
+++ b/platform/fabric/core/msp/mspimpl.go
@@ -173,7 +173,7 @@ func NewBccspMspWithKeyStore(version MSPVersion, keyStore bccsp.KeyStore, bccsp 
 	return thisMSP, nil
 }
 
-func (msp *bccspmsp) getCertFromPem(idBytes []byte) (*x509.Certificate, error) {
+func (*bccspmsp) getCertFromPem(idBytes []byte) (*x509.Certificate, error) {
 	if idBytes == nil {
 		return nil, errors.New("getCertFromPem error: nil idBytes")
 	}
@@ -207,12 +207,12 @@ func (msp *bccspmsp) getIdentityFromConf(idBytes []byte) (Identity, bccsp.Key, e
 		return nil, nil, err
 	}
 
-	mspId, err := newIdentity(cert, certPubK, msp)
+	mspID, err := newIdentity(cert, certPubK, msp)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return mspId, certPubK, nil
+	return mspID, certPubK, nil
 }
 
 func (msp *bccspmsp) getSigningIdentityFromConf(sidInfo *m.SigningIdentityInfo) (SigningIdentity, error) {
@@ -283,7 +283,7 @@ func (msp *bccspmsp) GetVersion() MSPVersion {
 }
 
 // GetType returns the type for this MSP
-func (msp *bccspmsp) GetType() ProviderType {
+func (*bccspmsp) GetType() ProviderType {
 	return FABRIC
 }
 
@@ -340,7 +340,7 @@ func (msp *bccspmsp) Validate(id Identity) error {
 func (msp *bccspmsp) hasOURole(id Identity, mspRole m.MSPRole_MSPRoleType) error {
 	// Check NodeOUs
 	if !msp.ouEnforcement {
-		return errors.New("NodeOUs not activated. Cannot tell apart identities.")
+		return errors.New("nodeOUs not activated. Cannot tell apart identities")
 	}
 
 	mspLogger.Debugf("MSP %s checking if the identity is a client", msp.name)
@@ -390,17 +390,17 @@ func (msp *bccspmsp) DeserializeIdentity(serializedID []byte) (Identity, error) 
 	mspLogger.Debug("Obtaining identity")
 
 	// We first deserialize to a SerializedIdentity to get the MSP ID
-	sId := &m.SerializedIdentity{}
-	err := proto.Unmarshal(serializedID, sId)
+	sID := &m.SerializedIdentity{}
+	err := proto.Unmarshal(serializedID, sID)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not deserialize a SerializedIdentity")
 	}
 
-	if sId.Mspid != msp.name {
-		return nil, errors.Errorf("expected MSP ID %s, received %s", msp.name, sId.Mspid)
+	if sID.Mspid != msp.name {
+		return nil, errors.Errorf("expected MSP ID %s, received %s", msp.name, sID.Mspid)
 	}
 
-	return msp.deserializeIdentityInternal(sId.IdBytes)
+	return msp.deserializeIdentityInternal(sID.IdBytes)
 }
 
 // deserializeIdentityInternal returns an identity given its byte-level representation
@@ -534,13 +534,13 @@ func (msp *bccspmsp) satisfiesPrincipalInternalPreV13(id Identity, principal *m.
 	case m.MSPPrincipal_IDENTITY:
 		// in this case we have to deserialize the principal's identity
 		// and compare it byte-by-byte with our cert
-		principalId, err := msp.DeserializeIdentity(principal.Principal)
+		principalID, err := msp.DeserializeIdentity(principal.Principal)
 		if err != nil {
 			return errors.WithMessage(err, "invalid identity principal, not a certificate")
 		}
 
-		if bytes.Equal(id.(*identity).cert.Raw, principalId.(*identity).cert.Raw) {
-			return principalId.Validate()
+		if bytes.Equal(id.(*identity).cert.Raw, principalID.(*identity).cert.Raw) {
+			return principalID.Validate()
 		}
 
 		return errors.New("The identities do not match")
@@ -619,56 +619,54 @@ func (msp *bccspmsp) satisfiesPrincipalInternalV142(id Identity, principal *m.MS
 		return errors.New("invalid identity type, expected *identity")
 	}
 
-	switch principal.PrincipalClassification {
-	case m.MSPPrincipal_ROLE:
-		if !msp.ouEnforcement {
-			break
-		}
+	if principal.PrincipalClassification == m.MSPPrincipal_ROLE {
+		if msp.ouEnforcement {
 
-		// Principal contains the msp role
-		mspRole := &m.MSPRole{}
-		err := proto.Unmarshal(principal.Principal, mspRole)
-		if err != nil {
-			return errors.Wrap(err, "could not unmarshal MSPRole from principal")
-		}
+			// Principal contains the msp role
+			mspRole := &m.MSPRole{}
+			err := proto.Unmarshal(principal.Principal, mspRole)
+			if err != nil {
+				return errors.Wrap(err, "could not unmarshal MSPRole from principal")
+			}
 
-		// at first, we check whether the MSP
-		// identifier is the same as that of the identity
-		if mspRole.MspIdentifier != msp.name {
-			return errors.Errorf("the identity is a member of a different MSP (expected %s, got %s)", mspRole.MspIdentifier, id.GetMSPIdentifier())
-		}
+			// at first, we check whether the MSP
+			// identifier is the same as that of the identity
+			if mspRole.MspIdentifier != msp.name {
+				return errors.Errorf("the identity is a member of a different MSP (expected %s, got %s)", mspRole.MspIdentifier, id.GetMSPIdentifier())
+			}
 
-		// now we validate the admin role only, the other roles are left to the v1.3 function
-		switch mspRole.Role {
-		case m.MSPRole_ADMIN:
-			mspLogger.Debugf("Checking if identity has been named explicitly as an admin for %s", msp.name)
-			// in the case of admin, we check that the
-			// id is exactly one of our admins
-			if msp.isInAdmins(id.(*identity)) {
+			// now we validate the admin role only, the other roles are left to the v1.3 function
+			switch mspRole.Role {
+			case m.MSPRole_ADMIN:
+				mspLogger.Debugf("Checking if identity has been named explicitly as an admin for %s", msp.name)
+				// in the case of admin, we check that the
+				// id is exactly one of our admins
+				if msp.isInAdmins(id.(*identity)) {
+					return nil
+				}
+
+				// or it carries the Admin OU, in this case check that the identity is valid as well.
+				mspLogger.Debugf("Checking if identity carries the admin ou for %s", msp.name)
+				if err := msp.Validate(id); err != nil {
+					return errors.Wrapf(err, "The identity is not valid under this MSP [%s]", msp.name)
+				}
+
+				if err := msp.hasOURole(id, m.MSPRole_ADMIN); err != nil {
+					return errors.Wrapf(err, "The identity is not an admin under this MSP [%s]", msp.name)
+				}
+
+				return nil
+			case m.MSPRole_ORDERER:
+				mspLogger.Debugf("Checking if identity satisfies role [%s] for %s", m.MSPRole_MSPRoleType_name[int32(mspRole.Role)], msp.name)
+				if err := msp.Validate(id); err != nil {
+					return errors.Wrapf(err, "The identity is not valid under this MSP [%s]", msp.name)
+				}
+
+				if err := msp.hasOURole(id, mspRole.Role); err != nil {
+					return errors.Wrapf(err, "The identity is not a [%s] under this MSP [%s]", m.MSPRole_MSPRoleType_name[int32(mspRole.Role)], msp.name)
+				}
 				return nil
 			}
-
-			// or it carries the Admin OU, in this case check that the identity is valid as well.
-			mspLogger.Debugf("Checking if identity carries the admin ou for %s", msp.name)
-			if err := msp.Validate(id); err != nil {
-				return errors.Wrapf(err, "The identity is not valid under this MSP [%s]", msp.name)
-			}
-
-			if err := msp.hasOURole(id, m.MSPRole_ADMIN); err != nil {
-				return errors.Wrapf(err, "The identity is not an admin under this MSP [%s]", msp.name)
-			}
-
-			return nil
-		case m.MSPRole_ORDERER:
-			mspLogger.Debugf("Checking if identity satisfies role [%s] for %s", m.MSPRole_MSPRoleType_name[int32(mspRole.Role)], msp.name)
-			if err := msp.Validate(id); err != nil {
-				return errors.Wrapf(err, "The identity is not valid under this MSP [%s]", msp.name)
-			}
-
-			if err := msp.hasOURole(id, mspRole.Role); err != nil {
-				return errors.Wrapf(err, "The identity is not a [%s] under this MSP [%s]", m.MSPRole_MSPRoleType_name[int32(mspRole.Role)], msp.name)
-			}
-			return nil
 		}
 	}
 
@@ -706,7 +704,7 @@ func (msp *bccspmsp) getCertificationChain(id Identity) ([]*x509.Certificate, er
 // getCertificationChainForBCCSPIdentity returns the certification chain of the passed bccsp identity within this msp
 func (msp *bccspmsp) getCertificationChainForBCCSPIdentity(id *identity) ([]*x509.Certificate, error) {
 	if id == nil {
-		return nil, errors.New("Invalid bccsp identity. Must be different from nil.")
+		return nil, errors.New("invalid bccsp identity. Must be different from nil")
 	}
 
 	// we expect to have a valid VerifyOptions instance
@@ -947,7 +945,7 @@ func (msp *bccspmsp) sanitizeCert(cert *x509.Certificate) (*x509.Certificate, er
 // IsWellFormed checks if the given identity can be deserialized into its provider-specific form.
 // In this MSP implementation, well formed means that the PEM has a Type which is either
 // the string 'CERTIFICATE' or the Type is missing altogether.
-func (msp *bccspmsp) IsWellFormed(identity *m.SerializedIdentity) error {
+func (*bccspmsp) IsWellFormed(identity *m.SerializedIdentity) error {
 	bl, rest := pem.Decode(identity.IdBytes)
 	if bl == nil {
 		return errors.New("PEM decoding resulted in an empty block")

--- a/platform/fabric/core/msp/mspimplsetup.go
+++ b/platform/fabric/core/msp/mspimplsetup.go
@@ -289,11 +289,11 @@ func (msp *bccspmsp) setupNodeOUs(config *m.FabricMSPConfig) error {
 		msp.ouEnforcement = config.FabricNodeOus.Enable
 
 		if config.FabricNodeOus.ClientOuIdentifier == nil || len(config.FabricNodeOus.ClientOuIdentifier.OrganizationalUnitIdentifier) == 0 {
-			return errors.New("Failed setting up NodeOUs. ClientOU must be different from nil.")
+			return errors.New("failed setting up NodeOUs. ClientOU must be different from nil")
 		}
 
 		if config.FabricNodeOus.PeerOuIdentifier == nil || len(config.FabricNodeOus.PeerOuIdentifier.OrganizationalUnitIdentifier) == 0 {
-			return errors.New("Failed setting up NodeOUs. PeerOU must be different from nil.")
+			return errors.New("failed setting up NodeOUs. PeerOU must be different from nil")
 		}
 
 		// ClientOU
@@ -615,7 +615,7 @@ func (msp *bccspmsp) preSetupV142(conf *m.FabricMSPConfig) error {
 	return nil
 }
 
-func (msp *bccspmsp) postSetupV1(conf *m.FabricMSPConfig) error {
+func (msp *bccspmsp) postSetupV1(_ *m.FabricMSPConfig) error {
 	// make sure that admins are valid members as well
 	// this way, when we validate an admin MSP principal
 	// we can simply check for exact match of certs

--- a/platform/fabric/core/msp/mspimplsetup_test.go
+++ b/platform/fabric/core/msp/mspimplsetup_test.go
@@ -85,7 +85,7 @@ oVYZAX2M8G3clTu+f6Si5KrRezNflbVHmvCrJWM=
 func TestTLSCAValidation(t *testing.T) { //nolint:paralleltest
 	gt := gomega.NewGomegaWithT(t)
 
-	t.Run("GoodCert", func(t *testing.T) { //nolint:paralleltest
+	t.Run("GoodCert", func(_ *testing.T) { //nolint:paralleltest
 		mspImpl := &bccspmsp{
 			opts: &x509.VerifyOptions{Roots: x509.NewCertPool(), Intermediates: x509.NewCertPool()},
 		}
@@ -96,7 +96,7 @@ func TestTLSCAValidation(t *testing.T) { //nolint:paralleltest
 		gt.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
-	t.Run("ExpiredCert", func(t *testing.T) { //nolint:paralleltest
+	t.Run("ExpiredCert", func(_ *testing.T) { //nolint:paralleltest
 		mspImpl := &bccspmsp{
 			opts: &x509.VerifyOptions{Roots: x509.NewCertPool(), Intermediates: x509.NewCertPool()},
 		}
@@ -107,7 +107,7 @@ func TestTLSCAValidation(t *testing.T) { //nolint:paralleltest
 		gt.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
-	t.Run("NonCACert", func(t *testing.T) { //nolint:paralleltest
+	t.Run("NonCACert", func(_ *testing.T) { //nolint:paralleltest
 		mspImpl := &bccspmsp{
 			opts: &x509.VerifyOptions{Roots: x509.NewCertPool(), Intermediates: x509.NewCertPool()},
 		}
@@ -118,7 +118,7 @@ func TestTLSCAValidation(t *testing.T) { //nolint:paralleltest
 		gt.Expect(err).To(gomega.MatchError("CA Certificate did not have the CA attribute, (SN: c9dff7f76657d46f082570f6965051f5)"))
 	})
 
-	t.Run("NoSKICert", func(t *testing.T) { //nolint:paralleltest
+	t.Run("NoSKICert", func(_ *testing.T) { //nolint:paralleltest
 		mspImpl := &bccspmsp{
 			opts: &x509.VerifyOptions{Roots: x509.NewCertPool(), Intermediates: x509.NewCertPool()},
 		}
@@ -171,7 +171,7 @@ func TestMalformedCertsChainSetup(t *testing.T) { //nolint:paralleltest
 func TestCAValidation(t *testing.T) { //nolint:paralleltest
 	gt := gomega.NewGomegaWithT(t)
 
-	t.Run("GoodCert", func(t *testing.T) { //nolint:paralleltest
+	t.Run("GoodCert", func(_ *testing.T) { //nolint:paralleltest
 		mspImpl := &bccspmsp{
 			opts: &x509.VerifyOptions{Roots: x509.NewCertPool(), Intermediates: x509.NewCertPool()},
 		}
@@ -185,7 +185,7 @@ func TestCAValidation(t *testing.T) { //nolint:paralleltest
 		gt.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
-	t.Run("NonCACert", func(t *testing.T) { //nolint:paralleltest
+	t.Run("NonCACert", func(_ *testing.T) { //nolint:paralleltest
 		mspImpl := &bccspmsp{
 			opts: &x509.VerifyOptions{Roots: x509.NewCertPool(), Intermediates: x509.NewCertPool()},
 		}
@@ -199,7 +199,7 @@ func TestCAValidation(t *testing.T) { //nolint:paralleltest
 		gt.Expect(err).To(gomega.MatchError("CA Certificate did not have the CA attribute, (SN: c9dff7f76657d46f082570f6965051f5)"))
 	})
 
-	t.Run("NoSKICert", func(t *testing.T) { //nolint:paralleltest
+	t.Run("NoSKICert", func(_ *testing.T) { //nolint:paralleltest
 		mspImpl := &bccspmsp{
 			opts: &x509.VerifyOptions{Roots: x509.NewCertPool(), Intermediates: x509.NewCertPool()},
 		}

--- a/platform/fabric/core/msp/mspmgrimpl.go
+++ b/platform/fabric/core/msp/mspmgrimpl.go
@@ -78,23 +78,23 @@ func (mgr *mspManagerImpl) DeserializeIdentity(serializedID []byte) (Identity, e
 		return nil, errors.New("channel doesn't exist")
 	}
 	// We first deserialize to a SerializedIdentity to get the MSP ID
-	sId := &msp.SerializedIdentity{}
-	err := proto.Unmarshal(serializedID, sId)
+	sID := &msp.SerializedIdentity{}
+	err := proto.Unmarshal(serializedID, sID)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not deserialize a SerializedIdentity")
 	}
 
 	// we can now attempt to obtain the MSP
-	msp := mgr.mspsMap[sId.Mspid]
+	msp := mgr.mspsMap[sID.Mspid]
 	if msp == nil {
-		return nil, errors.Errorf("MSP %s is not defined on channel", sId.Mspid)
+		return nil, errors.Errorf("MSP %s is not defined on channel", sID.Mspid)
 	}
 
 	switch t := msp.(type) {
 	case *bccspmsp:
-		return t.deserializeIdentityInternal(sId.IdBytes)
+		return t.deserializeIdentityInternal(sID.IdBytes)
 	case *idemixMSPWrapper:
-		return t.deserializeIdentityInternal(sId.IdBytes)
+		return t.deserializeIdentityInternal(sID.IdBytes)
 	default:
 		return t.DeserializeIdentity(serializedID)
 	}

--- a/platform/fabric/core/msp/nodeous_test.go
+++ b/platform/fabric/core/msp/nodeous_test.go
@@ -425,7 +425,7 @@ func TestValidMSPWithNodeOUMissingClassification(t *testing.T) { //nolint:parall
 	// the configuration enables NodeOUs but client ou identifier is missing
 	_, err := getLocalMSPWithVersionAndError(t, "testdata/nodeousbadconf1", MSPv1_3)
 	require.Error(t, err)
-	require.Equal(t, "Failed setting up NodeOUs. ClientOU must be different from nil.", err.Error())
+	require.Equal(t, "failed setting up NodeOUs. ClientOU must be different from nil", err.Error())
 
 	_, err = getLocalMSPWithVersionAndError(t, "testdata/nodeousbadconf1", MSPv1_4_3)
 	require.Error(t, err)
@@ -435,7 +435,7 @@ func TestValidMSPWithNodeOUMissingClassification(t *testing.T) { //nolint:parall
 	// the configuration enables NodeOUs but peer ou identifier is missing
 	_, err = getLocalMSPWithVersionAndError(t, "testdata/nodeousbadconf2", MSPv1_3)
 	require.Error(t, err)
-	require.Equal(t, "Failed setting up NodeOUs. PeerOU must be different from nil.", err.Error())
+	require.Equal(t, "failed setting up NodeOUs. PeerOU must be different from nil", err.Error())
 
 	_, err = getLocalMSPWithVersionAndError(t, "testdata/nodeousbadconf2", MSPv1_4_3)
 	require.NoError(t, err)

--- a/platform/fabric/core/protoutil/txutils_test.go
+++ b/platform/fabric/core/protoutil/txutils_test.go
@@ -221,7 +221,7 @@ func TestCreateSignedTx(t *testing.T) {
 		{Payload: []byte("payload2"), Response: &pb.Response{Status: int32(200)}},
 	}
 	_, err = protoutil.CreateSignedTx(prop, signID, responses...)
-	if err == nil || strings.HasPrefix(err.Error(), "ProposalResponsePayloads do not match (base64):") == false {
+	if err == nil || !strings.HasPrefix(err.Error(), "ProposalResponsePayloads do not match (base64):") {
 		require.FailNow(t, "Error is expected when response payloads do not match")
 	}
 

--- a/platform/fabric/delivery_test.go
+++ b/platform/fabric/delivery_test.go
@@ -30,11 +30,11 @@ type mockDelivery struct {
 	TriggerDeliveryCallback func(callback driver.DeliveryCallback)
 }
 
-func (m *mockDelivery) Start(ctx context.Context) error {
+func (*mockDelivery) Start(_ context.Context) error {
 	return nil
 }
 
-func (m *mockDelivery) ScanBlock(ctx context.Context, callback driver.BlockCallback) error {
+func (m *mockDelivery) ScanBlock(_ context.Context, callback driver.BlockCallback) error {
 	m.ScanBlockCount++
 	if m.TriggerBlockCallback != nil {
 		m.TriggerBlockCallback(callback)
@@ -42,7 +42,7 @@ func (m *mockDelivery) ScanBlock(ctx context.Context, callback driver.BlockCallb
 	return m.CallbackError
 }
 
-func (m *mockDelivery) ScanBlockFrom(ctx context.Context, block uint64, callback driver.BlockCallback) error {
+func (m *mockDelivery) ScanBlockFrom(_ context.Context, block uint64, callback driver.BlockCallback) error {
 	m.ScanBlockFromCount++
 	m.LastBlockNum = block
 	if m.TriggerBlockCallback != nil {
@@ -51,7 +51,7 @@ func (m *mockDelivery) ScanBlockFrom(ctx context.Context, block uint64, callback
 	return m.CallbackError
 }
 
-func (m *mockDelivery) Scan(ctx context.Context, txID string, callback driver.DeliveryCallback) error {
+func (m *mockDelivery) Scan(_ context.Context, txID string, callback driver.DeliveryCallback) error {
 	m.ScanCount++
 	m.LastTxID = txID
 	if m.TriggerDeliveryCallback != nil {
@@ -60,7 +60,7 @@ func (m *mockDelivery) Scan(ctx context.Context, txID string, callback driver.De
 	return m.CallbackError
 }
 
-func (m *mockDelivery) ScanFromBlock(ctx context.Context, block uint64, callback driver.DeliveryCallback) error {
+func (m *mockDelivery) ScanFromBlock(_ context.Context, block uint64, callback driver.DeliveryCallback) error {
 	m.ScanFromBlockCount++
 	m.LastBlockNum = block
 	if m.TriggerDeliveryCallback != nil {
@@ -88,7 +88,7 @@ func TestDelivery(t *testing.T) {
 		require.True(t, res)
 		callbackInvoked = true
 	}
-	err := delivery.ScanBlock(ctx, func(ctx context.Context, block *common.Block) (bool, error) {
+	err := delivery.ScanBlock(ctx, func(_ context.Context, _ *common.Block) (bool, error) {
 		return true, nil
 	})
 	require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestDelivery(t *testing.T) {
 
 	// Test ScanBlockFrom
 	callbackInvoked = false
-	err = delivery.ScanBlockFrom(ctx, uint64(20), func(ctx context.Context, block *common.Block) (bool, error) {
+	err = delivery.ScanBlockFrom(ctx, uint64(20), func(_ context.Context, _ *common.Block) (bool, error) {
 		callbackInvoked = true
 		return true, nil
 	})
@@ -137,22 +137,22 @@ func TestDelivery(t *testing.T) {
 	md.CallbackResult = false
 	md.CallbackError = errors.New("scan error")
 
-	err = delivery.ScanBlock(ctx, func(ctx context.Context, block *common.Block) (bool, error) {
+	err = delivery.ScanBlock(ctx, func(_ context.Context, _ *common.Block) (bool, error) {
 		return true, nil
 	})
 	require.ErrorContains(t, err, "scan error")
 
-	err = delivery.ScanBlockFrom(ctx, uint64(20), func(ctx context.Context, block *common.Block) (bool, error) {
+	err = delivery.ScanBlockFrom(ctx, uint64(20), func(_ context.Context, _ *common.Block) (bool, error) {
 		return true, nil
 	})
 	require.ErrorContains(t, err, "scan error")
 
-	err = delivery.Scan(ctx, "txid1", func(tx *ProcessedTransaction) (bool, error) {
+	err = delivery.Scan(ctx, "txid1", func(_ *ProcessedTransaction) (bool, error) {
 		return true, nil
 	})
 	require.ErrorContains(t, err, "scan error")
 
-	err = delivery.ScanFromBlock(ctx, uint64(30), func(tx *ProcessedTransaction) (bool, error) {
+	err = delivery.ScanFromBlock(ctx, uint64(30), func(_ *ProcessedTransaction) (bool, error) {
 		return true, nil
 	})
 	require.ErrorContains(t, err, "scan error")

--- a/platform/fabric/events_test.go
+++ b/platform/fabric/events_test.go
@@ -33,19 +33,19 @@ type mockSubscriber struct {
 	m        sync.RWMutex
 }
 
-func (m *mockSubscriber) Subscribe(chaincodeName string, listener events.Listener) {
+func (m *mockSubscriber) Subscribe(_ string, listener events.Listener) {
 	m.m.Lock()
 	defer m.m.Unlock()
 	m.listener = listener
 }
 
-func (m *mockSubscriber) Unsubscribe(chaincodeName string, listener events.Listener) {
+func (m *mockSubscriber) Unsubscribe(_ string, _ events.Listener) {
 	m.m.Lock()
 	defer m.m.Unlock()
 	m.listener = nil
 }
 
-func (m *mockSubscriber) Publish(chaincodeName string, event *committer.ChaincodeEvent) {
+func (m *mockSubscriber) Publish(_ string, event *committer.ChaincodeEvent) {
 	m.m.RLock()
 	l := m.listener
 	m.m.RUnlock()

--- a/platform/fabric/ledger_test.go
+++ b/platform/fabric/ledger_test.go
@@ -23,7 +23,7 @@ func (m *mockBlock) DataAt(i int) []byte {
 	return m.data[i]
 }
 
-func (m *mockBlock) ProcessedTransaction(i int) (driver.ProcessedTransaction, error) {
+func (*mockBlock) ProcessedTransaction(_ int) (driver.ProcessedTransaction, error) {
 	return nil, nil
 }
 
@@ -56,21 +56,21 @@ type mockLedger struct {
 	mockLedgerErr  error
 }
 
-func (m *mockLedger) GetBlockNumberByTxID(txID string) (uint64, error) {
+func (m *mockLedger) GetBlockNumberByTxID(_ string) (uint64, error) {
 	if m.mockBlockErr != nil {
 		return 0, m.mockBlockErr
 	}
 	return m.mockBlockNum, nil
 }
 
-func (m *mockLedger) GetTransactionByID(txID string) (driver.ProcessedTransaction, error) {
+func (m *mockLedger) GetTransactionByID(_ string) (driver.ProcessedTransaction, error) {
 	if m.mockTxErr != nil {
 		return nil, m.mockTxErr
 	}
 	return m.mockTx, nil
 }
 
-func (m *mockLedger) GetBlockByNumber(number uint64) (driver.Block, error) {
+func (m *mockLedger) GetBlockByNumber(_ uint64) (driver.Block, error) {
 	if m.mockBlockErr != nil {
 		return nil, m.mockBlockErr
 	}

--- a/platform/fabric/membership_test.go
+++ b/platform/fabric/membership_test.go
@@ -19,11 +19,11 @@ import (
 
 type mockSigningIdentity struct{}
 
-func (m *mockSigningIdentity) Serialize() ([]byte, error) {
+func (*mockSigningIdentity) Serialize() ([]byte, error) {
 	return []byte("serialized"), nil
 }
 
-func (m *mockSigningIdentity) Sign(msg []byte) ([]byte, error) {
+func (*mockSigningIdentity) Sign(_ []byte) ([]byte, error) {
 	return []byte("sig"), nil
 }
 
@@ -86,7 +86,7 @@ type mockMSPManagerInner struct {
 	deserializeIdentity driver.MSPIdentity
 }
 
-func (m *mockMSPManagerInner) DeserializeIdentity(serializedIdentity []byte) (driver.MSPIdentity, error) {
+func (m *mockMSPManagerInner) DeserializeIdentity(_ []byte) (driver.MSPIdentity, error) {
 	return m.deserializeIdentity, m.deserializeErr
 }
 
@@ -153,7 +153,7 @@ func TestIdentityInfo(t *testing.T) {
 	mockIInfo := &driver.IdentityInfo{
 		ID:           "id1",
 		EnrollmentID: "eid1",
-		GetIdentity: func(opts *driver.IdentityOptions) (view.Identity, []byte, error) {
+		GetIdentity: func(_ *driver.IdentityOptions) (view.Identity, []byte, error) {
 			return view.Identity("ident"), []byte("audit"), nil
 		},
 	}

--- a/platform/fabric/processor_test.go
+++ b/platform/fabric/processor_test.go
@@ -44,7 +44,7 @@ type mockProcessorManagerInner struct {
 	LastProcessor driver.Processor
 }
 
-func (m *mockProcessorManagerInner) AddProcessor(ns string, p driver.Processor) error {
+func (m *mockProcessorManagerInner) AddProcessor(_ string, p driver.Processor) error {
 	m.AddProcessorCount++
 	m.LastProcessor = p
 	return m.LastError
@@ -56,7 +56,7 @@ func (m *mockProcessorManagerInner) SetDefaultProcessor(p driver.Processor) erro
 	return m.LastError
 }
 
-func (m *mockProcessorManagerInner) AddChannelProcessor(channel, ns string, p driver.Processor) error {
+func (m *mockProcessorManagerInner) AddChannelProcessor(_, _ string, p driver.Processor) error {
 	m.AddChannelProcessorCount++
 	m.LastProcessor = p
 	return m.LastError

--- a/platform/fabric/sdk/dig/generic/providers.go
+++ b/platform/fabric/sdk/dig/generic/providers.go
@@ -58,7 +58,7 @@ func NewDriver(in struct {
 	ConfigProvider  config.Provider
 	MetricsProvider metrics.Provider
 	EndpointService identity.EndpointService
-	IdProvider      identity.ViewIdentityProvider
+	IDProvider      identity.ViewIdentityProvider
 	KVS             *kvs.KVS
 	AuditInfoKVS    driver2.AuditInfoStore
 	SignerKVS       driver2.SignerInfoStore
@@ -74,7 +74,7 @@ func NewDriver(in struct {
 			in.MetricsProvider,
 			in.EndpointService,
 			in.ChannelProvider,
-			in.IdProvider,
+			in.IDProvider,
 			in.IdentityLoaders,
 			in.SignerKVS,
 			in.AuditInfoKVS,

--- a/platform/fabric/sdk/dig/sdk.go
+++ b/platform/fabric/sdk/dig/sdk.go
@@ -183,12 +183,12 @@ func registerProcessorsForDrivers(in struct {
 			return fmt.Errorf("could not find default FNS: %w", err)
 		}
 		for _, name := range in.CoreConfig.Names() {
-			if c, err := in.CoreConfig.Config(name); err != nil || c.Driver != d.Name {
+			c, err := in.CoreConfig.Config(name)
+			if err != nil || c.Driver != d.Name {
 				logger.Infof("Skipping registration because network driver [%s] is not the selected driver [%s]", c.Driver, d)
 				continue
-			} else {
-				logger.Infof("did not skip: %s", c.Driver)
 			}
+			logger.Infof("did not skip: %s", c.Driver)
 			fns, err := in.NetworkServiceProvider.FabricNetworkService(name)
 			if err != nil {
 				return fmt.Errorf("could not find FNS [%s]: %w", name, err)

--- a/platform/fabric/services/chaincode/common_test.go
+++ b/platform/fabric/services/chaincode/common_test.go
@@ -18,8 +18,8 @@ import (
 
 type dummySubscriber struct{}
 
-func (d *dummySubscriber) Subscribe(topic string, listener events.Listener)   {}
-func (d *dummySubscriber) Unsubscribe(topic string, listener events.Listener) {}
+func (*dummySubscriber) Subscribe(_ string, _ events.Listener)   {}
+func (*dummySubscriber) Unsubscribe(_ string, _ events.Listener) {}
 
 func setupMockContext(t *testing.T) (*mock.Context, *ledgermock.ChaincodeInvocation, *endorsermock.Envelope) {
 	t.Helper()

--- a/platform/fabric/services/chaincode/events_test.go
+++ b/platform/fabric/services/chaincode/events_test.go
@@ -22,7 +22,7 @@ import (
 func TestEventsView(t *testing.T) {
 	t.Parallel()
 
-	mockCallback := func(event *chaincode.Event) (bool, error) {
+	mockCallback := func(_ *chaincode.Event) (bool, error) {
 		return true, nil
 	}
 
@@ -97,11 +97,11 @@ type mockSubscriber struct {
 	listener events.Listener
 }
 
-func (m *mockSubscriber) Subscribe(topic string, listener events.Listener) {
+func (m *mockSubscriber) Subscribe(_ string, listener events.Listener) {
 	m.listener = listener
 }
 
-func (m *mockSubscriber) Unsubscribe(topic string, listener events.Listener) {}
+func (*mockSubscriber) Unsubscribe(_ string, _ events.Listener) {}
 
 type mockEvent struct {
 	topic string

--- a/platform/fabric/services/crypto/provider_test.go
+++ b/platform/fabric/services/crypto/provider_test.go
@@ -128,7 +128,7 @@ func TestProviderHashPanicsOnHasherError(t *testing.T) {
 				require.Equal(t, []byte("hello world"), msg)
 				return nil, errors.New("hash failed")
 			},
-			getHashFunc: func(opts bccsp.HashOpts) (hash.Hash, error) {
+			getHashFunc: func(_ bccsp.HashOpts) (hash.Hash, error) {
 				t.Fatal("GetHash should not be called")
 				return nil, nil
 			},
@@ -145,7 +145,7 @@ func TestProviderGetHashPanicsOnHasherError(t *testing.T) {
 
 	p := &provider{
 		hasher: &fakeHasher{
-			hashFunc: func(msg []byte, opts bccsp.HashOpts) ([]byte, error) {
+			hashFunc: func(_ []byte, _ bccsp.HashOpts) ([]byte, error) {
 				t.Fatal("Hash should not be called")
 				return nil, nil
 			},

--- a/platform/fabric/services/db/driver/memory/config.go
+++ b/platform/fabric/services/db/driver/memory/config.go
@@ -15,7 +15,7 @@ var Op = &optsProvider{}
 
 type optsProvider struct{}
 
-func (p *optsProvider) GetOpts(params ...string) sqlite2.Opts {
+func (*optsProvider) GetOpts(params ...string) sqlite2.Opts {
 	return sqlite2.Opts{
 		DataSource:      "file::memory:?cache=shared",
 		SkipPragmas:     false,
@@ -28,7 +28,7 @@ func (p *optsProvider) GetOpts(params ...string) sqlite2.Opts {
 	}
 }
 
-func (p *optsProvider) GetConfig(params ...string) sqlite2.Config {
+func (*optsProvider) GetConfig(params ...string) sqlite2.Config {
 	return sqlite2.Config{
 		DataSource:      "file::memory:?cache=shared",
 		SkipPragmas:     false,

--- a/platform/fabric/services/db/driver/sql/common/data_test.go
+++ b/platform/fabric/services/db/driver/sql/common/data_test.go
@@ -44,7 +44,7 @@ func GetData(t *testing.T, get getFunc) {
 	Expect(result).To(Equal(data))
 }
 
-func GetData_NoData(t *testing.T, get getFunc) {
+func GetDataNoData(t *testing.T, get getFunc) {
 	t.Helper()
 	RegisterTestingT(t)
 
@@ -66,7 +66,7 @@ func GetData_NoData(t *testing.T, get getFunc) {
 	Expect(result).To(BeNil())
 }
 
-func ExistData_True(t *testing.T, exists existsFunc) {
+func ExistDataTrue(t *testing.T, exists existsFunc) {
 	t.Helper()
 	RegisterTestingT(t)
 
@@ -89,7 +89,7 @@ func ExistData_True(t *testing.T, exists existsFunc) {
 	Expect(result).To(BeTrue())
 }
 
-func ExistData_False(t *testing.T, exist existsFunc) {
+func ExistDataFalse(t *testing.T, exist existsFunc) {
 	t.Helper()
 	RegisterTestingT(t)
 
@@ -111,7 +111,7 @@ func ExistData_False(t *testing.T, exist existsFunc) {
 	Expect(result).To(BeFalse())
 }
 
-func PutData_Success(t *testing.T, put putFunc) {
+func PutDataSuccess(t *testing.T, put putFunc) {
 	t.Helper()
 	RegisterTestingT(t)
 
@@ -133,7 +133,7 @@ func PutData_Success(t *testing.T, put putFunc) {
 	Expect(err).ToNot(HaveOccurred())
 }
 
-func PutData_Conflict(t *testing.T, put putFunc) {
+func PutDataConflict(t *testing.T, put putFunc) {
 	t.Helper()
 	RegisterTestingT(t)
 

--- a/platform/fabric/services/db/driver/sql/common/endorsetx_test.go
+++ b/platform/fabric/services/db/driver/sql/common/endorsetx_test.go
@@ -21,31 +21,31 @@ func TestEnvelope_GetData(t *testing.T) { //nolint:paralleltest
 }
 
 func TestEnvelope_GetData_NoData(t *testing.T) { //nolint:paralleltest
-	GetData_NoData(t, func(db *sql.DB, key string) ([]byte, error) {
+	GetDataNoData(t, func(db *sql.DB, key string) ([]byte, error) {
 		return mockEnvelopeStore(db).GetEnvelope(context.Background(), key)
 	})
 }
 
 func TestEnvelope_ExistData_True(t *testing.T) { //nolint:paralleltest
-	ExistData_True(t, func(db *sql.DB, key string) (bool, error) {
+	ExistDataTrue(t, func(db *sql.DB, key string) (bool, error) {
 		return mockEnvelopeStore(db).ExistsEnvelope(context.Background(), key)
 	})
 }
 
 func TestEnvelope_ExistData_False(t *testing.T) { //nolint:paralleltest
-	ExistData_False(t, func(db *sql.DB, key string) (bool, error) {
+	ExistDataFalse(t, func(db *sql.DB, key string) (bool, error) {
 		return mockEnvelopeStore(db).ExistsEnvelope(context.Background(), key)
 	})
 }
 
 func TestEnvelope_PutData_Success(t *testing.T) { //nolint:paralleltest
-	PutData_Success(t, func(db *sql.DB, key string, data []byte) error {
+	PutDataSuccess(t, func(db *sql.DB, key string, data []byte) error {
 		return mockEnvelopeStore(db).PutEnvelope(context.Background(), key, data)
 	})
 }
 
 func TestEnvelope_PutData_Conflict(t *testing.T) { //nolint:paralleltest
-	PutData_Conflict(t, func(db *sql.DB, key string, data []byte) error {
+	PutDataConflict(t, func(db *sql.DB, key string, data []byte) error {
 		return mockEnvelopeStore(db).PutEnvelope(context.Background(), key, data)
 	})
 }

--- a/platform/fabric/services/db/driver/sql/common/envelope_test.go
+++ b/platform/fabric/services/db/driver/sql/common/envelope_test.go
@@ -21,31 +21,31 @@ func TestEndorseTX_GetData(t *testing.T) { //nolint:paralleltest
 }
 
 func TestEndorseTX_GetData_NoData(t *testing.T) { //nolint:paralleltest
-	GetData_NoData(t, func(db *sql.DB, key string) ([]byte, error) {
+	GetDataNoData(t, func(db *sql.DB, key string) ([]byte, error) {
 		return mockEndorseTXStore(db).GetEndorseTx(context.Background(), key)
 	})
 }
 
 func TestEndorseTX_ExistData_True(t *testing.T) { //nolint:paralleltest
-	ExistData_True(t, func(db *sql.DB, key string) (bool, error) {
+	ExistDataTrue(t, func(db *sql.DB, key string) (bool, error) {
 		return mockEndorseTXStore(db).ExistsEndorseTx(context.Background(), key)
 	})
 }
 
 func TestEndorseTX_ExistData_False(t *testing.T) { //nolint:paralleltest
-	ExistData_False(t, func(db *sql.DB, key string) (bool, error) {
+	ExistDataFalse(t, func(db *sql.DB, key string) (bool, error) {
 		return mockEndorseTXStore(db).ExistsEndorseTx(context.Background(), key)
 	})
 }
 
 func TestEndorseTX_PutData_Success(t *testing.T) { //nolint:paralleltest
-	PutData_Success(t, func(db *sql.DB, key string, data []byte) error {
+	PutDataSuccess(t, func(db *sql.DB, key string, data []byte) error {
 		return mockEndorseTXStore(db).PutEndorseTx(context.Background(), key, data)
 	})
 }
 
 func TestEndorseTX_PutData_Conflict(t *testing.T) { //nolint:paralleltest
-	PutData_Conflict(t, func(db *sql.DB, key string, data []byte) error {
+	PutDataConflict(t, func(db *sql.DB, key string, data []byte) error {
 		return mockEndorseTXStore(db).PutEndorseTx(context.Background(), key, data)
 	})
 }

--- a/platform/fabric/services/db/driver/sql/common/metadata_test.go
+++ b/platform/fabric/services/db/driver/sql/common/metadata_test.go
@@ -21,31 +21,31 @@ func TestMetadata_GetData(t *testing.T) { //nolint:paralleltest
 }
 
 func TestMetadata_GetData_NoData(t *testing.T) { //nolint:paralleltest
-	GetData_NoData(t, func(db *sql.DB, key string) ([]byte, error) {
+	GetDataNoData(t, func(db *sql.DB, key string) ([]byte, error) {
 		return mockMetadataStore(db).GetMetadata(context.Background(), key)
 	})
 }
 
 func TestMetadata_ExistData_True(t *testing.T) { //nolint:paralleltest
-	ExistData_True(t, func(db *sql.DB, key string) (bool, error) {
+	ExistDataTrue(t, func(db *sql.DB, key string) (bool, error) {
 		return mockMetadataStore(db).ExistMetadata(context.Background(), key)
 	})
 }
 
 func TestMetadata_ExistData_False(t *testing.T) { //nolint:paralleltest
-	ExistData_False(t, func(db *sql.DB, key string) (bool, error) {
+	ExistDataFalse(t, func(db *sql.DB, key string) (bool, error) {
 		return mockMetadataStore(db).ExistMetadata(context.Background(), key)
 	})
 }
 
 func TestMetadata_PutData_Success(t *testing.T) { //nolint:paralleltest
-	PutData_Success(t, func(db *sql.DB, key string, data []byte) error {
+	PutDataSuccess(t, func(db *sql.DB, key string, data []byte) error {
 		return mockMetadataStore(db).PutMetadata(context.Background(), key, data)
 	})
 }
 
 func TestMetadata_PutData_Conflict(t *testing.T) { //nolint:paralleltest
-	PutData_Conflict(t, func(db *sql.DB, key string, data []byte) error {
+	PutDataConflict(t, func(db *sql.DB, key string, data []byte) error {
 		return mockMetadataStore(db).PutMetadata(context.Background(), key, data)
 	})
 }

--- a/platform/fabric/services/db/driver/sql/common/vault.go
+++ b/platform/fabric/services/db/driver/sql/common/vault.go
@@ -85,11 +85,11 @@ func (db *VaultStore) NewTxLockVaultReader(ctx context.Context, txID driver.TxID
 	}
 
 	return newTxVaultReader(func() (*vaultReader, releaseFunc, error) {
-		return db.newTxLockVaultReader(ctx, isolationLevel)
+		return db.buildTxLockVaultReader(ctx, isolationLevel)
 	}), nil
 }
 
-func (db *VaultStore) newTxLockVaultReader(ctx context.Context, isolationLevel driver.IsolationLevel) (*vaultReader, releaseFunc, error) {
+func (db *VaultStore) buildTxLockVaultReader(ctx context.Context, isolationLevel driver.IsolationLevel) (*vaultReader, releaseFunc, error) {
 	il, err := db.il.Map(isolationLevel)
 	if err != nil {
 		return nil, nil, err
@@ -111,10 +111,10 @@ func (db *VaultStore) newTxLockVaultReader(ctx context.Context, isolationLevel d
 func (db *VaultStore) NewGlobalLockVaultReader(ctx context.Context) (driver.LockedVaultReader, error) {
 	logger.DebugfContext(ctx, "start acquire global lock")
 	defer logger.DebugfContext(ctx, "end acquire global lock")
-	return newTxVaultReader(db.newGlobalLockVaultReader), nil
+	return newTxVaultReader(db.buildGlobalLockVaultReader), nil
 }
 
-func (db *VaultStore) newGlobalLockVaultReader() (*vaultReader, releaseFunc, error) {
+func (db *VaultStore) buildGlobalLockVaultReader() (*vaultReader, releaseFunc, error) {
 	db.GlobalLock.Lock()
 	release := func() error {
 		db.GlobalLock.Unlock()

--- a/platform/fabric/services/db/driver/sql/postgres/endorsetx.go
+++ b/platform/fabric/services/db/driver/sql/postgres/endorsetx.go
@@ -19,9 +19,9 @@ type EndorseTxStore struct {
 }
 
 func NewEndorseTxStore(dbs *common2.RWDB, tables common.TableNames) (*EndorseTxStore, error) {
-	return newEndorseTxStore(dbs.ReadDB, dbs.WriteDB, tables.EndorseTx), nil
+	return buildEndorseTxStore(dbs.ReadDB, dbs.WriteDB, tables.EndorseTx), nil
 }
 
-func newEndorseTxStore(readDB, writeDB *sql.DB, table string) *EndorseTxStore {
+func buildEndorseTxStore(readDB, writeDB *sql.DB, table string) *EndorseTxStore {
 	return &EndorseTxStore{EndorseTxStore: common.NewEndorseTxStore(readDB, writeDB, table, &postgres2.ErrorMapper{})}
 }

--- a/platform/fabric/services/db/driver/sql/postgres/envelope.go
+++ b/platform/fabric/services/db/driver/sql/postgres/envelope.go
@@ -19,9 +19,9 @@ type EnvelopeStore struct {
 }
 
 func NewEnvelopeStore(dbs *common2.RWDB, tables common.TableNames) (*EnvelopeStore, error) {
-	return newEnvelopeStore(dbs.ReadDB, dbs.WriteDB, tables.Envelope), nil
+	return buildEnvelopeStore(dbs.ReadDB, dbs.WriteDB, tables.Envelope), nil
 }
 
-func newEnvelopeStore(readDB, writeDB *sql.DB, table string) *EnvelopeStore {
+func buildEnvelopeStore(readDB, writeDB *sql.DB, table string) *EnvelopeStore {
 	return &EnvelopeStore{EnvelopeStore: common.NewEnvelopeStore(readDB, writeDB, table, &postgres2.ErrorMapper{})}
 }

--- a/platform/fabric/services/db/driver/sql/postgres/metadata.go
+++ b/platform/fabric/services/db/driver/sql/postgres/metadata.go
@@ -19,9 +19,9 @@ type MetadataStore struct {
 }
 
 func NewMetadataStore(dbs *common2.RWDB, tables common.TableNames) (*MetadataStore, error) {
-	return newMetadataStore(dbs.ReadDB, dbs.WriteDB, tables.Metadata), nil
+	return buildMetadataStore(dbs.ReadDB, dbs.WriteDB, tables.Metadata), nil
 }
 
-func newMetadataStore(readDB, writeDB *sql.DB, table string) *MetadataStore {
+func buildMetadataStore(readDB, writeDB *sql.DB, table string) *MetadataStore {
 	return &MetadataStore{MetadataStore: common.NewMetadataStore(readDB, writeDB, table, &postgres2.ErrorMapper{})}
 }

--- a/platform/fabric/services/db/driver/sql/postgres/vault.go
+++ b/platform/fabric/services/db/driver/sql/postgres/vault.go
@@ -29,14 +29,14 @@ type VaultStore struct {
 // NewVaultStore creates a postgres-backed VaultStore for the given
 // read/write database and table names.
 func NewVaultStore(dbs *common3.RWDB, tables common4.TableNames) (*VaultStore, error) {
-	return newVaultStore(dbs.ReadDB, dbs.WriteDB, common4.VaultTables{
+	return buildVaultStore(dbs.ReadDB, dbs.WriteDB, common4.VaultTables{
 		StateTable:  tables.State,
 		StatusTable: tables.Status,
 	}), nil
 }
 
-// newVaultStore is the internal constructor.
-func newVaultStore(readDB, writeDB *sql.DB, tables common4.VaultTables) *VaultStore {
+// buildVaultStore is the internal constructor.
+func buildVaultStore(readDB, writeDB *sql.DB, tables common4.VaultTables) *VaultStore {
 	return &VaultStore{
 		VaultStore: common4.NewVaultStore(writeDB, readDB, tables, &postgres2.ErrorMapper{}, postgres2.NewSanitizer(), postgres2.IsolationLevels),
 		tables:     tables,

--- a/platform/fabric/services/db/driver/sql/sqlite/endorsetx.go
+++ b/platform/fabric/services/db/driver/sql/sqlite/endorsetx.go
@@ -20,9 +20,9 @@ type EndorseTxStore struct {
 }
 
 func NewEndorseTxStore(dbs *common3.RWDB, tables common.TableNames) (*EndorseTxStore, error) {
-	return newEndorseTxStore(dbs.ReadDB, sqlite2.NewRetryWriteDB(dbs.WriteDB), tables.EndorseTx), nil
+	return buildEndorseTxStore(dbs.ReadDB, sqlite2.NewRetryWriteDB(dbs.WriteDB), tables.EndorseTx), nil
 }
 
-func newEndorseTxStore(readDB *sql.DB, writeDB common4.WriteDB, table string) *EndorseTxStore {
+func buildEndorseTxStore(readDB *sql.DB, writeDB common4.WriteDB, table string) *EndorseTxStore {
 	return &EndorseTxStore{EndorseTxStore: common.NewEndorseTxStore(writeDB, readDB, table, &sqlite2.ErrorMapper{})}
 }

--- a/platform/fabric/services/db/driver/sql/sqlite/envelope.go
+++ b/platform/fabric/services/db/driver/sql/sqlite/envelope.go
@@ -20,9 +20,9 @@ type EnvelopeStore struct {
 }
 
 func NewEnvelopeStore(dbs *common3.RWDB, tables common.TableNames) (*EnvelopeStore, error) {
-	return newEnvelopeStore(dbs.ReadDB, sqlite2.NewRetryWriteDB(dbs.WriteDB), tables.Envelope), nil
+	return buildEnvelopeStore(dbs.ReadDB, sqlite2.NewRetryWriteDB(dbs.WriteDB), tables.Envelope), nil
 }
 
-func newEnvelopeStore(readDB *sql.DB, writeDB common2.WriteDB, table string) *EnvelopeStore {
+func buildEnvelopeStore(readDB *sql.DB, writeDB common2.WriteDB, table string) *EnvelopeStore {
 	return &EnvelopeStore{EnvelopeStore: common.NewEnvelopeStore(writeDB, readDB, table, &sqlite2.ErrorMapper{})}
 }

--- a/platform/fabric/services/db/driver/sql/sqlite/metadata.go
+++ b/platform/fabric/services/db/driver/sql/sqlite/metadata.go
@@ -20,9 +20,9 @@ type MetadataStore struct {
 }
 
 func NewMetadataStore(dbs *common3.RWDB, tables common.TableNames) (*MetadataStore, error) {
-	return newMetadataStore(dbs.ReadDB, sqlite2.NewRetryWriteDB(dbs.WriteDB), tables.Metadata), nil
+	return buildMetadataStore(dbs.ReadDB, sqlite2.NewRetryWriteDB(dbs.WriteDB), tables.Metadata), nil
 }
 
-func newMetadataStore(readDB *sql.DB, writeDB common2.WriteDB, table string) *MetadataStore {
+func buildMetadataStore(readDB *sql.DB, writeDB common2.WriteDB, table string) *MetadataStore {
 	return &MetadataStore{MetadataStore: common.NewMetadataStore(writeDB, readDB, table, &sqlite2.ErrorMapper{})}
 }

--- a/platform/fabric/services/db/driver/sql/sqlite/vault.go
+++ b/platform/fabric/services/db/driver/sql/sqlite/vault.go
@@ -28,13 +28,13 @@ type VaultStore struct {
 }
 
 func NewVaultStore(dbs *common3.RWDB, tables common.TableNames) (*VaultStore, error) {
-	return newVaultStore(dbs.ReadDB, sqlite2.NewRetryWriteDB(dbs.WriteDB), common.VaultTables{
+	return buildVaultStore(dbs.ReadDB, sqlite2.NewRetryWriteDB(dbs.WriteDB), common.VaultTables{
 		StateTable:  tables.State,
 		StatusTable: tables.Status,
 	}), nil
 }
 
-func newVaultStore(readDB *sql.DB, writeDB common5.WriteDB, tables common.VaultTables) *VaultStore {
+func buildVaultStore(readDB *sql.DB, writeDB common5.WriteDB, tables common.VaultTables) *VaultStore {
 	return &VaultStore{
 		VaultStore: common.NewVaultStore(writeDB, readDB, tables, &sqlite2.ErrorMapper{}, sqlite2.NewSanitizer(), sqlite2.IsolationLevels),
 		tables:     tables,

--- a/platform/fabric/services/endorser/builder.go
+++ b/platform/fabric/services/endorser/builder.go
@@ -55,7 +55,7 @@ func (t *Builder) NewTransaction(ctx context.Context, opts ...fabric.Transaction
 }
 
 func (t *Builder) NewTransactionFromBytes(bytes []byte) (*Transaction, error) {
-	tx, err := t.newTransaction(context.Background(), nil, "", "", nil, bytes, false)
+	tx, err := t.buildTransaction(context.Background(), nil, "", "", nil, bytes, false)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func (t *Builder) NewTransactionFromBytes(bytes []byte) (*Transaction, error) {
 }
 
 func (t *Builder) NewTransactionFromEnvelopeBytes(ctx context.Context, bytes []byte) (*Transaction, error) {
-	tx, err := t.newTransaction(ctx, nil, "", "", nil, bytes, true)
+	tx, err := t.buildTransaction(ctx, nil, "", "", nil, bytes, true)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (t *Builder) NewTransactionFromEnvelopeBytes(ctx context.Context, bytes []b
 func (t *Builder) NewTransactionWithIdentity(id view.Identity) (*Transaction, error) {
 	logger.Debugf("NewTransactionWithIdentity with identity %s\n", id.UniqueID())
 
-	tx, err := t.newTransaction(context.Background(), id, "", "", nil, nil, false)
+	tx, err := t.buildTransaction(context.Background(), id, "", "", nil, nil, false)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (t *Builder) NewTransactionWithIdentity(id view.Identity) (*Transaction, er
 	return tx, nil
 }
 
-func (t *Builder) newTransaction(ctx context.Context, creator []byte, network, channel string, nonce, raw []byte, envelope bool) (*Transaction, error) {
+func (t *Builder) buildTransaction(ctx context.Context, creator []byte, network, channel string, nonce, raw []byte, envelope bool) (*Transaction, error) {
 	return t.newTransactionWithType(ctx, creator, network, channel, nonce, raw, envelope, nil, nil)
 }
 
@@ -153,7 +153,7 @@ func NewTransactionFromBytes(viewCtx view.Context, bytes []byte) (*Builder, *Tra
 
 func NewTransactionWithSigner(viewCtx view.Context, network, channel string, id view.Identity) (*Builder, *Transaction, error) {
 	txBuilder := NewBuilderWithServiceProvider(viewCtx)
-	tx, err := txBuilder.newTransaction(viewCtx.Context(), id, network, channel, nil, nil, false)
+	tx, err := txBuilder.buildTransaction(viewCtx.Context(), id, network, channel, nil, nil, false)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -163,7 +163,7 @@ func NewTransactionWithSigner(viewCtx view.Context, network, channel string, id 
 
 func NewTransactionWith(ctx context.Context, sp services.Provider, network, channel string, id view.Identity) (*Builder, *Transaction, error) {
 	txBuilder := NewBuilderWithServiceProvider(sp)
-	tx, err := txBuilder.newTransaction(ctx, id, network, channel, nil, nil, false)
+	tx, err := txBuilder.buildTransaction(ctx, id, network, channel, nil, nil, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/platform/fabric/services/endorser/endorsement_test.go
+++ b/platform/fabric/services/endorser/endorsement_test.go
@@ -853,4 +853,4 @@ func TestVerifierProviderWrapper(t *testing.T) {
 
 type fakeView struct{}
 
-func (v *fakeView) Call(context view.Context) (any, error) { return nil, nil }
+func (*fakeView) Call(_ view.Context) (any, error) { return nil, nil }

--- a/platform/fabric/services/endorser/finality.go
+++ b/platform/fabric/services/endorser/finality.go
@@ -57,7 +57,7 @@ func NewFinalityWithTimeoutView(tx *Transaction, timeout time.Duration) *finalit
 
 type FinalityViewFactory struct{}
 
-func (p *FinalityViewFactory) NewView(in []byte) (view.View, error) {
+func (*FinalityViewFactory) NewView(in []byte) (view.View, error) {
 	f := &finalityView{Finality: &Finality{}}
 	if err := json.Unmarshal(in, f.Finality); err != nil {
 		return nil, errors.Wrapf(err, "failed unmarshalling input")

--- a/platform/fabric/services/endorser/transaction.go
+++ b/platform/fabric/services/endorser/transaction.go
@@ -48,7 +48,7 @@ func (t *Transaction) SetProposal(chaincode, version, function string, params ..
 	t.Transaction.SetProposal(chaincode, version, function, params...)
 }
 
-func (t *Transaction) Chaincode() (string, string) {
+func (t *Transaction) Chaincode() (name, version string) {
 	return t.Transaction.Chaincode(), t.Transaction.ChaincodeVersion()
 }
 

--- a/platform/fabric/services/rwset/composite.go
+++ b/platform/fabric/services/rwset/composite.go
@@ -36,13 +36,13 @@ func CreateCompositeKey(objectType string, attributes []string) (string, error) 
 	return ck.String(), nil
 }
 
-func CreateRangeKeysForPartialCompositeKey(objectType string, attributes []string) (string, string, error) {
+func CreateRangeKeysForPartialCompositeKey(objectType string, attributes []string) (startKey, endKey string, err error) {
 	partialCompositeKey, err := CreateCompositeKey(objectType, attributes)
 	if err != nil {
 		return "", "", err
 	}
-	startKey := partialCompositeKey
-	endKey := partialCompositeKey + fmt.Sprint(maxUnicodeRuneValue)
+	startKey = partialCompositeKey
+	endKey = partialCompositeKey + fmt.Sprint(maxUnicodeRuneValue)
 
 	return startKey, endKey, nil
 }

--- a/platform/fabric/services/state/cc/query/main.go
+++ b/platform/fabric/services/state/cc/query/main.go
@@ -20,13 +20,13 @@ const (
 
 type CC struct{}
 
-func (cc *CC) Init(stub shim.ChaincodeStubInterface) *pb.Response {
+func (*CC) Init(_ shim.ChaincodeStubInterface) *pb.Response {
 	fmt.Println("Init...")
 
 	return shim.Success(nil)
 }
 
-func (cc *CC) Invoke(stub shim.ChaincodeStubInterface) *pb.Response {
+func (*CC) Invoke(stub shim.ChaincodeStubInterface) *pb.Response {
 	fn, _ := stub.GetFunctionAndParameters()
 
 	fmt.Printf("Invoke function [%s]...\n", fn)

--- a/platform/fabric/services/state/certification.go
+++ b/platform/fabric/services/state/certification.go
@@ -32,7 +32,7 @@ type TxTransientStore interface {
 	GetTransient(key string) []byte
 }
 
-func SetCertificationType(tx TxTransientStore, typ string, value []byte) error {
+func SetCertificationType(tx TxTransientStore, typ string, _ []byte) error {
 	switch typ {
 	case ChaincodeCertification:
 		if err := tx.SetTransient(CertificationType, []byte(ChaincodeCertification)); err != nil {
@@ -130,7 +130,7 @@ func (n *Namespace) certifyInput(id string) error {
 // by invoking the generic state query chaincode and verifying peer endorsements.
 type ChaincodeCertifier struct{}
 
-func (c *ChaincodeCertifier) VerifyInputCertificationAt(n *Namespace, index int, key string) error {
+func (*ChaincodeCertifier) VerifyInputCertificationAt(n *Namespace, index int, key string) error {
 	typ, _, err := GetCertificationType(n.tx)
 	if err != nil {
 		return errors.Wrapf(err, "failed getting certification type")
@@ -201,7 +201,7 @@ func (c *ChaincodeCertifier) VerifyInputCertificationAt(n *Namespace, index int,
 	}
 }
 
-func (c *ChaincodeCertifier) CertifyInput(n *Namespace, id string) error {
+func (*ChaincodeCertifier) CertifyInput(n *Namespace, id string) error {
 	typ, _, err := GetCertificationType(n.tx)
 	if err != nil {
 		return errors.Wrapf(err, "failed getting certification type")
@@ -245,11 +245,11 @@ func (c *ChaincodeCertifier) CertifyInput(n *Namespace, id string) error {
 // cert. Verification re-reads the committed value and branches on the hiding mode.
 type TrustedReadCertifier struct{}
 
-func (c *TrustedReadCertifier) CertifyInput(n *Namespace, id string) error {
+func (*TrustedReadCertifier) CertifyInput(_ *Namespace, _ string) error {
 	return nil
 }
 
-func (c *TrustedReadCertifier) VerifyInputCertificationAt(n *Namespace, index int, key string) error {
+func (*TrustedReadCertifier) VerifyInputCertificationAt(n *Namespace, index int, key string) error {
 	rwSet, err := n.tx.RWSet()
 	if err != nil {
 		return errors.Wrap(err, "failed getting rw set")
@@ -310,7 +310,7 @@ func (c *CertificationView) Call(viewCtx view.Context) (any, error) {
 
 type CertificationViewFactory struct{}
 
-func (c *CertificationViewFactory) NewView(in []byte) (view.View, error) {
+func (*CertificationViewFactory) NewView(in []byte) (view.View, error) {
 	f := &CertificationView{CertificationRequest: &CertificationRequest{}}
 	err := json.Unmarshal(in, f.CertificationRequest)
 	if err != nil {

--- a/platform/fabric/services/state/certification_test.go
+++ b/platform/fabric/services/state/certification_test.go
@@ -58,8 +58,8 @@ func TestResolveCertifierDefaultsToChaincode(t *testing.T) {
 
 type stubCertifier struct{}
 
-func (s *stubCertifier) CertifyInput(*Namespace, string) error                    { return nil }
-func (s *stubCertifier) VerifyInputCertificationAt(*Namespace, int, string) error { return nil }
+func (*stubCertifier) CertifyInput(*Namespace, string) error                    { return nil }
+func (*stubCertifier) VerifyInputCertificationAt(*Namespace, int, string) error { return nil }
 
 func TestResolveCertifierUsesRegistered(t *testing.T) {
 	t.Parallel()
@@ -297,7 +297,7 @@ func TestNamespaceVerifyInputCertificationAtBranches(t *testing.T) {
 		tx, rwset, driverTx := newTestStateTransaction("assetns")
 		driverTx.transient[CertificationType] = []byte(ChaincodeCertification)
 		tx.Provider = &mockServiceProvider{
-			getFn: func(v any) (any, error) {
+			getFn: func(_ any) (any, error) {
 				return nil, errors.New("service missing")
 			},
 		}
@@ -315,7 +315,7 @@ func TestNamespaceVerifyInputCertificationAtBranches(t *testing.T) {
 		tx, rwset, driverTx := newTestStateTransaction("assetns")
 		driverTx.transient[CertificationType] = []byte(ChaincodeCertification)
 		tx.Provider = &mockServiceProvider{
-			getFn: func(v any) (any, error) {
+			getFn: func(_ any) (any, error) {
 				return nil, errors.New("service missing")
 			},
 		}
@@ -355,7 +355,7 @@ func TestNamespaceCertifyInputBranches(t *testing.T) {
 		tx, _, driverTx := newTestStateTransaction("assetns")
 		driverTx.transient[CertificationType] = []byte(ChaincodeCertification)
 		tx.Provider = &mockServiceProvider{
-			getFn: func(v any) (any, error) {
+			getFn: func(_ any) (any, error) {
 				return nil, errors.New("service missing")
 			},
 		}
@@ -373,7 +373,7 @@ type testCertificationVault struct {
 	keyCalled cdriver.PKey
 }
 
-func (t *testCertificationVault) GetState(context.Context, cdriver.Namespace, cdriver.PKey, any) error {
+func (*testCertificationVault) GetState(context.Context, cdriver.Namespace, cdriver.PKey, any) error {
 	return nil
 }
 

--- a/platform/fabric/services/state/common_test.go
+++ b/platform/fabric/services/state/common_test.go
@@ -52,11 +52,11 @@ func newTestRWSet() *testRWSet {
 	}
 }
 
-func (t *testRWSet) IsValid() error {
+func (*testRWSet) IsValid() error {
 	return nil
 }
 
-func (t *testRWSet) IsClosed() bool {
+func (*testRWSet) IsClosed() bool {
 	return false
 }
 
@@ -184,17 +184,17 @@ func (t *testRWSet) Namespaces() []cdriver.Namespace {
 	return namespaces
 }
 
-func (t *testRWSet) AppendRWSet(_ []byte, _ ...cdriver.Namespace) error {
+func (*testRWSet) AppendRWSet(_ []byte, _ ...cdriver.Namespace) error {
 	return nil
 }
 
-func (t *testRWSet) Bytes() ([]byte, error) {
+func (*testRWSet) Bytes() ([]byte, error) {
 	return []byte("rwset"), nil
 }
 
-func (t *testRWSet) Done() {}
+func (*testRWSet) Done() {}
 
-func (t *testRWSet) Equals(_ any, _ ...cdriver.Namespace) error {
+func (*testRWSet) Equals(_ any, _ ...cdriver.Namespace) error {
 	return nil
 }
 
@@ -232,51 +232,51 @@ func newTestDriverTransaction(rwset fdriver.RWSet) *testDriverTransaction {
 	}
 }
 
-func (t *testDriverTransaction) Creator() view.Identity                  { return view.Identity("creator") }
-func (t *testDriverTransaction) Nonce() []byte                           { return []byte("nonce") }
-func (t *testDriverTransaction) ID() string                              { return t.id }
-func (t *testDriverTransaction) Network() string                         { return t.network }
-func (t *testDriverTransaction) Channel() string                         { return t.channel }
-func (t *testDriverTransaction) Function() string                        { return t.function }
-func (t *testDriverTransaction) Parameters() [][]byte                    { return cloneRawSlices(t.params) }
-func (t *testDriverTransaction) Chaincode() string                       { return t.chaincode }
-func (t *testDriverTransaction) ChaincodeVersion() string                { return t.chaincodeVersion }
-func (t *testDriverTransaction) Results() ([]byte, error)                { return nil, nil }
-func (t *testDriverTransaction) From(fdriver.Transaction) error          { return nil }
-func (t *testDriverTransaction) SetFromBytes([]byte) error               { return nil }
-func (t *testDriverTransaction) SetFromEnvelopeBytes([]byte) error       { return nil }
-func (t *testDriverTransaction) Proposal() fdriver.Proposal              { return nil }
-func (t *testDriverTransaction) SignedProposal() fdriver.SignedProposal  { return nil }
-func (t *testDriverTransaction) ResetTransient()                         { t.transient = fdriver.TransientMap{} }
-func (t *testDriverTransaction) SetRWSet() error                         { return nil }
-func (t *testDriverTransaction) RWS() fdriver.RWSet                      { return t.rwset }
-func (t *testDriverTransaction) Done() error                             { return nil }
-func (t *testDriverTransaction) Close()                                  {}
-func (t *testDriverTransaction) Raw() ([]byte, error)                    { return []byte("raw"), nil }
-func (t *testDriverTransaction) Endorse() error                          { return nil }
-func (t *testDriverTransaction) EndorseWithIdentity(view.Identity) error { return nil }
-func (t *testDriverTransaction) EndorseWithSigner(view.Identity, fdriver.Signer) error {
+func (*testDriverTransaction) Creator() view.Identity                  { return view.Identity("creator") }
+func (*testDriverTransaction) Nonce() []byte                           { return []byte("nonce") }
+func (t *testDriverTransaction) ID() string                            { return t.id }
+func (t *testDriverTransaction) Network() string                       { return t.network }
+func (t *testDriverTransaction) Channel() string                       { return t.channel }
+func (t *testDriverTransaction) Function() string                      { return t.function }
+func (t *testDriverTransaction) Parameters() [][]byte                  { return cloneRawSlices(t.params) }
+func (t *testDriverTransaction) Chaincode() string                     { return t.chaincode }
+func (t *testDriverTransaction) ChaincodeVersion() string              { return t.chaincodeVersion }
+func (*testDriverTransaction) Results() ([]byte, error)                { return nil, nil }
+func (*testDriverTransaction) From(fdriver.Transaction) error          { return nil }
+func (*testDriverTransaction) SetFromBytes([]byte) error               { return nil }
+func (*testDriverTransaction) SetFromEnvelopeBytes([]byte) error       { return nil }
+func (*testDriverTransaction) Proposal() fdriver.Proposal              { return nil }
+func (*testDriverTransaction) SignedProposal() fdriver.SignedProposal  { return nil }
+func (t *testDriverTransaction) ResetTransient()                       { t.transient = fdriver.TransientMap{} }
+func (*testDriverTransaction) SetRWSet() error                         { return nil }
+func (t *testDriverTransaction) RWS() fdriver.RWSet                    { return t.rwset }
+func (*testDriverTransaction) Done() error                             { return nil }
+func (*testDriverTransaction) Close()                                  {}
+func (*testDriverTransaction) Raw() ([]byte, error)                    { return []byte("raw"), nil }
+func (*testDriverTransaction) Endorse() error                          { return nil }
+func (*testDriverTransaction) EndorseWithIdentity(view.Identity) error { return nil }
+func (*testDriverTransaction) EndorseWithSigner(view.Identity, fdriver.Signer) error {
 	return nil
 }
 
-func (t *testDriverTransaction) EndorseProposal() error { return nil }
+func (*testDriverTransaction) EndorseProposal() error { return nil }
 
-func (t *testDriverTransaction) EndorseProposalWithIdentity(view.Identity) error { return nil }
+func (*testDriverTransaction) EndorseProposalWithIdentity(view.Identity) error { return nil }
 
-func (t *testDriverTransaction) EndorseProposalResponse() error { return nil }
+func (*testDriverTransaction) EndorseProposalResponse() error { return nil }
 
-func (t *testDriverTransaction) EndorseProposalResponseWithIdentity(view.Identity) error { return nil }
+func (*testDriverTransaction) EndorseProposalResponseWithIdentity(view.Identity) error { return nil }
 
-func (t *testDriverTransaction) AppendProposalResponse(fdriver.ProposalResponse) error { return nil }
+func (*testDriverTransaction) AppendProposalResponse(fdriver.ProposalResponse) error { return nil }
 
-func (t *testDriverTransaction) ProposalHasBeenEndorsedBy(view.Identity) error { return nil }
+func (*testDriverTransaction) ProposalHasBeenEndorsedBy(view.Identity) error { return nil }
 
-func (t *testDriverTransaction) StoreTransient() error { return nil }
+func (*testDriverTransaction) StoreTransient() error { return nil }
 
-func (t *testDriverTransaction) ProposalResponses() ([]fdriver.ProposalResponse, error) {
+func (*testDriverTransaction) ProposalResponses() ([]fdriver.ProposalResponse, error) {
 	return nil, nil
 }
-func (t *testDriverTransaction) Envelope() (fdriver.Envelope, error) { return nil, nil }
+func (*testDriverTransaction) Envelope() (fdriver.Envelope, error) { return nil, nil }
 
 func (t *testDriverTransaction) FunctionAndParameters() (string, []string) {
 	res := make([]string, 0, len(t.params))
@@ -427,15 +427,15 @@ func (t *testLocalMembership) IsMe(_ context.Context, id view.Identity) bool {
 	return t.defaultIdentity.Equal(id)
 }
 
-func (t *testLocalMembership) DefaultSigningIdentity() fdriver.SigningIdentity {
+func (*testLocalMembership) DefaultSigningIdentity() fdriver.SigningIdentity {
 	return nil
 }
 
-func (t *testLocalMembership) RegisterX509MSP(string, string, string) error {
+func (*testLocalMembership) RegisterX509MSP(string, string, string) error {
 	return nil
 }
 
-func (t *testLocalMembership) RegisterIdemixMSP(string, string, string) error {
+func (*testLocalMembership) RegisterIdemixMSP(string, string, string) error {
 	return nil
 }
 
@@ -448,15 +448,15 @@ func (t *testLocalMembership) GetIdentityByID(id string) (view.Identity, error) 
 	return nil, fmt.Errorf("identity [%s] not found", id)
 }
 
-func (t *testLocalMembership) GetIdentityInfoByLabel(string, string) *fdriver.IdentityInfo {
+func (*testLocalMembership) GetIdentityInfoByLabel(string, string) *fdriver.IdentityInfo {
 	return nil
 }
 
-func (t *testLocalMembership) GetIdentityInfoByIdentity(string, view.Identity) *fdriver.IdentityInfo {
+func (*testLocalMembership) GetIdentityInfoByIdentity(string, view.Identity) *fdriver.IdentityInfo {
 	return nil
 }
 
-func (t *testLocalMembership) Refresh() error {
+func (*testLocalMembership) Refresh() error {
 	return nil
 }
 
@@ -489,15 +489,15 @@ func (t *testFabricDriverFNS) Name() string {
 	return t.name
 }
 
-func (t *testFabricDriverFNS) OrderingService() fdriver.Ordering {
+func (*testFabricDriverFNS) OrderingService() fdriver.Ordering {
 	return nil
 }
 
-func (t *testFabricDriverFNS) TransactionManager() fdriver.TransactionManager {
+func (*testFabricDriverFNS) TransactionManager() fdriver.TransactionManager {
 	return nil
 }
 
-func (t *testFabricDriverFNS) ProcessorManager() fdriver.ProcessorManager {
+func (*testFabricDriverFNS) ProcessorManager() fdriver.ProcessorManager {
 	return nil
 }
 
@@ -516,19 +516,19 @@ func (t *testFabricDriverFNS) Channel(string) (fdriver.Channel, error) {
 	return t.channel, nil
 }
 
-func (t *testFabricDriverFNS) Ledger(string) (fdriver.Ledger, error) {
+func (*testFabricDriverFNS) Ledger(string) (fdriver.Ledger, error) {
 	return nil, nil
 }
 
-func (t *testFabricDriverFNS) Committer(string) (fdriver.Committer, error) {
+func (*testFabricDriverFNS) Committer(string) (fdriver.Committer, error) {
 	return nil, nil
 }
 
-func (t *testFabricDriverFNS) SignerService() fdriver.SignerService {
+func (*testFabricDriverFNS) SignerService() fdriver.SignerService {
 	return nil
 }
 
-func (t *testFabricDriverFNS) ConfigService() fdriver.ConfigService {
+func (*testFabricDriverFNS) ConfigService() fdriver.ConfigService {
 	return nil
 }
 
@@ -537,11 +537,11 @@ type testFabricDriverFNSProvider struct {
 	err error
 }
 
-func (t *testFabricDriverFNSProvider) Names() []string {
+func (*testFabricDriverFNSProvider) Names() []string {
 	return []string{""}
 }
 
-func (t *testFabricDriverFNSProvider) DefaultName() string {
+func (*testFabricDriverFNSProvider) DefaultName() string {
 	return ""
 }
 

--- a/platform/fabric/services/state/composite.go
+++ b/platform/fabric/services/state/composite.go
@@ -35,13 +35,13 @@ func CreateCompositeKey(objectType string, attributes []string) (string, error) 
 	return ck.String(), nil
 }
 
-func CreateRangeKeysForPartialCompositeKey(objectType string, attributes []string) (string, string, error) {
+func CreateRangeKeysForPartialCompositeKey(objectType string, attributes []string) (startKey, endKey string, err error) {
 	partialCompositeKey, err := CreateCompositeKey(objectType, attributes)
 	if err != nil {
 		return "", "", err
 	}
-	startKey := partialCompositeKey
-	endKey := partialCompositeKey + string(MaxUnicodeRuneValue)
+	startKey = partialCompositeKey
+	endKey = partialCompositeKey + string(MaxUnicodeRuneValue)
 
 	return startKey, endKey, nil
 }

--- a/platform/fabric/services/state/contract.go
+++ b/platform/fabric/services/state/contract.go
@@ -13,7 +13,7 @@ import (
 
 type contractMetaHandler struct{}
 
-func (s2 *contractMetaHandler) StoreMeta(ns *Namespace, s any, namespace, key string, options *addOutputOptions) error {
+func (*contractMetaHandler) StoreMeta(ns *Namespace, _ any, namespace, key string, options *addOutputOptions) error {
 	if len(options.contract) == 0 {
 		return nil
 	}

--- a/platform/fabric/services/state/flow.go
+++ b/platform/fabric/services/state/flow.go
@@ -54,7 +54,7 @@ func NewPayloadReceiveView() *payloadReceiveView {
 	return &payloadReceiveView{}
 }
 
-func (s payloadReceiveView) Call(viewCtx view.Context) (any, error) {
+func (payloadReceiveView) Call(viewCtx view.Context) (any, error) {
 	// Wait to receive a state
 	ch := viewCtx.Session().Receive()
 

--- a/platform/fabric/services/state/flow_test.go
+++ b/platform/fabric/services/state/flow_test.go
@@ -28,7 +28,7 @@ type mockSession struct {
 	sent    [][]byte
 }
 
-func (m *mockSession) Info() view.SessionInfo { return view.SessionInfo{} }
+func (*mockSession) Info() view.SessionInfo { return view.SessionInfo{} }
 
 func (m *mockSession) Send(_ context.Context, payload []byte) error {
 	if m.sendErr != nil {
@@ -44,7 +44,7 @@ func (m *mockSession) SendError(ctx context.Context, payload []byte) error {
 
 func (m *mockSession) Receive() <-chan *view.Message { return m.recv }
 
-func (m *mockSession) Close() {}
+func (*mockSession) Close() {}
 
 type mockViewContext struct {
 	session      view.Session
@@ -54,15 +54,15 @@ type mockViewContext struct {
 	isMeFn       func(id view.Identity) bool
 }
 
-func (m *mockViewContext) ID() string        { return "ctx" }
-func (m *mockViewContext) Me() view.Identity { return view.Identity("me") }
+func (*mockViewContext) ID() string        { return "ctx" }
+func (*mockViewContext) Me() view.Identity { return view.Identity("me") }
 func (m *mockViewContext) IsMe(id view.Identity) bool {
 	if m.isMeFn != nil {
 		return m.isMeFn(id)
 	}
 	return false
 }
-func (m *mockViewContext) Initiator() view.View { return nil }
+func (*mockViewContext) Initiator() view.View { return nil }
 func (m *mockViewContext) GetSession(caller view.View, party view.Identity, boundToViews ...view.View) (view.Session, error) {
 	if m.getSessionFn != nil {
 		return m.getSessionFn(caller, party, boundToViews...)
@@ -70,18 +70,18 @@ func (m *mockViewContext) GetSession(caller view.View, party view.Identity, boun
 	return nil, nil
 }
 
-func (m *mockViewContext) GetSessionByID(string, view.Identity) (view.Session, error) {
+func (*mockViewContext) GetSessionByID(string, view.Identity) (view.Session, error) {
 	return nil, nil
 }
-func (m *mockViewContext) Session() view.Session    { return m.session }
-func (m *mockViewContext) Context() context.Context { return context.Background() }
+func (m *mockViewContext) Session() view.Session  { return m.session }
+func (*mockViewContext) Context() context.Context { return context.Background() }
 func (m *mockViewContext) RunView(v view.View, opts ...view.RunViewOption) (any, error) {
 	if m.runViewFn != nil {
 		return m.runViewFn(v, opts...)
 	}
 	return nil, nil
 }
-func (m *mockViewContext) OnError(func()) {}
+func (*mockViewContext) OnError(func()) {}
 func (m *mockViewContext) GetService(v any) (any, error) {
 	if m.getServiceFn != nil {
 		return m.getServiceFn(v)
@@ -89,7 +89,7 @@ func (m *mockViewContext) GetService(v any) (any, error) {
 	return nil, nil
 }
 
-func (m *mockViewContext) StartSpanFrom(ctx context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
+func (*mockViewContext) StartSpanFrom(ctx context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
 	return ctx, trace.SpanFromContext(ctx)
 }
 
@@ -101,7 +101,7 @@ type mockCodec struct {
 	unmarshalFn   func(raw []byte, v any) error
 }
 
-func (m *mockCodec) Marshal(v any) ([]byte, error) {
+func (m *mockCodec) Marshal(_ any) ([]byte, error) {
 	if m.marshalErr != nil {
 		return nil, m.marshalErr
 	}
@@ -121,7 +121,7 @@ type mockMarshaller struct {
 	err error
 }
 
-func (m *mockMarshaller) Marshal(v any) ([]byte, error) {
+func (m *mockMarshaller) Marshal(_ any) ([]byte, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -130,7 +130,7 @@ func (m *mockMarshaller) Marshal(v any) ([]byte, error) {
 
 type mockVaultService struct{}
 
-func (m *mockVaultService) Vault(string, string) (Vault, error) {
+func (*mockVaultService) Vault(string, string) (Vault, error) {
 	return nil, nil
 }
 
@@ -148,7 +148,7 @@ func TestGetVaultService(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 		p := &mockServiceProvider{
-			getFn: func(v any) (any, error) {
+			getFn: func(_ any) (any, error) {
 				return &mockVaultService{}, nil
 			},
 		}
@@ -161,7 +161,7 @@ func TestGetVaultService(t *testing.T) {
 		t.Parallel()
 		expected := errors.New("get service failed")
 		p := &mockServiceProvider{
-			getFn: func(v any) (any, error) {
+			getFn: func(_ any) (any, error) {
 				return nil, expected
 			},
 		}
@@ -450,7 +450,7 @@ func TestRunViewWrappers(t *testing.T) {
 	t.Run("RequestRecipientIdentity wrapper", func(t *testing.T) {
 		t.Parallel()
 		ctx := &mockViewContext{
-			runViewFn: func(v view.View, opts ...view.RunViewOption) (any, error) {
+			runViewFn: func(_ view.View, _ ...view.RunViewOption) (any, error) {
 				return view.Identity("recipient"), nil
 			},
 		}
@@ -462,7 +462,7 @@ func TestRunViewWrappers(t *testing.T) {
 	t.Run("ReceiveTransaction wrapper error", func(t *testing.T) {
 		t.Parallel()
 		ctx := &mockViewContext{
-			runViewFn: func(v view.View, opts ...view.RunViewOption) (any, error) {
+			runViewFn: func(_ view.View, _ ...view.RunViewOption) (any, error) {
 				return nil, errors.New("run failed")
 			},
 		}
@@ -474,7 +474,7 @@ func TestRunViewWrappers(t *testing.T) {
 		t.Parallel()
 		expected := &Transaction{}
 		ctx := &mockViewContext{
-			runViewFn: func(v view.View, opts ...view.RunViewOption) (any, error) {
+			runViewFn: func(_ view.View, _ ...view.RunViewOption) (any, error) {
 				return expected, nil
 			},
 		}
@@ -487,7 +487,7 @@ func TestRunViewWrappers(t *testing.T) {
 		t.Parallel()
 		expected := &Transaction{}
 		ctx := &mockViewContext{
-			runViewFn: func(v view.View, opts ...view.RunViewOption) (any, error) {
+			runViewFn: func(_ view.View, _ ...view.RunViewOption) (any, error) {
 				return expected, nil
 			},
 		}
@@ -499,7 +499,7 @@ func TestRunViewWrappers(t *testing.T) {
 	t.Run("SendAndReceiveTransaction wrapper error on send", func(t *testing.T) {
 		t.Parallel()
 		ctx := &mockViewContext{
-			runViewFn: func(v view.View, opts ...view.RunViewOption) (any, error) {
+			runViewFn: func(_ view.View, _ ...view.RunViewOption) (any, error) {
 				return nil, errors.New("send failed")
 			},
 		}
@@ -512,7 +512,7 @@ func TestRunViewWrappers(t *testing.T) {
 		expected := &Transaction{}
 		callCount := 0
 		ctx := &mockViewContext{
-			runViewFn: func(v view.View, opts ...view.RunViewOption) (any, error) {
+			runViewFn: func(_ view.View, _ ...view.RunViewOption) (any, error) {
 				callCount++
 				if callCount == 1 {
 					return nil, nil
@@ -529,7 +529,7 @@ func TestRunViewWrappers(t *testing.T) {
 	t.Run("SendBackAndReceiveTransaction wrapper error on send", func(t *testing.T) {
 		t.Parallel()
 		ctx := &mockViewContext{
-			runViewFn: func(v view.View, opts ...view.RunViewOption) (any, error) {
+			runViewFn: func(_ view.View, _ ...view.RunViewOption) (any, error) {
 				return nil, errors.New("send back failed")
 			},
 		}
@@ -542,7 +542,7 @@ func TestRunViewWrappers(t *testing.T) {
 		expected := &Transaction{}
 		callCount := 0
 		ctx := &mockViewContext{
-			runViewFn: func(v view.View, opts ...view.RunViewOption) (any, error) {
+			runViewFn: func(_ view.View, _ ...view.RunViewOption) (any, error) {
 				callCount++
 				if callCount == 1 {
 					return nil, nil
@@ -574,7 +574,7 @@ func TestTransactionConstructorsErrorAndWrap(t *testing.T) {
 	t.Run("new transaction error paths", func(t *testing.T) {
 		t.Parallel()
 		ctx := &mockViewContext{
-			getServiceFn: func(v any) (any, error) {
+			getServiceFn: func(_ any) (any, error) {
 				return nil, errors.New("service missing")
 			},
 		}
@@ -787,7 +787,7 @@ func TestRecipientViewsAndWrappers(t *testing.T) {
 	t.Run("recipient wrappers", func(t *testing.T) {
 		t.Parallel()
 		ctx := &mockViewContext{
-			runViewFn: func(v view.View, opts ...view.RunViewOption) (any, error) {
+			runViewFn: func(v view.View, _ ...view.RunViewOption) (any, error) {
 				switch v.(type) {
 				case *RespondRequestRecipientIdentityView:
 					return view.Identity("me"), nil
@@ -953,7 +953,7 @@ type mockProcessTransactionForRWSetProcessor struct {
 	id      string
 }
 
-func (m *mockProcessTransactionForRWSetProcessor) Network() string { return "net" }
+func (*mockProcessTransactionForRWSetProcessor) Network() string { return "net" }
 func (m *mockProcessTransactionForRWSetProcessor) Channel() string {
 	if m.channel == "" {
 		return "ch"
@@ -968,13 +968,13 @@ func (m *mockProcessTransactionForRWSetProcessor) ID() string {
 	return m.id
 }
 
-func (m *mockProcessTransactionForRWSetProcessor) FunctionAndParameters() (string, []string) {
+func (*mockProcessTransactionForRWSetProcessor) FunctionAndParameters() (string, []string) {
 	return "fn", nil
 }
 
 type mockRequestForRWSetProcessor struct{}
 
-func (m *mockRequestForRWSetProcessor) ID() string { return "req-id" }
+func (*mockRequestForRWSetProcessor) ID() string { return "req-id" }
 
 func TestRWSetProcessorProcessChannelError(t *testing.T) {
 	t.Parallel()
@@ -995,7 +995,7 @@ func (m *mockDriverMetadataService) Exists(context.Context, string) bool {
 	return m.exists
 }
 
-func (m *mockDriverMetadataService) StoreTransient(context.Context, string, fdriver.TransientMap) error {
+func (*mockDriverMetadataService) StoreTransient(context.Context, string, fdriver.TransientMap) error {
 	return nil
 }
 
@@ -1006,11 +1006,11 @@ func (m *mockDriverMetadataService) LoadTransient(context.Context, string) (fdri
 	return m.transientMap, nil
 }
 
-func (m *mockDriverMetadataService) PutFieldMapping(context.Context, string, string, []byte, fdriver.TransientMap) error {
+func (*mockDriverMetadataService) PutFieldMapping(context.Context, string, string, []byte, fdriver.TransientMap) error {
 	return nil
 }
 
-func (m *mockDriverMetadataService) GetFieldMapping(context.Context, string, string, []byte) (fdriver.TransientMap, error) {
+func (*mockDriverMetadataService) GetFieldMapping(context.Context, string, string, []byte) (fdriver.TransientMap, error) {
 	return nil, nil
 }
 
@@ -1026,18 +1026,18 @@ func (m *mockDriverChannel) Name() string {
 	return m.name
 }
 
-func (m *mockDriverChannel) Committer() fdriver.Committer                           { return nil }
-func (m *mockDriverChannel) Vault() fdriver.Vault                                   { return nil }
-func (m *mockDriverChannel) Delivery() fdriver.Delivery                             { return nil }
-func (m *mockDriverChannel) Ledger() fdriver.Ledger                                 { return nil }
-func (m *mockDriverChannel) Finality() fdriver.Finality                             { return nil }
-func (m *mockDriverChannel) ChannelMembership() fdriver.ChannelMembership           { return nil }
-func (m *mockDriverChannel) ChaincodeManager() fdriver.ChaincodeManager             { return nil }
-func (m *mockDriverChannel) RWSetLoader() fdriver.RWSetLoader                       { return nil }
-func (m *mockDriverChannel) EnvelopeService() fdriver.EnvelopeService               { return nil }
-func (m *mockDriverChannel) TransactionService() fdriver.EndorserTransactionService { return nil }
-func (m *mockDriverChannel) MetadataService() fdriver.MetadataService               { return m.metadata }
-func (m *mockDriverChannel) Close() error                                           { return nil }
+func (*mockDriverChannel) Committer() fdriver.Committer                           { return nil }
+func (*mockDriverChannel) Vault() fdriver.Vault                                   { return nil }
+func (*mockDriverChannel) Delivery() fdriver.Delivery                             { return nil }
+func (*mockDriverChannel) Ledger() fdriver.Ledger                                 { return nil }
+func (*mockDriverChannel) Finality() fdriver.Finality                             { return nil }
+func (*mockDriverChannel) ChannelMembership() fdriver.ChannelMembership           { return nil }
+func (*mockDriverChannel) ChaincodeManager() fdriver.ChaincodeManager             { return nil }
+func (*mockDriverChannel) RWSetLoader() fdriver.RWSetLoader                       { return nil }
+func (*mockDriverChannel) EnvelopeService() fdriver.EnvelopeService               { return nil }
+func (*mockDriverChannel) TransactionService() fdriver.EndorserTransactionService { return nil }
+func (m *mockDriverChannel) MetadataService() fdriver.MetadataService             { return m.metadata }
+func (*mockDriverChannel) Close() error                                           { return nil }
 
 func TestRWSetProcessorProcessKnownTransaction(t *testing.T) {
 	t.Parallel()

--- a/platform/fabric/services/state/json.go
+++ b/platform/fabric/services/state/json.go
@@ -12,7 +12,7 @@ import (
 
 type JSONCodec struct{}
 
-func (j *JSONCodec) Marshal(v any) ([]byte, error) {
+func (*JSONCodec) Marshal(v any) ([]byte, error) {
 	s, ok := v.(Serializable)
 	if ok {
 		return s.Bytes()
@@ -20,7 +20,7 @@ func (j *JSONCodec) Marshal(v any) ([]byte, error) {
 	return json.Marshal(v)
 }
 
-func (j *JSONCodec) Unmarshal(data []byte, v any) error {
+func (*JSONCodec) Unmarshal(data []byte, v any) error {
 	s, ok := v.(State)
 	if ok {
 		return s.SetFromBytes(data)

--- a/platform/fabric/services/state/namespace.go
+++ b/platform/fabric/services/state/namespace.go
@@ -34,6 +34,7 @@ type Command struct {
 	// Name of the commands
 	Name string
 	// Ids contains the identities that the command involves
+	//nolint:revive // var-naming: renaming this exported struct field is an API break; see follow-up
 	Ids Identities
 }
 

--- a/platform/fabric/services/state/namespace_test.go
+++ b/platform/fabric/services/state/namespace_test.go
@@ -346,7 +346,7 @@ func TestNamespaceGetService(t *testing.T) {
 	tx, _, _ := newTestStateTransaction("assetns")
 	expected := &mockVaultService{}
 	tx.Provider = &mockServiceProvider{
-		getFn: func(v any) (any, error) {
+		getFn: func(_ any) (any, error) {
 			return expected, nil
 		},
 	}
@@ -406,7 +406,7 @@ func TestHelperErrorPathsAndStreamMethods(t *testing.T) {
 		t.Parallel()
 		expected := errors.New("service missing")
 		p := &mockServiceProvider{
-			getFn: func(v any) (any, error) {
+			getFn: func(_ any) (any, error) {
 				return nil, expected
 			},
 		}

--- a/platform/fabric/services/state/recipients.go
+++ b/platform/fabric/services/state/recipients.go
@@ -202,7 +202,7 @@ type ExchangeRecipientIdentitiesView struct {
 
 // ExchangeRecipientIdentities runs the ExchangeRecipientIdentitiesView against the passed receiver.
 // The function returns, the recipient identity of the sender, the recipient identity of the receiver.
-func ExchangeRecipientIdentities(viewCtx view.Context, recipient view.Identity, opts ...ServiceOption) (view.Identity, view.Identity, error) {
+func ExchangeRecipientIdentities(viewCtx view.Context, recipient view.Identity, opts ...ServiceOption) (sender, receiver view.Identity, err error) {
 	opt, err := CompileServiceOptions(opts...)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to compile service options")
@@ -292,7 +292,7 @@ type RespondExchangeRecipientIdentitiesView struct {
 }
 
 // RespondExchangeRecipientIdentities runs the RespondExchangeRecipientIdentitiesView
-func RespondExchangeRecipientIdentities(viewCtx view.Context, opts ...ServiceOption) (view.Identity, view.Identity, error) {
+func RespondExchangeRecipientIdentities(viewCtx view.Context, opts ...ServiceOption) (sender, receiver view.Identity, err error) {
 	opt, err := CompileServiceOptions(opts...)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to compile service options")

--- a/platform/fabric/services/state/rwsetextractor.go
+++ b/platform/fabric/services/state/rwsetextractor.go
@@ -26,7 +26,7 @@ func NewRWSetProcessor(network Network) *RWSetProcessor {
 	return &RWSetProcessor{network: network}
 }
 
-func (r *RWSetProcessor) Process(req fabric.Request, tx fabric.ProcessTransaction, rws *fabric.RWSet, ns string) error {
+func (r *RWSetProcessor) Process(_ fabric.Request, tx fabric.ProcessTransaction, rws *fabric.RWSet, ns string) error {
 	txID := tx.ID()
 
 	ch, err := r.network.Channel(tx.Channel())
@@ -66,11 +66,10 @@ func (r *RWSetProcessor) Process(req fabric.Request, tx fabric.ProcessTransactio
 		if err != nil {
 			panic("filed creating mapping key")
 		}
-		if len(transientMap[k]) != 0 {
-			meta[k] = transientMap[k]
-		} else {
+		if len(transientMap[k]) == 0 {
 			continue
 		}
+		meta[k] = transientMap[k]
 
 		logger.Debugf("Set metadata for key [%s][%v]", key, string(meta[k]))
 		err = rws.SetStateMetadata(ns, key, meta)

--- a/platform/fabric/services/state/script/api/transaction.go
+++ b/platform/fabric/services/state/script/api/transaction.go
@@ -30,7 +30,7 @@ type Output struct {
 	Death     Script // Death script descriptor
 }
 
-func (o1 *Output) Equals(o2 *Output) bool {
+func (*Output) Equals(_ *Output) bool {
 	panic("implement me")
 }
 

--- a/platform/fabric/services/state/script/ownable/validation.go
+++ b/platform/fabric/services/state/script/ownable/validation.go
@@ -13,7 +13,7 @@ import (
 
 type InputStateValidator struct{}
 
-func (s InputStateValidator) Validate(tx api.Transaction, index uint32) error {
+func (InputStateValidator) Validate(tx api.Transaction, index uint32) error {
 	ownableState := &State{}
 
 	_, scripts, err := tx.GetInputAt(int(index), ownableState)
@@ -39,7 +39,7 @@ func (s InputStateValidator) Validate(tx api.Transaction, index uint32) error {
 
 type OutputStateValidator struct{}
 
-func (s OutputStateValidator) Validate(tx api.Transaction, index uint32) error {
+func (OutputStateValidator) Validate(tx api.Transaction, index uint32) error {
 	ownableState := &State{}
 
 	scripts, err := tx.GetOutputAt(int(index), ownableState)

--- a/platform/fabric/services/state/script/statevalidation.go
+++ b/platform/fabric/services/state/script/statevalidation.go
@@ -16,7 +16,7 @@ type MultiplexStateValidator struct {
 	OutputStateValidators map[string]api.StateValidator
 }
 
-func (m MultiplexStateValidator) Validate(tx api.Transaction, index uint32) error {
+func (m MultiplexStateValidator) Validate(tx api.Transaction, _ uint32) error {
 	for index := range tx.Inputs() {
 		scripts, err := tx.GetInputScriptsAt(index)
 		if err != nil {

--- a/platform/fabric/services/state/tags.go
+++ b/platform/fabric/services/state/tags.go
@@ -98,7 +98,7 @@ func (n *Namespace) getFieldMapping(namespace, key string, flag bool) (map[strin
 	return mapping, nil
 }
 
-func (n *Namespace) marshalTags(set *fabric.RWSet, source any) (any, map[string][]byte, error) {
+func (*Namespace) marshalTags(_ *fabric.RWSet, source any) (any, map[string][]byte, error) {
 	// dest: source -> dest
 	t := reflect.TypeOf(source).Elem()
 	dest := reflect.New(t).Interface()
@@ -152,7 +152,7 @@ func (n *Namespace) marshalTags(set *fabric.RWSet, source any) (any, map[string]
 	return dest, mapping, nil
 }
 
-func (n *Namespace) unmarshalTags(set *fabric.RWSet, source any, mapping map[string][]byte) error {
+func (*Namespace) unmarshalTags(_ *fabric.RWSet, source any, mapping map[string][]byte) error {
 	t := reflect.TypeOf(source).Elem()
 	v := reflect.ValueOf(source).Elem()
 	for i := 0; i < t.NumField(); i++ {

--- a/platform/fabric/services/storage/vault/cache.go
+++ b/platform/fabric/services/storage/vault/cache.go
@@ -49,7 +49,7 @@ func NewCachedVault(backed driver2.VaultStore, cacheSize int) CachedVaultStore {
 	}
 }
 
-func (s *notCachedStore) Invalidate(...driver.TxID) {}
+func (*notCachedStore) Invalidate(...driver.TxID) {}
 
 type cachedStore struct {
 	driver.VaultStore

--- a/platform/fabric/services/storage/vault/cache_test.go
+++ b/platform/fabric/services/storage/vault/cache_test.go
@@ -70,42 +70,42 @@ func (m *mockVaultStore) SetStatuses(_ context.Context, code driver.TxStatusCode
 }
 
 // Stub implementations to satisfy driver.VaultStore (embeds VaultReader).
-func (m *mockVaultStore) GetStateMetadata(_ context.Context, _ driver.Namespace, _ driver.PKey) (driver.Metadata, driver.RawVersion, error) {
+func (*mockVaultStore) GetStateMetadata(_ context.Context, _ driver.Namespace, _ driver.PKey) (driver.Metadata, driver.RawVersion, error) {
 	return nil, nil, nil
 }
 
-func (m *mockVaultStore) GetState(_ context.Context, _ driver.Namespace, _ driver.PKey) (*driver.VaultRead, error) {
+func (*mockVaultStore) GetState(_ context.Context, _ driver.Namespace, _ driver.PKey) (*driver.VaultRead, error) {
 	return nil, nil
 }
 
-func (m *mockVaultStore) GetStates(_ context.Context, _ driver.Namespace, _ ...driver.PKey) (driver.TxStateIterator, error) {
+func (*mockVaultStore) GetStates(_ context.Context, _ driver.Namespace, _ ...driver.PKey) (driver.TxStateIterator, error) {
 	return nil, nil
 }
 
-func (m *mockVaultStore) GetStateRange(_ context.Context, _ driver.Namespace, _, _ driver.PKey) (driver.TxStateIterator, error) {
+func (*mockVaultStore) GetStateRange(_ context.Context, _ driver.Namespace, _, _ driver.PKey) (driver.TxStateIterator, error) {
 	return nil, nil
 }
 
-func (m *mockVaultStore) GetAllStates(_ context.Context, _ driver.Namespace) (driver.TxStateIterator, error) {
+func (*mockVaultStore) GetAllStates(_ context.Context, _ driver.Namespace) (driver.TxStateIterator, error) {
 	return nil, nil
 }
-func (m *mockVaultStore) GetLast(_ context.Context) (*driver.TxStatus, error) { return nil, nil }
-func (m *mockVaultStore) GetTxStatuses(_ context.Context, _ ...driver.TxID) (driver.TxStatusIterator, error) {
-	return nil, nil
-}
-
-func (m *mockVaultStore) GetAllTxStatuses(_ context.Context, _ driver.Pagination) (*driver.PageIterator[*driver.TxStatus], error) {
+func (*mockVaultStore) GetLast(_ context.Context) (*driver.TxStatus, error) { return nil, nil }
+func (*mockVaultStore) GetTxStatuses(_ context.Context, _ ...driver.TxID) (driver.TxStatusIterator, error) {
 	return nil, nil
 }
 
-func (m *mockVaultStore) NewTxLockVaultReader(_ context.Context, _ driver.TxID, _ driver.IsolationLevel) (driver.LockedVaultReader, error) {
+func (*mockVaultStore) GetAllTxStatuses(_ context.Context, _ driver.Pagination) (*driver.PageIterator[*driver.TxStatus], error) {
 	return nil, nil
 }
 
-func (m *mockVaultStore) NewGlobalLockVaultReader(_ context.Context) (driver.LockedVaultReader, error) {
+func (*mockVaultStore) NewTxLockVaultReader(_ context.Context, _ driver.TxID, _ driver.IsolationLevel) (driver.LockedVaultReader, error) {
 	return nil, nil
 }
-func (m *mockVaultStore) Close() error { return nil }
+
+func (*mockVaultStore) NewGlobalLockVaultReader(_ context.Context) (driver.LockedVaultReader, error) {
+	return nil, nil
+}
+func (*mockVaultStore) Close() error { return nil }
 
 // --- notCachedStore tests ---
 

--- a/platform/fabric/services/storage/vault/vaultstore_test.go
+++ b/platform/fabric/services/storage/vault/vaultstore_test.go
@@ -160,8 +160,8 @@ func NewOffsetPagination(offset, pageSize int) driver.Pagination {
 	return offsetPagination
 }
 
-func NewKeysetPagination(offset, pageSize int, sqlIdName dbdriver.FieldName, idFieldName pagination.PropertyName[string]) driver.Pagination {
-	keysetPagination, err := pagination.KeysetWithField[string](offset, pageSize, sqlIdName, idFieldName)
+func NewKeysetPagination(offset, pageSize int, sqlIDName dbdriver.FieldName, idFieldName pagination.PropertyName[string]) driver.Pagination {
+	keysetPagination, err := pagination.KeysetWithField[string](offset, pageSize, sqlIDName, idFieldName)
 	if err != nil {
 		Expect(err).ToNot(HaveOccurred())
 	}

--- a/platform/fabric/sig_test.go
+++ b/platform/fabric/sig_test.go
@@ -31,25 +31,25 @@ func (m *fakeSignerService) GetSigner(id view.Identity) (driver.Signer, error) {
 	return m.LastSigner, m.LastError
 }
 
-func (m *fakeSignerService) AreMe(ctx context.Context, identities ...view.Identity) []string {
+func (*fakeSignerService) AreMe(_ context.Context, _ ...view.Identity) []string {
 	return nil
 }
 
-func (m *fakeSignerService) IsMe(ctx context.Context, id view.Identity) bool {
+func (*fakeSignerService) IsMe(_ context.Context, _ view.Identity) bool {
 	return false
 }
 
-func (m *fakeSignerService) GetSigningIdentity(id view.Identity) (driver2.SigningIdentity, error) {
+func (*fakeSignerService) GetSigningIdentity(_ view.Identity) (driver2.SigningIdentity, error) {
 	return nil, nil
 }
 
-func (m *fakeSignerService) GetVerifier(id view.Identity) (driver2.Verifier, error) {
+func (*fakeSignerService) GetVerifier(_ view.Identity) (driver2.Verifier, error) {
 	return nil, nil
 }
 
 type dummySigner struct{}
 
-func (d *dummySigner) Sign(message []byte) ([]byte, error) {
+func (*dummySigner) Sign(_ []byte) ([]byte, error) {
 	return nil, nil
 }
 

--- a/platform/fabric/transaction_test.go
+++ b/platform/fabric/transaction_test.go
@@ -286,27 +286,27 @@ type mockTxManager struct {
 	mtx *mock.Transaction
 }
 
-func (m *mockTxManager) NewTransaction(ctx context.Context, txType driver.TransactionType, creator view.Identity, nonce []byte, txID, channel string, rawRequest []byte) (driver.Transaction, error) {
+func (m *mockTxManager) NewTransaction(_ context.Context, _ driver.TransactionType, _ view.Identity, _ []byte, _, _ string, _ []byte) (driver.Transaction, error) {
 	return m.mtx, nil
 }
 
-func (m *mockTxManager) NewTransactionFromBytes(ctx context.Context, channel string, raw []byte) (driver.Transaction, error) {
+func (m *mockTxManager) NewTransactionFromBytes(_ context.Context, _ string, _ []byte) (driver.Transaction, error) {
 	return m.mtx, nil
 }
 
-func (m *mockTxManager) NewTransactionFromEnvelopeBytes(ctx context.Context, channel string, raw []byte) (driver.Transaction, error) {
+func (m *mockTxManager) NewTransactionFromEnvelopeBytes(_ context.Context, _ string, _ []byte) (driver.Transaction, error) {
 	return m.mtx, nil
 }
 
-func (m *mockTxManager) NewEnvelope() driver.Envelope {
+func (*mockTxManager) NewEnvelope() driver.Envelope {
 	return &mock.Envelope{}
 }
 
-func (m *mockTxManager) NewProposalResponseFromBytes(raw []byte) (driver.ProposalResponse, error) {
+func (*mockTxManager) NewProposalResponseFromBytes(_ []byte) (driver.ProposalResponse, error) {
 	return &mock.ProposalResponse{}, nil
 }
 
-func (m *mockTxManager) ComputeTxID(id *driver.TxIDComponents) string {
+func (*mockTxManager) ComputeTxID(id *driver.TxIDComponents) string {
 	id.Nonce = []byte("nonce")
 	id.Creator = []byte("creator")
 	return "computed_txid"

--- a/platform/fabric/vault.go
+++ b/platform/fabric/vault.go
@@ -82,11 +82,11 @@ func (r *RWSet) KeyExist(key, ns string) (bool, error) {
 }
 
 func (r *RWSet) Equals(rws any, nss ...string) error {
-	if rw, ok := rws.(*RWSet); !ok {
+	rw, ok := rws.(*RWSet)
+	if !ok {
 		return errors.Errorf("expected instance of *RWSet, got [%t]", rws)
-	} else {
-		return r.RWSet.Equals(rw.RWSet, nss...)
 	}
+	return r.RWSet.Equals(rw.RWSet, nss...)
 }
 
 // Vault models a key-value store that can be updated by committing rwsets

--- a/platform/fabric/vault_test.go
+++ b/platform/fabric/vault_test.go
@@ -93,12 +93,12 @@ type mockEnvSvc struct {
 	count int
 }
 
-func (m *mockEnvSvc) StoreEnvelope(ctx context.Context, id string, env any) error {
+func (m *mockEnvSvc) StoreEnvelope(_ context.Context, _ string, _ any) error {
 	m.count++
 	return nil
 }
 
-func (m *mockEnvSvc) Exists(ctx context.Context, id string) bool {
+func (*mockEnvSvc) Exists(_ context.Context, _ string) bool {
 	return true
 }
 
@@ -107,7 +107,7 @@ type mockTxSvc struct {
 	count int
 }
 
-func (m *mockTxSvc) StoreTransaction(ctx context.Context, id string, raw []byte) error {
+func (m *mockTxSvc) StoreTransaction(_ context.Context, _ string, _ []byte) error {
 	m.count++
 	return nil
 }
@@ -118,16 +118,16 @@ type mockMetaSvc struct {
 	existsReturns bool
 }
 
-func (m *mockMetaSvc) StoreTransient(ctx context.Context, id string, tm fdriver.TransientMap) error {
+func (m *mockMetaSvc) StoreTransient(_ context.Context, _ string, _ fdriver.TransientMap) error {
 	m.count++
 	return nil
 }
 
-func (m *mockMetaSvc) Exists(ctx context.Context, txid string) bool {
+func (m *mockMetaSvc) Exists(_ context.Context, _ string) bool {
 	return m.existsReturns
 }
 
-func (m *mockMetaSvc) LoadTransient(ctx context.Context, txid string) (fdriver.TransientMap, error) {
+func (*mockMetaSvc) LoadTransient(_ context.Context, _ string) (fdriver.TransientMap, error) {
 	return nil, nil
 }
 

--- a/platform/fabricx/core/channel/provider.go
+++ b/platform/fabricx/core/channel/provider.go
@@ -73,7 +73,7 @@ func NewProvider(
 	}
 }
 
-func (p *provider) NewChannel(nw fdriver.FabricNetworkService, channelName string, quiet bool) (fdriver.Channel, error) {
+func (p *provider) NewChannel(nw fdriver.FabricNetworkService, channelName string, _ bool) (fdriver.Channel, error) {
 	vault, err := p.newVault(channelName, nw.ConfigService(), nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed creating vault for channel [%s]", channelName)

--- a/platform/fabricx/core/channel/wrappers.go
+++ b/platform/fabricx/core/channel/wrappers.go
@@ -72,7 +72,7 @@ func (f *finalityServiceAdapter) IsFinal(ctx context.Context, txID string) error
 
 	// Create a listener that will be called when the transaction reaches finality
 	listener := &finalityListener{
-		onStatusFunc: func(ctx context.Context, txID string, status int, statusMessage string) {
+		onStatusFunc: func(_ context.Context, txID string, status int, statusMessage string) {
 			var err error
 			switch status {
 			case fdriver.Valid:
@@ -132,11 +132,11 @@ func (l *finalityListener) OnStatus(ctx context.Context, txID string, status int
 
 type fakeVault struct{}
 
-func (f *fakeVault) GetLastTxID(ctx context.Context) (string, error) {
+func (*fakeVault) GetLastTxID(_ context.Context) (string, error) {
 	return "", nil
 }
 
-func (f *fakeVault) GetLastBlock(context.Context) (uint64, error) {
+func (*fakeVault) GetLastBlock(context.Context) (uint64, error) {
 	return 0, nil
 }
 
@@ -210,27 +210,27 @@ func (n *committerService) IsFinal(ctx context.Context, txID string) error {
 	return nil
 }
 
-func (n *committerService) ReloadConfigTransactions() error {
+func (*committerService) ReloadConfigTransactions() error {
 	return nil
 }
 
-func (n *committerService) Commit(_ context.Context, block *common.Block) error {
+func (*committerService) Commit(_ context.Context, _ *common.Block) error {
 	return nil
 }
 
-func (n *committerService) Start(_ context.Context) error {
+func (*committerService) Start(_ context.Context) error {
 	return nil
 }
 
-func (n *committerService) ProcessNamespace(nss ...cdriver.Namespace) error {
+func (*committerService) ProcessNamespace(_ ...cdriver.Namespace) error {
 	return nil
 }
 
-func (n *committerService) AddTransactionFilter(tf fdriver.TransactionFilter) error {
+func (*committerService) AddTransactionFilter(_ fdriver.TransactionFilter) error {
 	return nil
 }
 
-func (n *committerService) Status(_ context.Context, txID cdriver.TxID) (fdriver.ValidationCode, string, error) {
+func (*committerService) Status(_ context.Context, _ cdriver.TxID) (fdriver.ValidationCode, string, error) {
 	return 0, "", nil
 }
 
@@ -252,11 +252,11 @@ func (n *committerService) RemoveFinalityListener(txID string, listener fdriver.
 	return nil
 }
 
-func (n *committerService) DiscardTx(_ context.Context, txID cdriver.TxID, message string) error {
+func (*committerService) DiscardTx(_ context.Context, _ cdriver.TxID, _ string) error {
 	return nil
 }
 
-func (n *committerService) CommitTX(_ context.Context, txID cdriver.TxID, block cdriver.BlockNum, indexInBlock cdriver.TxNum, envelope *common.Envelope) error {
+func (*committerService) CommitTX(_ context.Context, _ cdriver.TxID, _ cdriver.BlockNum, _ cdriver.TxNum, _ *common.Envelope) error {
 	return nil
 }
 
@@ -264,6 +264,6 @@ type noopDeliveryService struct {
 	generic.DeliveryService
 }
 
-func (n *noopDeliveryService) Start(_ context.Context) error {
+func (*noopDeliveryService) Start(_ context.Context) error {
 	return nil
 }

--- a/platform/fabricx/core/committer/config/config_test.go
+++ b/platform/fabricx/core/committer/config/config_test.go
@@ -68,7 +68,7 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 	t.Run("explicit zero listenerTTL overrides default to disable expiry", func(t *testing.T) {
 		t.Parallel()
 		fakeConfigService := &mock.ServiceBackend{}
-		fakeConfigService.UnmarshalKeyStub = func(key string, rawVal any) error {
+		fakeConfigService.UnmarshalKeyStub = func(_ string, rawVal any) error {
 			if cfg, ok := rawVal.(**config.Config); ok {
 				(*cfg).ListenerTTL = 0
 			}
@@ -83,7 +83,7 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 	t.Run("explicit zero handler and interval settings fall back to defaults", func(t *testing.T) {
 		t.Parallel()
 		fakeConfigService := &mock.ServiceBackend{}
-		fakeConfigService.UnmarshalKeyStub = func(key string, rawVal any) error {
+		fakeConfigService.UnmarshalKeyStub = func(_ string, rawVal any) error {
 			if cfg, ok := rawVal.(**config.Config); ok {
 				(*cfg).HandlerTimeout = 0
 				(*cfg).HandlerWorkers = 0
@@ -106,7 +106,7 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 	t.Run("negative handlerWorkers falls back to default", func(t *testing.T) {
 		t.Parallel()
 		fakeConfigService := &mock.ServiceBackend{}
-		fakeConfigService.UnmarshalKeyStub = func(key string, rawVal any) error {
+		fakeConfigService.UnmarshalKeyStub = func(_ string, rawVal any) error {
 			if cfg, ok := rawVal.(**config.Config); ok {
 				(*cfg).HandlerWorkers = -1
 			}
@@ -121,7 +121,7 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 	t.Run("negative handlerQueueSize falls back to default", func(t *testing.T) {
 		t.Parallel()
 		fakeConfigService := &mock.ServiceBackend{}
-		fakeConfigService.UnmarshalKeyStub = func(key string, rawVal any) error {
+		fakeConfigService.UnmarshalKeyStub = func(_ string, rawVal any) error {
 			if cfg, ok := rawVal.(**config.Config); ok {
 				(*cfg).HandlerQueueSize = -1
 			}
@@ -138,7 +138,7 @@ func TestNewNotificationServiceConfig(t *testing.T) {
 	t.Run("configured finality durations are preserved", func(t *testing.T) {
 		t.Parallel()
 		fakeConfigService := &mock.ServiceBackend{}
-		fakeConfigService.UnmarshalKeyStub = func(key string, rawVal any) error {
+		fakeConfigService.UnmarshalKeyStub = func(_ string, rawVal any) error {
 			if cfg, ok := rawVal.(**config.Config); ok {
 				(*cfg).HandlerTimeout = 7 * time.Second
 				(*cfg).HandlerWorkers = 4

--- a/platform/fabricx/core/committer/grpc/grpc.go
+++ b/platform/fabricx/core/committer/grpc/grpc.go
@@ -66,7 +66,7 @@ func (c *ClientProvider) QueryServiceClient(network string) (*grpc.ClientConn, e
 // getOrCreate returns the cached *grpc.ClientConn for the given network, or
 // dials a new one via loadCfg and caches it. Under a benign race two callers
 // may both dial; the loser closes its connection and returns the winner's.
-func (c *ClientProvider) getOrCreate(
+func (*ClientProvider) getOrCreate(
 	cache *sync.Map,
 	network string,
 	loadCfg func(string) (*config.Config, error),

--- a/platform/fabricx/core/committer/grpc/grpc_test.go
+++ b/platform/fabricx/core/committer/grpc/grpc_test.go
@@ -42,7 +42,7 @@ func TestClientProvider_NotificationServiceClient(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 		fakeConfigProvider := &mock.ServiceConfigProvider{}
-		fakeConfigProvider.NotificationServiceConfigStub = func(network string) (*config.Config, error) {
+		fakeConfigProvider.NotificationServiceConfigStub = func(_ string) (*config.Config, error) {
 			return &config.Config{
 				Endpoints: []config.Endpoint{{Address: "localhost:1234"}},
 			}, nil
@@ -82,7 +82,7 @@ func TestClientProvider_NotificationServiceClient(t *testing.T) {
 	t.Run("client conn error (multiple endpoints)", func(t *testing.T) {
 		t.Parallel()
 		fakeConfigProvider := &mock.ServiceConfigProvider{}
-		fakeConfigProvider.NotificationServiceConfigStub = func(network string) (*config.Config, error) {
+		fakeConfigProvider.NotificationServiceConfigStub = func(_ string) (*config.Config, error) {
 			return &config.Config{
 				Endpoints: []config.Endpoint{{Address: "localhost:1234"}, {Address: "localhost:5678"}},
 			}, nil
@@ -98,7 +98,7 @@ func TestClientProvider_NotificationServiceClient(t *testing.T) {
 	t.Run("caches per network", func(t *testing.T) {
 		t.Parallel()
 		fakeConfigProvider := &mock.ServiceConfigProvider{}
-		fakeConfigProvider.NotificationServiceConfigStub = func(network string) (*config.Config, error) {
+		fakeConfigProvider.NotificationServiceConfigStub = func(_ string) (*config.Config, error) {
 			return &config.Config{
 				Endpoints: []config.Endpoint{{Address: "localhost:1234"}},
 			}, nil
@@ -124,7 +124,7 @@ func TestClientProvider_QueryServiceClient(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 		fakeConfigProvider := &mock.ServiceConfigProvider{}
-		fakeConfigProvider.QueryServiceConfigStub = func(network string) (*config.Config, error) {
+		fakeConfigProvider.QueryServiceConfigStub = func(_ string) (*config.Config, error) {
 			return &config.Config{
 				Endpoints: []config.Endpoint{{Address: "localhost:5678"}},
 			}, nil
@@ -152,7 +152,7 @@ func TestClientProvider_QueryServiceClient(t *testing.T) {
 	t.Run("client conn error (multiple endpoints)", func(t *testing.T) {
 		t.Parallel()
 		fakeConfigProvider := &mock.ServiceConfigProvider{}
-		fakeConfigProvider.QueryServiceConfigStub = func(network string) (*config.Config, error) {
+		fakeConfigProvider.QueryServiceConfigStub = func(_ string) (*config.Config, error) {
 			return &config.Config{
 				Endpoints: []config.Endpoint{{Address: "localhost:5678"}, {Address: "localhost:9999"}},
 			}, nil
@@ -168,7 +168,7 @@ func TestClientProvider_QueryServiceClient(t *testing.T) {
 	t.Run("caches per network", func(t *testing.T) {
 		t.Parallel()
 		fakeConfigProvider := &mock.ServiceConfigProvider{}
-		fakeConfigProvider.QueryServiceConfigStub = func(network string) (*config.Config, error) {
+		fakeConfigProvider.QueryServiceConfigStub = func(_ string) (*config.Config, error) {
 			return &config.Config{
 				Endpoints: []config.Endpoint{{Address: "localhost:5678"}},
 			}, nil
@@ -191,12 +191,12 @@ func TestClientProvider_QueryServiceClient(t *testing.T) {
 	t.Run("notification and query caches are independent", func(t *testing.T) {
 		t.Parallel()
 		fakeConfigProvider := &mock.ServiceConfigProvider{}
-		fakeConfigProvider.NotificationServiceConfigStub = func(network string) (*config.Config, error) {
+		fakeConfigProvider.NotificationServiceConfigStub = func(_ string) (*config.Config, error) {
 			return &config.Config{
 				Endpoints: []config.Endpoint{{Address: "localhost:1111"}},
 			}, nil
 		}
-		fakeConfigProvider.QueryServiceConfigStub = func(network string) (*config.Config, error) {
+		fakeConfigProvider.QueryServiceConfigStub = func(_ string) (*config.Config, error) {
 			return &config.Config{
 				Endpoints: []config.Endpoint{{Address: "localhost:2222"}},
 			}, nil

--- a/platform/fabricx/core/committer/txhandler.go
+++ b/platform/fabricx/core/committer/txhandler.go
@@ -63,27 +63,24 @@ func (h *handler) HandleFabricxTransaction(ctx context.Context, blkMetadata *cb.
 	}
 	logger.Debugf("handle transaction [txID=%s] [status=%s]", tx.TxID, statusCode.String())
 
-	switch statusCode {
-	case committerpb.Status_COMMITTED:
+	if statusCode == committerpb.Status_COMMITTED {
 		processed, err := h.committer.CommitEndorserTransaction(ctx, event.TxID, tx.BlkNum, tx.TxNum, tx.Envelope, event)
-		if err != nil {
-			if errors.HasCause(err, committer.ErrDiscardTX) {
-				// in this case, we will discard the transaction
-				event.ValidationCode = driver.Invalid
-				event.ValidationMessage = err.Error()
-
-				// escaping the switch and discard
-				break
+		if err == nil {
+			if !processed {
+				logger.Debugf("TODO: Should we try to get chaincode events?")
+				// if err := h.committer.GetChaincodeEvents(tx.Envelope, tx.BlkNum); err != nil {
+				//	return nil, fmt.Errorf("failed to publish chaincode events [%s]: %w", event.TxID, err)
+				//}
 			}
+			return event, nil
+		}
+		if !errors.HasCause(err, committer.ErrDiscardTX) {
 			return nil, errors.Wrapf(err, "committing endorser transaction [txID=%s]", event.TxID)
 		}
-		if !processed {
-			logger.Debugf("TODO: Should we try to get chaincode events?")
-			// if err := h.committer.GetChaincodeEvents(tx.Envelope, tx.BlkNum); err != nil {
-			//	return nil, fmt.Errorf("failed to publish chaincode events [%s]: %w", event.TxID, err)
-			//}
-		}
-		return event, nil
+		// in this case, we will discard the transaction
+		event.ValidationCode = driver.Invalid
+		event.ValidationMessage = err.Error()
+		// escaping and discard
 	}
 
 	logger.Warnf("discarding transaction [txID=%s] [reason=%v]", tx.TxID, statusCode.String())

--- a/platform/fabricx/core/finality/nlm_test.go
+++ b/platform/fabricx/core/finality/nlm_test.go
@@ -49,7 +49,7 @@ type mockListener struct {
 	lock    sync.RWMutex
 }
 
-func (m *mockListener) OnStatus(ctx context.Context, txID string, status int, errMsg string) {
+func (m *mockListener) OnStatus(_ context.Context, txID string, status int, _ string) {
 	m.lock.Lock()
 	m.txID = txID
 	m.status = status
@@ -125,7 +125,7 @@ func setupTest(tb testing.TB) (*notificationListenerManager, *mock.Notifier_Open
 	fakeClient := &mock.NotifierClient{}
 
 	// Configure the client to return our fake stream
-	fakeClient.OpenNotificationStreamStub = func(c context.Context, opts ...grpc.CallOption) (committerpb.Notifier_OpenNotificationStreamClient, error) {
+	fakeClient.OpenNotificationStreamStub = func(c context.Context, _ ...grpc.CallOption) (committerpb.Notifier_OpenNotificationStreamClient, error) {
 		fakeStream.ContextReturns(c)
 		return fakeStream, nil
 	}

--- a/platform/fabricx/core/finality/provider_test.go
+++ b/platform/fabricx/core/finality/provider_test.go
@@ -86,7 +86,7 @@ func setupMockNotificationManager(t *testing.T, streamBehavior func(context.Cont
 	fakeClient := &mock2.NotifierClient{}
 
 	// Configure the client to return our fake stream
-	fakeClient.OpenNotificationStreamStub = func(c context.Context, opts ...grpc.CallOption) (committerpb.Notifier_OpenNotificationStreamClient, error) {
+	fakeClient.OpenNotificationStreamStub = func(c context.Context, _ ...grpc.CallOption) (committerpb.Notifier_OpenNotificationStreamClient, error) {
 		fakeStream.ContextReturns(c)
 
 		// Apply custom stream behavior if provided
@@ -233,7 +233,7 @@ func TestProvider_NewManager(t *testing.T) {
 		listenStarted := make(chan struct{})
 
 		// Mock with stream that blocks until context is done
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(_ string, _ GRPCClientProvider, _ config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					close(listenStarted)
@@ -273,7 +273,7 @@ func TestProvider_NewManager(t *testing.T) {
 		provider := NewListenerManagerProvider(mockGRPC, nil)
 
 		// Mock with stream that blocks
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(_ string, _ GRPCClientProvider, _ config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					<-ctx.Done()
@@ -305,7 +305,7 @@ func TestProvider_NewManager(t *testing.T) {
 		mockGRPC := &mockGRPCClientProvider{}
 		provider := NewListenerManagerProvider(mockGRPC, nil)
 
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(_ string, _ GRPCClientProvider, _ config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					<-ctx.Done()
@@ -342,8 +342,8 @@ func TestProvider_NewManager(t *testing.T) {
 		listenStarted := make(chan struct{})
 
 		// Mock stream that returns error immediately
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
-			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
+		provider.newNotificationManager = func(_ string, _ GRPCClientProvider, _ config.Config) (*notificationListenerManager, error) {
+			return setupMockNotificationManager(t, func(_ context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					close(listenStarted)
 					return nil, errors.New("stream error")
@@ -377,7 +377,7 @@ func TestProvider_NewManager(t *testing.T) {
 		listenStarted := make(chan struct{})
 
 		// Mock stream that blocks until context canceled
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(_ string, _ GRPCClientProvider, _ config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					close(listenStarted)
@@ -416,7 +416,7 @@ func TestProvider_NewManager(t *testing.T) {
 		expectedErr := errors.New("failed to create manager")
 
 		// Mock that returns error
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(_ string, _ GRPCClientProvider, _ config.Config) (*notificationListenerManager, error) {
 			return nil, expectedErr
 		}
 
@@ -442,7 +442,7 @@ func TestProvider_NewManager(t *testing.T) {
 		mockGRPC := &mockGRPCClientProvider{}
 		provider := NewListenerManagerProvider(mockGRPC, nil)
 
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(_ string, _ GRPCClientProvider, _ config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					<-ctx.Done()
@@ -489,7 +489,7 @@ func TestProvider_NewManager(t *testing.T) {
 		provider := NewListenerManagerProvider(mockGRPC, fakeConfigProvider)
 
 		var receivedCfg config.Config
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(_ string, _ GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
 			receivedCfg = cfg
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
@@ -517,7 +517,7 @@ func TestProvider_NewManager(t *testing.T) {
 
 		var receivedCfg config.Config
 		var called bool
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(_ string, _ GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
 			called = true
 			receivedCfg = cfg
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
@@ -545,7 +545,7 @@ func TestProvider_NewManager(t *testing.T) {
 		fakeConfigProvider.setReturns(nil, expectedErr)
 
 		provider := NewListenerManagerProvider(mockGRPC, fakeConfigProvider)
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(_ string, _ GRPCClientProvider, _ config.Config) (*notificationListenerManager, error) {
 			t.Fatal("newNotificationManager must not be called when config resolution fails")
 			return nil, nil
 		}
@@ -574,7 +574,7 @@ func TestGetListenerManager(t *testing.T) {
 
 		mockGRPC := &mockGRPCClientProvider{}
 		provider := NewListenerManagerProvider(mockGRPC, nil)
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(_ string, _ GRPCClientProvider, _ config.Config) (*notificationListenerManager, error) {
 			return setupMockNotificationManager(t, func(ctx context.Context, stream *mock2.Notifier_OpenNotificationStreamClient) {
 				stream.RecvStub = func() (*committerpb.NotificationResponse, error) {
 					<-ctx.Done()
@@ -586,7 +586,7 @@ func TestGetListenerManager(t *testing.T) {
 		ctx := t.Context()
 		provider.Initialize(ctx)
 
-		mockSP.GetServiceStub = func(serviceType any) (any, error) {
+		mockSP.GetServiceStub = func(_ any) (any, error) {
 			return provider, nil
 		}
 
@@ -607,7 +607,7 @@ func TestGetListenerManager(t *testing.T) {
 		mockSP := &mock2.ServicesProvider{}
 		expectedErr := errors.New("service not found")
 
-		mockSP.GetServiceStub = func(serviceType any) (any, error) {
+		mockSP.GetServiceStub = func(_ any) (any, error) {
 			return nil, expectedErr
 		}
 
@@ -627,14 +627,14 @@ func TestGetListenerManager(t *testing.T) {
 		provider := NewListenerManagerProvider(mockGRPC, nil)
 		expectedErr := errors.New("creation failed")
 
-		provider.newNotificationManager = func(network string, gcp GRPCClientProvider, cfg config.Config) (*notificationListenerManager, error) {
+		provider.newNotificationManager = func(_ string, _ GRPCClientProvider, _ config.Config) (*notificationListenerManager, error) {
 			return nil, expectedErr
 		}
 
 		ctx := t.Context()
 		provider.Initialize(ctx)
 
-		mockSP.GetServiceStub = func(serviceType any) (any, error) {
+		mockSP.GetServiceStub = func(_ any) (any, error) {
 			return provider, nil
 		}
 

--- a/platform/fabricx/core/ledger/provider.go
+++ b/platform/fabricx/core/ledger/provider.go
@@ -64,7 +64,7 @@ func NewProvider(grpcClientProvider GRPCClientProvider, queryServiceProvider que
 		baseCtx:              deferred.NewHolder[context.Context]("ledger provider base context"),
 	}
 	p.ledgers = lazy.NewProvider[string, driver.Ledger](func(s string) (driver.Ledger, error) {
-		return p.newLedger(s)
+		return p.buildLedger(s)
 	})
 	return p
 }
@@ -96,16 +96,16 @@ func (p *Provider) Initialize(ctx context.Context) {
 // NewLedger returns a ledger instance for the specified network.
 // The channel parameter must be empty as FabricX does not support channels.
 // It returns an error wrapping driver.ErrNotInitialized if Initialize has not
-// run yet; newLedger reports that, before it opens any connection, on the first
+// run yet; buildLedger reports that, before it opens any connection, on the first
 // call for a network. Later calls are served from the cache, which cannot hold a
 // ledger unless one was built — so unless Initialize had run.
-func (p *Provider) NewLedger(network, channel string) (driver.Ledger, error) {
+func (p *Provider) NewLedger(network, _ string) (driver.Ledger, error) {
 	return p.ledgers.Get(network)
 }
 
-// newLedger creates a new ledger instance for the specified network.
+// buildLedger creates a new ledger instance for the specified network.
 // It establishes a gRPC connection and creates the necessary client stubs.
-func (p *Provider) newLedger(network string) (driver.Ledger, error) {
+func (p *Provider) buildLedger(network string) (driver.Ledger, error) {
 	baseCtx, err := p.baseCtx.Get()
 	if err != nil {
 		return nil, err

--- a/platform/fabricx/core/membership/membership.go
+++ b/platform/fabricx/core/membership/membership.go
@@ -163,16 +163,16 @@ func capabilitiesSupported(res channelconfig.Resources) error {
 }
 
 func toMSPIdentity(identity view.Identity) (*msppb.Identity, error) {
-	sId := &m.SerializedIdentity{}
-	err := proto.Unmarshal(identity, sId)
+	sID := &m.SerializedIdentity{}
+	err := proto.Unmarshal(identity, sID)
 	if err != nil {
 		return nil, err
 	}
 
 	sid := &msppb.Identity{
-		MspId: sId.GetMspid(),
+		MspId: sID.GetMspid(),
 		Creator: &msppb.Identity_Certificate{
-			Certificate: sId.GetIdBytes(),
+			Certificate: sID.GetIdBytes(),
 		},
 	}
 

--- a/platform/fabricx/core/membership/membership_test.go
+++ b/platform/fabricx/core/membership/membership_test.go
@@ -115,9 +115,9 @@ type mockMSPIdentity struct {
 	validateErr error
 }
 
-func (m *mockMSPIdentity) Validate() error              { return m.validateErr }
-func (m *mockMSPIdentity) Verify(msg, sig []byte) error { return nil }
-func (m *mockMSPIdentity) GetMSPIdentifier() string     { return "Org1MSP" }
+func (m *mockMSPIdentity) Validate() error        { return m.validateErr }
+func (*mockMSPIdentity) Verify(_, _ []byte) error { return nil }
+func (*mockMSPIdentity) GetMSPIdentifier() string { return "Org1MSP" }
 
 type mockMSPManager struct {
 	fxmsp.MSPManager
@@ -125,7 +125,7 @@ type mockMSPManager struct {
 	deserializeErr error
 }
 
-func (m *mockMSPManager) DeserializeIdentity(identity *msppb.Identity) (fxmsp.Identity, error) {
+func (m *mockMSPManager) DeserializeIdentity(_ *msppb.Identity) (fxmsp.Identity, error) {
 	return m.identity, m.deserializeErr
 }
 
@@ -799,12 +799,12 @@ type rawSignedProposal struct {
 	sp *pb.SignedProposal
 }
 
-func (r *rawSignedProposal) ProposalBytes() []byte    { return r.sp.ProposalBytes }
-func (r *rawSignedProposal) Signature() []byte        { return r.sp.Signature }
-func (r *rawSignedProposal) ProposalHash() []byte     { return nil }
-func (r *rawSignedProposal) ChaincodeName() string    { return "" }
-func (r *rawSignedProposal) ChaincodeVersion() string { return "" }
-func (r *rawSignedProposal) Internal() any            { return r.sp }
+func (r *rawSignedProposal) ProposalBytes() []byte  { return r.sp.ProposalBytes }
+func (r *rawSignedProposal) Signature() []byte      { return r.sp.Signature }
+func (*rawSignedProposal) ProposalHash() []byte     { return nil }
+func (*rawSignedProposal) ChaincodeName() string    { return "" }
+func (*rawSignedProposal) ChaincodeVersion() string { return "" }
+func (r *rawSignedProposal) Internal() any          { return r.sp }
 
 // idemixSignerSerializer adapts an Idemix driver.Signer and pre-serialised
 // identity bytes to the identity.SignerSerializer interface expected by

--- a/platform/fabricx/core/transaction/endorsementmerge_test.go
+++ b/platform/fabricx/core/transaction/endorsementmerge_test.go
@@ -27,14 +27,14 @@ type mockProposalResponse struct {
 }
 
 func (m *mockProposalResponse) Payload() []byte           { return m.payload }
-func (m *mockProposalResponse) Results() []byte           { return nil }
-func (m *mockProposalResponse) Endorser() []byte          { return nil }
+func (*mockProposalResponse) Results() []byte             { return nil }
+func (*mockProposalResponse) Endorser() []byte            { return nil }
 func (m *mockProposalResponse) EndorserSignature() []byte { return m.endorserSignature }
-func (m *mockProposalResponse) ResponseStatus() int32     { return 200 }
-func (m *mockProposalResponse) ResponseMessage() string   { return "" }
-func (m *mockProposalResponse) Bytes() ([]byte, error)    { return nil, nil }
+func (*mockProposalResponse) ResponseStatus() int32       { return 200 }
+func (*mockProposalResponse) ResponseMessage() string     { return "" }
+func (*mockProposalResponse) Bytes() ([]byte, error)      { return nil, nil }
 
-func (m *mockProposalResponse) VerifyEndorsement(_ driver.VerifierProvider) error {
+func (*mockProposalResponse) VerifyEndorsement(_ driver.VerifierProvider) error {
 	return nil
 }
 

--- a/platform/fabricx/core/transaction/factory.go
+++ b/platform/fabricx/core/transaction/factory.go
@@ -24,7 +24,7 @@ func NewFactory(fns driver.FabricNetworkService) *Factory {
 	return &Factory{fns: fns}
 }
 
-func (e *Factory) NewTransaction(ctx context.Context, channelName string, nonce, creator []byte, txID driver2.TxID, rawRequest []byte) (driver.Transaction, error) {
+func (e *Factory) NewTransaction(ctx context.Context, channelName string, nonce, creator []byte, txID driver2.TxID, _ []byte) (driver.Transaction, error) {
 	ch, err := e.fns.Channel(channelName)
 	if err != nil {
 		return nil, err

--- a/platform/fabricx/core/transaction/manager.go
+++ b/platform/fabricx/core/transaction/manager.go
@@ -30,15 +30,15 @@ func NewManager() *Manager {
 	return &Manager{}
 }
 
-func (m *Manager) ComputeTxID(id *driver.TxIDComponents) string {
+func (*Manager) ComputeTxID(id *driver.TxIDComponents) string {
 	return transaction.ComputeTxID(id)
 }
 
-func (m *Manager) NewEnvelope() driver.Envelope {
+func (*Manager) NewEnvelope() driver.Envelope {
 	return NewEmptyEnvelope()
 }
 
-func (m *Manager) NewProposalResponseFromBytes(raw []byte) (driver.ProposalResponse, error) {
+func (*Manager) NewProposalResponseFromBytes(raw []byte) (driver.ProposalResponse, error) {
 	return NewProposalResponseFromBytes(raw)
 }
 
@@ -85,7 +85,7 @@ func (m *Manager) NewTransactionFromBytes(ctx context.Context, channel string, r
 	return tx, nil
 }
 
-func (m *Manager) NewTransactionFromEnvelopeBytes(context.Context, string, []byte) (driver.Transaction, error) {
+func (*Manager) NewTransactionFromEnvelopeBytes(context.Context, string, []byte) (driver.Transaction, error) {
 	// TODO: implement me
 	panic("NewTransactionFromEnvelopeBytes >> implement me")
 }
@@ -94,15 +94,15 @@ func (m *Manager) AddTransactionFactory(transactionType driver.TransactionType, 
 	m.transactionFactories.Store(transactionType, factory)
 }
 
-func (m *Manager) NewProcessedTransactionFromEnvelopePayload(envelopePayload []byte) (driver.ProcessedTransaction, int32, error) {
+func (*Manager) NewProcessedTransactionFromEnvelopePayload(envelopePayload []byte) (driver.ProcessedTransaction, int32, error) {
 	return NewProcessedTransactionFromEnvelopePayload(envelopePayload)
 }
 
-func (m *Manager) NewProcessedTransactionFromEnvelopeRaw(envelope []byte) (driver.ProcessedTransaction, error) {
+func (*Manager) NewProcessedTransactionFromEnvelopeRaw(envelope []byte) (driver.ProcessedTransaction, error) {
 	return NewProcessedTransactionFromEnvelopeRaw(envelope)
 }
 
-func (m *Manager) NewProcessedTransaction(pt []byte) (driver.ProcessedTransaction, error) {
+func (*Manager) NewProcessedTransaction(pt []byte) (driver.ProcessedTransaction, error) {
 	return NewProcessedTransaction(pt)
 }
 

--- a/platform/fabricx/core/transaction/transaction.go
+++ b/platform/fabricx/core/transaction/transaction.go
@@ -36,9 +36,9 @@ import (
 var logger = logging.MustGetLogger()
 
 type Transaction struct {
-	ctx   context.Context
-	fns   driver.FabricNetworkService
-	rwset driver.RWSet
+	ctx         context.Context
+	fns         driver.FabricNetworkService
+	rwSetHandle driver.RWSet
 
 	// TODO: remove channel and use fns(Channel)
 	channel driver.Channel
@@ -280,21 +280,21 @@ func (t *Transaction) SetRWSet() error {
 		if err != nil {
 			return errors.Wrap(err, "get rws from proposal response")
 		}
-		t.rwset, err = t.channel.Vault().NewRWSetFromBytes(t.ctx, t.ID(), results)
+		t.rwSetHandle, err = t.channel.Vault().NewRWSetFromBytes(t.ctx, t.ID(), results)
 		if err != nil {
 			return errors.Wrap(err, "populate rws from proposal response")
 		}
 	case len(t.RWSet) != 0:
 		logger.Debugf("populate rws from rwset")
 		var err error
-		t.rwset, err = t.channel.Vault().NewRWSetFromBytes(t.ctx, t.ID(), t.RWSet)
+		t.rwSetHandle, err = t.channel.Vault().NewRWSetFromBytes(t.ctx, t.ID(), t.RWSet)
 		if err != nil {
 			return errors.Wrap(err, "populate rws from existing rws")
 		}
 	default:
 		logger.Debugf("populate rws from scratch")
 		var err error
-		t.rwset, err = t.channel.Vault().NewRWSet(t.ctx, t.ID())
+		t.rwSetHandle, err = t.channel.Vault().NewRWSet(t.ctx, t.ID())
 		if err != nil {
 			return errors.Wrap(err, "create fresh rws")
 		}
@@ -303,23 +303,23 @@ func (t *Transaction) SetRWSet() error {
 }
 
 func (t *Transaction) RWS() driver.RWSet {
-	return t.rwset
+	return t.rwSetHandle
 }
 
 func (t *Transaction) Done() error {
-	logger.Debugf("transaction [%s] done [%v]", t.ID(), t.rwset)
-	if t.rwset != nil {
+	logger.Debugf("transaction [%s] done [%v]", t.ID(), t.rwSetHandle)
+	if t.rwSetHandle != nil {
 		// There is a simulation in progress:
 		// 1. terminate it
 		// 2. append it to the payload
 		logger.Debugf("Call rwset done ...")
-		t.rwset.Done()
+		t.rwSetHandle.Done()
 		var err error
-		t.RWSet, err = t.rwset.Bytes()
+		t.RWSet, err = t.rwSetHandle.Bytes()
 		if err != nil {
 			return errors.Wrap(err, "marshalling rws")
 		}
-		logger.Debugf("terminated simulation with [%s][len:%d]", t.rwset.Namespaces(), len(t.RWSet))
+		logger.Debugf("terminated simulation with [%s][len:%d]", t.rwSetHandle.Namespaces(), len(t.RWSet))
 	}
 
 	t.dedupRWSet()
@@ -337,10 +337,10 @@ func (t *Transaction) dedupRWSet() {
 }
 
 func (t *Transaction) Close() {
-	logger.Debugf("closing transaction [txID=%s] [rwset set=%v]", t.ID(), t.rwset != nil)
-	if t.rwset != nil {
-		t.rwset.Done()
-		t.rwset = nil
+	logger.Debugf("closing transaction [txID=%s] [rwset set=%v]", t.ID(), t.rwSetHandle != nil)
+	if t.rwSetHandle != nil {
+		t.rwSetHandle.Done()
+		t.rwSetHandle = nil
 	}
 }
 
@@ -352,9 +352,9 @@ func (t *Transaction) Close() {
 // therefore find it nil whenever the transaction already carries a proposal response —
 // read the payload instead, which is what the receiving side reconstructs from.
 func (t *Transaction) Raw() ([]byte, error) {
-	if t.rwset != nil {
+	if t.rwSetHandle != nil {
 		var err error
-		t.RWSet, err = t.rwset.Bytes()
+		t.RWSet, err = t.rwSetHandle.Bytes()
 		if err != nil {
 			return nil, errors.Wrap(err, "marshalling rws")
 		}
@@ -364,13 +364,13 @@ func (t *Transaction) Raw() ([]byte, error) {
 }
 
 func (t *Transaction) GetRWSet() (driver.RWSet, error) {
-	if t.rwset == nil {
+	if t.rwSetHandle == nil {
 		err := t.SetRWSet()
 		if err != nil {
 			return nil, err
 		}
 	}
-	return t.rwset, nil
+	return t.rwSetHandle, nil
 }
 
 func (t *Transaction) Bytes() ([]byte, error) {
@@ -441,7 +441,7 @@ func (t *Transaction) EndorseWithSigner(identity view.Identity, s driver.Signer)
 		if err != nil {
 			return errors.Wrap(err, "getting proposal response")
 		}
-		err = t.appendProposalResponse(t.proposalResponse)
+		err = t.recordProposalResponse(t.proposalResponse)
 		if err != nil {
 			return errors.Wrap(err, "failed appending proposal response")
 		}
@@ -493,7 +493,7 @@ func (t *Transaction) EndorseProposalResponseWithIdentity(identity view.Identity
 	if err != nil {
 		return errors.Wrap(err, "generate signed proposal response")
 	}
-	return t.appendProposalResponse(t.proposalResponse)
+	return t.recordProposalResponse(t.proposalResponse)
 }
 
 func (t *Transaction) AppendProposalResponse(response driver.ProposalResponse) error {
@@ -502,7 +502,7 @@ func (t *Transaction) AppendProposalResponse(response driver.ProposalResponse) e
 		return errors.Errorf("wrong proposal response type: %T", response)
 	}
 
-	return t.appendProposalResponse(resp.PR())
+	return t.recordProposalResponse(resp.PR())
 }
 
 func (t *Transaction) ProposalHasBeenEndorsedBy(party view.Identity) error {
@@ -529,7 +529,7 @@ func (t *Transaction) StoreTransient() error {
 // not persisted); a preimage stored for a tx that later aborts is harmless because the read
 // path re-queries the committed value and re-hashes, and digest-keying makes it unreachable.
 func (t *Transaction) persistFieldMappings() error {
-	if t.rwset == nil {
+	if t.rwSetHandle == nil {
 		return nil
 	}
 	for tkey, blob := range t.TTransient {
@@ -542,7 +542,7 @@ func (t *Transaction) persistFieldMappings() error {
 		if err != nil {
 			continue
 		}
-		writeVal, err := t.rwset.GetState(ns, key, cdriver.FromIntermediate)
+		writeVal, err := t.rwSetHandle.GetState(ns, key, cdriver.FromIntermediate)
 		if err != nil || len(writeVal) == 0 {
 			logger.Warnf("no write value for field-mapping [%s:%s]; skipping persist", ns, key)
 			continue
@@ -626,7 +626,7 @@ func (t *Transaction) generateProposal(signer SerializableSigner) error {
 	return nil
 }
 
-func (t *Transaction) appendProposalResponse(response *pb.ProposalResponse) error {
+func (t *Transaction) recordProposalResponse(response *pb.ProposalResponse) error {
 	for _, r := range t.TProposalResponses {
 		if bytes.Equal(r.Endorsement.Endorser, response.Endorsement.Endorser) {
 			logger.Debugf("an endorsement from [%s] found, skip it", view.Identity(r.Endorsement.Endorser))

--- a/platform/fabricx/core/transaction/transaction_test.go
+++ b/platform/fabricx/core/transaction/transaction_test.go
@@ -302,7 +302,7 @@ func TestAppendProposalResponse(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			tx := &Transaction{TProposalResponses: tc.existing}
-			err := tx.appendProposalResponse(tc.response)
+			err := tx.recordProposalResponse(tc.response)
 			require.NoError(t, err)
 			require.Len(t, tx.TProposalResponses, tc.expectedCount)
 			if tc.assert != nil {
@@ -373,10 +373,10 @@ func TestStoreTransientPersistsFieldMappings(t *testing.T) {
 	ch.MetadataServiceReturns(fakeMDS)
 
 	tx := &Transaction{
-		ctx:     t.Context(),
-		TTxID:   "tx1",
-		channel: ch,
-		rwset:   fakeRWSet,
+		ctx:         t.Context(),
+		TTxID:       "tx1",
+		channel:     ch,
+		rwSetHandle: fakeRWSet,
 		TTransient: driver.TransientMap{
 			fmKey:               blob,
 			"CertificationType": []byte("ChaincodesCertification"), // must be ignored
@@ -414,11 +414,11 @@ func TestStoreTransientNoFieldMappingsIsNoop(t *testing.T) {
 	ch.MetadataServiceReturns(fakeMDS)
 
 	tx := &Transaction{
-		ctx:        t.Context(),
-		TTxID:      "tx1",
-		channel:    ch,
-		rwset:      fakeRWSet,
-		TTransient: driver.TransientMap{"CertificationType": []byte("x")},
+		ctx:         t.Context(),
+		TTxID:       "tx1",
+		channel:     ch,
+		rwSetHandle: fakeRWSet,
+		TTransient:  driver.TransientMap{"CertificationType": []byte("x")},
 	}
 
 	require.NoError(t, tx.StoreTransient())
@@ -501,7 +501,7 @@ func TestToMSPSignerIdentityWithCertificateID(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			id, err := toMSPSignerIdentityWithCertificateID(tc.identity, func(mspID string) (bool, error) {
+			id, err := toMSPSignerIdentityWithCertificateID(tc.identity, func(_ string) (bool, error) {
 				return tc.isIdemix, nil
 			})
 			if tc.expectedError != "" {
@@ -668,8 +668,8 @@ type testSerializableSigner struct {
 	signErr error
 }
 
-func (s *testSerializableSigner) Sign(message []byte) ([]byte, error) { return s.signRes, s.signErr }
-func (s *testSerializableSigner) Serialize() ([]byte, error)          { return s.creator, nil }
+func (s *testSerializableSigner) Sign(_ []byte) ([]byte, error) { return s.signRes, s.signErr }
+func (s *testSerializableSigner) Serialize() ([]byte, error)    { return s.creator, nil }
 
 func testSignedProposalBytes(t *testing.T) *peer.SignedProposal {
 	t.Helper()
@@ -766,7 +766,7 @@ func TestTransactionDoneRawGetRWSetAndClose(t *testing.T) {
 		fakeRWSet.BytesReturns([]byte("rwset-bytes"), nil)
 		fakeRWSet.NamespacesReturns([]commondriver.Namespace{"ns1"})
 
-		tx := &Transaction{TTxID: "tx1", rwset: fakeRWSet}
+		tx := &Transaction{TTxID: "tx1", rwSetHandle: fakeRWSet}
 		err := tx.Done()
 		require.NoError(t, err)
 		require.Equal(t, 1, fakeRWSet.DoneCallCount())
@@ -778,7 +778,7 @@ func TestTransactionDoneRawGetRWSetAndClose(t *testing.T) {
 		fakeRWSet := &mock.RWSet{}
 		fakeRWSet.BytesReturns(nil, errors.New("boom"))
 
-		tx := &Transaction{TTxID: "tx1", rwset: fakeRWSet}
+		tx := &Transaction{TTxID: "tx1", rwSetHandle: fakeRWSet}
 		err := tx.Done()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "marshalling rws")
@@ -789,7 +789,7 @@ func TestTransactionDoneRawGetRWSetAndClose(t *testing.T) {
 		fakeRWSet := &mock.RWSet{}
 		fakeRWSet.BytesReturns([]byte("raw-rwset"), nil)
 
-		tx := &Transaction{TTxID: "tx1", rwset: fakeRWSet}
+		tx := &Transaction{TTxID: "tx1", rwSetHandle: fakeRWSet}
 		raw, err := tx.Raw()
 		require.NoError(t, err)
 		require.Contains(t, string(raw), `"RWSet":"cmF3LXJ3c2V0"`)
@@ -800,7 +800,7 @@ func TestTransactionDoneRawGetRWSetAndClose(t *testing.T) {
 		fakeRWSet := &mock.RWSet{}
 		fakeRWSet.BytesReturns(nil, errors.New("boom"))
 
-		tx := &Transaction{TTxID: "tx1", rwset: fakeRWSet}
+		tx := &Transaction{TTxID: "tx1", rwSetHandle: fakeRWSet}
 		_, err := tx.Raw()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "marshalling rws")
@@ -809,7 +809,7 @@ func TestTransactionDoneRawGetRWSetAndClose(t *testing.T) {
 	t.Run("get rwset returns existing one", func(t *testing.T) {
 		t.Parallel()
 		fakeRWSet := &mock.RWSet{}
-		tx := &Transaction{rwset: fakeRWSet}
+		tx := &Transaction{rwSetHandle: fakeRWSet}
 		got, err := tx.GetRWSet()
 		require.NoError(t, err)
 		require.Same(t, fakeRWSet, got)
@@ -831,7 +831,7 @@ func TestTransactionDoneRawGetRWSetAndClose(t *testing.T) {
 	t.Run("close terminates and clears rwset", func(t *testing.T) {
 		t.Parallel()
 		fakeRWSet := &mock.RWSet{}
-		tx := &Transaction{TTxID: "tx3", rwset: fakeRWSet}
+		tx := &Transaction{TTxID: "tx3", rwSetHandle: fakeRWSet}
 		tx.Close()
 		require.Equal(t, 1, fakeRWSet.DoneCallCount())
 		require.Nil(t, tx.RWS())
@@ -845,7 +845,7 @@ func TestTransactionBytesNoTransient(t *testing.T) {
 	fakeRWSet.BytesReturns([]byte("rwset-bytes"), nil)
 	fakeRWSet.NamespacesReturns([]commondriver.Namespace{"ns1"})
 
-	tx := &Transaction{TTxID: "tx1", TTransient: driver.TransientMap{"secret": []byte("value")}, rwset: fakeRWSet}
+	tx := &Transaction{TTxID: "tx1", TTransient: driver.TransientMap{"secret": []byte("value")}, rwSetHandle: fakeRWSet}
 	raw, err := tx.BytesNoTransient()
 	require.NoError(t, err)
 
@@ -987,7 +987,7 @@ func TestGetProposalResponse(t *testing.T) {
 		sp, err := newSignedProposal(signedProposal)
 		require.NoError(t, err)
 
-		tx := &Transaction{TTxID: "tx1", signedProposal: sp, rwset: fakeRWSet}
+		tx := &Transaction{TTxID: "tx1", signedProposal: sp, rwSetHandle: fakeRWSet}
 		resp, err := tx.getProposalResponse(fakeSigner)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -1015,7 +1015,7 @@ func TestGetProposalResponse(t *testing.T) {
 		fakeRWSet := &mock.RWSet{}
 		fakeRWSet.BytesReturns(rwsetBytes, nil)
 
-		tx := &Transaction{TTxID: "tx1", signedProposal: &SignedProposal{}, rwset: fakeRWSet}
+		tx := &Transaction{TTxID: "tx1", signedProposal: &SignedProposal{}, rwSetHandle: fakeRWSet}
 		resp, err := tx.getProposalResponse(&testSerializableSigner{})
 		require.Error(t, err)
 		require.Nil(t, resp)
@@ -1093,10 +1093,10 @@ func TestEndorseProposalResponseWithIdentity(t *testing.T) {
 			fakeRWSet.BytesReturns(tc.rwsetPayload, nil)
 
 			tx := &Transaction{
-				ctx:   t.Context(),
-				TTxID: "tx1",
-				fns:   fakeFNS,
-				rwset: fakeRWSet,
+				ctx:         t.Context(),
+				TTxID:       "tx1",
+				fns:         fakeFNS,
+				rwSetHandle: fakeRWSet,
 				channel: func() *mock.Channel {
 					ch := &mock.Channel{}
 					ch.MetadataServiceReturns(&mock.MetadataService{})

--- a/platform/fabricx/core/vault/marshal.go
+++ b/platform/fabricx/core/vault/marshal.go
@@ -37,7 +37,7 @@ func NewMarshaller() *Marshaller {
 // nsInfo maps each namespace to its version information and must contain an entry for every
 // namespace present in the RWSet. Returns an error if a namespace is missing from nsInfo or if
 // marshalling fails. Taking nsInfo as a parameter keeps the marshaller stateless and race-free.
-func (m *Marshaller) Marshal(txID string, rws *vault.ReadWriteSet, nsInfo map[driver.Namespace]driver.RawVersion) ([]byte, error) {
+func (*Marshaller) Marshal(txID string, rws *vault.ReadWriteSet, nsInfo map[driver.Namespace]driver.RawVersion) ([]byte, error) {
 	logger.Debugf("Marshal rws into fabricx proto [txID=%v]", txID)
 	if logger.IsEnabledFor(zap.DebugLevel) {
 		str, _ := json.MarshalIndent(rws, "", "\t")
@@ -205,7 +205,7 @@ func (m *Marshaller) RWSetFromBytes(raw []byte, namespaces ...string) (*vault.Re
 // current one.
 //
 // Returns an error if deserialization fails or if adding reads/writes fails.
-func (m *Marshaller) Append(destination *vault.ReadWriteSet, raw []byte, namespaces ...string) (map[driver.Namespace]driver.RawVersion, error) {
+func (*Marshaller) Append(destination *vault.ReadWriteSet, raw []byte, namespaces ...string) (map[driver.Namespace]driver.RawVersion, error) {
 	var txIn applicationpb.Tx
 	if err := proto.Unmarshal(raw, &txIn); err != nil {
 		return nil, errors.Wrapf(err, "unmarshal tx from [len=%d][%s]", len(raw), logging.SHA256Base64(raw))

--- a/platform/fabricx/core/vault/vault.go
+++ b/platform/fabricx/core/vault/vault.go
@@ -65,7 +65,7 @@ type queryExecutor struct {
 
 // GetState retrieves the state for a specific namespace and key from the remote QueryService.
 // Returns nil if the key does not exist.
-func (qe *queryExecutor) GetState(ctx context.Context, namespace cdriver.Namespace, key cdriver.PKey) (*cdriver.VaultRead, error) {
+func (qe *queryExecutor) GetState(_ context.Context, namespace cdriver.Namespace, key cdriver.PKey) (*cdriver.VaultRead, error) {
 	vaultValue, err := qe.qs.GetState(namespace, key)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get state for namespace=%s, key=%s", namespace, key)
@@ -83,7 +83,7 @@ func (qe *queryExecutor) GetState(ctx context.Context, namespace cdriver.Namespa
 // GetStateMetadata retrieves metadata for a specific namespace and key.
 // Since QueryService doesn't support direct metadata queries, this returns empty metadata
 // and the version from the state value.
-func (qe *queryExecutor) GetStateMetadata(ctx context.Context, namespace cdriver.Namespace, key cdriver.PKey) (cdriver.Metadata, cdriver.RawVersion, error) {
+func (qe *queryExecutor) GetStateMetadata(_ context.Context, namespace cdriver.Namespace, key cdriver.PKey) (cdriver.Metadata, cdriver.RawVersion, error) {
 	// QueryService doesn't support metadata queries directly
 	// Return empty metadata and version from state
 	vaultValue, err := qe.qs.GetState(namespace, key)
@@ -97,13 +97,13 @@ func (qe *queryExecutor) GetStateMetadata(ctx context.Context, namespace cdriver
 }
 
 // GetStateRange returns an error as range queries are not supported by the QueryService.
-func (qe *queryExecutor) GetStateRange(ctx context.Context, namespace cdriver.Namespace, startKey, endKey cdriver.PKey) (cdriver.VersionedResultsIterator, error) {
+func (*queryExecutor) GetStateRange(_ context.Context, _ cdriver.Namespace, _, _ cdriver.PKey) (cdriver.VersionedResultsIterator, error) {
 	// QueryService doesn't support range queries
 	return nil, errors.New("GetStateRange not supported by VaultX QueryService")
 }
 
 // Done performs cleanup for the query executor. Currently a no-op as no cleanup is needed.
-func (qe *queryExecutor) Done() error {
+func (*queryExecutor) Done() error {
 	// No cleanup needed for query executor
 	return nil
 }
@@ -283,7 +283,7 @@ func (v *Vault) namespaceVersion(ns cdriver.Namespace) (cdriver.RawVersion, erro
 
 // IsClosed returns whether this RWSet has been closed. Always returns false
 // as RWSets in this implementation are not explicitly closed.
-func (r *rwSetWrapper) IsClosed() bool {
+func (*rwSetWrapper) IsClosed() bool {
 	return false
 }
 
@@ -594,7 +594,7 @@ func (r *rwSetWrapper) Bytes() ([]byte, error) {
 }
 
 // Done is a no-op. The vault does not retain the ReadWriteSet.
-func (r *rwSetWrapper) Done() {
+func (*rwSetWrapper) Done() {
 }
 
 // Equals compares this RWSet with another RWSet for equality.
@@ -681,7 +681,7 @@ func (v *Vault) NewRWSetFromBytes(ctx context.Context, txID cdriver.TxID, rwset 
 // SetDiscarded is not supported: the fabricx wiring has no local commit pipeline
 // (see platform/fabricx/core/channel/provider.go). Reaching this method means the
 // vault was wired into a generic committer, which is a programming error.
-func (v *Vault) SetDiscarded(context.Context, cdriver.TxID, string) error {
+func (*Vault) SetDiscarded(context.Context, cdriver.TxID, string) error {
 	panic("fabricx vault: SetDiscarded called; fabricx has no local commit pipeline")
 }
 
@@ -701,7 +701,7 @@ func (v *Vault) Status(ctx context.Context, txID cdriver.TxID) (fdriver.Validati
 // remote QueryService in a single batched query. A txID that the committer does not know
 // is omitted from the batched result and is reported here as Unknown
 // ("not final yet"). The result preserves the order of the input txIDs.
-func (v *Vault) Statuses(ctx context.Context, txIDs ...cdriver.TxID) ([]cdriver.TxValidationStatus[fdriver.ValidationCode], error) {
+func (v *Vault) Statuses(_ context.Context, txIDs ...cdriver.TxID) ([]cdriver.TxValidationStatus[fdriver.ValidationCode], error) {
 	ids := make([]string, len(txIDs))
 	copy(ids, txIDs)
 
@@ -727,14 +727,14 @@ func (v *Vault) Statuses(ctx context.Context, txIDs ...cdriver.TxID) ([]cdriver.
 // DiscardTx is not supported: the fabricx wiring has no local commit pipeline
 // (see platform/fabricx/core/channel/provider.go). Reaching this method means the
 // vault was wired into a generic committer, which is a programming error.
-func (v *Vault) DiscardTx(context.Context, cdriver.TxID, string) error {
+func (*Vault) DiscardTx(context.Context, cdriver.TxID, string) error {
 	panic("fabricx vault: DiscardTx called; fabricx has no local commit pipeline")
 }
 
 // CommitTX is not supported: the fabricx wiring has no local commit pipeline
 // (see platform/fabricx/core/channel/provider.go). Reaching this method means the
 // vault was wired into a generic committer, which is a programming error.
-func (v *Vault) CommitTX(context.Context, cdriver.TxID, cdriver.BlockNum, cdriver.TxNum) error {
+func (*Vault) CommitTX(context.Context, cdriver.TxID, cdriver.BlockNum, cdriver.TxNum) error {
 	panic("fabricx vault: CommitTX called; fabricx has no local commit pipeline")
 }
 
@@ -765,24 +765,24 @@ func (v *Vault) InspectRWSet(ctx context.Context, rwset []byte, namespaces ...cd
 // RWSExists is not supported: the fabricx wiring has no local commit pipeline
 // (see platform/fabricx/core/channel/provider.go). Reaching this method means the
 // vault was wired into a generic committer, which is a programming error.
-func (v *Vault) RWSExists(context.Context, cdriver.TxID) bool {
+func (*Vault) RWSExists(context.Context, cdriver.TxID) bool {
 	panic("fabricx vault: RWSExists called; fabricx has no local commit pipeline")
 }
 
 // Match is not supported: the fabricx wiring has no local commit pipeline
 // (see platform/fabricx/core/channel/provider.go). Reaching this method means the
 // vault was wired into a generic committer, which is a programming error.
-func (v *Vault) Match(context.Context, cdriver.TxID, []byte) error {
+func (*Vault) Match(context.Context, cdriver.TxID, []byte) error {
 	panic("fabricx vault: Match called; fabricx has no local commit pipeline")
 }
 
 // Close is a no-op. The vault holds no per-transaction state to release.
-func (v *Vault) Close() error {
+func (*Vault) Close() error {
 	return nil
 }
 
 // versionEqual compares two version byte slices for equality.
-func (v *Vault) versionEqual(v1, v2 cdriver.RawVersion) bool {
+func (*Vault) versionEqual(v1, v2 cdriver.RawVersion) bool {
 	if len(v1) != len(v2) {
 		return false
 	}
@@ -796,7 +796,7 @@ func (v *Vault) versionEqual(v1, v2 cdriver.RawVersion) bool {
 
 // mapStatusToValidationCode converts a committerpb.Status code to a fdriver.ValidationCode.
 // Maps COMMITTED to Valid, STATUS_UNSPECIFIED to Unknown, and all others to Invalid.
-func (v *Vault) mapStatusToValidationCode(statusCode int32) fdriver.ValidationCode {
+func (*Vault) mapStatusToValidationCode(statusCode int32) fdriver.ValidationCode {
 	// Map committerpb.Status to fdriver.ValidationCode
 	switch committerpb.Status(statusCode) {
 	case committerpb.Status_COMMITTED:

--- a/platform/fabricx/core/vault/vault_test.go
+++ b/platform/fabricx/core/vault/vault_test.go
@@ -31,9 +31,9 @@ type mockMDS struct {
 	fieldMappings map[string]fdriver.TransientMap // keyed by string(valueDigest)
 }
 
-func (m *mockMDS) Exists(context.Context, string) bool                                { return false }
-func (m *mockMDS) StoreTransient(context.Context, string, fdriver.TransientMap) error { return nil }
-func (m *mockMDS) LoadTransient(context.Context, string) (fdriver.TransientMap, error) {
+func (*mockMDS) Exists(context.Context, string) bool                                { return false }
+func (*mockMDS) StoreTransient(context.Context, string, fdriver.TransientMap) error { return nil }
+func (*mockMDS) LoadTransient(context.Context, string) (fdriver.TransientMap, error) {
 	return nil, nil
 }
 
@@ -146,11 +146,11 @@ func (m *mockQueryService) GetTransactionStatuses(txIDs []string) (map[string]in
 	return out, nil
 }
 
-func (m *mockQueryService) GetConfigTransaction() (*queryservice.ConfigTransactionInfo, error) {
+func (*mockQueryService) GetConfigTransaction() (*queryservice.ConfigTransactionInfo, error) {
 	return nil, nil
 }
 
-func (m *mockQueryService) GetNamespacePolicies() (*applicationpb.NamespacePolicies, error) {
+func (*mockQueryService) GetNamespacePolicies() (*applicationpb.NamespacePolicies, error) {
 	return nil, nil
 }
 

--- a/platform/fabricx/sdk/dig/providers.go
+++ b/platform/fabricx/sdk/dig/providers.go
@@ -43,7 +43,7 @@ func NewDriver(in struct {
 	ConfigProvider  config.Provider
 	MetricsProvider metrics.Provider
 	EndpointService identity.EndpointService
-	IdProvider      identity.ViewIdentityProvider
+	IDProvider      identity.ViewIdentityProvider
 	KVS             *kvs.KVS
 	SignerInfoStore driver.SignerInfoStore
 	AuditInfoStore  driver.AuditInfoStore
@@ -58,7 +58,7 @@ func NewDriver(in struct {
 			in.MetricsProvider,
 			in.EndpointService,
 			in.ChannelProvider,
-			in.IdProvider,
+			in.IDProvider,
 			in.IdentityLoaders,
 			in.KVS,
 			in.SignerInfoStore,
@@ -82,7 +82,7 @@ func NewChannelProvider(in struct {
 	ListenerManagerProvider finality.ListenerManagerProvider
 	IdentityLoaders         []identity.NamedIdentityLoader `group:"identity-loaders"`
 	EndpointService         identity.EndpointService
-	IdProvider              identity.ViewIdentityProvider
+	IDProvider              identity.ViewIdentityProvider
 	EnvelopeStore           fdriver.EnvelopeStore
 	MetadataStore           fdriver.MetadataStore
 	EndorseTxStore          fdriver.EndorseTxStore
@@ -100,7 +100,7 @@ func NewChannelProvider(in struct {
 			return vault.New(configService, channelName, in.QueryServiceProvider, in.MetadataStore)
 		},
 		channelConfigProvider,
-		func(channelName string, nw fdriver.FabricNetworkService, chaincodeManager fdriver.ChaincodeManager) (fdriver.Ledger, error) {
+		func(channelName string, nw fdriver.FabricNetworkService, _ fdriver.ChaincodeManager) (fdriver.Ledger, error) {
 			return in.LedgerProvider.NewLedger(nw.Name(), channelName)
 		},
 		func(channel string, nw fdriver.FabricNetworkService, envelopeService fdriver.EnvelopeService, transactionService fdriver.EndorserTransactionService, vault fdriver.RWSetInspector) (fdriver.RWSetLoader, error) {

--- a/platform/view/sdk/dig/servers.go
+++ b/platform/view/sdk/dig/servers.go
@@ -207,15 +207,15 @@ func NewServerConfig(configProvider driver.ConfigService) (grpc2.ServerConfig, e
 // is done. It returns immediately; each server runs in its own goroutine. A nil server is
 // skipped.
 func Serve(grpcServer *grpc2.GRPCServer, webServer Server, ops OperationsServer, operationsSystem *operations.System, kvss *kvs.KVS, ctx context.Context) {
-	serve(grpcServer, webServer, ops, operationsSystem, kvss, ctx)
+	startServe(grpcServer, webServer, ops, operationsSystem, kvss, ctx)
 }
 
-// serve starts the GRPC server, web server, and operations system in their own
+// startServe starts the GRPC server, web server, and operations system in their own
 // goroutines, plus a shutdown goroutine that stops them when ctx is done. It
 // returns a *sync.WaitGroup tracking the three server goroutines so callers
 // (and tests) can confirm they have actually stopped before proceeding with
 // teardown.
-func serve(grpcServer *grpc2.GRPCServer, webServer Server, ops OperationsServer, operationsSystem *operations.System, kvss *kvs.KVS, ctx context.Context) *sync.WaitGroup {
+func startServe(grpcServer *grpc2.GRPCServer, webServer Server, ops OperationsServer, operationsSystem *operations.System, kvss *kvs.KVS, ctx context.Context) *sync.WaitGroup {
 	var wg sync.WaitGroup
 
 	wg.Go(func() {

--- a/platform/view/sdk/dig/servers_test.go
+++ b/platform/view/sdk/dig/servers_test.go
@@ -32,7 +32,7 @@ func newFakeServer() *fakeServer {
 	}
 }
 
-func (f *fakeServer) RegisterHandler(_ string, _ http.Handler, _ bool) {}
+func (*fakeServer) RegisterHandler(_ string, _ http.Handler, _ bool) {}
 
 func (f *fakeServer) Start() error {
 	<-f.stopCh
@@ -54,8 +54,8 @@ func (f *fakeServer) stopped() bool {
 func TestServe_WaitsForServersOnShutdown(t *testing.T) { //nolint:paralleltest // relies on server-goroutine shutdown timing; must run serially
 	ctx, cancel := context.WithCancel(context.Background())
 	ws := newFakeServer() // Start blocks until Stop
-	// Zero OperationsServer: the endpoints share the web listener, so serve starts none.
-	wg := serve(nil, ws, OperationsServer{}, nil, nil, ctx)
+	// Zero OperationsServer: the endpoints share the web listener, so startServe starts none.
+	wg := startServe(nil, ws, OperationsServer{}, nil, nil, ctx)
 	cancel()
 	done := make(chan struct{})
 	go func() { wg.Wait(); close(done) }()

--- a/platform/view/sdk/dig/support/endpoint/resolver.go
+++ b/platform/view/sdk/dig/support/endpoint/resolver.go
@@ -30,7 +30,7 @@ type entry struct {
 	Identity       Identity          `yaml:"identity,omitempty"`
 	Addresses      map[string]string `yaml:"addresses,omitempty"`
 	Aliases        []string          `yaml:"aliases,omitempty"`
-	Id             []byte
+	ID             []byte
 	IdentityGetter func() (view.Identity, []byte, error)
 }
 
@@ -40,7 +40,7 @@ func (r *entry) GetIdentity() (view.Identity, error) {
 		return id, err
 	}
 
-	return r.Id, nil
+	return r.ID, nil
 }
 
 type ConfigService interface {
@@ -114,21 +114,21 @@ func (r *ResolversLoader) LoadResolvers() error {
 			if err != nil {
 				return err
 			}
-			resolver.Id = raw
+			resolver.ID = raw
 			logger.Debugf("resolver [%s,%s][%s] %s",
 				resolver.Name, resolver.Domain, resolver.Addresses,
-				view.Identity(resolver.Id).UniqueID(),
+				view.Identity(resolver.ID).UniqueID(),
 			)
 
 			// Add entry
-			if _, err := r.backend.AddResolver(resolver.Name, resolver.Domain, resolver.Addresses, resolver.Aliases, resolver.Id); err != nil {
+			if _, err := r.backend.AddResolver(resolver.Name, resolver.Domain, resolver.Addresses, resolver.Aliases, resolver.ID); err != nil {
 				return errors.Wrapf(err, "failed adding resolver")
 			}
 
 			// Bind Aliases
 			for _, alias := range resolver.Aliases {
 				logger.Debugf("binding [%s] to [%s]", resolver.Name, alias)
-				if err := r.backend.Bind(context.Background(), resolver.Id, []byte(alias)); err != nil {
+				if err := r.backend.Bind(context.Background(), resolver.ID, []byte(alias)); err != nil {
 					return errors.WithMessagef(err, "failed binding identity [%s] to alias [%s]", resolver.Name, alias)
 				}
 			}

--- a/platform/view/sdk/dig/test_utils.go
+++ b/platform/view/sdk/dig/test_utils.go
@@ -21,20 +21,20 @@ type mockConfigService struct {
 	bools   map[string]bool
 }
 
-func (s *mockConfigService) GetString(key string) string      { return s.strings[key] }
-func (s *mockConfigService) GetInt(string) int                { return 0 }
-func (s *mockConfigService) GetDuration(string) time.Duration { return 0 }
-func (s *mockConfigService) GetBool(key string) bool          { return s.bools[key] }
-func (s *mockConfigService) GetStringSlice(string) []string   { return nil }
-func (s *mockConfigService) IsSet(string) bool                { return false }
-func (s *mockConfigService) UnmarshalKey(string, any) error   { return nil }
-func (s *mockConfigService) ConfigFileUsed() string           { return "" }
-func (s *mockConfigService) GetPath(string) string            { return "" }
-func (s *mockConfigService) TranslatePath(string) string      { return "" }
+func (s *mockConfigService) GetString(key string) string    { return s.strings[key] }
+func (*mockConfigService) GetInt(string) int                { return 0 }
+func (*mockConfigService) GetDuration(string) time.Duration { return 0 }
+func (s *mockConfigService) GetBool(key string) bool        { return s.bools[key] }
+func (*mockConfigService) GetStringSlice(string) []string   { return nil }
+func (*mockConfigService) IsSet(string) bool                { return false }
+func (*mockConfigService) UnmarshalKey(string, any) error   { return nil }
+func (*mockConfigService) ConfigFileUsed() string           { return "" }
+func (*mockConfigService) GetPath(string) string            { return "" }
+func (*mockConfigService) TranslatePath(string) string      { return "" }
 
-func (s *mockConfigService) RawSubtree(string) (map[string]any, bool) { return nil, false }
+func (*mockConfigService) RawSubtree(string) (map[string]any, bool) { return nil, false }
 
-func (s *mockConfigService) RawSubtrees(string) []map[string]any { return nil }
+func (*mockConfigService) RawSubtrees(string) []map[string]any { return nil }
 
 type Opt = func(*mockConfigService)
 

--- a/platform/view/sdk/vfsdk/container_test.go
+++ b/platform/view/sdk/vfsdk/container_test.go
@@ -27,7 +27,7 @@ type myDependentFactory struct {
 
 type myFactory struct{}
 
-func (o *myFactory) NewView([]byte) (view.View, error) { return nil, nil }
+func (*myFactory) NewView([]byte) (view.View, error) { return nil, nil }
 
 func TestInvalidFactory(t *testing.T) {
 	t.Parallel()

--- a/platform/view/sdk/vfsdk/options.go
+++ b/platform/view/sdk/vfsdk/options.go
@@ -8,6 +8,7 @@ package vfsdk
 
 type FactoryOption func(*factoryEntry)
 
+//nolint:revive // var-naming: renaming this exported func is an API break; see follow-up
 func WithFactoryId(fid string) FactoryOption {
 	return func(f *factoryEntry) {
 		f.fids = append(f.fids, fid)

--- a/platform/view/services/comm/host/libp2p/bandwidthreporter.go
+++ b/platform/view/services/comm/host/libp2p/bandwidthreporter.go
@@ -31,20 +31,20 @@ func (r *metricsReporter) LogRecvMessageStream(size int64, proto protocol.ID, p 
 	r.m.BytesReceived.With(PeerId, p.String(), ProtocolId, string(proto)).Add(float64(size))
 }
 
-func (r *metricsReporter) LogSentMessage(int64)                       {}
-func (r *metricsReporter) LogRecvMessage(int64)                       {}
-func (r *metricsReporter) GetBandwidthForPeer(peer.ID) metrics2.Stats { return metrics2.Stats{} }
-func (r *metricsReporter) GetBandwidthForProtocol(protocol.ID) metrics2.Stats {
+func (*metricsReporter) LogSentMessage(int64)                       {}
+func (*metricsReporter) LogRecvMessage(int64)                       {}
+func (*metricsReporter) GetBandwidthForPeer(peer.ID) metrics2.Stats { return metrics2.Stats{} }
+func (*metricsReporter) GetBandwidthForProtocol(protocol.ID) metrics2.Stats {
 	return metrics2.Stats{}
 }
-func (r *metricsReporter) GetBandwidthTotals() metrics2.Stats { return metrics2.Stats{} }
-func (r *metricsReporter) GetBandwidthByPeer() map[peer.ID]metrics2.Stats {
+func (*metricsReporter) GetBandwidthTotals() metrics2.Stats { return metrics2.Stats{} }
+func (*metricsReporter) GetBandwidthByPeer() map[peer.ID]metrics2.Stats {
 	return map[peer.ID]metrics2.Stats{}
 }
 
-func (r *metricsReporter) GetBandwidthByProtocol() map[protocol.ID]metrics2.Stats {
+func (*metricsReporter) GetBandwidthByProtocol() map[protocol.ID]metrics2.Stats {
 	return map[protocol.ID]metrics2.Stats{}
 }
 
-func (r *metricsReporter) Reset()                   {}
-func (r *metricsReporter) TrimIdle(since time.Time) {}
+func (*metricsReporter) Reset()               {}
+func (*metricsReporter) TrimIdle(_ time.Time) {}

--- a/platform/view/services/comm/host/libp2p/host.go
+++ b/platform/view/services/comm/host/libp2p/host.go
@@ -164,7 +164,7 @@ func (h *host) Start(newStreamCallback func(stream host2.P2PStream)) error {
 	logger.Debugf("libp2p: Starting host [%s] (bootstrap: %v, bootstrapNode: [%s])...", h.ID(), h.bootstrap, h.bootstrapNode)
 	if h.bootstrap {
 		h.Peerstore().AddAddrs(h.ID(), h.Addrs(), time.Hour)
-		if err := h.start(false, newStreamCallback); err != nil {
+		if err := h.startHost(false, newStreamCallback); err != nil {
 			logger.Errorf("libp2p: failed to start bootstrap host [%s]: %v", h.ID(), err)
 			return err
 		}
@@ -189,7 +189,7 @@ func (h *host) Start(newStreamCallback func(stream host2.P2PStream)) error {
 		return err
 	}
 	logger.Debugf("libp2p: host [%s] connected to bootstrap node [%s]", h.ID(), h.bootstrapNode)
-	if err := h.start(false, newStreamCallback); err != nil {
+	if err := h.startHost(false, newStreamCallback); err != nil {
 		logger.Errorf("libp2p: failed to start host [%s]: %v", h.ID(), err)
 		return err
 	}
@@ -197,7 +197,7 @@ func (h *host) Start(newStreamCallback func(stream host2.P2PStream)) error {
 	return nil
 }
 
-func (h *host) StreamHash(input host2.StreamInfo) host2.StreamHash {
+func (*host) StreamHash(input host2.StreamInfo) host2.StreamHash {
 	return streamHash(input)
 }
 
@@ -292,7 +292,7 @@ func (h *host) startFinder() {
 	}
 }
 
-func (h *host) start(failAdv bool, newStreamCallback func(stream host2.P2PStream)) error {
+func (h *host) startHost(failAdv bool, newStreamCallback func(stream host2.P2PStream)) error {
 	logger.Debugf("libp2p: Advertising rendez-vous [%s]...", rendezVousString)
 	_, err := h.finder.Advertise(context.Background(), rendezVousString)
 	if err != nil {

--- a/platform/view/services/comm/host/libp2p/metrics.go
+++ b/platform/view/services/comm/host/libp2p/metrics.go
@@ -9,7 +9,9 @@ package libp2p
 import metrics2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics"
 
 const (
-	PeerId     = "peer"
+	//nolint:revive // var-naming: renaming this exported const is an API break; see follow-up
+	PeerId = "peer"
+	//nolint:revive // var-naming: renaming this exported const is an API break; see follow-up
 	ProtocolId = "protocol"
 )
 

--- a/platform/view/services/comm/host/libp2p/p2p_test.go
+++ b/platform/view/services/comm/host/libp2p/p2p_test.go
@@ -96,7 +96,7 @@ func freeLibP2PAddresses(t *testing.T, n int) []string {
 	return addresses
 }
 
-func setupTwoNodes(t *testing.T) (*comm.HostNode, *comm.HostNode) {
+func setupTwoNodes(t *testing.T) (node1, node2 *comm.HostNode) {
 	t.Helper()
 	bootstrapSK, bootstrapID := generateKey(t)
 	nodeSK, nodeID := generateKey(t)
@@ -125,7 +125,7 @@ func setupTwoNodes(t *testing.T) (*comm.HostNode, *comm.HostNode) {
 		&comm.HostNode{P2PNode: anotherNode, ID: nodeID, Address: nodeEndpoint}
 }
 
-func setupThreeNodes(t *testing.T) (*comm.HostNode, *comm.HostNode, *comm.HostNode) {
+func setupThreeNodes(t *testing.T) (bootstrap, n1, n2 *comm.HostNode) {
 	t.Helper()
 	bootstrapSK, bootstrapID := generateKey(t)
 	node1SK, node1ID := generateKey(t)

--- a/platform/view/services/comm/host/libp2p/pki.go
+++ b/platform/view/services/comm/host/libp2p/pki.go
@@ -19,7 +19,7 @@ import (
 
 type PKIDSynthesizer struct{}
 
-func (p PKIDSynthesizer) PublicKeyID(key any) ([]byte, error) {
+func (PKIDSynthesizer) PublicKeyID(key any) ([]byte, error) {
 	switch d := key.(type) {
 	case *ecdsa.PublicKey:
 		raw, err := x509.MarshalPKIXPublicKey(d)

--- a/platform/view/services/comm/host/libp2p/sig_exchange_test.go
+++ b/platform/view/services/comm/host/libp2p/sig_exchange_test.go
@@ -72,11 +72,11 @@ func (ecdsaSigDeserializer) DeserializeVerifier(raw []byte) (cdriver.Verifier, e
 	return v, err
 }
 
-func (ecdsaSigDeserializer) DeserializeSigner(raw []byte) (cdriver.Signer, error) {
+func (ecdsaSigDeserializer) DeserializeSigner(_ []byte) (cdriver.Signer, error) {
 	return nil, nil
 }
 
-func (ecdsaSigDeserializer) Info(raw, auditInfo []byte) (string, error) {
+func (ecdsaSigDeserializer) Info(raw, _ []byte) (string, error) {
 	return view.Identity(raw).UniqueID(), nil
 }
 

--- a/platform/view/services/comm/host/libp2p/stream.go
+++ b/platform/view/services/comm/host/libp2p/stream.go
@@ -31,7 +31,7 @@ func (s *stream) Hash() host2.StreamHash {
 	return streamHash(s.info)
 }
 
-func (s *stream) Context() context.Context { return context.TODO() }
+func (*stream) Context() context.Context { return context.TODO() }
 
 func (s *stream) Close() error {
 	logger.Debugf("libp2p: Closing stream to [%s] (address: [%s], hash: [%s])...", s.RemotePeerID(), s.RemotePeerAddress(), s.Hash())

--- a/platform/view/services/comm/host/websocket/config.go
+++ b/platform/view/services/comm/host/websocket/config.go
@@ -187,16 +187,16 @@ func (c *config) CertPath() string { return c.identityCertPath }
 func (c *config) MaxSubConns() int { return c.maxSubConns }
 
 // ReadHeaderTimeout returns how long the server waits for request headers.
-func (c *config) ReadHeaderTimeout() time.Duration { return 10 * time.Second }
+func (*config) ReadHeaderTimeout() time.Duration { return 10 * time.Second }
 
 // ReadTimeout returns how long the server waits to read a request.
-func (c *config) ReadTimeout() time.Duration { return 30 * time.Second }
+func (*config) ReadTimeout() time.Duration { return 30 * time.Second }
 
 // WriteTimeout returns how long the server allows for writing a response.
-func (c *config) WriteTimeout() time.Duration { return 30 * time.Second }
+func (*config) WriteTimeout() time.Duration { return 30 * time.Second }
 
 // IdleTimeout returns how long an idle connection is kept open.
-func (c *config) IdleTimeout() time.Duration { return 120 * time.Second }
+func (*config) IdleTimeout() time.Duration { return 120 * time.Second }
 
 // CORSAllowedOrigins returns the origins permitted to open a websocket connection. An empty
 // result disables CORS.
@@ -338,7 +338,7 @@ func newServerTLSConfig(clientRootCAPool *x509.CertPool, opts grpc.SecureOptions
 
 	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 	if caPoolProvider != nil {
-		tlsConfig.GetConfigForClient = func(chi *tls.ClientHelloInfo) (*tls.Config, error) {
+		tlsConfig.GetConfigForClient = func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
 			extraCAs := caPoolProvider.ExtraCAs()
 			if len(extraCAs) == 0 {
 				return tlsConfig, nil

--- a/platform/view/services/comm/host/websocket/dynamic_ca_test.go
+++ b/platform/view/services/comm/host/websocket/dynamic_ca_test.go
@@ -35,7 +35,7 @@ type mockEndpointService struct {
 	resolvers []endpoint.ResolverInfo
 }
 
-func (m *mockEndpointService) ExtractPKI(id []byte) []byte {
+func (*mockEndpointService) ExtractPKI(id []byte) []byte {
 	return id
 }
 
@@ -51,7 +51,7 @@ func (m *mockEndpointService) AddResolver(id []byte) {
 	m.resolvers = append(m.resolvers, endpoint.ResolverInfo{ID: id})
 }
 
-func (m *mockEndpointService) UpdateResolver(name, domain string, addresses map[string]string, aliases []string, id []byte) (view.Identity, error) {
+func (m *mockEndpointService) UpdateResolver(name, domain string, addresses map[string]string, _ []string, id []byte) (view.Identity, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	found := false
@@ -81,11 +81,11 @@ func convert(o map[string]string) map[endpoint.PortName]string {
 	return r
 }
 
-func (m *mockEndpointService) GetIdentity(label string, pkID []byte) (view.Identity, error) {
+func (*mockEndpointService) GetIdentity(_ string, _ []byte) (view.Identity, error) {
 	return nil, nil
 }
 
-func (m *mockEndpointService) GetResolver(ctx context.Context, id view.Identity) (*endpoint.Resolver, error) {
+func (m *mockEndpointService) GetResolver(_ context.Context, id view.Identity) (*endpoint.Resolver, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	for _, r := range m.resolvers {

--- a/platform/view/services/comm/host/websocket/host.go
+++ b/platform/view/services/comm/host/websocket/host.go
@@ -148,7 +148,7 @@ func (h *host) Lookup(peerID host2.PeerID) ([]host2.PeerIPAddress, bool) {
 	return h.routing.LookupAll(peerID)
 }
 
-func (h *host) StreamHash(info host2.StreamInfo) string {
+func (*host) StreamHash(info host2.StreamInfo) string {
 	return StreamHash(info)
 }
 
@@ -160,7 +160,7 @@ func (h *host) Close() error {
 	return err
 }
 
-func (h *host) Wait() {}
+func (*host) Wait() {}
 
 func StreamHash(info host2.StreamInfo) host2.StreamHash {
 	var sb strings.Builder

--- a/platform/view/services/comm/host/websocket/host_timeout_test.go
+++ b/platform/view/services/comm/host/websocket/host_timeout_test.go
@@ -99,19 +99,19 @@ type mockConfig struct {
 	listenAddress host2.PeerIPAddress
 }
 
-func (m *mockConfig) ListenAddress() host2.PeerIPAddress                        { return m.listenAddress }
-func (m *mockConfig) ClientTLSConfig(websocket.ExtraCAPoolProvider) *tls.Config { return nil }
-func (m *mockConfig) ServerTLSConfig(websocket.ExtraCAPoolProvider) *tls.Config { return nil }
-func (m *mockConfig) CertPath() string                                          { return "" }
-func (m *mockConfig) MaxSubConns() int                                          { return 100 }
-func (m *mockConfig) ReadHeaderTimeout() time.Duration                          { return 10 * time.Second }
+func (m *mockConfig) ListenAddress() host2.PeerIPAddress                      { return m.listenAddress }
+func (*mockConfig) ClientTLSConfig(websocket.ExtraCAPoolProvider) *tls.Config { return nil }
+func (*mockConfig) ServerTLSConfig(websocket.ExtraCAPoolProvider) *tls.Config { return nil }
+func (*mockConfig) CertPath() string                                          { return "" }
+func (*mockConfig) MaxSubConns() int                                          { return 100 }
+func (*mockConfig) ReadHeaderTimeout() time.Duration                          { return 10 * time.Second }
 
-func (m *mockConfig) ReadTimeout() time.Duration { return 30 * time.Second }
+func (*mockConfig) ReadTimeout() time.Duration { return 30 * time.Second }
 
-func (m *mockConfig) WriteTimeout() time.Duration { return 30 * time.Second }
+func (*mockConfig) WriteTimeout() time.Duration { return 30 * time.Second }
 
-func (m *mockConfig) IdleTimeout() time.Duration   { return 120 * time.Second }
-func (m *mockConfig) CORSAllowedOrigins() []string { return nil }
+func (*mockConfig) IdleTimeout() time.Duration   { return 120 * time.Second }
+func (*mockConfig) CORSAllowedOrigins() []string { return nil }
 
 // noopProvider returns a stream provider that does nothing
 func noopProvider() websocket.StreamProvider {
@@ -120,14 +120,14 @@ func noopProvider() websocket.StreamProvider {
 
 type noopStreamProvider struct{}
 
-func (n *noopStreamProvider) NewClientStream(info host2.StreamInfo, ctx context.Context, src host2.PeerID, config *tls.Config) (host2.P2PStream, error) {
+func (*noopStreamProvider) NewClientStream(_ host2.StreamInfo, _ context.Context, _ host2.PeerID, _ *tls.Config) (host2.P2PStream, error) {
 	return nil, nil
 }
 
-func (n *noopStreamProvider) NewServerStream(writer http.ResponseWriter, request *http.Request, newStreamCallback func(host2.P2PStream)) error {
+func (*noopStreamProvider) NewServerStream(_ http.ResponseWriter, _ *http.Request, _ func(host2.P2PStream)) error {
 	return nil
 }
 
-func (n *noopStreamProvider) Close() error {
+func (*noopStreamProvider) Close() error {
 	return nil
 }

--- a/platform/view/services/comm/host/websocket/p2p_test.go
+++ b/platform/view/services/comm/host/websocket/p2p_test.go
@@ -109,7 +109,7 @@ func TestMTLSCallerIdentityBinding(t *testing.T) { //nolint:paralleltest
 	require.Equal(t, []byte("pong"), reply.Payload)
 }
 
-func setupTwoNodes(t *testing.T) (*comm.HostNode, *comm.HostNode) {
+func setupTwoNodes(t *testing.T) (node1, node2 *comm.HostNode) {
 	t.Helper()
 	tlsFiles := generateTLSFiles(t)
 
@@ -162,7 +162,7 @@ func TestSessionsTwoNodesTestRound(t *testing.T) { //nolint:paralleltest
 	comm.SessionsNodesTestRound(t, bootstrapNode, []*comm.HostNode{node1, node2}, 50)
 }
 
-func setupThreeNodes(t *testing.T) (*comm.HostNode, *comm.HostNode, *comm.HostNode) {
+func setupThreeNodes(t *testing.T) (bootstrap, node1, node2 *comm.HostNode) {
 	t.Helper()
 	// Create TLS certificates for three nodes: bootstrap, node1, node2
 	dir := t.TempDir()
@@ -402,8 +402,8 @@ func generateTLSFiles(t *testing.T) generatedTLSFiles {
 func TestSessionInfoSecurityGuarantees(t *testing.T) { //nolint:paralleltest
 	ctx := t.Context()
 	// Simpler: Alice, Bob and Charlie all share the same CA.
-	allTlsFiles := generateThreeNodesTLSFiles(t)
-	aliceNode, bobNode := setupTwoNodesFromTLS(t, allTlsFiles.alice, allTlsFiles.bob, allTlsFiles.caCert)
+	allTLSFiles := generateThreeNodesTLSFiles(t)
+	aliceNode, bobNode := setupTwoNodesFromTLS(t, allTLSFiles.alice, allTLSFiles.bob, allTLSFiles.caCert)
 	aliceNode.Start(ctx)
 	bobNode.Start(ctx)
 	defer aliceNode.Stop()
@@ -429,17 +429,17 @@ func TestSessionInfoSecurityGuarantees(t *testing.T) { //nolint:paralleltest
 	// Claim 2: RemotePKID is cryptographically verified and bound to transport identity
 	require.Equal(t, []byte(aliceNode.ID), info.RemotePKID, "RemotePKID mismatch")
 
-	charlieID := mustPeerIDFromCert(t, allTlsFiles.charlie.cert)
+	charlieID := mustPeerIDFromCert(t, allTLSFiles.charlie.cert)
 	charlieAddresses := freeTCPAddresses(t, 2)
 	charlieHost, _ := newStaticRouteHostProvider(&routing.StaticIDRouter{
 		charlieID:  []host2.PeerIPAddress{charlieAddresses[0]},
 		bobNode.ID: []host2.PeerIPAddress{bobNode.Address},
 	}, websocket.NewConfigFromProperties(
 		charlieAddresses[1],
-		allTlsFiles.charlie.key,
-		allTlsFiles.charlie.cert,
-		[]string{allTlsFiles.caCert},
-		[]string{allTlsFiles.caCert},
+		allTLSFiles.charlie.key,
+		allTLSFiles.charlie.cert,
+		[]string{allTLSFiles.caCert},
+		[]string{allTLSFiles.caCert},
 		true,
 		100, nil,
 	)).GetNewHost()
@@ -528,7 +528,7 @@ func generateThreeNodesTLSFiles(t *testing.T) threeNodesTLSFiles {
 	}
 }
 
-func setupTwoNodesFromTLS(t *testing.T, alice, bob nodeTLSFiles, caCert string) (*comm.HostNode, *comm.HostNode) {
+func setupTwoNodesFromTLS(t *testing.T, alice, bob nodeTLSFiles, caCert string) (aliceNode, bobNode *comm.HostNode) {
 	t.Helper()
 	addrs := freeTCPAddresses(t, 2)
 	aliceAddr := addrs[0]
@@ -540,11 +540,11 @@ func setupTwoNodesFromTLS(t *testing.T, alice, bob nodeTLSFiles, caCert string) 
 		bobID:   []host2.PeerIPAddress{bobAddr},
 	}
 	aliceH, _ := newStaticRouteHostProvider(routes, websocket.NewConfigFromProperties(aliceAddr, alice.key, alice.cert, []string{caCert}, []string{caCert}, true, 100, nil)).GetNewHost()
-	aliceNode, _ := comm.NewNode(t.Context(), aliceH, &disabled.Provider{})
+	aliceP2P, _ := comm.NewNode(t.Context(), aliceH, &disabled.Provider{})
 	bobH, _ := newStaticRouteHostProvider(routes, websocket.NewConfigFromProperties(bobAddr, bob.key, bob.cert, []string{caCert}, []string{caCert}, true, 100, nil)).GetNewHost()
-	bobNode, _ := comm.NewNode(t.Context(), bobH, &disabled.Provider{})
-	return &comm.HostNode{P2PNode: aliceNode, ID: aliceID, Address: aliceAddr},
-		&comm.HostNode{P2PNode: bobNode, ID: bobID, Address: bobAddr}
+	bobP2P, _ := comm.NewNode(t.Context(), bobH, &disabled.Provider{})
+	return &comm.HostNode{P2PNode: aliceP2P, ID: aliceID, Address: aliceAddr},
+		&comm.HostNode{P2PNode: bobP2P, ID: bobID, Address: bobAddr}
 }
 
 func writePEM(t *testing.T, path, typ string, raw []byte) {
@@ -559,7 +559,7 @@ func newStaticRouteHostProvider(routes *routing.StaticIDRouter, config websocket
 	return &staticRoutHostProvider{routes: routes, config: config}
 }
 
-func (p *staticRoutHostProvider) ExtraCAs() [][]byte {
+func (*staticRoutHostProvider) ExtraCAs() [][]byte {
 	return nil
 }
 

--- a/platform/view/services/comm/host/websocket/pki.go
+++ b/platform/view/services/comm/host/websocket/pki.go
@@ -17,7 +17,7 @@ import (
 
 type PKIDSynthesizer struct{}
 
-func (p PKIDSynthesizer) PublicKeyID(key any) ([]byte, error) {
+func (PKIDSynthesizer) PublicKeyID(key any) ([]byte, error) {
 	switch d := key.(type) {
 	case *ecdsa.PublicKey:
 		id, err := ecdsaPubKeyID(d)

--- a/platform/view/services/comm/host/websocket/server_test.go
+++ b/platform/view/services/comm/host/websocket/server_test.go
@@ -19,7 +19,7 @@ import (
 func TestWithRecovery(t *testing.T) {
 	t.Parallel()
 
-	panicking := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	panicking := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		panic("something went wrong")
 	})
 
@@ -35,7 +35,7 @@ func TestWithLogging(t *testing.T) {
 
 	t.Run("2xx does not log error", func(t *testing.T) {
 		t.Parallel()
-		ok := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ok := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		})
 		h := withLogging(ok)
@@ -47,7 +47,7 @@ func TestWithLogging(t *testing.T) {
 
 	t.Run("4xx still completes the request", func(t *testing.T) {
 		t.Parallel()
-		notFound := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		notFound := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 		})
 		h := withLogging(notFound)
@@ -59,7 +59,7 @@ func TestWithLogging(t *testing.T) {
 
 	t.Run("implicit 200 when WriteHeader is never called", func(t *testing.T) {
 		t.Parallel()
-		silent := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+		silent := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 		h := withLogging(silent)
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/p2p", nil)
@@ -72,7 +72,7 @@ func TestWithCORS(t *testing.T) {
 	t.Parallel()
 
 	allowed := []string{"https://example.com"}
-	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
@@ -125,7 +125,7 @@ func TestNewHandler_Routing(t *testing.T) {
 	t.Parallel()
 
 	var called bool
-	provider := &fakeStreamProvider{fn: func(w http.ResponseWriter, r *http.Request) {
+	provider := &fakeStreamProvider{fn: func(w http.ResponseWriter, _ *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusSwitchingProtocols)
 	}}

--- a/platform/view/services/comm/host/websocket/websocket_test_utils.go
+++ b/platform/view/services/comm/host/websocket/websocket_test_utils.go
@@ -19,7 +19,7 @@ import (
 )
 
 // GenerateTestCert generates a self-signed certificate for testing purposes.
-func GenerateTestCert(cn string) ([]byte, []byte, error) {
+func GenerateTestCert(cn string) (cert, key []byte, err error) {
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, nil, err

--- a/platform/view/services/comm/host/websocket/ws/multiplexed_provider.go
+++ b/platform/view/services/comm/host/websocket/ws/multiplexed_provider.go
@@ -41,6 +41,7 @@ const (
 	pingInterval                            = 30 * time.Second
 )
 
+//nolint:revive // var-naming: renaming this exported type alias is an API break; see follow-up
 type SubConnId = string
 
 type MultiplexedMessage struct {
@@ -217,7 +218,7 @@ func newClientConn(conn *websocket.Conn, tracer trace.Tracer, m *Metrics, maxSub
 }
 
 func (c *multiplexedClientConn) newClientSubConn(ctx context.Context, src host2.PeerID, info host2.StreamInfo) (*stream, error) {
-	id := strconv.FormatUint(c.subConnId.Add(1), 10)
+	id := strconv.FormatUint(c.subConnID.Add(1), 10)
 	spanContext := trace.SpanContextFromContext(ctx)
 	marshalledSpanContext, err := tracing.MarshalContext(spanContext)
 	if err != nil {
@@ -420,7 +421,7 @@ type multiplexedBaseConn struct {
 	// mu protects concurrent use of our subConns
 	mu        sync.RWMutex
 	subConns  map[SubConnId]*subConn
-	subConnId atomic.Uint64
+	subConnID atomic.Uint64
 
 	tracer      trace.Tracer
 	m           *Metrics

--- a/platform/view/services/comm/host/websocket/ws/multiplexed_provider_test.go
+++ b/platform/view/services/comm/host/websocket/ws/multiplexed_provider_test.go
@@ -441,7 +441,7 @@ func clientRun(p *MultiplexedProvider, srvEndpoint, sessionID string, src host.P
 	}
 }
 
-func testMutualTLSConfigs(t *testing.T, insecureSkipVerify bool) (*tls.Config, *tls.Config, host.PeerID) {
+func testMutualTLSConfigs(t *testing.T, insecureSkipVerify bool) (serverConfig, clientConfig *tls.Config, clientID host.PeerID) {
 	t.Helper()
 
 	caPriv, err := ecdsa.GenerateKey(elliptic.P256(), crand.Reader)

--- a/platform/view/services/comm/host/websocket/ws/race_test.go
+++ b/platform/view/services/comm/host/websocket/ws/race_test.go
@@ -36,8 +36,8 @@ func (c *raceConn) ReadMessage() (int, []byte, error) {
 	return r.msgType, r.msg, r.err
 }
 
-func (c *raceConn) WriteMessage(messageType int, data []byte) error { return nil }
-func (c *raceConn) Close() error {
+func (*raceConn) WriteMessage(_ int, _ []byte) error { return nil }
+func (*raceConn) Close() error {
 	return nil
 }
 

--- a/platform/view/services/comm/host/websocket/ws/simple_provider.go
+++ b/platform/view/services/comm/host/websocket/ws/simple_provider.go
@@ -27,11 +27,11 @@ func NewSimpleProvider() *SimpleProvider {
 
 type SimpleProvider struct{}
 
-func (p *SimpleProvider) Close() error {
+func (*SimpleProvider) Close() error {
 	return nil
 }
 
-func (p *SimpleProvider) NewClientStream(info host2.StreamInfo, ctx context.Context, src host2.PeerID, config *tls.Config) (host2.P2PStream, error) {
+func (*SimpleProvider) NewClientStream(info host2.StreamInfo, ctx context.Context, src host2.PeerID, config *tls.Config) (host2.P2PStream, error) {
 	logger.Debugf("Creating new stream from [%s] to [%s@%s]...", src, info.RemotePeerID, info.RemotePeerAddress)
 	tlsEnabled := config != nil
 	url := url.URL{Scheme: schemes[tlsEnabled], Host: info.RemotePeerAddress, Path: "/p2p"}
@@ -73,7 +73,7 @@ func (p *SimpleProvider) NewClientStream(info host2.StreamInfo, ctx context.Cont
 	return NewWSStream(conn, trace.ContextWithSpanContext(context.Background(), spanContext), info), nil
 }
 
-func (p *SimpleProvider) NewServerStream(writer http.ResponseWriter, request *http.Request, newStreamCallback func(host2.P2PStream)) error {
+func (*SimpleProvider) NewServerStream(writer http.ResponseWriter, request *http.Request, newStreamCallback func(host2.P2PStream)) error {
 	expectedPeerID, err := expectedPeerIDFromRequest(request)
 	if err != nil {
 		return errors.Wrapf(err, "failed extracting expected peerID from TLS certificate")

--- a/platform/view/services/comm/host/websocket/ws/stream.go
+++ b/platform/view/services/comm/host/websocket/ws/stream.go
@@ -75,7 +75,7 @@ func NewWSStream(conn connection, ctx context.Context, info host2.StreamInfo) *s
 	// Start ping sender if the underlying connection is a websocket.Conn
 	if c, ok := s.conn.(*gwebsocket.Conn); ok {
 		// Set pong handler to reset read deadline
-		c.SetPongHandler(func(appData string) error {
+		c.SetPongHandler(func(_ string) error {
 			_ = c.SetReadDeadline(time.Now().Add(readTimeout))
 			return nil
 		})

--- a/platform/view/services/comm/host/websocket/ws/stream_timeout_test.go
+++ b/platform/view/services/comm/host/websocket/ws/stream_timeout_test.go
@@ -204,7 +204,7 @@ func (m *mockWebSocketConn) ReadMessage() (int, []byte, error) {
 }
 
 // WriteMessage implements the websocket.Conn interface
-func (m *mockWebSocketConn) WriteMessage(messageType int, data []byte) error {
+func (m *mockWebSocketConn) WriteMessage(_ int, data []byte) error {
 	// Simulate writing by sending to writeCh
 	select {
 	case m.writeCh <- data:

--- a/platform/view/services/comm/io/msgconn.go
+++ b/platform/view/services/comm/io/msgconn.go
@@ -92,6 +92,6 @@ func (c *commSCCMsgConn) Read() ([]byte, error) {
 	return msg.Payload, nil
 }
 
-func (c *commSCCMsgConn) Flush() error {
+func (*commSCCMsgConn) Flush() error {
 	return nil
 }

--- a/platform/view/services/comm/io/msgconn_test.go
+++ b/platform/view/services/comm/io/msgconn_test.go
@@ -265,7 +265,7 @@ func (m *mockSession) Receive() <-chan *view.Message {
 	return m.ch
 }
 
-func (m *mockSession) Info() view.SessionInfo {
+func (*mockSession) Info() view.SessionInfo {
 	return view.SessionInfo{}
 }
 
@@ -279,7 +279,7 @@ func (m *mockSession) SessionID() string {
 	return m.sessionID
 }
 
-func (m *mockSession) Context() view.Context {
+func (*mockSession) Context() view.Context {
 	return nil
 }
 
@@ -300,6 +300,6 @@ func (m *mockSession) ReceiveWithTimeout(timeout time.Duration) (*view.Message, 
 	}
 }
 
-func (m *mockSession) String() string {
+func (*mockSession) String() string {
 	return "mock-session"
 }

--- a/platform/view/services/comm/io/streamio/reader_enhanced_test.go
+++ b/platform/view/services/comm/io/streamio/reader_enhanced_test.go
@@ -183,6 +183,6 @@ func (e *errorMsgReader) Read() ([]byte, error) {
 
 type nilMsgReader struct{}
 
-func (n *nilMsgReader) Read() ([]byte, error) {
+func (*nilMsgReader) Read() ([]byte, error) {
 	return nil, nil
 }

--- a/platform/view/services/comm/p2p.go
+++ b/platform/view/services/comm/p2p.go
@@ -470,7 +470,7 @@ func (s *streamHandler) handleIncoming() {
 	}
 }
 
-func (s *streamHandler) close(ctx context.Context) {
+func (s *streamHandler) close(_ context.Context) {
 	if s.closed.Swap(true) {
 		return
 	}

--- a/platform/view/services/comm/p2p_remedy_test.go
+++ b/platform/view/services/comm/p2p_remedy_test.go
@@ -26,15 +26,15 @@ type mockHost struct {
 	host2.P2PHost
 }
 
-func (m *mockHost) PeerID() host2.PeerID {
+func (*mockHost) PeerID() host2.PeerID {
 	return "mock-peer"
 }
 
-func (m *mockHost) Start(newStreamCallback func(stream host2.P2PStream)) error {
+func (*mockHost) Start(_ func(stream host2.P2PStream)) error {
 	return nil
 }
 
-func (m *mockHost) Close() error {
+func (*mockHost) Close() error {
 	return nil
 }
 
@@ -43,9 +43,9 @@ type mockStream struct {
 	ctx context.Context
 }
 
-func (m *mockStream) Hash() host2.StreamHash            { return "hash" }
-func (m *mockStream) Write(p []byte) (n int, err error) { return len(p), nil }
-func (m *mockStream) Read(p []byte) (n int, err error) {
+func (*mockStream) Hash() host2.StreamHash            { return "hash" }
+func (*mockStream) Write(p []byte) (n int, err error) { return len(p), nil }
+func (m *mockStream) Read(_ []byte) (n int, err error) {
 	select {
 	case <-m.ctx.Done():
 		return 0, io.EOF
@@ -53,14 +53,14 @@ func (m *mockStream) Read(p []byte) (n int, err error) {
 		return 0, io.EOF
 	}
 }
-func (m *mockStream) Close() error             { return nil }
+func (*mockStream) Close() error               { return nil }
 func (m *mockStream) Context() context.Context { return m.ctx }
 
-func (m *mockHost) NewStream(ctx context.Context, info host2.StreamInfo) (host2.P2PStream, error) {
+func (*mockHost) NewStream(ctx context.Context, _ host2.StreamInfo) (host2.P2PStream, error) {
 	return &mockStream{ctx: ctx}, nil
 }
 
-func (m *mockHost) StreamHash(info host2.StreamInfo) host2.StreamHash {
+func (*mockHost) StreamHash(_ host2.StreamInfo) host2.StreamHash {
 	return "hash"
 }
 

--- a/platform/view/services/comm/pingpong_test.go
+++ b/platform/view/services/comm/pingpong_test.go
@@ -134,7 +134,7 @@ type pingPongMockNode struct {
 	latency time.Duration
 }
 
-func (m *pingPongMockNode) sendTo(ctx context.Context, info host2.StreamInfo, msg proto.Message, session *NetworkStreamSession) error {
+func (m *pingPongMockNode) sendTo(_ context.Context, _ host2.StreamInfo, msg proto.Message, session *NetworkStreamSession) error {
 	// In a real implementation, this would send the message over the network
 	// For our test, we'll simulate network latency by sending the message back
 	// after a short delay

--- a/platform/view/services/comm/pki.go
+++ b/platform/view/services/comm/pki.go
@@ -16,7 +16,7 @@ import (
 
 type PKExtractor struct{}
 
-func (p *PKExtractor) ExtractPublicKey(id view.Identity) (any, error) {
+func (*PKExtractor) ExtractPublicKey(id view.Identity) (any, error) {
 	certRaw, _ := pem.Decode(id)
 	if certRaw == nil {
 		return nil, errors.Errorf("pem decoding returned nil")

--- a/platform/view/services/comm/session/support_test.go
+++ b/platform/view/services/comm/session/support_test.go
@@ -21,42 +21,42 @@ type mockSession struct {
 	ch <-chan *view.Message
 }
 
-func (m *mockSession) Info() view.SessionInfo { return view.SessionInfo{} }
+func (*mockSession) Info() view.SessionInfo { return view.SessionInfo{} }
 
-func (m *mockSession) Send(context.Context, []byte) error { return nil }
+func (*mockSession) Send(context.Context, []byte) error { return nil }
 
-func (m *mockSession) SendError(context.Context, []byte) error { return nil }
+func (*mockSession) SendError(context.Context, []byte) error { return nil }
 
 func (m *mockSession) Receive() <-chan *view.Message { return m.ch }
 
-func (m *mockSession) Close() {}
+func (*mockSession) Close() {}
 
 type mockContext struct {
 	s view.Session
 }
 
-func (m *mockContext) ID() string              { return "" }
-func (m *mockContext) Me() view.Identity       { return nil }
-func (m *mockContext) IsMe(view.Identity) bool { return false }
-func (m *mockContext) Initiator() view.View    { return nil }
-func (m *mockContext) GetSession(view.View, view.Identity, ...view.View) (view.Session, error) {
+func (*mockContext) ID() string              { return "" }
+func (*mockContext) Me() view.Identity       { return nil }
+func (*mockContext) IsMe(view.Identity) bool { return false }
+func (*mockContext) Initiator() view.View    { return nil }
+func (*mockContext) GetSession(view.View, view.Identity, ...view.View) (view.Session, error) {
 	return nil, nil
 }
 
-func (m *mockContext) GetSessionByID(string, view.Identity) (view.Session, error) {
+func (*mockContext) GetSessionByID(string, view.Identity) (view.Session, error) {
 	return nil, nil
 }
-func (m *mockContext) Context() context.Context { return context.Background() }
-func (m *mockContext) Session() view.Session    { return m.s }
-func (m *mockContext) RunView(view.View, ...view.RunViewOption) (any, error) {
+func (*mockContext) Context() context.Context { return context.Background() }
+func (m *mockContext) Session() view.Session  { return m.s }
+func (*mockContext) RunView(view.View, ...view.RunViewOption) (any, error) {
 	return nil, nil
 }
-func (m *mockContext) OnError(func()) {}
-func (m *mockContext) GetService(any) (any, error) {
+func (*mockContext) OnError(func()) {}
+func (*mockContext) GetService(any) (any, error) {
 	return nil, nil
 }
 
-func (m *mockContext) StartSpanFrom(ctx context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
+func (*mockContext) StartSpanFrom(ctx context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
 	return ctx, trace.SpanFromContext(ctx)
 }
 

--- a/platform/view/services/comm/session_deadlock_test.go
+++ b/platform/view/services/comm/session_deadlock_test.go
@@ -205,7 +205,7 @@ func TestSessionRecoverAfterClose(t *testing.T) { //nolint:paralleltest
 // mockSenderDeadlock implements the sender interface for testing.
 type mockSenderDeadlock struct{}
 
-func (m *mockSenderDeadlock) sendTo(ctx context.Context, info host2.StreamInfo, msg proto.Message, session *NetworkStreamSession) error {
+func (*mockSenderDeadlock) sendTo(_ context.Context, _ host2.StreamInfo, _ proto.Message, _ *NetworkStreamSession) error {
 	// For the purpose of this test, we just need to avoid errors.
 	return nil
 }

--- a/platform/view/services/comm/session_test.go
+++ b/platform/view/services/comm/session_test.go
@@ -32,7 +32,7 @@ const (
 
 type mockSender struct{}
 
-func (m *mockSender) sendTo(ctx context.Context, info host2.StreamInfo, msg proto.Message, session *NetworkStreamSession) error {
+func (*mockSender) sendTo(_ context.Context, _ host2.StreamInfo, _ proto.Message, _ *NetworkStreamSession) error {
 	return nil
 }
 

--- a/platform/view/services/comm/sessions_test_utils.go
+++ b/platform/view/services/comm/sessions_test_utils.go
@@ -132,7 +132,7 @@ func RunResponder(t *testing.T, ctx context.Context, node *HostNode) {
 			wg.Add(1)
 			go func(msg *view.Message) {
 				defer wg.Done()
-				runResponder(t, ctx, node, msg)
+				respondToSession(t, ctx, node, msg)
 			}(firstMsg)
 		}
 	}()
@@ -140,7 +140,7 @@ func RunResponder(t *testing.T, ctx context.Context, node *HostNode) {
 	wg.Wait()
 }
 
-func runResponder(t *testing.T, ctx context.Context, node *HostNode, msg *view.Message) {
+func respondToSession(t *testing.T, ctx context.Context, node *HostNode, msg *view.Message) {
 	t.Helper()
 	messagesToReceive := messages(msg.SessionID)
 	if string(messagesToReceive[0]) != string(msg.Payload) {

--- a/platform/view/services/comm/stress_test.go
+++ b/platform/view/services/comm/stress_test.go
@@ -210,7 +210,7 @@ type mockOversizedStream struct {
 	onClose func()
 }
 
-func (m *mockOversizedStream) Read(p []byte) (int, error) {
+func (*mockOversizedStream) Read(p []byte) (int, error) {
 	// Send a varint for 11MB (11 * 1024 * 1024 = 11534336)
 	// Varint for 11534336 is [0x80, 0x80, 0xBF, 0x05]
 	oversizedVarint := []byte{0x80, 0x80, 0xBF, 0x05}
@@ -239,6 +239,6 @@ type mockCounter struct {
 	val atomic.Int64
 }
 
-func (m *mockCounter) Inc()                                       { m.val.Add(1) }
-func (m *mockCounter) Add(delta float64)                          { m.val.Add(int64(delta)) }
-func (m *mockCounter) With(labelValues ...string) metrics.Counter { return m }
+func (m *mockCounter) Inc()                             { m.val.Add(1) }
+func (m *mockCounter) Add(delta float64)                { m.val.Add(int64(delta)) }
+func (m *mockCounter) With(_ ...string) metrics.Counter { return m }

--- a/platform/view/services/comm/timeout_test.go
+++ b/platform/view/services/comm/timeout_test.go
@@ -196,13 +196,13 @@ func TestServiceStartRetryDelay(t *testing.T) { //nolint:paralleltest
 // Mock implementations for timeout tests
 type mockSenderTimeout struct{}
 
-func (m *mockSenderTimeout) sendTo(ctx context.Context, info host2.StreamInfo, msg proto.Message, session *NetworkStreamSession) error {
+func (*mockSenderTimeout) sendTo(_ context.Context, _ host2.StreamInfo, _ proto.Message, _ *NetworkStreamSession) error {
 	return nil
 }
 
 type mockFailingHostProvider struct{}
 
-func (m *mockFailingHostProvider) GetNewHost() (host2.P2PHost, error) {
+func (*mockFailingHostProvider) GetNewHost() (host2.P2PHost, error) {
 	return &mockHostForTimeout{}, errors.New("simulated host creation failure")
 }
 
@@ -210,38 +210,38 @@ type mockHostForTimeout struct {
 	host2.P2PHost
 }
 
-func (m *mockHostForTimeout) PeerID() host2.PeerID {
+func (*mockHostForTimeout) PeerID() host2.PeerID {
 	return "mock-peer"
 }
 
-func (m *mockHostForTimeout) Start(newStreamCallback func(stream host2.P2PStream)) error {
+func (*mockHostForTimeout) Start(_ func(stream host2.P2PStream)) error {
 	return nil
 }
 
-func (m *mockHostForTimeout) Close() error {
+func (*mockHostForTimeout) Close() error {
 	return nil
 }
 
 type mockEndpointService struct{}
 
-func (m *mockEndpointService) GetIdentity(label string, pkID []byte) (view.Identity, error) {
+func (*mockEndpointService) GetIdentity(_ string, _ []byte) (view.Identity, error) {
 	return nil, nil
 }
 
 type mockConfigService struct{}
 
-func (m *mockConfigService) GetString(key string) string {
+func (*mockConfigService) GetString(_ string) string {
 	return ""
 }
 
-func (m *mockConfigService) GetPath(key string) string {
+func (*mockConfigService) GetPath(_ string) string {
 	return ""
 }
 
-func (m *mockConfigService) GetInt(key string) int {
+func (*mockConfigService) GetInt(_ string) int {
 	return 4 // default numWorkers
 }
 
-func (m *mockConfigService) IsSet(key string) bool {
+func (*mockConfigService) IsSet(_ string) bool {
 	return false
 }

--- a/platform/view/services/config/config_util.go
+++ b/platform/view/services/config/config_util.go
@@ -24,7 +24,7 @@ import (
 // customDecodeHook adds the additional functions of parsing durations from strings
 // as well as parsing strings of the format "[thing1, thing2, thing3]" into string slices
 // Note that whitespace around slice elements is removed
-func customDecodeHook(f, t reflect.Type, data any) (any, error) {
+func customDecodeHook(f, _ reflect.Type, data any) (any, error) {
 	if f.Kind() != reflect.String {
 		return data, nil
 	}

--- a/platform/view/services/config/provider.go
+++ b/platform/view/services/config/provider.go
@@ -223,7 +223,7 @@ func (p *Provider) String() string {
 
 // ProvideFromRaw returns a new Provider whose configuration is loaded from the given byte representation.
 // The function expects a valid `yaml` representation.
-func (p *Provider) ProvideFromRaw(raw []byte) (*Provider, error) {
+func (*Provider) ProvideFromRaw(raw []byte) (*Provider, error) {
 	newProvider := &Provider{
 		eventSystem: simple.NewEventBus(),
 	}
@@ -349,7 +349,7 @@ func (p *Provider) setupEnv() error {
 // the configuration we need.  If Backend == nil, we will initialize the global
 // koanf instance
 // ----------------------------------------------------------------------------------
-func (p *Provider) initConfigPaths(confPath string) ([]string, error) {
+func (*Provider) initConfigPaths(confPath string) ([]string, error) {
 	var paths []string
 
 	if len(confPath) != 0 {
@@ -416,7 +416,7 @@ type eventListener struct {
 }
 
 // OnReceive is called when a merge configuration event is received.
-func (e *eventListener) OnReceive(event events.Event) {
+func (e *eventListener) OnReceive(_ events.Event) {
 	e.handler.OnMergeConfig()
 }
 
@@ -424,12 +424,12 @@ func (e *eventListener) OnReceive(event events.Event) {
 type MergeConfigEvent struct{}
 
 // Topic returns the merge configuration event topic.
-func (m *MergeConfigEvent) Topic() string {
+func (*MergeConfigEvent) Topic() string {
 	return MergeConfigEventTopic
 }
 
 // Message returns the merge configuration event message.
-func (m *MergeConfigEvent) Message() any {
+func (*MergeConfigEvent) Message() any {
 	return nil
 }
 

--- a/platform/view/services/config/provider_test.go
+++ b/platform/view/services/config/provider_test.go
@@ -185,7 +185,7 @@ type mockProvider struct {
 	service any
 }
 
-func (m *mockProvider) GetService(v any) (any, error) {
+func (m *mockProvider) GetService(_ any) (any, error) {
 	return m.service, nil
 }
 

--- a/platform/view/services/endpoint/pki.go
+++ b/platform/view/services/endpoint/pki.go
@@ -18,7 +18,7 @@ type DefaultPublicKeyIDSynthesizer struct{}
 // PublicKeyID generates a unique identifier for a public key by marshaling it to
 // PKIX format and computing its SHA-256 hash.
 // Returns an error if the key cannot be marshaled (e.g., unsupported key type).
-func (d DefaultPublicKeyIDSynthesizer) PublicKeyID(key any) ([]byte, error) {
+func (DefaultPublicKeyIDSynthesizer) PublicKeyID(key any) ([]byte, error) {
 	raw, err := x509.MarshalPKIXPublicKey(key)
 	if err != nil {
 		return nil, err

--- a/platform/view/services/endpoint/service.go
+++ b/platform/view/services/endpoint/service.go
@@ -78,6 +78,8 @@ type Resolver struct {
 func (r *Resolver) GetName() string { return r.Name }
 
 // GetId returns the identity associated with this resolver.
+//
+//nolint:revive // var-naming: renaming this exported method is an API break; see follow-up
 func (r *Resolver) GetId() view.Identity { return r.ID }
 
 // GetAddress returns the address for the specified port name.
@@ -159,7 +161,7 @@ func (r *Service) Resolve(ctx context.Context, id view.Identity) (view.Identity,
 
 // GetResolver returns the resolver associated with the given identity.
 func (r *Service) GetResolver(ctx context.Context, id view.Identity) (*Resolver, error) {
-	return r.resolver(ctx, id)
+	return r.lookupResolver(ctx, id)
 }
 
 // Bind associates ephemeral identities with a long-term identity in the binding store.
@@ -367,17 +369,18 @@ func (r *Service) ExtractPKI(id []byte) []byte {
 	defer r.pkiExtractorsLock.RUnlock()
 
 	for _, extractor := range r.publicKeyExtractors {
-		if pk, err := extractor.ExtractPublicKey(id); pk != nil {
-			logger.Debugf("pki resolved for [%s]", id)
-			pkiID, err := r.publicKeyIDSynthesizer.PublicKeyID(pk)
-			if err != nil {
-				logger.Errorf("failed to synthesize public key ID for [%s]: %v", id, err)
-				continue
-			}
-			return pkiID
-		} else {
+		pk, err := extractor.ExtractPublicKey(id)
+		if pk == nil {
 			logger.Debugf("pki not resolved by [%s] for [%s]: [%s]", logging.Identifier(extractor), id, err)
+			continue
 		}
+		logger.Debugf("pki resolved for [%s]", id)
+		pkiID, err := r.publicKeyIDSynthesizer.PublicKeyID(pk)
+		if err != nil {
+			logger.Errorf("failed to synthesize public key ID for [%s]: %v", id, err)
+			continue
+		}
+		return pkiID
 	}
 	logger.Warnf("cannot resolve pki for [%s]", id)
 	return nil
@@ -400,7 +403,7 @@ func (r *Service) ResolveIdentities(endpoints ...string) ([]view.Identity, error
 
 // Resolver returns the resolver and PKI ID for the given identity.
 func (r *Service) Resolver(ctx context.Context, id view.Identity) (*Resolver, []byte, error) {
-	resolver, err := r.resolver(ctx, id)
+	resolver, err := r.lookupResolver(ctx, id)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -481,7 +484,7 @@ func (r *Service) PkiResolve(resolver *Resolver) []byte {
 
 // resolver attempts to find a resolver for the given identity, checking both
 // direct lookups and binding store lookups for long-term identities.
-func (r *Service) resolver(ctx context.Context, party view.Identity) (*Resolver, error) {
+func (r *Service) lookupResolver(ctx context.Context, party view.Identity) (*Resolver, error) {
 	// We can skip this check, but in case the long term was passed directly, this is going to spare us a DB lookup
 	resolver, err := r.resolverByIdentity(party)
 	if err == nil {

--- a/platform/view/services/endpoint/service_extended_test.go
+++ b/platform/view/services/endpoint/service_extended_test.go
@@ -336,7 +336,7 @@ type mockPublicKeyIDSynthesizer struct {
 	called bool
 }
 
-func (m *mockPublicKeyIDSynthesizer) PublicKeyID(key any) ([]byte, error) {
+func (m *mockPublicKeyIDSynthesizer) PublicKeyID(_ any) ([]byte, error) {
 	m.called = true
 	return m.id, nil
 }
@@ -442,7 +442,7 @@ type mockPublicKeyExtractor struct {
 	called bool
 }
 
-func (m *mockPublicKeyExtractor) ExtractPublicKey(id view.Identity) (any, error) {
+func (m *mockPublicKeyExtractor) ExtractPublicKey(_ view.Identity) (any, error) {
 	m.called = true
 	return m.key, m.err
 }
@@ -645,7 +645,7 @@ func TestConcurrency(t *testing.T) {
 
 		wg.Add(numGoroutines)
 		for i := range numGoroutines {
-			go func(idx int) {
+			go func(_ int) {
 				defer wg.Done()
 				_, err := service.UpdateResolver(
 					"test",

--- a/platform/view/services/grpc/client_test.go
+++ b/platform/view/services/grpc/client_test.go
@@ -38,7 +38,7 @@ type echoServer struct {
 	testpb.UnimplementedEchoServiceServer
 }
 
-func (es *echoServer) EchoCall(ctx context.Context,
+func (*echoServer) EchoCall(_ context.Context,
 	echo *testpb.Echo,
 ) (*testpb.Echo, error) {
 	return echo, nil
@@ -290,7 +290,7 @@ func TestNewConnection(t *testing.T) {
 			name: "server TLS pinning success",
 			config: grpc3.ClientConfig{
 				SecOpts: grpc3.SecureOptions{
-					VerifyCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+					VerifyCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 						if bytes.Equal(rawCerts[0], testCerts.serverCert.Certificate[0]) {
 							return nil
 						}
@@ -315,7 +315,7 @@ func TestNewConnection(t *testing.T) {
 			name: "server TLS pinning failure",
 			config: grpc3.ClientConfig{
 				SecOpts: grpc3.SecureOptions{
-					VerifyCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+					VerifyCertificate: func(_ [][]byte, _ [][]*x509.Certificate) error {
 						return errors.New("TLS certificate mismatch")
 					},
 					Certificate:       testCerts.certPEM,

--- a/platform/view/services/grpc/creds.go
+++ b/platform/view/services/grpc/creds.go
@@ -89,7 +89,7 @@ func (t *TLSConfig) SetClientCAs(certPool *x509.CertPool) {
 }
 
 // ClientHandshake is not implemented for `serverCreds`.
-func (sc *serverCreds) ClientHandshake(context.Context,
+func (*serverCreds) ClientHandshake(context.Context,
 	string, net.Conn,
 ) (net.Conn, credentials.AuthInfo, error) {
 	return nil, nil, ErrClientHandshakeNotImplemented
@@ -111,7 +111,7 @@ func (sc *serverCreds) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.
 }
 
 // Info provides the ProtocolInfo of this TransportCredentials.
-func (sc *serverCreds) Info() credentials.ProtocolInfo {
+func (*serverCreds) Info() credentials.ProtocolInfo {
 	return credentials.ProtocolInfo{
 		SecurityProtocol: "tls",
 		SecurityVersion:  "1.2", //nolint:staticcheck // SA1019: kept for callers still reading ProtocolInfo.SecurityVersion
@@ -127,7 +127,7 @@ func (sc *serverCreds) Clone() credentials.TransportCredentials {
 
 // OverrideServerName overrides the server name used to verify the hostname
 // on the returned certificates from the server.
-func (sc *serverCreds) OverrideServerName(string) error {
+func (*serverCreds) OverrideServerName(string) error {
 	return ErrOverrideHostnameNotSupported
 }
 
@@ -145,7 +145,7 @@ func (dtc *DynamicClientCredentials) ClientHandshake(ctx context.Context, author
 	return credentials.NewTLS(dtc.latestConfig()).ClientHandshake(ctx, authority, rawConn)
 }
 
-func (dtc *DynamicClientCredentials) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+func (*DynamicClientCredentials) ServerHandshake(_ net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	return nil, nil, ErrServerHandshakeNotImplemented
 }
 

--- a/platform/view/services/grpc/server.go
+++ b/platform/view/services/grpc/server.go
@@ -75,63 +75,62 @@ func NewGRPCServerFromListener(listener net.Listener, serverConfig ServerConfig)
 	secureConfig := serverConfig.SecOpts
 	if secureConfig.UseTLS {
 		// both key and cert are required
-		if secureConfig.Key != nil && secureConfig.Certificate != nil {
-			// load server public and private keys
-			commLogger.Debugf("Load server public and private keys")
-			cert, err := tls.X509KeyPair(secureConfig.Certificate, secureConfig.Key)
-			if err != nil {
-				return nil, err
+		if secureConfig.Key == nil || secureConfig.Certificate == nil {
+			return nil, errors.New("serverConfig.SecOpts must contain both Key and Certificate when UseTLS is true")
+		}
+		// load server public and private keys
+		commLogger.Debugf("Load server public and private keys")
+		cert, err := tls.X509KeyPair(secureConfig.Certificate, secureConfig.Key)
+		if err != nil {
+			return nil, err
+		}
+
+		grpcServer.serverCertificate.Store(cert)
+
+		// set up our TLS config
+		if len(secureConfig.CipherSuites) == 0 {
+			secureConfig.CipherSuites = DefaultTLSCipherSuites
+		}
+		getCert := func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			cert := grpcServer.serverCertificate.Load().(tls.Certificate)
+			return &cert, nil
+		}
+
+		grpcServer.tls = NewTLSConfig(&tls.Config{
+			VerifyPeerCertificate:  secureConfig.VerifyCertificate,
+			GetCertificate:         getCert,
+			SessionTicketsDisabled: true,
+			CipherSuites:           secureConfig.CipherSuites,
+		})
+
+		if serverConfig.SecOpts.TimeShift > 0 {
+			timeShift := serverConfig.SecOpts.TimeShift
+			grpcServer.tls.config.Time = func() time.Time {
+				return time.Now().Add((-1) * timeShift)
 			}
+		}
+		grpcServer.tls.config.ClientAuth = tls.RequestClientCert
+		// check if client authentication is required
+		if secureConfig.RequireClientCert {
+			// require TLS client auth
+			grpcServer.tls.config.ClientAuth = tls.RequireAndVerifyClientCert
+			// if we have client root CAs, create a certPool
+			if len(secureConfig.ClientRootCAs) > 0 {
+				grpcServer.clientRootCAs = make(map[string]*x509.Certificate)
 
-			grpcServer.serverCertificate.Store(cert)
-
-			// set up our TLS config
-			if len(secureConfig.CipherSuites) == 0 {
-				secureConfig.CipherSuites = DefaultTLSCipherSuites
-			}
-			getCert := func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
-				cert := grpcServer.serverCertificate.Load().(tls.Certificate)
-				return &cert, nil
-			}
-
-			grpcServer.tls = NewTLSConfig(&tls.Config{
-				VerifyPeerCertificate:  secureConfig.VerifyCertificate,
-				GetCertificate:         getCert,
-				SessionTicketsDisabled: true,
-				CipherSuites:           secureConfig.CipherSuites,
-			})
-
-			if serverConfig.SecOpts.TimeShift > 0 {
-				timeShift := serverConfig.SecOpts.TimeShift
-				grpcServer.tls.config.Time = func() time.Time {
-					return time.Now().Add((-1) * timeShift)
-				}
-			}
-			grpcServer.tls.config.ClientAuth = tls.RequestClientCert
-			// check if client authentication is required
-			if secureConfig.RequireClientCert {
-				// require TLS client auth
-				grpcServer.tls.config.ClientAuth = tls.RequireAndVerifyClientCert
-				// if we have client root CAs, create a certPool
-				if len(secureConfig.ClientRootCAs) > 0 {
-					grpcServer.clientRootCAs = make(map[string]*x509.Certificate)
-
-					grpcServer.tls.config.ClientCAs = x509.NewCertPool()
-					for _, clientRootCA := range secureConfig.ClientRootCAs {
-						err = grpcServer.appendClientRootCA(clientRootCA)
-						if err != nil {
-							return nil, err
-						}
+				grpcServer.tls.config.ClientCAs = x509.NewCertPool()
+				for _, clientRootCA := range secureConfig.ClientRootCAs {
+					err = grpcServer.appendClientRootCA(clientRootCA)
+					if err != nil {
+						return nil, err
 					}
 				}
 			}
-
-			// create credentials and add to server options
-			creds := NewServerTransportCredentials(grpcServer.tls, serverConfig.Logger)
-			serverOpts = append(serverOpts, grpc.Creds(creds))
-		} else {
-			return nil, errors.New("serverConfig.SecOpts must contain both Key and Certificate when UseTLS is true")
 		}
+
+		// create credentials and add to server options
+		creds := NewServerTransportCredentials(grpcServer.tls, serverConfig.Logger)
+		serverOpts = append(serverOpts, grpc.Creds(creds))
 	}
 	// set max send and recv msg sizes
 	serverOpts = append(serverOpts, grpc.MaxSendMsgSize(MaxSendMsgSize))

--- a/platform/view/services/grpc/server_test.go
+++ b/platform/view/services/grpc/server_test.go
@@ -87,11 +87,11 @@ type emptyServiceServer struct {
 	testpb.UnsafeEmptyServiceServer
 }
 
-func (ess *emptyServiceServer) EmptyCall(context.Context, *testpb.Empty) (*testpb.Empty, error) {
+func (*emptyServiceServer) EmptyCall(context.Context, *testpb.Empty) (*testpb.Empty, error) {
 	return new(testpb.Empty), nil
 }
 
-func (esss *emptyServiceServer) EmptyStream(stream testpb.EmptyService_EmptyStreamServer) error {
+func (*emptyServiceServer) EmptyStream(stream testpb.EmptyService_EmptyStreamServer) error {
 	for {
 		_, err := stream.Recv()
 		if errors.Is(err, io.EOF) {
@@ -704,7 +704,7 @@ func TestVerifyCertificateCallback(t *testing.T) {
 	serverKeyPair, err := ca.NewServerCertKeyPair("127.0.0.1")
 	require.NoError(t, err)
 
-	verifyFunc := func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+	verifyFunc := func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 		if bytes.Equal(rawCerts[0], authorizedClientKeyPair.TLSCert.Raw) {
 			return nil
 		}
@@ -917,9 +917,8 @@ func runMutualAuth(t *testing.T, servers []testServer, trustedClients, unTrusted
 			// we expect success from trusted clients
 			if err != nil {
 				return err
-			} else {
-				t.Logf("Trusted client%d successfully connected to %s", j, srvAddr)
 			}
+			t.Logf("Trusted client%d successfully connected to %s", j, srvAddr)
 		}
 
 		// loop through all the untrusted clients
@@ -930,11 +929,10 @@ func runMutualAuth(t *testing.T, servers []testServer, trustedClients, unTrusted
 				grpc.WithTransportCredentials(credentials.NewTLS(unTrustedClients[k])),
 			)
 			// we expect failure from untrusted clients
-			if err != nil {
-				t.Logf("Untrusted client%d was correctly rejected by %s", k, srvAddr)
-			} else {
+			if err == nil {
 				return errors.Errorf("Untrusted client %d should not have been able to connect to %s", k, srvAddr)
 			}
+			t.Logf("Untrusted client%d was correctly rejected by %s", k, srvAddr)
 		}
 	}
 
@@ -1244,19 +1242,19 @@ func TestServerInterceptors(t *testing.T) {
 	// set up interceptors
 	usiCount := uint32(0)
 	ssiCount := uint32(0)
-	usi1 := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+	usi1 := func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
 		atomic.AddUint32(&usiCount, 1)
 		return handler(ctx, req)
 	}
-	usi2 := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+	usi2 := func(_ context.Context, _ any, _ *grpc.UnaryServerInfo, _ grpc.UnaryHandler) (resp any, err error) {
 		atomic.AddUint32(&usiCount, 1)
 		return nil, status.Error(codes.Aborted, msg)
 	}
-	ssi1 := func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	ssi1 := func(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		atomic.AddUint32(&ssiCount, 1)
 		return handler(srv, ss)
 	}
-	ssi2 := func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	ssi2 := func(_ any, _ grpc.ServerStream, _ *grpc.StreamServerInfo, _ grpc.StreamHandler) error {
 		atomic.AddUint32(&ssiCount, 1)
 		return status.Error(codes.Aborted, msg)
 	}

--- a/platform/view/services/grpc/serverstatshandler.go
+++ b/platform/view/services/grpc/serverstatshandler.go
@@ -19,17 +19,17 @@ type ServerStatsHandler struct {
 	ClosedConnCounter metrics.Counter
 }
 
-func (h *ServerStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
+func (*ServerStatsHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
 	return ctx
 }
 
-func (h *ServerStatsHandler) HandleRPC(ctx context.Context, s stats.RPCStats) {}
+func (*ServerStatsHandler) HandleRPC(_ context.Context, _ stats.RPCStats) {}
 
-func (h *ServerStatsHandler) TagConn(ctx context.Context, info *stats.ConnTagInfo) context.Context {
+func (*ServerStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
 	return ctx
 }
 
-func (h *ServerStatsHandler) HandleConn(ctx context.Context, s stats.ConnStats) {
+func (h *ServerStatsHandler) HandleConn(_ context.Context, s stats.ConnStats) {
 	switch s.(type) {
 	case *stats.ConnBegin:
 		h.OpenConnCounter.Add(1)

--- a/platform/view/services/id/kms/driver/file/driver.go
+++ b/platform/view/services/id/kms/driver/file/driver.go
@@ -24,7 +24,7 @@ func NewDriver() driver.NamedDriver {
 
 type Driver struct{}
 
-func (d *Driver) Load(configProvider driver.ConfigProvider) (view.Identity, driver.Signer, driver.Verifier, error) {
+func (*Driver) Load(configProvider driver.ConfigProvider) (view.Identity, driver.Signer, driver.Verifier, error) {
 	idPEM, err := os.ReadFile(configProvider.GetPath("fsc.identity.cert.file"))
 	if err != nil {
 		return nil, nil, nil, errors.Wrapf(err, "failed loading SFC Node Identity")

--- a/platform/view/services/id/x509/deserializer.go
+++ b/platform/view/services/id/x509/deserializer.go
@@ -25,7 +25,7 @@ type Deserializer struct{}
 // deserializer used by sig.Service, so its output must not be treated as an
 // authorization decision on its own - callers must check the resulting
 // identity against an explicit allow-list before trusting it.
-func (x *Deserializer) DeserializeVerifier(raw []byte) (driver.Verifier, error) {
+func (*Deserializer) DeserializeVerifier(raw []byte) (driver.Verifier, error) {
 	genericPublicKey, err := PemDecodeKey(raw)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed parsing received public key")
@@ -38,11 +38,11 @@ func (x *Deserializer) DeserializeVerifier(raw []byte) (driver.Verifier, error) 
 	return NewVerifier(publicKey), nil
 }
 
-func (x *Deserializer) DeserializeSigner(raw []byte) (driver.Signer, error) {
+func (*Deserializer) DeserializeSigner(_ []byte) (driver.Signer, error) {
 	return nil, errors.New("not supported")
 }
 
-func (x *Deserializer) Info(raw, auditInfo []byte) (string, error) {
+func (*Deserializer) Info(raw, _ []byte) (string, error) {
 	cert, err := PemDecodeCert(raw)
 	if err != nil {
 		return "", err

--- a/platform/view/services/id/x509/x509_test.go
+++ b/platform/view/services/id/x509/x509_test.go
@@ -161,7 +161,7 @@ func TestVerifyRejectsInvalidEncodings(t *testing.T) {
 	require.EqualError(t, err, "signature not valid")
 }
 
-func newTestMaterial(t *testing.T, commonName string) (*ecdsa.PrivateKey, []byte, []byte, []byte) {
+func newTestMaterial(t *testing.T, commonName string) (key *ecdsa.PrivateKey, cert, pubKeyPEM, privKeyPEM []byte) {
 	t.Helper()
 
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/platform/view/services/metrics/disabled/provider.go
+++ b/platform/view/services/metrics/disabled/provider.go
@@ -12,28 +12,28 @@ import (
 
 type Provider struct{}
 
-func (p *Provider) NewCounter(o metrics.CounterOpts) metrics.Counter       { return &Counter{} }
-func (p *Provider) NewGauge(o metrics.GaugeOpts) metrics.Gauge             { return &Gauge{} }
-func (p *Provider) NewHistogram(o metrics.HistogramOpts) metrics.Histogram { return &Histogram{} }
+func (*Provider) NewCounter(_ metrics.CounterOpts) metrics.Counter       { return &Counter{} }
+func (*Provider) NewGauge(_ metrics.GaugeOpts) metrics.Gauge             { return &Gauge{} }
+func (*Provider) NewHistogram(_ metrics.HistogramOpts) metrics.Histogram { return &Histogram{} }
 
 type Counter struct{}
 
-func (c *Counter) Add(delta float64) {}
-func (c *Counter) With(labelValues ...string) metrics.Counter {
+func (*Counter) Add(_ float64) {}
+func (c *Counter) With(_ ...string) metrics.Counter {
 	return c
 }
 
 type Gauge struct{}
 
-func (g *Gauge) Add(delta float64) {}
-func (g *Gauge) Set(delta float64) {}
-func (g *Gauge) With(labelValues ...string) metrics.Gauge {
+func (*Gauge) Add(_ float64) {}
+func (*Gauge) Set(_ float64) {}
+func (g *Gauge) With(_ ...string) metrics.Gauge {
 	return g
 }
 
 type Histogram struct{}
 
-func (h *Histogram) Observe(value float64) {}
-func (h *Histogram) With(labelValues ...string) metrics.Histogram {
+func (*Histogram) Observe(_ float64) {}
+func (h *Histogram) With(_ ...string) metrics.Histogram {
 	return h
 }

--- a/platform/view/services/metrics/operations/fakes/handler.go
+++ b/platform/view/services/metrics/operations/fakes/handler.go
@@ -13,7 +13,7 @@ type Handler struct {
 	Text string
 }
 
-func (h *Handler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+func (h *Handler) ServeHTTP(resp http.ResponseWriter, _ *http.Request) {
 	resp.WriteHeader(h.Code)
 	_, _ = resp.Write([]byte(h.Text))
 }

--- a/platform/view/services/metrics/prometheus/provider.go
+++ b/platform/view/services/metrics/prometheus/provider.go
@@ -67,7 +67,7 @@ func Replacers() map[string]string {
 	return replacers
 }
 
-func (p *Provider) applyNamespaceSubsystem(namespace, subsystem *string) {
+func (*Provider) applyNamespaceSubsystem(namespace, subsystem *string) {
 	ns, ss := parseFullPkgName(GetPackageName(), Replacers())
 	if len(*namespace) == 0 {
 		*namespace = ns
@@ -148,11 +148,11 @@ func GetPackageName() string {
 	return fullFuncName[:lastSlash+dotAfterSlash]
 }
 
-func parseFullPkgName(fullPkgName string, replacements map[string]string, params ...string) (string, string) {
+func parseFullPkgName(fullPkgName string, replacements map[string]string, params ...string) (namespace, subsystem string) {
 	parts := append(strings.Split(fullPkgName, "/"), params...)
-	subsystem := parts[len(parts)-1]
+	subsystem = parts[len(parts)-1]
 	namespaceParts := parts[:len(parts)-1]
-	namespace := strings.Join(namespaceParts, "_")
+	namespace = strings.Join(namespaceParts, "_")
 
 	for old, newVal := range replacements {
 		namespace = strings.ReplaceAll(namespace, old, newVal)

--- a/platform/view/services/sig/service.go
+++ b/platform/view/services/sig/service.go
@@ -314,7 +314,7 @@ type si struct {
 	signer driver2.Signer
 }
 
-func (s *si) Verify(message, signature []byte) error {
+func (*si) Verify(_, _ []byte) error {
 	panic("implement me")
 }
 

--- a/platform/view/services/sig/service_test.go
+++ b/platform/view/services/sig/service_test.go
@@ -61,7 +61,7 @@ func TestService_RegisterSigner(t *testing.T) {
 		{
 			name:   "nil signer returns error",
 			signer: nil,
-			setupStore: func(store *mock.SignerInfoStore) {
+			setupStore: func(_ *mock.SignerInfoStore) {
 				// no setup needed
 			},
 			expectedErr:    "invalid signer",
@@ -103,7 +103,7 @@ func TestService_RegisterSigner(t *testing.T) {
 				existingSigner := &mock.Signer{}
 				s.signers[identity.UniqueID()] = driver2.SignerEntry{Signer: existingSigner}
 			},
-			setupStore: func(store *mock.SignerInfoStore) {
+			setupStore: func(_ *mock.SignerInfoStore) {
 				// should not be called
 			},
 			expectInCache:  true,
@@ -332,7 +332,7 @@ func TestService_IsMe(t *testing.T) {
 			preRegister: func(s *Service) {
 				s.signers[identity.UniqueID()] = driver2.SignerEntry{Signer: &mock.Signer{}}
 			},
-			setupStore: func(store *mock.SignerInfoStore) {
+			setupStore: func(_ *mock.SignerInfoStore) {
 				// should not be called
 			},
 			expected: true,
@@ -396,7 +396,7 @@ func TestService_AreMe(t *testing.T) {
 				s.signers[id1.UniqueID()] = driver2.SignerEntry{Signer: &mock.Signer{}}
 				s.signers[id2.UniqueID()] = driver2.SignerEntry{Signer: &mock.Signer{}}
 			},
-			setupStore: func(store *mock.SignerInfoStore) {
+			setupStore: func(_ *mock.SignerInfoStore) {
 				// should not be called
 			},
 			expectedCount:  2,
@@ -490,7 +490,7 @@ func TestService_Info(t *testing.T) {
 			setupAuditStore: func(store *mock.AuditInfoStore) {
 				store.GetAuditInfoReturns(nil, errors.New("not found"))
 			},
-			setupDeserializer: func(des *mock.Deserializer) {
+			setupDeserializer: func(_ *mock.Deserializer) {
 				// should not be called
 			},
 			expectedContains: "unable to identify identity",
@@ -544,7 +544,7 @@ func TestService_GetSigner(t *testing.T) {
 			preRegister: func(s *Service) {
 				s.signers[identity.UniqueID()] = driver2.SignerEntry{Signer: &mock.Signer{}}
 			},
-			setupDeserializer: func(des *mock.Deserializer) {
+			setupDeserializer: func(_ *mock.Deserializer) {
 				// should not be called
 			},
 			expectSigner:     true,
@@ -618,7 +618,7 @@ func TestService_GetVerifier(t *testing.T) {
 			preRegister: func(s *Service) {
 				s.verifiers[identity.UniqueID()] = VerifierEntry{Verifier: &mock.Verifier{}}
 			},
-			setupDeserializer: func(des *mock.Deserializer) {
+			setupDeserializer: func(_ *mock.Deserializer) {
 				// should not be called
 			},
 			expectVerifier:   true,
@@ -711,7 +711,7 @@ func TestService_GetSigningIdentity(t *testing.T) {
 			setupSigner: func() driver2.Signer {
 				return nil
 			},
-			preRegister: func(s *Service, signer driver2.Signer) {
+			preRegister: func(_ *Service, _ driver2.Signer) {
 				// don't register
 			},
 			expectedErr: "cannot find signer",

--- a/platform/view/services/storage/driver/driver.go
+++ b/platform/view/services/storage/driver/driver.go
@@ -16,10 +16,13 @@ import (
 
 var (
 	// UniqueKeyViolation happens when we try to insert a record with a conflicting unique key (e.g. replicas)
+	//nolint:revive // error-naming: renaming this exported error var to the ErrFoo form is an API break; see follow-up
 	UniqueKeyViolation = errors.New("unique key violation")
 	// DeadlockDetected happens when two transactions are taking place at the same time and interact with the same rows
+	//nolint:revive // error-naming: renaming this exported error var to the ErrFoo form is an API break; see follow-up
 	DeadlockDetected = errors.New("deadlock detected")
 	// SqlBusy happens when two transactions are trying to write at the same time. Can be avoided by opening the database in exclusive mode
+	//nolint:revive // var-naming: renaming this exported error var is an API break; see follow-up
 	SqlBusy = errors.New("sql is busy")
 )
 

--- a/platform/view/services/storage/driver/memory/config.go
+++ b/platform/view/services/storage/driver/memory/config.go
@@ -15,7 +15,7 @@ var Op = &optsProvider{}
 
 type optsProvider struct{}
 
-func (p *optsProvider) GetOpts(params ...string) sqlite2.Opts {
+func (*optsProvider) GetOpts(params ...string) sqlite2.Opts {
 	return sqlite2.Opts{
 		DataSource:      "file::memory:?cache=shared",
 		SkipPragmas:     false,
@@ -28,7 +28,7 @@ func (p *optsProvider) GetOpts(params ...string) sqlite2.Opts {
 	}
 }
 
-func (p *optsProvider) GetConfig(params ...string) sqlite2.Config {
+func (*optsProvider) GetConfig(params ...string) sqlite2.Config {
 	return sqlite2.Config{
 		DataSource:      "file::memory:?cache=shared",
 		SkipPragmas:     false,

--- a/platform/view/services/storage/driver/memory/driver_test.go
+++ b/platform/view/services/storage/driver/memory/driver_test.go
@@ -39,23 +39,23 @@ func (f *fakePersistence) CreateSchema() error {
 	return f.createSchemaErr
 }
 
-func (f *fakePersistence) Close() error {
+func (*fakePersistence) Close() error {
 	return nil
 }
 
-func (f *fakePersistence) BeginUpdate() error {
+func (*fakePersistence) BeginUpdate() error {
 	return nil
 }
 
-func (f *fakePersistence) Commit() error {
+func (*fakePersistence) Commit() error {
 	return nil
 }
 
-func (f *fakePersistence) Discard() error {
+func (*fakePersistence) Discard() error {
 	return nil
 }
 
-func (f *fakePersistence) Stats() any {
+func (*fakePersistence) Stats() any {
 	return nil
 }
 

--- a/platform/view/services/storage/driver/multiplexed/driver_test.go
+++ b/platform/view/services/storage/driver/multiplexed/driver_test.go
@@ -93,7 +93,7 @@ func TestDriver_NewKVS(t *testing.T) {
 		mockDriver.NewKVSReturns(&mock.KeyValueStore{}, nil)
 
 		config := &mock.Config{}
-		config.UnmarshalKeyStub = func(key string, v any) error {
+		config.UnmarshalKeyStub = func(_ string, v any) error {
 			if ptr, ok := v.(*driver.PersistenceType); ok {
 				*ptr = "postgres"
 			}
@@ -114,7 +114,7 @@ func TestDriver_NewKVS(t *testing.T) {
 		mockDriver.NewKVSReturns(&mock.KeyValueStore{}, nil)
 
 		config := &mock.Config{}
-		config.UnmarshalKeyStub = func(key string, v any) error {
+		config.UnmarshalKeyStub = func(_ string, v any) error {
 			if ptr, ok := v.(*driver.PersistenceType); ok {
 				*ptr = "postgres"
 			}
@@ -135,7 +135,7 @@ func TestDriver_NewKVS(t *testing.T) {
 		mockDriver.NewKVSReturns(&mock.KeyValueStore{}, nil)
 
 		config := &mock.Config{}
-		config.UnmarshalKeyStub = func(key string, v any) error {
+		config.UnmarshalKeyStub = func(_ string, v any) error {
 			if ptr, ok := v.(*driver.PersistenceType); ok {
 				*ptr = ""
 			}
@@ -167,7 +167,7 @@ func TestDriver_NewKVS(t *testing.T) {
 		t.Parallel()
 
 		config := &mock.Config{}
-		config.UnmarshalKeyStub = func(key string, v any) error {
+		config.UnmarshalKeyStub = func(_ string, v any) error {
 			if ptr, ok := v.(*driver.PersistenceType); ok {
 				*ptr = "postgres"
 			}
@@ -190,7 +190,7 @@ func TestDriver_NewKVS(t *testing.T) {
 		mockDriver.NewKVSReturns(nil, errors.New("driver error"))
 
 		config := &mock.Config{}
-		config.UnmarshalKeyStub = func(key string, v any) error {
+		config.UnmarshalKeyStub = func(_ string, v any) error {
 			if ptr, ok := v.(*driver.PersistenceType); ok {
 				*ptr = "postgres"
 			}
@@ -213,7 +213,7 @@ func TestDriver_NewBinding(t *testing.T) {
 	mockDriver.NewBindingReturns(&mock.BindingStore{}, nil)
 
 	config := &mock.Config{}
-	config.UnmarshalKeyStub = func(key string, v any) error {
+	config.UnmarshalKeyStub = func(_ string, v any) error {
 		if ptr, ok := v.(*driver.PersistenceType); ok {
 			*ptr = "sqlite"
 		}
@@ -251,7 +251,7 @@ func TestDriver_NewSignerInfo(t *testing.T) {
 	t.Parallel()
 
 	config := &mock.Config{}
-	config.UnmarshalKeyStub = func(key string, v any) error {
+	config.UnmarshalKeyStub = func(_ string, v any) error {
 		if ptr, ok := v.(*driver.PersistenceType); ok {
 			*ptr = "postgres"
 		}
@@ -289,7 +289,7 @@ func TestDriver_NewAuditInfo(t *testing.T) {
 	t.Parallel()
 
 	config := &mock.Config{}
-	config.UnmarshalKeyStub = func(key string, v any) error {
+	config.UnmarshalKeyStub = func(_ string, v any) error {
 		if ptr, ok := v.(*driver.PersistenceType); ok {
 			*ptr = "memory"
 		}
@@ -367,7 +367,7 @@ func TestDriver_getDriver(t *testing.T) {
 			if tt.configErr != nil {
 				config.UnmarshalKeyReturns(tt.configErr)
 			} else {
-				config.UnmarshalKeyStub = func(key string, v any) error {
+				config.UnmarshalKeyStub = func(_ string, v any) error {
 					if ptr, ok := v.(*driver.PersistenceType); ok {
 						*ptr = tt.driverType
 					}

--- a/platform/view/services/storage/driver/notifier/persistence_test.go
+++ b/platform/view/services/storage/driver/notifier/persistence_test.go
@@ -24,11 +24,11 @@ import (
 // fakeIterator is a simple fake for testing
 type fakeIterator struct{}
 
-func (f *fakeIterator) Next() (*driver.UnversionedRead, error) {
+func (*fakeIterator) Next() (*driver.UnversionedRead, error) {
 	return nil, nil
 }
 
-func (f *fakeIterator) Close() {
+func (*fakeIterator) Close() {
 }
 
 var _ iterators.Iterator[*driver.UnversionedRead] = (*fakeIterator)(nil)

--- a/platform/view/services/storage/driver/pagination/keyset.go
+++ b/platform/view/services/storage/driver/pagination/keyset.go
@@ -36,24 +36,26 @@ type keyset[I comparable, V any] struct {
 }
 
 // KeysetWithField creates a keyset pagination where the id has field name idFieldName
-func KeysetWithField[I comparable](offset, pageSize int, sqlIdName dbdriver.FieldName, idFieldName PropertyName[I]) (*keyset[I, any], error) {
+func KeysetWithField[I comparable](offset, pageSize int, sqlIDName dbdriver.FieldName, idFieldName PropertyName[I]) (*keyset[I, any], error) {
 	if strings.ToUpper(string(idFieldName[0])) != string(idFieldName[0]) {
 		return nil, errors.New("must use exported field")
 	}
-	return Keyset(offset, pageSize, sqlIdName, idFieldName.ExtractField)
+	return Keyset(offset, pageSize, sqlIDName, idFieldName.ExtractField)
 }
 
 type id[I comparable] interface {
-	Id() I
+	ID() I
 }
 
 // KeysetWithId creates a keyset pagination where the result object implements id[I]
-func KeysetWithId[I comparable, V id[I]](offset, pageSize int, sqlIdName dbdriver.FieldName) (*keyset[I, V], error) {
-	return Keyset[I, V](offset, pageSize, sqlIdName, func(v V) I { return v.Id() })
+//
+//nolint:revive // var-naming: renaming this exported func is an API break; see follow-up
+func KeysetWithId[I comparable, V id[I]](offset, pageSize int, sqlIDName dbdriver.FieldName) (*keyset[I, V], error) {
+	return Keyset[I, V](offset, pageSize, sqlIDName, func(v V) I { return v.ID() })
 }
 
-func (k *keyset[I, any]) Serialize() ([]byte, error) {
-	ret, err := json.Marshal(k)
+func (p *keyset[I, any]) Serialize() ([]byte, error) {
+	ret, err := json.Marshal(p)
 	return ret, err
 }
 
@@ -80,24 +82,24 @@ func KeysetFromRaw[I comparable](raw []byte, idFieldName PropertyName[I]) (*keys
 
 // Keyset creates a keyset pagination.
 //
-// sqlIdName has to be a plain column identifier: it is written into ORDER BY and
+// sqlIDName has to be a plain column identifier: it is written into ORDER BY and
 // into the cursor comparison verbatim, so an empty one would silently drop the
 // ORDER BY and page through rows in arbitrary order. Every other constructor in
 // this package, [KeysetFromRaw] included, goes through here.
-func Keyset[I comparable, V any](offset, pageSize int, sqlIdName dbdriver.FieldName, idGetter func(V) I) (*keyset[I, V], error) {
+func Keyset[I comparable, V any](offset, pageSize int, sqlIDName dbdriver.FieldName, idGetter func(V) I) (*keyset[I, V], error) {
 	if offset < 0 {
 		return nil, errors.Errorf("offset must be greater than zero. Offset: %d", offset)
 	}
 	if pageSize < 0 {
 		return nil, errors.Errorf("page size must be greater than zero. pageSize: %d", pageSize)
 	}
-	if err := sqlIdName.Validate(); err != nil {
+	if err := sqlIDName.Validate(); err != nil {
 		return nil, errors.WithMessage(err, "invalid keyset id column")
 	}
 	return &keyset[I, V]{
 		Offset:    offset,
 		PageSize:  pageSize,
-		SQLIDName: sqlIdName,
+		SQLIDName: sqlIDName,
 		idGetter:  idGetter,
 		FirstID:   nilElement[I](),
 		LastID:    nilElement[I](),
@@ -116,7 +118,7 @@ func nilElement[I any]() I {
 	}
 }
 
-func (p *keyset[I, V]) nilElement() I {
+func (*keyset[I, V]) zeroElement() I {
 	return nilElement[I]()
 }
 
@@ -131,7 +133,7 @@ func (p *keyset[I, V]) GoToOffset(offset int) (driver.Pagination, error) {
 			SQLIDName: p.SQLIDName,
 			idGetter:  p.idGetter,
 			FirstID:   p.LastID,
-			LastID:    p.nilElement(),
+			LastID:    p.zeroElement(),
 		}, nil
 	}
 	return &keyset[I, V]{
@@ -139,8 +141,8 @@ func (p *keyset[I, V]) GoToOffset(offset int) (driver.Pagination, error) {
 		PageSize:  p.PageSize,
 		SQLIDName: p.SQLIDName,
 		idGetter:  p.idGetter,
-		FirstID:   p.nilElement(),
-		LastID:    p.nilElement(),
+		FirstID:   p.zeroElement(),
+		LastID:    p.zeroElement(),
 	}, nil
 }
 
@@ -160,16 +162,16 @@ func (p *keyset[I, V]) Prev() (driver.Pagination, error) { return p.GoBack(1) }
 
 func (p *keyset[I, V]) Next() (driver.Pagination, error) { return p.GoForward(1) }
 
-func (k *keyset[I, V]) Equal(other driver.Pagination) bool {
+func (p *keyset[I, V]) Equal(other driver.Pagination) bool {
 	otherKeyset, ok := other.(*keyset[I, V])
 	if !ok {
 		return false
 	}
 
-	return k.Offset == otherKeyset.Offset &&
-		k.PageSize == otherKeyset.PageSize &&
-		k.SQLIDName == otherKeyset.SQLIDName &&
-		k.FirstID == otherKeyset.FirstID &&
-		k.LastID == otherKeyset.LastID
+	return p.Offset == otherKeyset.Offset &&
+		p.PageSize == otherKeyset.PageSize &&
+		p.SQLIDName == otherKeyset.SQLIDName &&
+		p.FirstID == otherKeyset.FirstID &&
+		p.LastID == otherKeyset.LastID
 	// Note: idGetter is not comparable and is intentionally skipped
 }

--- a/platform/view/services/storage/driver/pagination/keyset_test.go
+++ b/platform/view/services/storage/driver/pagination/keyset_test.go
@@ -37,7 +37,7 @@ func render(p driver.Pagination) (string, []sqlbuild.Param) {
 		Build()
 }
 
-func setupPaginationWithLastId() *driver.PageIterator[*any] {
+func setupPaginationWithLastID() *driver.PageIterator[*any] {
 	p := utils.MustGet(pagination.KeysetWithField[string](200, 10, "col_id", "StringField"))
 	query, args := render(p)
 	Expect(query).To(Equal("SELECT field1, col_id FROM test ORDER BY col_id ASC LIMIT 10 OFFSET 200"))
@@ -65,7 +65,7 @@ func setupPaginationWithLastId() *driver.PageIterator[*any] {
 func TestKeysetSimple(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
-	page := setupPaginationWithLastId()
+	page := setupPaginationWithLastID()
 
 	nextPagination, err := page.Pagination.Next()
 	Expect(err).ToNot(HaveOccurred())
@@ -80,7 +80,7 @@ func TestKeysetSimple(t *testing.T) { //nolint:paralleltest
 func TestKeysetSkippingPage(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
-	page := setupPaginationWithLastId()
+	page := setupPaginationWithLastID()
 
 	nextPagination, err := page.Pagination.Next()
 	Expect(err).ToNot(HaveOccurred())
@@ -98,7 +98,7 @@ func TestKeysetSkippingPage(t *testing.T) { //nolint:paralleltest
 func TestKeysetGoingBack(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
-	page := setupPaginationWithLastId()
+	page := setupPaginationWithLastID()
 
 	nextPagination, err := page.Pagination.Prev()
 	page.Pagination = nextPagination
@@ -112,7 +112,7 @@ func TestKeysetGoingBack(t *testing.T) { //nolint:paralleltest
 func TestKeysetGoingNextBack(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
-	page := setupPaginationWithLastId()
+	page := setupPaginationWithLastID()
 
 	nextPagination, err := page.Pagination.Next()
 	page.Pagination = nextPagination
@@ -210,7 +210,7 @@ func TestKeysetInt(t *testing.T) { //nolint:paralleltest
 func TestKeysetSeriliazation(t *testing.T) { //nolint:paralleltest
 	RegisterTestingT(t)
 
-	page := setupPaginationWithLastId()
+	page := setupPaginationWithLastID()
 
 	buf, err := page.Pagination.Serialize()
 	Expect(err).ToNot(HaveOccurred())

--- a/platform/view/services/storage/driver/pagination/none.go
+++ b/platform/view/services/storage/driver/pagination/none.go
@@ -19,20 +19,20 @@ func (p *empty) Prev() (driver.Pagination, error) {
 	return p, nil
 }
 
-func (p *empty) Next() (driver.Pagination, error) {
+func (*empty) Next() (driver.Pagination, error) {
 	return &empty{}, nil
 }
 
-func (e *empty) Equal(other driver.Pagination) bool {
+func (*empty) Equal(other driver.Pagination) bool {
 	_, ok := other.(*empty)
 	return ok
 }
 
-func (k *empty) Serialize() ([]byte, error) {
+func (*empty) Serialize() ([]byte, error) {
 	return []byte{}, nil
 }
 
-func EmptyFromRaw(raw []byte) (*empty, error) {
+func EmptyFromRaw(_ []byte) (*empty, error) {
 	return &empty{}, nil
 }
 
@@ -43,23 +43,23 @@ func None() *none {
 	return &none{}
 }
 
-func (p *none) Prev() (driver.Pagination, error) {
+func (*none) Prev() (driver.Pagination, error) {
 	return Empty(), nil
 }
 
-func (p *none) Next() (driver.Pagination, error) {
+func (*none) Next() (driver.Pagination, error) {
 	return Empty(), nil
 }
 
-func (e *none) Equal(other driver.Pagination) bool {
+func (*none) Equal(other driver.Pagination) bool {
 	_, ok := other.(*none)
 	return ok
 }
 
-func (k *none) Serialize() ([]byte, error) {
+func (*none) Serialize() ([]byte, error) {
 	return []byte{}, nil
 }
 
-func NoneFromRaw(raw []byte) (*none, error) {
+func NoneFromRaw(_ []byte) (*none, error) {
 	return &none{}, nil
 }

--- a/platform/view/services/storage/driver/pagination/offset.go
+++ b/platform/view/services/storage/driver/pagination/offset.go
@@ -39,8 +39,8 @@ func (p *offset) GoToOffset(os int) (driver.Pagination, error) {
 	}, nil
 }
 
-func (k *offset) Serialize() ([]byte, error) {
-	ret, err := json.Marshal(k)
+func (p *offset) Serialize() ([]byte, error) {
+	ret, err := json.Marshal(p)
 	return ret, err
 }
 
@@ -70,12 +70,12 @@ func (p *offset) GoBack(numOfpages int) (driver.Pagination, error) {
 func (p *offset) Prev() (driver.Pagination, error) { return p.GoBack(1) }
 func (p *offset) Next() (driver.Pagination, error) { return p.GoForward(1) }
 
-func (o *offset) Equal(other driver.Pagination) bool {
+func (p *offset) Equal(other driver.Pagination) bool {
 	otherOffset, ok := other.(*offset)
 	if !ok {
 		return false
 	}
 
-	return o.Offset == otherOffset.Offset &&
-		o.PageSize == otherOffset.PageSize
+	return p.Offset == otherOffset.Offset &&
+		p.PageSize == otherOffset.PageSize
 }

--- a/platform/view/services/storage/driver/pagination/page.go
+++ b/platform/view/services/storage/driver/pagination/page.go
@@ -20,13 +20,13 @@ func NewPage[V any](results collections.Iterator[*V], pagination driver.Paginati
 	case *keyset[string, any]:
 		return newKeysetTypedPage[string, V](results, p)
 	case *offset, *empty, *none:
-		return newPage[V](results, pagination)
+		return buildPage[V](results, pagination)
 	default:
 		panic("Unsupported pagination type")
 	}
 }
 
-func newPage[V any](results iterators.Iterator[*V], pagination driver.Pagination) (*driver.PageIterator[*V], error) {
+func buildPage[V any](results iterators.Iterator[*V], pagination driver.Pagination) (*driver.PageIterator[*V], error) {
 	return &driver.PageIterator[*V]{Items: results, Pagination: pagination}, nil
 }
 
@@ -40,9 +40,9 @@ func newKeysetTypedPage[I comparable, V any](results iterators.Iterator[*V], pag
 	if err != nil {
 		return nil, err
 	}
-	p.FirstID = p.nilElement()
+	p.FirstID = p.zeroElement()
 	if len(items) == 0 {
-		p.LastID = p.nilElement()
+		p.LastID = p.zeroElement()
 	} else {
 		p.LastID = p.idGetter(*items[len(items)-1])
 	}

--- a/platform/view/services/storage/driver/pagination/paging.go
+++ b/platform/view/services/storage/driver/pagination/paging.go
@@ -17,7 +17,7 @@ import (
 // through a method rather than a type switch keeps the pagination types
 // unexported while covering every instantiation of the generic keyset.
 type pageable interface {
-	paging() sqlbuild.Paging
+	toPaging() sqlbuild.Paging
 }
 
 // Paging translates p into the SQL fragment a SELECT needs. A nil pagination
@@ -33,26 +33,26 @@ func Paging(p driver.Pagination) sqlbuild.Paging {
 	if !ok {
 		panic(fmt.Sprintf("invalid pagination option %+v", p))
 	}
-	return pg.paging()
+	return pg.toPaging()
 }
 
-func (p *none) paging() sqlbuild.Paging {
+func (*none) toPaging() sqlbuild.Paging {
 	return sqlbuild.Paging{}
 }
 
-func (p *empty) paging() sqlbuild.Paging {
+func (*empty) toPaging() sqlbuild.Paging {
 	// LIMIT 0: an empty pagination returns no rows, rather than every row.
 	return sqlbuild.Paging{Limit: new(0)}
 }
 
-func (p *offset) paging() sqlbuild.Paging {
+func (p *offset) toPaging() sqlbuild.Paging {
 	return sqlbuild.Paging{Limit: new(p.PageSize), Offset: p.Offset}
 }
 
-func (k *keyset[I, V]) paging() sqlbuild.Paging {
+func (k *keyset[I, V]) toPaging() sqlbuild.Paging {
 	col := string(k.SQLIDName)
 	pag := sqlbuild.Paging{OrderBy: col, Limit: new(k.PageSize)}
-	if k.FirstID != k.nilElement() {
+	if k.FirstID != k.zeroElement() {
 		pag.Where = sqlbuild.Gt(col, k.FirstID)
 	} else {
 		pag.Offset = k.Offset

--- a/platform/view/services/storage/driver/pagination/paging_test.go
+++ b/platform/view/services/storage/driver/pagination/paging_test.go
@@ -163,7 +163,7 @@ func TestKeysetRejectsEmptyColumnName(t *testing.T) {
 
 type keysetID struct{ TxID string }
 
-func (k keysetID) Id() string { return k.TxID }
+func (k keysetID) ID() string { return k.TxID }
 
 // The column name is interpolated straight into ORDER BY and into the cursor
 // comparison, and a deserialized cursor is untrusted input.

--- a/platform/view/services/storage/driver/sql/common/binding.go
+++ b/platform/view/services/storage/driver/sql/common/binding.go
@@ -67,22 +67,22 @@ func (db *BindingStore) HaveSameBinding(ctx context.Context, this, that view.Ide
 	}
 	defer utils.IgnoreErrorFunc(rows.Close)
 
-	longTermIds := make([]view.Identity, 0, 2)
+	longTermIDs := make([]view.Identity, 0, 2)
 	for rows.Next() {
 		var longTerm view.Identity
 		if err := rows.Scan(&longTerm); err != nil {
 			return false, err
 		}
-		longTermIds = append(longTermIds, longTerm)
+		longTermIDs = append(longTermIDs, longTerm)
 	}
 	if err := rows.Err(); err != nil {
 		return false, errors.Wrapf(err, "error iterating rows")
 	}
-	if len(longTermIds) != 2 {
-		return false, errors.Errorf("%d entries found instead of 2", len(longTermIds))
+	if len(longTermIDs) != 2 {
+		return false, errors.Errorf("%d entries found instead of 2", len(longTermIDs))
 	}
 
-	return longTermIds[0].Equal(longTermIds[1]), nil
+	return longTermIDs[0].Equal(longTermIDs[1]), nil
 }
 
 func (db *BindingStore) CreateSchema() error {

--- a/platform/view/services/storage/driver/sql/common/signerinfo_test.go
+++ b/platform/view/services/storage/driver/sql/common/signerinfo_test.go
@@ -22,7 +22,7 @@ import (
 
 type dummyUniqueErrorWrapper struct{}
 
-func (d *dummyUniqueErrorWrapper) WrapError(err error) error {
+func (*dummyUniqueErrorWrapper) WrapError(_ error) error {
 	return driver.UniqueKeyViolation
 }
 

--- a/platform/view/services/storage/driver/sql/common/unversioned_test.go
+++ b/platform/view/services/storage/driver/sql/common/unversioned_test.go
@@ -26,7 +26,7 @@ var (
 
 type dummyErrorWrapper struct{}
 
-func (d *dummyErrorWrapper) WrapError(err error) error {
+func (*dummyErrorWrapper) WrapError(err error) error {
 	return err
 }
 

--- a/platform/view/services/storage/driver/sql/postgres/auditinfo.go
+++ b/platform/view/services/storage/driver/sql/postgres/auditinfo.go
@@ -18,9 +18,9 @@ type AuditInfoStore struct {
 }
 
 func NewAuditInfoStore(dbs *common2.RWDB, tables common3.TableNames) (*AuditInfoStore, error) {
-	return newAuditInfoStore(dbs.ReadDB, dbs.WriteDB, tables.AuditInfo), nil
+	return buildAuditInfoStore(dbs.ReadDB, dbs.WriteDB, tables.AuditInfo), nil
 }
 
-func newAuditInfoStore(readDB, writeDB *sql.DB, table string) *AuditInfoStore {
+func buildAuditInfoStore(readDB, writeDB *sql.DB, table string) *AuditInfoStore {
 	return &AuditInfoStore{AuditInfoStore: common3.NewAuditInfoStore(writeDB, readDB, table, &ErrorMapper{})}
 }

--- a/platform/view/services/storage/driver/sql/postgres/binding.go
+++ b/platform/view/services/storage/driver/sql/postgres/binding.go
@@ -22,10 +22,10 @@ type BindingStore struct {
 }
 
 func NewBindingStore(dbs *common2.RWDB, tables common3.TableNames) (*BindingStore, error) {
-	return newBindingStore(dbs.ReadDB, dbs.WriteDB, tables.Binding), nil
+	return buildBindingStore(dbs.ReadDB, dbs.WriteDB, tables.Binding), nil
 }
 
-func newBindingStore(readDB, writeDB *sql.DB, table string) *BindingStore {
+func buildBindingStore(readDB, writeDB *sql.DB, table string) *BindingStore {
 	errorWrapper := &ErrorMapper{}
 	return &BindingStore{
 		BindingStore: common3.NewBindingStore(readDB, writeDB, table, errorWrapper),

--- a/platform/view/services/storage/driver/sql/postgres/errormapper.go
+++ b/platform/view/services/storage/driver/sql/postgres/errormapper.go
@@ -22,7 +22,7 @@ var errorMap = map[string]error{
 
 type ErrorMapper struct{}
 
-func (m *ErrorMapper) WrapError(err error) error {
+func (*ErrorMapper) WrapError(err error) error {
 	var pgErr *pgconn.PgError
 	if !errors2.As(err, &pgErr) {
 		logger.Warnf("error of type [%T] not pgError", err)

--- a/platform/view/services/storage/driver/sql/postgres/keyvalue.go
+++ b/platform/view/services/storage/driver/sql/postgres/keyvalue.go
@@ -15,7 +15,7 @@ import (
 )
 
 func NewKeyValueStore(dbs *common3.RWDB, tables common4.TableNames) (*common4.KeyValueStore, error) {
-	return newKeyValueStore(dbs.ReadDB, dbs.WriteDB, tables.KVS), nil
+	return buildKeyValueStore(dbs.ReadDB, dbs.WriteDB, tables.KVS), nil
 }
 
 type KeyValueStoreNotifier struct {
@@ -37,7 +37,7 @@ func (db *KeyValueStoreNotifier) CreateSchema() error {
 	return db.Notifier.CreateSchema()
 }
 
-func newKeyValueStore(readDB, writeDB *sql.DB, table string) *common4.KeyValueStore {
+func buildKeyValueStore(readDB, writeDB *sql.DB, table string) *common4.KeyValueStore {
 	errorWrapper := &ErrorMapper{}
 
 	return common4.NewKeyValueStore(readDB, writeDB, table, errorWrapper)

--- a/platform/view/services/storage/driver/sql/postgres/notifier.go
+++ b/platform/view/services/storage/driver/sql/postgres/notifier.go
@@ -86,7 +86,7 @@ func NewNotifier(writeDB *sql.DB, table, dataSource string, notifyOperations []d
 		primaryKeys:      primaryKeys,
 		listener: &pgxlisten.Listener{
 			Connect: func(ctx context.Context) (*pgx.Conn, error) { return pgx.Connect(ctx, dataSource) },
-			LogError: func(ctx context.Context, err error) {
+			LogError: func(_ context.Context, err error) {
 				logger.Errorf("error encountered in [%s]: %s", dataSource, err.Error())
 			},
 			ReconnectDelay: reconnectInterval,

--- a/platform/view/services/storage/driver/sql/postgres/signerinfo.go
+++ b/platform/view/services/storage/driver/sql/postgres/signerinfo.go
@@ -18,9 +18,9 @@ type SignerInfoStore struct {
 }
 
 func NewSignerInfoStore(dbs *common2.RWDB, tables common3.TableNames) (*SignerInfoStore, error) {
-	return newSignerInfoStore(dbs.ReadDB, dbs.WriteDB, tables.SignerInfo), nil
+	return buildSignerInfoStore(dbs.ReadDB, dbs.WriteDB, tables.SignerInfo), nil
 }
 
-func newSignerInfoStore(readDB, writeDB *sql.DB, table string) *SignerInfoStore {
+func buildSignerInfoStore(readDB, writeDB *sql.DB, table string) *SignerInfoStore {
 	return &SignerInfoStore{SignerInfoStore: common3.NewSignerInfoStore(readDB, writeDB, table, &ErrorMapper{})}
 }

--- a/platform/view/services/storage/driver/sql/postgres/sql_test.go
+++ b/platform/view/services/storage/driver/sql/postgres/sql_test.go
@@ -49,7 +49,7 @@ func TestPostgres(t *testing.T) {
 	}, func(string) (driver.UnversionedNotifier, error) {
 		return NewPersistenceWithOpts(cp, NewDbProvider(), "", func(dbs *common.RWDB, tables common3.TableNames) (*KeyValueStoreNotifier, error) {
 			return &KeyValueStoreNotifier{
-				KeyValueStore: newKeyValueStore(dbs.ReadDB, dbs.WriteDB, tables.KVS),
+				KeyValueStore: buildKeyValueStore(dbs.ReadDB, dbs.WriteDB, tables.KVS),
 				Notifier:      NewNotifier(dbs.WriteDB, tables.KVS, pgConnStr, AllOperations, *NewSimplePrimaryKey("ns"), *NewBytePrimaryKey("pkey")),
 			}, nil
 		})
@@ -58,7 +58,7 @@ func TestPostgres(t *testing.T) {
 	})
 }
 
-func setupDBWithTLS(tb testing.TB) (string, string) {
+func setupDBWithTLS(tb testing.TB) (pgConnStr, caPath string) {
 	tb.Helper()
 
 	tempDir := tb.TempDir()
@@ -96,14 +96,15 @@ echo "ssl_key_file = '/var/lib/postgresql/server.key'" >> "$PGDATA/postgresql.co
 	)(cfg)
 
 	logger := &testLogger{tb}
-	terminate, pgConnStr, err := StartPostgres(tb.Context(), cfg, logger)
+	var terminate func()
+	terminate, pgConnStr, err = StartPostgres(tb.Context(), cfg, logger)
 	if err != nil {
 		tb.Fatal(err)
 	}
 	tb.Cleanup(terminate)
 
 	// Since we are creating a CA from scratch, write it for the client to use.
-	caPath := filepath.Join(tempDir, "ca.crt")
+	caPath = filepath.Join(tempDir, "ca.crt")
 	err = os.WriteFile(caPath, ca.CertBytes(), 0o644)
 	require.NoError(tb, err)
 
@@ -128,7 +129,7 @@ func TestPostgresWithTLS(t *testing.T) {
 	}, func(string) (driver.UnversionedNotifier, error) {
 		return NewPersistenceWithOpts(cp, NewDbProvider(), "", func(dbs *common.RWDB, tables common3.TableNames) (*KeyValueStoreNotifier, error) {
 			return &KeyValueStoreNotifier{
-				KeyValueStore: newKeyValueStore(dbs.ReadDB, dbs.WriteDB, tables.KVS),
+				KeyValueStore: buildKeyValueStore(dbs.ReadDB, dbs.WriteDB, tables.KVS),
 				Notifier:      NewNotifier(dbs.WriteDB, tables.KVS, pgConnStr, AllOperations, *NewSimplePrimaryKey("ns"), *NewBytePrimaryKey("pkey")),
 			}, nil
 		})

--- a/platform/view/services/storage/driver/sql/postgres/tls_test.go
+++ b/platform/view/services/storage/driver/sql/postgres/tls_test.go
@@ -67,7 +67,7 @@ func decodeYAML(input, output any) error {
 	return dec.Decode(input)
 }
 
-func generateSelfSignedCert(t *testing.T, tempDir string) (string, string) {
+func generateSelfSignedCert(t *testing.T, tempDir string) (certPath, keyPath string) {
 	t.Helper()
 
 	ca, err := tlsgen.NewCA()
@@ -76,11 +76,11 @@ func generateSelfSignedCert(t *testing.T, tempDir string) (string, string) {
 	serverKeyPair, err := ca.NewServerCertKeyPair("127.0.0.1")
 	require.NoError(t, err)
 
-	certPath := filepath.Join(tempDir, "cert.pem")
+	certPath = filepath.Join(tempDir, "cert.pem")
 	err = os.WriteFile(certPath, serverKeyPair.Cert, 0o644)
 	require.NoError(t, err)
 
-	keyPath := filepath.Join(tempDir, "key.pem")
+	keyPath = filepath.Join(tempDir, "key.pem")
 	err = os.WriteFile(keyPath, serverKeyPair.Key, 0o600)
 	require.NoError(t, err)
 
@@ -226,7 +226,7 @@ func TestCreateTLSConnConfig(t *testing.T) {
 			tlsCfg: TLSConfig{
 				SSLMode: "invalid-mode",
 			},
-			verify: func(t *testing.T, connConfig *pgx.ConnConfig, err error) {
+			verify: func(t *testing.T, _ *pgx.ConnConfig, err error) {
 				t.Helper()
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unsupported ssl mode")
@@ -239,7 +239,7 @@ func TestCreateTLSConnConfig(t *testing.T) {
 				SSLMode:      "verify-full",
 				RootCertPath: filepath.Join(tempDir, "nonexistent.pem"),
 			},
-			verify: func(t *testing.T, connConfig *pgx.ConnConfig, err error) {
+			verify: func(t *testing.T, _ *pgx.ConnConfig, err error) {
 				t.Helper()
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to read root certificate")
@@ -253,7 +253,7 @@ func TestCreateTLSConnConfig(t *testing.T) {
 				CertPath: certPath,
 				KeyPath:  filepath.Join(tempDir, "nonexistent.pem"),
 			},
-			verify: func(t *testing.T, connConfig *pgx.ConnConfig, err error) {
+			verify: func(t *testing.T, _ *pgx.ConnConfig, err error) {
 				t.Helper()
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "failed to load client key pair")

--- a/platform/view/services/storage/driver/sql/sqlite/auditinfo.go
+++ b/platform/view/services/storage/driver/sql/sqlite/auditinfo.go
@@ -18,9 +18,9 @@ type AuditInfoStore struct {
 }
 
 func NewAuditInfoStore(dbs *common3.RWDB, tables common2.TableNames) (*AuditInfoStore, error) {
-	return newAuditInfoStore(dbs.ReadDB, NewRetryWriteDB(dbs.WriteDB), tables.AuditInfo), nil
+	return buildAuditInfoStore(dbs.ReadDB, NewRetryWriteDB(dbs.WriteDB), tables.AuditInfo), nil
 }
 
-func newAuditInfoStore(readDB *sql.DB, writeDB common2.WriteDB, table string) *AuditInfoStore {
+func buildAuditInfoStore(readDB *sql.DB, writeDB common2.WriteDB, table string) *AuditInfoStore {
 	return &AuditInfoStore{AuditInfoStore: common2.NewAuditInfoStore(writeDB, readDB, table, &ErrorMapper{})}
 }

--- a/platform/view/services/storage/driver/sql/sqlite/binding.go
+++ b/platform/view/services/storage/driver/sql/sqlite/binding.go
@@ -22,10 +22,10 @@ type BindingStore struct {
 }
 
 func NewBindingStore(dbs *common3.RWDB, tables common2.TableNames) (*BindingStore, error) {
-	return newBindingStore(dbs.ReadDB, NewRetryWriteDB(dbs.WriteDB), tables.Binding), nil
+	return buildBindingStore(dbs.ReadDB, NewRetryWriteDB(dbs.WriteDB), tables.Binding), nil
 }
 
-func newBindingStore(readDB *sql.DB, writeDB common2.WriteDB, table string) *BindingStore {
+func buildBindingStore(readDB *sql.DB, writeDB common2.WriteDB, table string) *BindingStore {
 	errorWrapper := &ErrorMapper{}
 	return &BindingStore{
 		BindingStore: common2.NewBindingStore(readDB, writeDB, table, errorWrapper),

--- a/platform/view/services/storage/driver/sql/sqlite/binding_test.go
+++ b/platform/view/services/storage/driver/sql/sqlite/binding_test.go
@@ -26,7 +26,7 @@ func newBindingStoreForTests(tb testing.TB) *BindingStore {
 	}
 	dbs := utils.MustGet(open(o))
 	tables := common.GetTableNames(o.TablePrefix, o.TableNameParams...)
-	db := newBindingStore(dbs.ReadDB, dbs.WriteDB, tables.Binding)
+	db := buildBindingStore(dbs.ReadDB, dbs.WriteDB, tables.Binding)
 	assert.NoError(tb, db.CreateSchema())
 	return db
 }

--- a/platform/view/services/storage/driver/sql/sqlite/errormapper.go
+++ b/platform/view/services/storage/driver/sql/sqlite/errormapper.go
@@ -23,7 +23,7 @@ var errorMap = map[int]error{
 
 type ErrorMapper struct{}
 
-func (m *ErrorMapper) WrapError(err error) error {
+func (*ErrorMapper) WrapError(err error) error {
 	var pgErr *sqlite.Error
 	if !errors2.As(err, &pgErr) {
 		return err

--- a/platform/view/services/storage/driver/sql/sqlite/sanitizer.go
+++ b/platform/view/services/storage/driver/sql/sqlite/sanitizer.go
@@ -10,6 +10,6 @@ func NewSanitizer() *stringSanitizer { return &stringSanitizer{} }
 
 type stringSanitizer struct{}
 
-func (s *stringSanitizer) Encode(str string) (string, error) { return str, nil }
+func (*stringSanitizer) Encode(str string) (string, error) { return str, nil }
 
-func (s *stringSanitizer) Decode(str string) (string, error) { return str, nil }
+func (*stringSanitizer) Decode(str string) (string, error) { return str, nil }

--- a/platform/view/services/storage/driver/sql/sqlite/signerinfo.go
+++ b/platform/view/services/storage/driver/sql/sqlite/signerinfo.go
@@ -18,9 +18,9 @@ type SignerInfoStore struct {
 }
 
 func NewSignerInfoStore(dbs *common3.RWDB, tables common2.TableNames) (*SignerInfoStore, error) {
-	return newSignerInfoStore(dbs.ReadDB, NewRetryWriteDB(dbs.WriteDB), tables.SignerInfo), nil
+	return buildSignerInfoStore(dbs.ReadDB, NewRetryWriteDB(dbs.WriteDB), tables.SignerInfo), nil
 }
 
-func newSignerInfoStore(readDB *sql.DB, writeDB common2.WriteDB, table string) *SignerInfoStore {
+func buildSignerInfoStore(readDB *sql.DB, writeDB common2.WriteDB, table string) *SignerInfoStore {
 	return &SignerInfoStore{SignerInfoStore: common2.NewSignerInfoStore(writeDB, readDB, table, &ErrorMapper{})}
 }

--- a/platform/view/services/storage/driver/sql/sqlite/sql_test.go
+++ b/platform/view/services/storage/driver/sql/sqlite/sql_test.go
@@ -25,12 +25,12 @@ func TestSqlite(t *testing.T) {
 	o := Opts{
 		DataSource: fmt.Sprintf("file:%s.sqlite?_pragma=busy_timeout(1000)", path.Join(tempDir, "benchmark")),
 	}
-	common.TestCases(t, func(name string) (driver.KeyValueStore, error) {
+	common.TestCases(t, func(_ string) (driver.KeyValueStore, error) {
 		p, err := NewKeyValueStore(utils.MustGet(open(o)), common.GetTableNames(o.TablePrefix, o.TableNameParams...))
 		assert.NoError(t, err)
 		assert.NoError(t, p.CreateSchema())
 		return p, nil
-	}, func(name string) (driver.UnversionedNotifier, error) {
+	}, func(_ string) (driver.UnversionedNotifier, error) {
 		p, err := NewKeyValueStoreNotifier(utils.MustGet(open(o)), "test")
 		assert.NoError(t, err)
 		assert.NoError(t, p.Persistence.(*KeyValueStore).CreateSchema())

--- a/platform/view/services/storage/driver/sql/sqlite/unversioned.go
+++ b/platform/view/services/storage/driver/sql/sqlite/unversioned.go
@@ -20,14 +20,14 @@ type KeyValueStore struct {
 }
 
 func NewKeyValueStore(dbs *common3.RWDB, tables common2.TableNames) (*KeyValueStore, error) {
-	return newKeyValueStore(dbs.ReadDB, dbs.WriteDB, tables.KVS), nil
+	return buildKeyValueStore(dbs.ReadDB, dbs.WriteDB, tables.KVS), nil
 }
 
 func NewKeyValueStoreNotifier(dbs *common3.RWDB, table string) (*notifier.UnversionedPersistenceNotifier, error) {
-	return notifier.NewUnversioned(newKeyValueStore(dbs.ReadDB, dbs.WriteDB, table)), nil
+	return notifier.NewUnversioned(buildKeyValueStore(dbs.ReadDB, dbs.WriteDB, table)), nil
 }
 
-func newKeyValueStore(readDB *sql.DB, writeDB common2.WriteDB, table string) *KeyValueStore {
+func buildKeyValueStore(readDB *sql.DB, writeDB common2.WriteDB, table string) *KeyValueStore {
 	var wrapper driver.SQLErrorWrapper = &ErrorMapper{}
 	return &KeyValueStore{
 		KeyValueStore: common2.NewKeyValueStore(writeDB, readDB, table, wrapper),

--- a/platform/view/services/storage/keys/utils.go
+++ b/platform/view/services/storage/keys/utils.go
@@ -51,4 +51,4 @@ func (r *DummyVersionedIterator) Next() (*driver.UnversionedRead, error) {
 	return r.Items[r.idx-1], nil
 }
 
-func (r *DummyVersionedIterator) Close() {}
+func (*DummyVersionedIterator) Close() {}

--- a/platform/view/services/storage/kvs/keys.go
+++ b/platform/view/services/storage/kvs/keys.go
@@ -59,13 +59,13 @@ func CreateCompositeKeyOrPanic(objectType string, attributes []string) string {
 	return k
 }
 
-func CreateRangeKeysForPartialCompositeKey(objectType string, attributes []string) (string, string, error) {
+func CreateRangeKeysForPartialCompositeKey(objectType string, attributes []string) (startKey, endKey string, err error) {
 	partialCompositeKey, err := CreateCompositeKey(objectType, attributes)
 	if err != nil {
 		return "", "", err
 	}
-	startKey := partialCompositeKey
-	endKey := partialCompositeKey + string(maxUnicodeRuneValue)
+	startKey = partialCompositeKey
+	endKey = partialCompositeKey + string(maxUnicodeRuneValue)
 
 	return startKey, endKey, nil
 }

--- a/platform/view/services/storage/kvs/kvs_test.go
+++ b/platform/view/services/storage/kvs/kvs_test.go
@@ -156,7 +156,7 @@ func testParallelWrites(t *testing.T, drv driver2.Driver) {
 	k1, err := createCompositeKey("parallel_key_2_", []string{"1"})
 	require.NoError(t, err)
 	for i := range n {
-		go func(i int) {
+		go func(_ int) {
 			err := kvstore.Put(context.Background(), k1, &stuff{"santa", 1})
 			assert.NoError(t, err) // assert: in goroutine
 			defer wg.Done()
@@ -320,7 +320,7 @@ func TestKVS_Put(t *testing.T) {
 			name:  "unmarshalable state",
 			id:    "key3",
 			state: make(chan int), // channels cannot be marshaled
-			setupMock: func(m *mock.KeyValueStore) {
+			setupMock: func(_ *mock.KeyValueStore) {
 				// SetState should not be called
 			},
 			wantErr: true,

--- a/platform/view/services/tlsconfig/resolve.go
+++ b/platform/view/services/tlsconfig/resolve.go
@@ -70,16 +70,15 @@ func ResolveClient(src Source, key string) (grpc.SecureOptions, error) {
 // identityCert and identityKey are the fsc.identity keypair the block falls back to: the peer
 // ID a host announces is derived from the public key of the certificate it presents, so the
 // transport keypair has to be the node's identity.
-func ResolveWebsocketP2P(src Source, key string, identityCert, identityKey *File) (grpc.SecureOptions, grpc.SecureOptions, error) {
-	var zero grpc.SecureOptions
+func ResolveWebsocketP2P(src Source, key string, identityCert, identityKey *File) (server, client grpc.SecureOptions, err error) {
 	raw, _ := src.RawSubtree(key)
 	t, err := decode[TLS](key, raw)
 	if err != nil {
-		return zero, zero, err
+		return server, client, err
 	}
 	cert, keyFile := cmp.Or(t.Cert, identityCert), cmp.Or(t.Key, identityKey)
 
-	server, err := buildServer(src, key, ServerTLS{
+	server, err = buildServer(src, key, ServerTLS{
 		Enabled:            t.Enabled,
 		Cert:               cert,
 		Key:                keyFile,
@@ -87,10 +86,10 @@ func ResolveWebsocketP2P(src Source, key string, identityCert, identityKey *File
 		ClientRootCAs:      t.ClientRootCAs,
 	}, true, true)
 	if err != nil {
-		return zero, zero, err
+		return server, client, err
 	}
 	// The client half falls back to the server half's keypair, identity default included.
-	client, err := buildClient(src, key, ClientTLS{
+	client, err = buildClient(src, key, ClientTLS{
 		Enabled:            t.Enabled,
 		RootCAs:            t.RootCAs,
 		ClientAuthEnabled:  t.ClientAuthEnabled,
@@ -99,7 +98,7 @@ func ResolveWebsocketP2P(src Source, key string, identityCert, identityKey *File
 		ServerNameOverride: t.ServerNameOverride,
 	}, cert, keyFile)
 	if err != nil {
-		return zero, zero, err
+		return server, client, err
 	}
 	return server, client, nil
 }

--- a/platform/view/services/tracing/config.go
+++ b/platform/view/services/tracing/config.go
@@ -113,11 +113,11 @@ func GetPackageName() string {
 	return fullFuncName[:lastSlash+dotAfterSlash]
 }
 
-func parseFullPkgName(fullPkgName string, replacements map[string]string, params ...string) (string, string) {
+func parseFullPkgName(fullPkgName string, replacements map[string]string, params ...string) (namespace, subsystem string) {
 	parts := append(strings.Split(fullPkgName, "/"), params...)
-	subsystem := parts[len(parts)-1]
+	subsystem = parts[len(parts)-1]
 	namespaceParts := parts[:len(parts)-1]
-	namespace := strings.Join(namespaceParts, "_")
+	namespace = strings.Join(namespaceParts, "_")
 
 	for old, newVal := range replacements {
 		namespace = strings.ReplaceAll(namespace, old, newVal)

--- a/platform/view/services/tracing/config_test.go
+++ b/platform/view/services/tracing/config_test.go
@@ -29,7 +29,7 @@ func TestGetPackageName(t *testing.T) {
 
 type ConfigHandler struct{}
 
-func (h *ConfigHandler) sendResponseLikeMethod() string {
+func (*ConfigHandler) sendResponseLikeMethod() string {
 	return callGetPackageName()
 }
 

--- a/platform/view/services/tracing/impl.go
+++ b/platform/view/services/tracing/impl.go
@@ -89,7 +89,7 @@ func NewProviderFromConfigService(confService driver.ConfigService) (Provider, e
 		return nil, errors.WithMessagef(err, "failed resolving %s", otlpTLSKey)
 	}
 	c.Otlp.TLS = tlsOpts
-	return newProviderFromConfig(c, confService.GetString("fsc.id"))
+	return buildProviderFromConfig(c, confService.GetString("fsc.id"))
 }
 
 // otlpTLSKey is the configuration subtree holding the OTLP collector connection's TLS.
@@ -98,10 +98,10 @@ const otlpTLSKey = "fsc.tracing.otlp.tls"
 // NewProviderFromConfig returns a tracing provider from an already-populated [Config],
 // including any resolved TLS it carries.
 func NewProviderFromConfig(c Config) (Provider, error) {
-	return newProviderFromConfig(c, ServiceName)
+	return buildProviderFromConfig(c, ServiceName)
 }
 
-func newProviderFromConfig(c Config, serviceName string) (Provider, error) {
+func buildProviderFromConfig(c Config, serviceName string) (Provider, error) {
 	var exporter sdktrace.SpanExporter
 	var err error
 	switch c.Provider {

--- a/platform/view/services/tracing/span.go
+++ b/platform/view/services/tracing/span.go
@@ -99,7 +99,7 @@ func newSpan(backingSpan trace.Span, labelNames []LabelName, operations metrics.
 	return s
 }
 
-func defaultNow(t time.Time) time.Time {
+func defaultNow(_ time.Time) time.Time {
 	// if t.IsZero() {
 	//	return time.Now()
 	//}

--- a/platform/view/services/tracing/tracer_test.go
+++ b/platform/view/services/tracing/tracer_test.go
@@ -33,7 +33,7 @@ func (c *recordingCounter) With(labelValues ...string) metrics.Counter {
 	return c
 }
 
-func (c *recordingCounter) Add(delta float64) {
+func (c *recordingCounter) Add(_ float64) {
 	c.addCalls++
 }
 
@@ -48,7 +48,7 @@ func (h *recordingHistogram) With(labelValues ...string) metrics.Histogram {
 	return h
 }
 
-func (h *recordingHistogram) Observe(value float64) {
+func (h *recordingHistogram) Observe(_ float64) {
 	h.observeCalls++
 }
 
@@ -70,7 +70,7 @@ func (p *recordingMetricsProvider) NewCounter(_ metrics.CounterOpts) metrics.Cou
 	return p.counter
 }
 
-func (p *recordingMetricsProvider) NewGauge(_ metrics.GaugeOpts) metrics.Gauge {
+func (*recordingMetricsProvider) NewGauge(_ metrics.GaugeOpts) metrics.Gauge {
 	// Not used by the tracer; return nil so a nil-deref surfaces if that changes.
 	return nil
 }
@@ -90,20 +90,20 @@ type recordingSpan struct {
 	ended      bool
 }
 
-func (s *recordingSpan) End(options ...trace.SpanEndOption) { s.ended = true }
-func (s *recordingSpan) AddEvent(name string, options ...trace.EventOption) {
+func (s *recordingSpan) End(_ ...trace.SpanEndOption) { s.ended = true }
+func (s *recordingSpan) AddEvent(name string, _ ...trace.EventOption) {
 	s.events = append(s.events, name)
 }
-func (s *recordingSpan) AddLink(link trace.Link)                             {}
-func (s *recordingSpan) IsRecording() bool                                   { return true }
-func (s *recordingSpan) RecordError(err error, options ...trace.EventOption) {}
-func (s *recordingSpan) SpanContext() trace.SpanContext                      { return trace.SpanContext{} }
-func (s *recordingSpan) SetStatus(code codes.Code, description string)       {}
-func (s *recordingSpan) SetName(name string)                                 { s.name = name }
+func (*recordingSpan) AddLink(_ trace.Link)                        {}
+func (*recordingSpan) IsRecording() bool                           { return true }
+func (*recordingSpan) RecordError(_ error, _ ...trace.EventOption) {}
+func (*recordingSpan) SpanContext() trace.SpanContext              { return trace.SpanContext{} }
+func (*recordingSpan) SetStatus(_ codes.Code, _ string)            {}
+func (s *recordingSpan) SetName(name string)                       { s.name = name }
 func (s *recordingSpan) SetAttributes(kv ...attribute.KeyValue) {
 	s.attributes = append(s.attributes, kv...)
 }
-func (s *recordingSpan) TracerProvider() trace.TracerProvider { return nil }
+func (*recordingSpan) TracerProvider() trace.TracerProvider { return nil }
 
 // recordingTracer creates recordingSpan instances and keeps a reference to each
 // one so tests can inspect what happened after Start returned.
@@ -116,7 +116,7 @@ type recordingTracer struct {
 func newRecordingTracer() *recordingTracer { return &recordingTracer{} }
 
 func (t *recordingTracer) Start(
-	ctx context.Context, name string, opts ...trace.SpanStartOption,
+	ctx context.Context, name string, _ ...trace.SpanStartOption,
 ) (context.Context, trace.Span) {
 	s := &recordingSpan{name: name}
 	t.spans = append(t.spans, s)
@@ -135,7 +135,7 @@ func newRecordingTracerProvider(rt *recordingTracer) *recordingTracerProvider {
 	return &recordingTracerProvider{tracer: rt}
 }
 
-func (p *recordingTracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.Tracer {
+func (p *recordingTracerProvider) Tracer(_ string, _ ...trace.TracerOption) trace.Tracer {
 	return p.tracer
 }
 

--- a/platform/view/services/view/child.go
+++ b/platform/view/services/view/child.go
@@ -158,7 +158,7 @@ func (w *ChildContext) Cleanup() {
 	}
 }
 
-func (w *ChildContext) safeInvoke(f func()) {
+func (*ChildContext) safeInvoke(f func()) {
 	defer func() {
 		if r := recover(); r != nil {
 			logger.Debugf("function [%s] panicked [%s]", f, r)

--- a/platform/view/services/view/context.go
+++ b/platform/view/services/view/context.go
@@ -295,13 +295,13 @@ func (c *Context) Caller() view.Identity {
 // Sessions are scoped by the caller view and cached.
 // The session can be bound to other caller views by passing them as additional parameters.
 func (c *Context) GetSession(caller view.View, party view.Identity, boundToViews ...view.View) (view.Session, error) {
-	viewId := getViewIdentifier(caller)
-	logger.DebugfContext(c.Context(), "[%s] GetSession [%s:%s]", c.me, viewId, party)
+	viewID := getViewIdentifier(caller)
+	logger.DebugfContext(c.Context(), "[%s] GetSession [%s:%s]", c.me, viewID, party)
 	// TODO: we need a mechanism to close all the sessions opened in this ctx,
 	// when the ctx goes out of scope
 
 	// is there already a session?
-	s, targetIdentity := c.sessions.GetFirstOpen(viewId, lazy.NewIterator(
+	s, targetIdentity := c.sessions.GetFirstOpen(viewID, lazy.NewIterator(
 		func() (view.Identity, error) { return party, nil },
 		func() (view.Identity, error) { return c.resolve(party) },
 		func() (view.Identity, error) { return c.resolve(c.idProvider.Identity(string(party))) },
@@ -309,10 +309,10 @@ func (c *Context) GetSession(caller view.View, party view.Identity, boundToViews
 
 	// a session is available, return it
 	if s != nil {
-		logger.DebugfContext(c.Context(), "[%s] Reusing session [%s:%s]", c.me, viewId, party)
+		logger.DebugfContext(c.Context(), "[%s] Reusing session [%s:%s]", c.me, viewID, party)
 		return s, nil
 	}
-	logger.DebugfContext(c.Context(), "[%s] No session found for [%s:%s], target [%s]", c.me, viewId, party, targetIdentity)
+	logger.DebugfContext(c.Context(), "[%s] No session found for [%s:%s], target [%s]", c.me, viewID, party, targetIdentity)
 
 	// create a session
 	if caller == nil {

--- a/platform/view/services/view/context_test.go
+++ b/platform/view/services/view/context_test.go
@@ -27,7 +27,7 @@ var emptyTracer = noop.NewTracerProvider().Tracer("empty")
 
 type DummyView struct{}
 
-func (d *DummyView) Call(_ view.Context) (any, error) {
+func (*DummyView) Call(_ view.Context) (any, error) {
 	return nil, nil
 }
 

--- a/platform/view/services/view/grpc/client/client.go
+++ b/platform/view/services/view/grpc/client/client.go
@@ -131,7 +131,7 @@ func (s *client) CallViewWithContext(ctx context.Context, fid string, input []by
 	return commandResp.GetCallViewResponse().GetResult(), nil
 }
 
-func (s *client) Initiate(fid string, in []byte) (string, error) {
+func (*client) Initiate(_ string, _ []byte) (string, error) {
 	panic("implement me")
 }
 

--- a/platform/view/services/view/grpc/client/config.go
+++ b/platform/view/services/view/grpc/client/config.go
@@ -27,6 +27,8 @@ type Config struct {
 }
 
 // ToJSon returns the JSON representation of the config.
+//
+//nolint:revive // var-naming: renaming this exported method is an API break; see follow-up
 func (config *Config) ToJSon() ([]byte, error) {
 	return json.Marshal(config)
 }
@@ -35,6 +37,8 @@ func (config *Config) ToJSon() ([]byte, error) {
 type Configs []Config
 
 // ToJSon returns the JSON representation of the list of configs.
+//
+//nolint:revive // var-naming: renaming this exported method is an API break; see follow-up
 func (configs *Configs) ToJSon() ([]byte, error) {
 	return json.MarshalIndent(configs, "", " ")
 }

--- a/platform/view/services/view/grpc/client/grpc_client_test.go
+++ b/platform/view/services/view/grpc/client/grpc_client_test.go
@@ -634,7 +634,7 @@ func (f *fakeStreamClient) CreateViewClient() (*grpc.ClientConn, protos.ViewServ
 	return nil, f.vsc, nil
 }
 
-func (f *fakeStreamClient) Certificate() *tls.Certificate {
+func (*fakeStreamClient) Certificate() *tls.Certificate {
 	return nil
 }
 
@@ -650,7 +650,7 @@ type fakeProtosVSC struct {
 	cmdRespErr *protos.Error
 }
 
-func (f *fakeProtosVSC) ProcessCommand(ctx context.Context, in *protos.SignedCommand, opts ...grpc.CallOption) (*protos.SignedCommandResponse, error) {
+func (f *fakeProtosVSC) ProcessCommand(ctx context.Context, _ *protos.SignedCommand, _ ...grpc.CallOption) (*protos.SignedCommandResponse, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -674,7 +674,7 @@ func (f *fakeProtosVSC) ProcessCommand(ctx context.Context, in *protos.SignedCom
 	return &protos.SignedCommandResponse{Response: b}, nil
 }
 
-func (f *fakeProtosVSC) StreamCommand(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[protos.SignedCommand, protos.SignedCommandResponse], error) {
+func (f *fakeProtosVSC) StreamCommand(ctx context.Context, _ ...grpc.CallOption) (grpc.BidiStreamingClient[protos.SignedCommand, protos.SignedCommandResponse], error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -691,7 +691,7 @@ type fakeBidiStream struct {
 	grpc.ClientStream
 }
 
-func (s *fakeBidiStream) Send(m *protos.SignedCommand) error {
+func (s *fakeBidiStream) Send(_ *protos.SignedCommand) error {
 	return s.f.sendErr
 }
 
@@ -714,9 +714,9 @@ func (s *fakeBidiStream) Recv() (*protos.SignedCommandResponse, error) {
 	return &protos.SignedCommandResponse{Response: b}, nil
 }
 
-func (s *fakeBidiStream) CloseSend() error { return nil }
+func (*fakeBidiStream) CloseSend() error { return nil }
 
-func (s *fakeBidiStream) SendMsg(m any) error {
+func (s *fakeBidiStream) SendMsg(_ any) error {
 	return s.f.sendMsgErr
 }
 
@@ -741,17 +741,17 @@ func (f *fakeSigningIdentity) Serialize() ([]byte, error) {
 	return f.serialized, f.serializeErr
 }
 
-func (f *fakeSigningIdentity) Sign(msg []byte) ([]byte, error) {
+func (f *fakeSigningIdentity) Sign(_ []byte) ([]byte, error) {
 	return f.signature, f.signErr
 }
 
 type failingReader struct{}
 
-func (r *failingReader) Read(p []byte) (n int, err error) {
+func (*failingReader) Read(_ []byte) (n int, err error) {
 	return 0, fmt.Errorf("read error")
 }
 
-func createTempIdentityFiles() (string, string, error) {
+func createTempIdentityFiles() (certPath, skPath string, err error) {
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return "", "", err
@@ -777,8 +777,8 @@ func createTempIdentityFiles() (string, string, error) {
 
 	dir := filepath.Join(os.TempDir(), fmt.Sprintf("id-%d", time.Now().UnixNano()))
 	_ = os.MkdirAll(dir, 0o755)
-	certPath := filepath.Join(dir, "cert.pem")
-	skPath := filepath.Join(dir, "sk.pem")
+	certPath = filepath.Join(dir, "cert.pem")
+	skPath = filepath.Join(dir, "sk.pem")
 	_ = os.WriteFile(certPath, certPEM, 0o644)
 	_ = os.WriteFile(skPath, skPEM, 0o644)
 	return certPath, skPath, nil
@@ -816,40 +816,40 @@ func (f *fakeServiceProvider) GetService(v any) (any, error) {
 
 type fakeFactory struct{}
 
-func (f *fakeFactory) NewView(in []byte) (view2.View, error) {
+func (*fakeFactory) NewView(_ []byte) (view2.View, error) {
 	return &fakeView{}, nil
 }
 
 type fakeView struct{}
 
-func (f *fakeView) Call(context view2.Context) (any, error) {
+func (*fakeView) Call(_ view2.Context) (any, error) {
 	return nil, nil
 }
 
 type fakeIdentityProvider struct{}
 
-func (f *fakeIdentityProvider) Identity(s string) view2.Identity { return nil }
-func (f *fakeIdentityProvider) DefaultIdentity() view2.Identity  { return nil }
+func (*fakeIdentityProvider) Identity(_ string) view2.Identity { return nil }
+func (*fakeIdentityProvider) DefaultIdentity() view2.Identity  { return nil }
 
 type fakeGauge struct{}
 
-func (f *fakeGauge) With(labelValues ...string) metrics.Gauge { return f }
-func (f *fakeGauge) Add(delta float64)                        {}
-func (f *fakeGauge) Set(value float64)                        {}
+func (f *fakeGauge) With(_ ...string) metrics.Gauge { return f }
+func (*fakeGauge) Add(_ float64)                    {}
+func (*fakeGauge) Set(_ float64)                    {}
 
 type fakeContextFactory struct {
 	err error
 	ctx view.ParentContext
 }
 
-func (f *fakeContextFactory) NewForInitiator(ctx context.Context, contextID string, id view2.Identity, v view2.View) (view.ParentContext, error) {
+func (f *fakeContextFactory) NewForInitiator(_ context.Context, _ string, _ view2.Identity, _ view2.View) (view.ParentContext, error) {
 	if f.err != nil {
 		return nil, f.err
 	}
 	return f.ctx, nil
 }
 
-func (f *fakeContextFactory) NewForResponder(ctx context.Context, contextID string, me view2.Identity, session view2.Session, party view2.Identity) (view.ParentContext, error) {
+func (*fakeContextFactory) NewForResponder(_ context.Context, _ string, _ view2.Identity, _ view2.Session, _ view2.Identity) (view.ParentContext, error) {
 	return nil, nil
 }
 
@@ -858,32 +858,32 @@ type fakeParentContext struct {
 }
 
 func (f *fakeParentContext) ID() string { return f.id }
-func (f *fakeParentContext) StartSpanFrom(c context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+func (*fakeParentContext) StartSpanFrom(c context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
 	return c, trace.SpanFromContext(c)
 }
-func (f *fakeParentContext) GetService(v any) (any, error) { return nil, nil }
-func (f *fakeParentContext) RunView(v view2.View, opts ...view2.RunViewOption) (any, error) {
+func (*fakeParentContext) GetService(_ any) (any, error) { return nil, nil }
+func (*fakeParentContext) RunView(_ view2.View, _ ...view2.RunViewOption) (any, error) {
 	return nil, nil
 }
-func (f *fakeParentContext) Me() view2.Identity          { return nil }
-func (f *fakeParentContext) IsMe(id view2.Identity) bool { return false }
-func (f *fakeParentContext) Initiator() view2.View       { return nil }
-func (f *fakeParentContext) GetSession(c view2.View, p view2.Identity, b ...view2.View) (view2.Session, error) {
+func (*fakeParentContext) Me() view2.Identity         { return nil }
+func (*fakeParentContext) IsMe(_ view2.Identity) bool { return false }
+func (*fakeParentContext) Initiator() view2.View      { return nil }
+func (*fakeParentContext) GetSession(_ view2.View, _ view2.Identity, _ ...view2.View) (view2.Session, error) {
 	return nil, nil
 }
 
-func (f *fakeParentContext) GetSessionByID(id string, p view2.Identity) (view2.Session, error) {
+func (*fakeParentContext) GetSessionByID(_ string, _ view2.Identity) (view2.Session, error) {
 	return nil, nil
 }
-func (f *fakeParentContext) Session() view2.Session   { return nil }
-func (f *fakeParentContext) Context() context.Context { return context.Background() }
-func (f *fakeParentContext) OnError(cb func())        {}
-func (f *fakeParentContext) Dispose()                 {}
-func (f *fakeParentContext) PutSessionByID(viewID string, party view2.Identity, session view2.Session) error {
+func (*fakeParentContext) Session() view2.Session   { return nil }
+func (*fakeParentContext) Context() context.Context { return context.Background() }
+func (*fakeParentContext) OnError(_ func())         {}
+func (*fakeParentContext) Dispose()                 {}
+func (*fakeParentContext) PutSessionByID(_ string, _ view2.Identity, _ view2.Session) error {
 	return nil
 }
-func (f *fakeParentContext) Cleanup() {}
-func (f *fakeParentContext) PutSession(caller view2.View, party view2.Identity, session view2.Session) error {
+func (*fakeParentContext) Cleanup() {}
+func (*fakeParentContext) PutSession(_ view2.View, _ view2.Identity, _ view2.Session) error {
 	return nil
 }
 
@@ -892,6 +892,6 @@ type fakeRunner struct {
 	err error
 }
 
-func (f *fakeRunner) RunView(viewCtx view2.Context, responder view2.View) (any, error) {
+func (f *fakeRunner) RunView(_ view2.Context, _ view2.View) (any, error) {
 	return f.res, f.err
 }

--- a/platform/view/services/view/grpc/server/marshal.go
+++ b/platform/view/services/view/grpc/server/marshal.go
@@ -97,7 +97,7 @@ func (s *ResponseMarshaler) createSignedCommandResponse(cr *protos.CommandRespon
 	}, nil
 }
 
-func (s *ResponseMarshaler) computeHash(data []byte) (hash []byte) {
+func (*ResponseMarshaler) computeHash(data []byte) (hash []byte) {
 	h := sha256.Sum256(data)
 	return h[:]
 }

--- a/platform/view/services/view/grpc/server/policy.go
+++ b/platform/view/services/view/grpc/server/policy.go
@@ -14,6 +14,6 @@ import (
 type YesPolicyChecker struct{}
 
 // Check checks if the given command is authorized. It always returns no error.
-func (y YesPolicyChecker) Check(sc *protos2.SignedCommand, c *protos2.Command) error {
+func (YesPolicyChecker) Check(_ *protos2.SignedCommand, _ *protos2.Command) error {
 	return nil
 }

--- a/platform/view/services/view/grpc/server/server.go
+++ b/platform/view/services/view/grpc/server/server.go
@@ -134,15 +134,15 @@ func (s *Server) StreamCommand(server protos.ViewService_StreamCommandServer) er
 	if err := server.RecvMsg(sc); err != nil {
 		return err
 	}
-	return s.streamCommand(sc, server)
+	return s.handleStreamCommand(sc, server)
 }
 
-func (s *Server) streamCommand(sc *protos.SignedCommand, commandServer protos.ViewService_StreamCommandServer) (err error) {
+func (s *Server) handleStreamCommand(sc *protos.SignedCommand, commandServer protos.ViewService_StreamCommandServer) (err error) {
 	ctx := commandServer.Context()
 	defer func() {
 		if r := recover(); r != nil {
 			logger.Errorf("processCommand triggered panic: %s\n%s\n", r, debug.Stack())
-			err = errors.Errorf("processCommand triggered panic: %s\n%s\n", r, debug.Stack())
+			err = errors.Errorf("processCommand triggered panic: %s\n%s", r, debug.Stack())
 		}
 	}()
 
@@ -185,7 +185,7 @@ func (s *Server) streamCommand(sc *protos.SignedCommand, commandServer protos.Vi
 }
 
 // ValidateHeader validates the given command header.
-func (s *Server) ValidateHeader(header *protos.Header) error {
+func (*Server) ValidateHeader(header *protos.Header) error {
 	if header == nil {
 		return errors.WithMessage(view.ErrCommandHeaderInvalid, "command header is required")
 	}

--- a/platform/view/services/view/grpc/server/server_test.go
+++ b/platform/view/services/view/grpc/server/server_test.go
@@ -66,7 +66,7 @@ func buildSignedCommand(t *testing.T, tlsCertHash []byte) *protos.SignedCommand 
 // stubMarshaller always returns a non-nil response and never errors.
 type stubMarshaller struct{}
 
-func (s *stubMarshaller) MarshalCommandResponse(_ []byte, payload any) (*protos.SignedCommandResponse, error) {
+func (*stubMarshaller) MarshalCommandResponse(_ []byte, _ any) (*protos.SignedCommandResponse, error) {
 	return &protos.SignedCommandResponse{}, nil
 }
 
@@ -92,10 +92,10 @@ func (f *fakeStreamServer) RecvMsg(m any) error {
 	return nil
 }
 
-func (f *fakeStreamServer) SendMsg(m any) error                  { return nil }
-func (f *fakeStreamServer) SetHeader(metadata.MD) error          { return nil }
-func (f *fakeStreamServer) SendHeader(metadata.MD) error         { return nil }
-func (f *fakeStreamServer) SetTrailer(metadata.MD)               {}
+func (*fakeStreamServer) SendMsg(_ any) error                    { return nil }
+func (*fakeStreamServer) SetHeader(metadata.MD) error            { return nil }
+func (*fakeStreamServer) SendHeader(metadata.MD) error           { return nil }
+func (*fakeStreamServer) SetTrailer(metadata.MD)                 {}
 func (f *fakeStreamServer) Recv() (*protos.SignedCommand, error) { return f.sc, nil }
 
 // newTestServer creates a Server wired with a noop tracing provider, YesPolicyChecker,

--- a/platform/view/services/view/grpc/server/view.go
+++ b/platform/view/services/view/grpc/server/view.go
@@ -155,12 +155,12 @@ func (s *viewHandler) RunView(ctx context.Context, manager ViewManager, view vie
 	}
 
 	// Run the view
-	go s.runView(view, context)
+	go s.runViewAsync(view, context)
 
 	return context.ID(), nil
 }
 
-func (s *viewHandler) runView(view view2.View, viewCtx view2.Context) {
+func (s *viewHandler) runViewAsync(view view2.View, viewCtx view2.Context) {
 	defer s.viewManager.DeleteContext(viewCtx.ID())
 	result, err := viewCtx.RunView(view)
 	if err != nil {

--- a/platform/view/services/view/grpc/server/view_test.go
+++ b/platform/view/services/view/grpc/server/view_test.go
@@ -51,17 +51,17 @@ func (f *fakeViewManager) NewView(id string, in []byte) (view2.View, error) {
 	return f.newViewReturns, f.newViewErr
 }
 
-func (f *fakeViewManager) InitiateView(ctx context.Context, view view2.View) (any, error) {
+func (f *fakeViewManager) InitiateView(_ context.Context, _ view2.View) (any, error) {
 	f.initiateViewCallCount++
 	return f.initiateViewReturns, f.initiateViewErr
 }
 
-func (f *fakeViewManager) InitiateContext(ctx context.Context, view view2.View) (view2.Context, error) {
+func (f *fakeViewManager) InitiateContext(_ context.Context, _ view2.View) (view2.Context, error) {
 	f.initiateContextCallCount++
 	return f.initiateContextReturns, f.initiateContextErr
 }
 
-func (f *fakeViewManager) DeleteContext(contextID string) {
+func (f *fakeViewManager) DeleteContext(_ string) {
 	f.deleteContextCallCount++
 	if f.deleteContextCh != nil {
 		select {
@@ -92,28 +92,28 @@ func (f *fakeContext) PutService(v any) error {
 	return nil
 }
 
-func (f *fakeContext) ResetSessions() error     { return nil }
-func (f *fakeContext) Context() context.Context { return context.Background() }
-func (f *fakeContext) StartSpanFrom(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+func (*fakeContext) ResetSessions() error     { return nil }
+func (*fakeContext) Context() context.Context { return context.Background() }
+func (*fakeContext) StartSpanFrom(ctx context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
 	return ctx, trace.SpanFromContext(ctx)
 }
-func (f *fakeContext) Initiator() view2.View         { return nil }
-func (f *fakeContext) Me() view2.Identity            { return nil }
-func (f *fakeContext) IsMe(view2.Identity) bool      { return false }
-func (f *fakeContext) Session() view2.Session        { return nil }
-func (f *fakeContext) GetService(v any) (any, error) { return nil, nil }
-func (f *fakeContext) GetSession(caller view2.View, p view2.Identity, views ...view2.View) (view2.Session, error) {
+func (*fakeContext) Initiator() view2.View         { return nil }
+func (*fakeContext) Me() view2.Identity            { return nil }
+func (*fakeContext) IsMe(view2.Identity) bool      { return false }
+func (*fakeContext) Session() view2.Session        { return nil }
+func (*fakeContext) GetService(_ any) (any, error) { return nil, nil }
+func (*fakeContext) GetSession(_ view2.View, _ view2.Identity, _ ...view2.View) (view2.Session, error) {
 	return nil, nil
 }
 
-func (f *fakeContext) GetSessionByID(id string, p view2.Identity) (view2.Session, error) {
+func (*fakeContext) GetSessionByID(_ string, _ view2.Identity) (view2.Session, error) {
 	return nil, nil
 }
 
-func (f *fakeContext) StartSession(view2.View, view2.Identity) (view2.Session, error) {
+func (*fakeContext) StartSession(view2.View, view2.Identity) (view2.Session, error) {
 	return nil, nil
 }
-func (f *fakeContext) OnError(func()) {}
+func (*fakeContext) OnError(func()) {}
 
 // fakeNonMutableContext implements view2.Context but deliberately not
 // view2.MutableContext, to exercise the mutable-context guard.
@@ -202,7 +202,7 @@ type fakeTracerProvider struct {
 	trace.TracerProvider
 }
 
-func (f *fakeTracerProvider) Tracer(name string, opts ...trace.TracerOption) trace.Tracer {
+func (*fakeTracerProvider) Tracer(name string, _ ...trace.TracerOption) trace.Tracer {
 	return noop.NewTracerProvider().Tracer(name)
 }
 

--- a/platform/view/services/view/manager.go
+++ b/platform/view/services/view/manager.go
@@ -305,7 +305,7 @@ func (cm *Manager) NewResponderContext(ctx context.Context, contextID string, se
 }
 
 // GetIdentifier returns the identifier for the given view.
-func (cm *Manager) GetIdentifier(f view.View) string {
+func (*Manager) GetIdentifier(f view.View) string {
 	return GetIdentifier(f)
 }
 
@@ -337,7 +337,7 @@ type Runner interface {
 
 type defaultRunner struct{}
 
-func (r *defaultRunner) RunView(viewCtx view.Context, responder view.View) (any, error) {
+func (*defaultRunner) RunView(viewCtx view.Context, responder view.View) (any, error) {
 	return viewCtx.RunView(responder)
 }
 

--- a/platform/view/services/view/p2p/service.go
+++ b/platform/view/services/view/p2p/service.go
@@ -59,7 +59,7 @@ type Runner interface {
 
 type defaultRunner struct{}
 
-func (r *defaultRunner) RunView(viewCtx view.Context, responder view.View) (any, error) {
+func (*defaultRunner) RunView(viewCtx view.Context, responder view.View) (any, error) {
 	return viewCtx.RunView(responder)
 }
 

--- a/platform/view/services/view/p2p/service_test.go
+++ b/platform/view/services/view/p2p/service_test.go
@@ -46,7 +46,7 @@ func (m *viewManagerMock) GetIdentity(endpoint string, pkID []byte) (view.Identi
 	return view.Identity("caller"), nil
 }
 
-func (m *viewManagerMock) NewResponderContext(ctx context.Context, contextID string, session view.Session, me, remote view.Identity) (view.Context, bool, error) {
+func (m *viewManagerMock) NewResponderContext(ctx context.Context, contextID string, session view.Session, me, _ view.Identity) (view.Context, bool, error) {
 	if m.NewSessionContextFunc != nil {
 		return m.NewSessionContextFunc(ctx, contextID, session, me)
 	}
@@ -95,7 +95,7 @@ func TestService(t *testing.T) {
 		require.Equal(t, "caller1", caller)
 		return &mock.View{}, nil, nil
 	}
-	vm.NewSessionContextFunc = func(ctx context.Context, contextID string, session view.Session, party view.Identity) (view.Context, bool, error) {
+	vm.NewSessionContextFunc = func(_ context.Context, contextID string, _ view.Session, _ view.Identity) (view.Context, bool, error) {
 		require.Equal(t, "ctx1", contextID)
 		vm.HandleResponderCalled <- struct{}{}
 		return &mock.Context{}, true, nil
@@ -141,7 +141,7 @@ func TestService_PanicIsReturnedToRemoteCaller(t *testing.T) {
 	vm := &viewManagerMock{
 		HandleResponderCalled: make(chan struct{}, 10),
 	}
-	vm.ExistResponderForCallerFunc = func(caller string) (view.View, view.Identity, error) {
+	vm.ExistResponderForCallerFunc = func(_ string) (view.View, view.Identity, error) {
 		return panicView, nil, nil
 	}
 
@@ -163,7 +163,7 @@ func TestService_PanicIsReturnedToRemoteCaller(t *testing.T) {
 		}()
 		return v.Call(respCtx)
 	}
-	vm.NewSessionContextFunc = func(ctx context.Context, contextID string, session view.Session, party view.Identity) (view.Context, bool, error) {
+	vm.NewSessionContextFunc = func(_ context.Context, _ string, _ view.Session, _ view.Identity) (view.Context, bool, error) {
 		vm.HandleResponderCalled <- struct{}{}
 		return respCtx, true, nil
 	}
@@ -212,7 +212,7 @@ func TestService_HandleResponderError(t *testing.T) {
 	vm := &viewManagerMock{
 		HandleResponderCalled: make(chan struct{}, 10),
 	}
-	vm.NewSessionContextFunc = func(ctx context.Context, contextID string, session view.Session, party view.Identity) (view.Context, bool, error) {
+	vm.NewSessionContextFunc = func(_ context.Context, _ string, _ view.Session, _ view.Identity) (view.Context, bool, error) {
 		vm.HandleResponderCalled <- struct{}{}
 		return &mock.Context{}, true, nil
 	}
@@ -263,20 +263,20 @@ type leakTestDeps struct {
 	respCtx   *mock.Context
 }
 
-func (d *leakTestDeps) ExistResponderForCaller(caller string) (view.View, view.Identity, error) {
+func (d *leakTestDeps) ExistResponderForCaller(_ string) (view.View, view.Identity, error) {
 	return d.responder, nil, nil
 }
 
-func (d *leakTestDeps) NewResponderContext(ctx context.Context, contextID string, session view.Session, me, remote view.Identity) (view.Context, bool, error) {
+func (d *leakTestDeps) NewResponderContext(ctx context.Context, _ string, _ view.Session, _, _ view.Identity) (view.Context, bool, error) {
 	d.respCtx.ContextReturns(ctx)
 	return d.respCtx, true, nil
 }
 
-func (d *leakTestDeps) DeleteContext(contextID string) {}
+func (*leakTestDeps) DeleteContext(_ string) {}
 
-func (d *leakTestDeps) DefaultIdentity() view.Identity { return view.Identity("me") }
+func (*leakTestDeps) DefaultIdentity() view.Identity { return view.Identity("me") }
 
-func (d *leakTestDeps) GetIdentity(endpoint string, pkID []byte) (view.Identity, error) {
+func (*leakTestDeps) GetIdentity(_ string, _ []byte) (view.Identity, error) {
 	return view.Identity("caller"), nil
 }
 

--- a/platform/view/services/view/registry.go
+++ b/platform/view/services/view/registry.go
@@ -86,9 +86,9 @@ func (cm *Registry) RegisterResponder(responder view.View, initiatedBy any) erro
 func (cm *Registry) RegisterResponderWithIdentity(responder view.View, id view.Identity, initiatedBy any) error {
 	switch t := initiatedBy.(type) {
 	case view.View:
-		cm.registerResponderWithIdentity(responder, id, cm.GetIdentifier(t))
+		cm.registerResponderForInitiatorID(responder, id, cm.GetIdentifier(t))
 	case string:
-		cm.registerResponderWithIdentity(responder, id, t)
+		cm.registerResponderForInitiatorID(responder, id, t)
 	default:
 		return errors.Errorf("initiatedBy must be a view or a string")
 	}
@@ -129,11 +129,11 @@ func (cm *Registry) GetResponder(initiatedBy any) (view.View, error) {
 }
 
 // GetIdentifier returns the identifier for the given view.
-func (cm *Registry) GetIdentifier(f view.View) string {
+func (*Registry) GetIdentifier(f view.View) string {
 	return GetIdentifier(f)
 }
 
-func (cm *Registry) registerResponderWithIdentity(responder view.View, id view.Identity, initiatedByID string) {
+func (cm *Registry) registerResponderForInitiatorID(responder view.View, id view.Identity, initiatedByID string) {
 	cm.viewsSync.Lock()
 	defer cm.viewsSync.Unlock()
 

--- a/platform/view/services/view/registry_test.go
+++ b/platform/view/services/view/registry_test.go
@@ -39,7 +39,7 @@ func TestRegistry(t *testing.T) {
 	require.Contains(t, err.Error(), "no factory found")
 
 	// NewView - panic in factory
-	factory.NewViewStub = func(in []byte) (view2.View, error) {
+	factory.NewViewStub = func(_ []byte) (view2.View, error) {
 		panic("factory-panic")
 	}
 	_, err = registry.NewView("v1", nil)

--- a/platform/view/services/view/sessions.go
+++ b/platform/view/services/view/sessions.go
@@ -40,10 +40,10 @@ func (s *Sessions) PutDefault(party view.Identity, session view.Session) {
 }
 
 // Get returns the session for the given view ID and party.
-func (s *Sessions) Get(viewId string, party view.Identity) view.Session {
+func (s *Sessions) Get(viewID string, party view.Identity) view.Session {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	key := lookupKey(viewId, party)
+	key := lookupKey(viewID, party)
 	session := s.s[key]
 	if logger.IsEnabledFor(zapcore.DebugLevel) {
 		logger.Debugf("Sessions.Get [%s] found [%t]", key, session != nil)
@@ -52,34 +52,34 @@ func (s *Sessions) Get(viewId string, party view.Identity) view.Session {
 }
 
 // GetFirstOpen returns the first open session for the given view ID and list of parties.
-func (s *Sessions) GetFirstOpen(viewId string, parties iterators.Iterator[view.Identity]) (view.Session, view.Identity) {
+func (s *Sessions) GetFirstOpen(viewID string, parties iterators.Iterator[view.Identity]) (view.Session, view.Identity) {
 	defer parties.Close()
-	var targetId view.Identity
+	var targetID view.Identity
 	for party, err := parties.Next(); !errors.Is(err, io.EOF); party, err = parties.Next() {
 		if err != nil {
 			continue
 		}
 
-		session := s.Get(viewId, party)
+		session := s.Get(viewID, party)
 		if session != nil {
 			if session.Info().Closed {
-				logger.Debugf("removing session [%s:%s], it is closed", viewId, party)
-				s.Delete(viewId, party)
+				logger.Debugf("removing session [%s:%s], it is closed", viewID, party)
+				s.Delete(viewID, party)
 				return nil, party
 			}
-			logger.Debugf("session for [%s] found with identifier [%s]", party, viewId)
+			logger.Debugf("session for [%s] found with identifier [%s]", party, viewID)
 			return session, party
 		}
-		targetId = party
+		targetID = party
 	}
-	return nil, targetId
+	return nil, targetID
 }
 
 // Put registers a session for the given view ID and party.
-func (s *Sessions) Put(viewId string, party view.Identity, session view.Session) {
+func (s *Sessions) Put(viewID string, party view.Identity, session view.Session) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	key := lookupKey(viewId, party)
+	key := lookupKey(viewID, party)
 	if logger.IsEnabledFor(zapcore.DebugLevel) {
 		logger.Debugf("Sessions.Put [%s] found [%t]", key, session != nil)
 	}
@@ -87,10 +87,10 @@ func (s *Sessions) Put(viewId string, party view.Identity, session view.Session)
 }
 
 // Delete removes the session for the given view ID and party.
-func (s *Sessions) Delete(viewId string, party view.Identity) {
+func (s *Sessions) Delete(viewID string, party view.Identity) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	delete(s.s, lookupKey(viewId, party))
+	delete(s.s, lookupKey(viewID, party))
 }
 
 // Reset removes all registered sessions.
@@ -111,6 +111,6 @@ func (s *Sessions) GetSessionIDs() []string {
 	return ids
 }
 
-func lookupKey(viewId string, party view.Identity) string {
-	return viewId + party.UniqueID()
+func lookupKey(viewID string, party view.Identity) string {
+	return viewID + party.UniqueID()
 }

--- a/platform/view/services/view/sp_test.go
+++ b/platform/view/services/view/sp_test.go
@@ -21,7 +21,7 @@ type MyInterface interface {
 
 type MyImpl struct{}
 
-func (m *MyImpl) Foo() {}
+func (*MyImpl) Foo() {}
 
 func TestSP(t *testing.T) {
 	t.Parallel()

--- a/platform/view/services/view/view_runview_test.go
+++ b/platform/view/services/view/view_runview_test.go
@@ -28,7 +28,7 @@ func TestRunView_CancelStopsAsyncRun(t *testing.T) { //nolint:paralleltest // us
 	done := make(chan struct{})
 
 	fake := &mock.Context{}
-	fake.RunViewStub = func(v view.View, opts ...view.RunViewOption) (any, error) {
+	fake.RunViewStub = func(_ view.View, opts ...view.RunViewOption) (any, error) {
 		options, err := view.CompileRunViewOptions(opts...)
 		if err != nil {
 			t.Errorf("failed compiling options: %v", err)
@@ -69,7 +69,7 @@ func TestRunView_PreservesChildContextOptions(t *testing.T) { //nolint:parallelt
 	compiled := make(chan *view.RunViewOptions, 1)
 
 	fake := &mock.Context{}
-	fake.RunViewStub = func(v view.View, opts ...view.RunViewOption) (any, error) {
+	fake.RunViewStub = func(_ view.View, opts ...view.RunViewOption) (any, error) {
 		options, err := view.CompileRunViewOptions(opts...)
 		if err != nil {
 			return nil, err
@@ -116,7 +116,7 @@ func TestRunView_CallerOptionWins(t *testing.T) { //nolint:paralleltest // uses 
 	compiled := make(chan *view.RunViewOptions, 1)
 
 	fake := &mock.Context{}
-	fake.RunViewStub = func(v view.View, opts ...view.RunViewOption) (any, error) {
+	fake.RunViewStub = func(_ view.View, opts ...view.RunViewOption) (any, error) {
 		options, err := view.CompileRunViewOptions(opts...)
 		if err != nil {
 			return nil, err

--- a/platform/view/services/view/view_test.go
+++ b/platform/view/services/view/view_test.go
@@ -24,7 +24,7 @@ func TestRunViewNow(t *testing.T) {
 	t.Parallel()
 	parent := &mock.ParentContext{}
 	parent.ContextReturns(context.Background())
-	parent.StartSpanFromStub = func(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	parent.StartSpanFromStub = func(ctx context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
 		return ctx, trace.SpanFromContext(ctx)
 	}
 
@@ -40,11 +40,11 @@ func TestRunViewNow_CallOption(t *testing.T) {
 	t.Parallel()
 	parent := &mock.ParentContext{}
 	parent.ContextReturns(context.Background())
-	parent.StartSpanFromStub = func(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	parent.StartSpanFromStub = func(ctx context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
 		return ctx, trace.SpanFromContext(ctx)
 	}
 
-	call := func(viewCtx view2.Context) (any, error) {
+	call := func(_ view2.Context) (any, error) {
 		return "call-result", nil
 	}
 
@@ -57,7 +57,7 @@ func TestRunViewNow_AsInitiator_NoSession(t *testing.T) {
 	t.Parallel()
 	parent := &mock.ParentContext{}
 	parent.ContextReturns(context.Background())
-	parent.StartSpanFromStub = func(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	parent.StartSpanFromStub = func(ctx context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
 		return ctx, trace.SpanFromContext(ctx)
 	}
 	parent.SessionReturns(nil)
@@ -73,7 +73,7 @@ func TestRunViewNow_AsInitiator_PutSessionError(t *testing.T) {
 	t.Parallel()
 	parent := &mock.ParentContext{}
 	parent.ContextReturns(context.Background())
-	parent.StartSpanFromStub = func(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	parent.StartSpanFromStub = func(ctx context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
 		return ctx, trace.SpanFromContext(ctx)
 	}
 	session := &mock.Session{}
@@ -92,12 +92,12 @@ func TestRunViewNow_PanicInView_CallsCleanupAndReturnsError(t *testing.T) {
 	t.Parallel()
 	parent := &mock.ParentContext{}
 	parent.ContextReturns(context.Background())
-	parent.StartSpanFromStub = func(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	parent.StartSpanFromStub = func(ctx context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
 		return ctx, trace.SpanFromContext(ctx)
 	}
 
 	v := &mock.View{}
-	v.CallStub = func(viewCtx view2.Context) (any, error) {
+	v.CallStub = func(_ view2.Context) (any, error) {
 		panic("boom")
 	}
 
@@ -111,7 +111,7 @@ func TestRunViewNow_NoViewAndNoCall(t *testing.T) {
 	t.Parallel()
 	parent := &mock.ParentContext{}
 	parent.ContextReturns(context.Background())
-	parent.StartSpanFromStub = func(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	parent.StartSpanFromStub = func(ctx context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
 		return ctx, trace.SpanFromContext(ctx)
 	}
 
@@ -137,7 +137,7 @@ func TestRunViewNow_SetsTracingSuccessAttribute(t *testing.T) {
 			parent := &mock.ParentContext{}
 			parent.ContextReturns(t.Context())
 			captured := &capturingSpan{Span: trace.SpanFromContext(t.Context())}
-			parent.StartSpanFromStub = func(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+			parent.StartSpanFromStub = func(ctx context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
 				return ctx, captured
 			}
 
@@ -159,7 +159,7 @@ func TestRunViewNow_SetsTracingSuccessAttribute(t *testing.T) {
 func TestRunCall(t *testing.T) {
 	t.Parallel()
 	ctx := &mock.Context{}
-	call := func(viewCtx view2.Context) (any, error) {
+	call := func(_ view2.Context) (any, error) {
 		return "res", nil
 	}
 	ctx.RunViewReturns("res", nil)
@@ -173,7 +173,7 @@ func TestAsResponder(t *testing.T) {
 	t.Parallel()
 	ctx := &mock.Context{}
 	session := &mock.Session{}
-	call := func(viewCtx view2.Context) (any, error) {
+	call := func(_ view2.Context) (any, error) {
 		return "res", nil
 	}
 	ctx.RunViewReturns("res", nil)
@@ -187,7 +187,7 @@ func TestAsInitiatorCall(t *testing.T) {
 	t.Parallel()
 	ctx := &mock.Context{}
 	v := &mock.View{}
-	call := func(viewCtx view2.Context) (any, error) {
+	call := func(_ view2.Context) (any, error) {
 		return "res", nil
 	}
 	ctx.RunViewReturns("res", nil)

--- a/platform/view/services/view/web/dispatcher.go
+++ b/platform/view/services/view/web/dispatcher.go
@@ -53,7 +53,7 @@ func (rd *Dispatcher) HandleRequest(reqctx *server.ReqContext) (response any, st
 }
 
 // ParsePayload parses the incoming payload.
-func (rd *Dispatcher) ParsePayload(bytes []byte) (any, error) {
+func (*Dispatcher) ParsePayload(bytes []byte) (any, error) {
 	return bytes, nil
 }
 

--- a/platform/view/services/view/web/view.go
+++ b/platform/view/services/view/web/view.go
@@ -53,7 +53,7 @@ func (s *viewHandler) CallView(context *server2.ReqContext, vid string, input []
 	}}, nil
 }
 
-func (s *viewHandler) StreamCallView(context *server2.ReqContext, vid string, input []byte) (any, error) {
+func (s *viewHandler) StreamCallView(context *server2.ReqContext, vid string, _ []byte) (any, error) {
 	return nil, s.c.StreamCallView(vid, context.ResponseWriter, context.Req)
 }
 

--- a/platform/view/services/view/web/web_test.go
+++ b/platform/view/services/view/web/web_test.go
@@ -293,7 +293,7 @@ func TestClientStreamCallView(t *testing.T) {
 
 func TestViewCallFunc(t *testing.T) {
 	t.Parallel()
-	f := viewCallFunc(func(context *server2.ReqContext, vid string, input []byte) (any, error) {
+	f := viewCallFunc(func(_ *server2.ReqContext, _ string, _ []byte) (any, error) {
 		return "result", nil
 	})
 	res, err := f.CallView(nil, "vid", nil)
@@ -305,7 +305,7 @@ type fakeViewCaller struct {
 	err error
 }
 
-func (f *fakeViewCaller) CallView(context *server2.ReqContext, vid string, input []byte) (any, error) {
+func (f *fakeViewCaller) CallView(_ *server2.ReqContext, _ string, _ []byte) (any, error) {
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -323,14 +323,14 @@ type fakeViewManager struct {
 	nonMutableCtx bool
 }
 
-func (f *fakeViewManager) NewView(id string, in []byte) (view2.View, error) {
+func (f *fakeViewManager) NewView(_ string, _ []byte) (view2.View, error) {
 	if f.err != nil {
 		return nil, f.err
 	}
 	return &fakeView{}, nil
 }
 
-func (f *fakeViewManager) InitiateView(ctx context.Context, v view2.View) (any, error) {
+func (f *fakeViewManager) InitiateView(_ context.Context, _ view2.View) (any, error) {
 	if f.initErr != nil {
 		return nil, f.initErr
 	}
@@ -340,7 +340,7 @@ func (f *fakeViewManager) InitiateView(ctx context.Context, v view2.View) (any, 
 	return []byte("result"), nil
 }
 
-func (f *fakeViewManager) InitiateContext(ctx context.Context, v view2.View) (view2.Context, error) {
+func (f *fakeViewManager) InitiateContext(_ context.Context, _ view2.View) (view2.Context, error) {
 	if f.initCtxErr != nil {
 		return nil, f.initCtxErr
 	}
@@ -354,19 +354,19 @@ func (f *fakeViewManager) InitiateContext(ctx context.Context, v view2.View) (vi
 	return &fakeViewContext{runErr: f.ctxRunErr, putServiceErr: f.putServiceErr, result: res}, nil
 }
 
-func (f *fakeViewManager) DeleteContext(contextID string) {}
+func (*fakeViewManager) DeleteContext(_ string) {}
 
 type fakeView struct{}
 
-func (f *fakeView) Call(context view2.Context) (any, error) {
+func (*fakeView) Call(_ view2.Context) (any, error) {
 	return nil, nil
 }
 
 type fakeIdentityProvider struct{}
 
-func (f *fakeIdentityProvider) DefaultIdentity() view2.Identity { return nil }
-func (f *fakeIdentityProvider) Admins() []view2.Identity        { return nil }
-func (f *fakeIdentityProvider) Clients() []view2.Identity       { return nil }
+func (*fakeIdentityProvider) DefaultIdentity() view2.Identity { return nil }
+func (*fakeIdentityProvider) Admins() []view2.Identity        { return nil }
+func (*fakeIdentityProvider) Clients() []view2.Identity       { return nil }
 
 type fakeViewContext struct {
 	runErr        error
@@ -374,52 +374,52 @@ type fakeViewContext struct {
 	result        any
 }
 
-func (f *fakeViewContext) ID() string { return "ctx-id" }
-func (f *fakeViewContext) RunView(v view2.View, opts ...view2.RunViewOption) (any, error) {
+func (*fakeViewContext) ID() string { return "ctx-id" }
+func (f *fakeViewContext) RunView(_ view2.View, _ ...view2.RunViewOption) (any, error) {
 	return f.result, f.runErr
 }
-func (f *fakeViewContext) Context() context.Context      { return context.Background() }
-func (f *fakeViewContext) GetService(v any) (any, error) { return nil, nil }
-func (f *fakeViewContext) Me() view2.Identity            { return nil }
-func (f *fakeViewContext) IsMe(id view2.Identity) bool   { return false }
-func (f *fakeViewContext) Initiator() view2.View         { return nil }
-func (f *fakeViewContext) GetSession(c view2.View, p view2.Identity, b ...view2.View) (view2.Session, error) {
+func (*fakeViewContext) Context() context.Context      { return context.Background() }
+func (*fakeViewContext) GetService(_ any) (any, error) { return nil, nil }
+func (*fakeViewContext) Me() view2.Identity            { return nil }
+func (*fakeViewContext) IsMe(_ view2.Identity) bool    { return false }
+func (*fakeViewContext) Initiator() view2.View         { return nil }
+func (*fakeViewContext) GetSession(_ view2.View, _ view2.Identity, _ ...view2.View) (view2.Session, error) {
 	return nil, nil
 }
 
-func (f *fakeViewContext) GetSessionByID(id string, p view2.Identity) (view2.Session, error) {
+func (*fakeViewContext) GetSessionByID(_ string, _ view2.Identity) (view2.Session, error) {
 	return nil, nil
 }
-func (f *fakeViewContext) Session() view2.Session  { return nil }
-func (f *fakeViewContext) OnError(callback func()) {}
-func (f *fakeViewContext) StartSpanFrom(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+func (*fakeViewContext) Session() view2.Session { return nil }
+func (*fakeViewContext) OnError(_ func())       {}
+func (*fakeViewContext) StartSpanFrom(ctx context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
 	return ctx, trace.SpanFromContext(ctx)
 }
-func (f *fakeViewContext) ResetSessions() error { return nil }
-func (f *fakeViewContext) PutService(v any) error {
+func (*fakeViewContext) ResetSessions() error { return nil }
+func (f *fakeViewContext) PutService(_ any) error {
 	return f.putServiceErr
 }
 
 type fakeNonMutableViewContext struct{}
 
-func (f *fakeNonMutableViewContext) ID() string { return "ctx-id" }
-func (f *fakeNonMutableViewContext) RunView(v view2.View, opts ...view2.RunViewOption) (any, error) {
+func (*fakeNonMutableViewContext) ID() string { return "ctx-id" }
+func (*fakeNonMutableViewContext) RunView(_ view2.View, _ ...view2.RunViewOption) (any, error) {
 	return []byte("result"), nil
 }
-func (f *fakeNonMutableViewContext) Context() context.Context      { return context.Background() }
-func (f *fakeNonMutableViewContext) GetService(v any) (any, error) { return nil, nil }
-func (f *fakeNonMutableViewContext) Me() view2.Identity            { return nil }
-func (f *fakeNonMutableViewContext) IsMe(id view2.Identity) bool   { return false }
-func (f *fakeNonMutableViewContext) Initiator() view2.View         { return nil }
-func (f *fakeNonMutableViewContext) GetSession(c view2.View, p view2.Identity, b ...view2.View) (view2.Session, error) {
+func (*fakeNonMutableViewContext) Context() context.Context      { return context.Background() }
+func (*fakeNonMutableViewContext) GetService(_ any) (any, error) { return nil, nil }
+func (*fakeNonMutableViewContext) Me() view2.Identity            { return nil }
+func (*fakeNonMutableViewContext) IsMe(_ view2.Identity) bool    { return false }
+func (*fakeNonMutableViewContext) Initiator() view2.View         { return nil }
+func (*fakeNonMutableViewContext) GetSession(_ view2.View, _ view2.Identity, _ ...view2.View) (view2.Session, error) {
 	return nil, nil
 }
 
-func (f *fakeNonMutableViewContext) GetSessionByID(id string, p view2.Identity) (view2.Session, error) {
+func (*fakeNonMutableViewContext) GetSessionByID(_ string, _ view2.Identity) (view2.Session, error) {
 	return nil, nil
 }
-func (f *fakeNonMutableViewContext) Session() view2.Session  { return nil }
-func (f *fakeNonMutableViewContext) OnError(callback func()) {}
-func (f *fakeNonMutableViewContext) StartSpanFrom(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+func (*fakeNonMutableViewContext) Session() view2.Session { return nil }
+func (*fakeNonMutableViewContext) OnError(_ func())       {}
+func (*fakeNonMutableViewContext) StartSpanFrom(ctx context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
 	return ctx, trace.SpanFromContext(ctx)
 }

--- a/platform/view/services/web/client/client.go
+++ b/platform/view/services/web/client/client.go
@@ -54,13 +54,13 @@ func (c *Config) WebURL() string {
 }
 
 func (c *Config) url(protocol string) string {
-	if c.isTlsEnabled() {
+	if c.isTLSEnabled() {
 		protocol += "s"
 	}
 	return fmt.Sprintf("%s://%s", protocol, c.Host)
 }
 
-func (c *Config) isTlsEnabled() bool {
+func (c *Config) isTLSEnabled() bool {
 	return c.CACertPath != "" || len(c.CACertRaw) != 0
 }
 
@@ -68,7 +68,7 @@ func (c *Config) isTlsEnabled() bool {
 type Client struct {
 	c             *http.Client
 	url           string
-	wsUrl         string
+	wsURL         string
 	tlsConfig     *tls.Config
 	metricsParser expfmt.TextParser
 }
@@ -111,7 +111,7 @@ func NewClient(config *Config) (*Client, error) {
 			}),
 		},
 		url:           config.WebURL(),
-		wsUrl:         config.WsURL(),
+		wsURL:         config.WsURL(),
 		tlsConfig:     tlsClientConfig,
 		metricsParser: expfmt.NewTextParser(model.LegacyValidation),
 	}, nil
@@ -128,7 +128,7 @@ func (c *Client) Metrics() (map[string]*dto.MetricFamily, error) {
 
 func (c *Client) StreamCallView(fid string, in []byte) (*WSStream, error) {
 	urlSuffix := fmt.Sprintf("/v1/Views/Stream/%s", fid)
-	stream, err := NewWSStream(c.wsUrl+urlSuffix, c.tlsConfig)
+	stream, err := NewWSStream(c.wsURL+urlSuffix, c.tlsConfig)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to init web socket stream")
 	}
@@ -190,6 +190,6 @@ func (c *Client) CallViewWithContext(ctx context.Context, fid string, in []byte)
 	return response.CallViewResponse.Result, nil
 }
 
-func (c *Client) Initiate(fid string, in []byte) (string, error) {
+func (*Client) Initiate(_ string, _ []byte) (string, error) {
 	panic("implement me")
 }

--- a/platform/view/services/web/client/client_test.go
+++ b/platform/view/services/web/client/client_test.go
@@ -168,7 +168,7 @@ func TestNewClient_Success_Configures_Client_Correctly(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, client)
 			require.Equal(t, tc.expectURL, client.url)
-			require.Equal(t, tc.expectWsURL, client.wsUrl)
+			require.Equal(t, tc.expectWsURL, client.wsURL)
 
 			if tc.expectTLS {
 				require.NotNil(t, client.tlsConfig)
@@ -267,14 +267,14 @@ func TestCallView_Error_Returns_Descriptive_Failure(t *testing.T) {
 	}{
 		{
 			name: "Non_200_Status_Code_Returns_Status_Error",
-			handler: func(w http.ResponseWriter, r *http.Request) {
+			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
 			},
 			expectedErrMsg: "status code",
 		},
 		{
 			name: "Invalid_JSON_Body_Returns_Unmarshal_Error",
-			handler: func(w http.ResponseWriter, r *http.Request) {
+			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte("not-json"))
 			},
@@ -282,7 +282,7 @@ func TestCallView_Error_Returns_Descriptive_Failure(t *testing.T) {
 		},
 		{
 			name: "Null_CallViewResponse_Returns_Invalid_Response_Error",
-			handler: func(w http.ResponseWriter, r *http.Request) {
+			handler: func(w http.ResponseWriter, _ *http.Request) {
 				resp := &protos.CommandResponse_CallViewResponse{}
 				w.WriteHeader(http.StatusOK)
 				_ = json.NewEncoder(w).Encode(resp)
@@ -313,7 +313,7 @@ func TestCallView_Error_Returns_Descriptive_Failure(t *testing.T) {
 func TestCallViewWithContext_Cancelled_Context_Returns_Error(t *testing.T) {
 	t.Parallel()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		<-r.Context().Done()
 	}))
 	defer server.Close()
@@ -396,7 +396,7 @@ func newTestClient(t *testing.T, server *httptest.Server) *Client {
 	return &Client{
 		c:             server.Client(),
 		url:           server.URL,
-		wsUrl:         "ws" + server.URL[4:],
+		wsURL:         "ws" + server.URL[4:],
 		metricsParser: expfmt.NewTextParser(model.LegacyValidation),
 	}
 }

--- a/platform/view/services/web/client/wsclient_test.go
+++ b/platform/view/services/web/client/wsclient_test.go
@@ -19,7 +19,7 @@ import (
 
 // wsUpgrader is a shared test upgrader with permissive origin checking.
 var wsUpgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool { return true },
+	CheckOrigin: func(_ *http.Request) bool { return true },
 }
 
 // toWsURL converts an httptest.Server URL from "http://..." to "ws://...".
@@ -91,7 +91,7 @@ func TestNewWSStream_Returns_Connected_Stream(t *testing.T) {
 func TestNewWSStream_Fails_When_Server_Does_Not_Upgrade(t *testing.T) {
 	t.Parallel()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()

--- a/platform/view/services/web/server/dummy.go
+++ b/platform/view/services/web/server/dummy.go
@@ -16,13 +16,13 @@ func NewDummyServer() *DummyServer {
 	return &DummyServer{}
 }
 
-func (d *DummyServer) RegisterHandler(s string, handler http.Handler, secure bool) {
+func (*DummyServer) RegisterHandler(_ string, _ http.Handler, _ bool) {
 }
 
-func (d *DummyServer) Start() error {
+func (*DummyServer) Start() error {
 	return nil
 }
 
-func (d *DummyServer) Stop() error {
+func (*DummyServer) Stop() error {
 	return nil
 }

--- a/platform/view/services/web/server/handler.go
+++ b/platform/view/services/web/server/handler.go
@@ -27,6 +27,7 @@ type Config struct {
 	MaxReqSize uint16
 }
 
+//nolint:revive // var-naming: renaming this exported type is an API break; see follow-up
 type HttpHandler struct {
 	mux *http.ServeMux
 }
@@ -48,6 +49,7 @@ type RequestHandler interface {
 	ParsePayload([]byte) (any, error)
 }
 
+//nolint:revive // var-naming: renaming this exported func is an API break; see follow-up
 func NewHttpHandler() *HttpHandler {
 	return &HttpHandler{mux: http.NewServeMux()}
 }
@@ -63,7 +65,7 @@ func (h *HttpHandler) RegisterURI(uri, method string, rh RequestHandler) {
 	h.mux.HandleFunc(method+" "+apiVersion+uri, f)
 }
 
-func (h *HttpHandler) handle(backToClient http.ResponseWriter, req *http.Request, rh RequestHandler) {
+func (*HttpHandler) handle(backToClient http.ResponseWriter, req *http.Request, rh RequestHandler) {
 	if _, err := negotiateContentType(req); err != nil {
 		sendErr(backToClient, http.StatusBadRequest, "bad content type", err)
 		return

--- a/platform/view/services/web/server/middleware/chain_test.go
+++ b/platform/view/services/web/server/middleware/chain_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Chain", func() {
 		}
 		chain = middleware.NewChain(one, two, three)
 
-		hello = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hello = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			_, err := w.Write([]byte("Hello!,"))
 			Expect(err).ToNot(HaveOccurred())

--- a/platform/view/services/web/server/server.go
+++ b/platform/view/services/web/server/server.go
@@ -90,7 +90,7 @@ func (s *Server) initializeServer() {
 	}
 }
 
-func (s *Server) HandlerChain(h http.Handler, secure bool) http.Handler {
+func (*Server) HandlerChain(h http.Handler, secure bool) http.Handler {
 	if secure {
 		return middleware2.NewChain(middleware2.RequireCert(), middleware2.WithRequestID(utils2.GenerateUUID)).Handler(h)
 	}

--- a/platform/view/services/web/server/server_test.go
+++ b/platform/view/services/web/server/server_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Server", func() {
 
 			rh := &mock.RequestHandler{}
 
-			rh.HandleRequestStub = func(ctx *server.ReqContext) (any, int) {
+			rh.HandleRequestStub = func(_ *server.ReqContext) (any, int) {
 				m := make(map[string]any)
 				m["status"] = "OK"
 				return m, 200
@@ -193,8 +193,8 @@ var _ = Describe("Server", func() {
 		err := srv.Start()
 		Expect(err).NotTo(HaveOccurred())
 
-		addApiURL := fmt.Sprintf("https://%s%s", srv.Addr(), someURL)
-		resp, err := client.Get(addApiURL)
+		addAPIURL := fmt.Sprintf("https://%s%s", srv.Addr(), someURL)
+		resp, err := client.Get(addAPIURL)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		Expect(resp.Header.Get("Content-Type")).To(Equal("text/plain; charset=utf-8"))
@@ -236,8 +236,8 @@ var _ = Describe("Server", func() {
 			err := srv.Start()
 			Expect(err).NotTo(HaveOccurred())
 
-			addApiURL := fmt.Sprintf("http://%s%s", srv.Addr(), someURL)
-			resp, err := client.Get(addApiURL)
+			addAPIURL := fmt.Sprintf("http://%s%s", srv.Addr(), someURL)
+			resp, err := client.Get(addAPIURL)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 			utils.IgnoreErrorFunc(resp.Body.Close)

--- a/platform/view/view/context_test.go
+++ b/platform/view/view/context_test.go
@@ -120,7 +120,7 @@ func TestCompileRunViewOptions(t *testing.T) {
 		},
 		{
 			name:        "Stops_On_First_Error",
-			opts:        []RunViewOption{WithSameContext(), func(o *RunViewOptions) error { return errors.New("option failed") }, AsInitiator()},
+			opts:        []RunViewOption{WithSameContext(), func(_ *RunViewOptions) error { return errors.New("option failed") }, AsInitiator()},
 			expectedErr: "option failed",
 		},
 	}


### PR DESCRIPTION
`revive` is a configurable style linter; this enables it with a curated 21-rule list (`linters.settings.revive`, replacing revive's defaults) rather than its full default set.

Part of #1755. This is the last linter in the series.

### Scoping

1119 findings across all 4 modules (909 root, 187 `integration`, 21 libp2p comm-host, 2 cc/query), triaged per rule:

- **Mechanical, applied directly**: `unused-parameter` (374) and `unused-receiver` (482), renamed to `_` (parameter/receiver names aren't part of a function's type, so this is safe even on exported functions); also most `var-naming`, `error-naming`, `error-strings`, `errorf`, `indent-error-flow`, `superfluous-else`, `early-return`, `unnecessary-stmt`, `bool-literal-in-expr` and `receiver-naming` findings on unexported identifiers.
- **errorf**: fixed with this project's `errors.Errorf`, not revive's suggested `fmt.Errorf`, which project convention forbids.
- **confusing-naming**: fixed by renaming the unexported side wherever nothing outside the package required that name. Deferred with `//nolint:revive` only where both colliding names are exported, typically because each independently satisfies the same exported interface.
- **var-naming on exported identifiers**: deferred with `//nolint:revive` per instance, since renaming an exported field, type, func, const or method is an API break. Test-only exported identifiers used solely inside their own test package were renamed instead.
- **unexported-return**: deferred via an `issues.exclusions.rules` entry scoped to revive and to this rule's text, over an explicit path list. A constructor returning an unexported concrete type that satisfies an exported interface is a deliberate Go idiom for hiding an implementation, not a defect — changing it is a public-API decision, not a lint fix. 121 findings across 68 root-module files, 9 across 7 integration files, 2 in the libp2p comm-host module.

`exported` and `package-comments` are deliberately left out of the rule list — golangci-lint only runs the rules named here, so omitting a rule is how it's disabled, rather than enabling it and suppressing every finding. Both are public-API documentation work, not a lint-commit fix: `exported` measured 3672 findings (one per exported symbol missing a doc comment) and `package-comments` measured 268 (one per package missing a package doc comment); 273 packages need one or the other. That documentation effort is tracked as a follow-up rather than done here.

One naming cascade worth calling out: `confusing-naming` flagged the vault package's test helper `newInterceptor` against the exported `NewInterceptor`. Renaming it collided with an unrelated `newTestInterceptor(qe VersionedQueryExecutor)` helper added to the same package by #1764 after this commit was originally written, so the renamed helper is `newVaultInterceptor` instead; #1764 also added three small fake query-executor types whose methods this rule flags for unused receivers, fixed the same way as everywhere else in this change.

### Verification

`go build`, `go vet` and `go test` all pass in the root, `integration` and libp2p modules. `make checks` exits 0 across all four modules.

### Note for reviewers

This branch is independent — rooted directly on current `main`, not stacked on any other PR in this series. It touches nearly every `.go` file in the repository (naming/style rules), but every hunk is either a mechanical rename or a `//nolint`/exclusion with a stated reason.
