### PR TITLE
test(fabric): improve test coverage for fabric sdk dig providers

### DIFF
--- a/platform/fabric/core/config_test.go
+++ b/platform/fabric/core/config_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	viewconfig "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/config"
 )
 
@@ -357,4 +358,19 @@ fabric:
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "rejected by policy")
 	assert.ElementsMatch(t, []string{"default"}, provider.Names())
+}
+
+type fakeDriver struct{}
+
+func (*fakeDriver) New(string, bool) (driver.FabricNetworkService, error) {
+	return nil, nil
+}
+
+func TestFSNProvider_Drivers(t *testing.T) {
+	t.Parallel()
+	p := newTestProvider(t, baseYAML)
+	d := &fakeDriver{}
+	provider, err := NewFabricNetworkServiceProvider(p, []NamedDriver{{Name: "generic", Driver: d}}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]driver.Driver{"generic": NamedDriver{Name: "generic", Driver: d}}, provider.Drivers())
 }

--- a/platform/fabric/core/provider.go
+++ b/platform/fabric/core/provider.go
@@ -8,6 +8,7 @@ package core
 
 import (
 	"context"
+	"maps"
 	"os"
 	"reflect"
 	"sync"
@@ -142,6 +143,11 @@ func (p *FSNProvider) Names() []string {
 // DefaultName returns the name of the default Fabric network.
 func (p *FSNProvider) DefaultName() string {
 	return p.config.DefaultName()
+}
+
+// Drivers returns a copy of the registered drivers map.
+func (p *FSNProvider) Drivers() map[string]driver.Driver {
+	return maps.Clone(p.drivers)
 }
 
 // FabricNetworkService returns the driver.FabricNetworkService for the given network name,

--- a/platform/fabric/sdk/dig/fns/providers_test.go
+++ b/platform/fabric/sdk/dig/fns/providers_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fns
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/dig"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	viewconfig "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/config"
+)
+
+type fakeDriver struct{}
+
+func (*fakeDriver) New(string, bool) (driver.FabricNetworkService, error) {
+	return nil, nil
+}
+
+// fabricEnabledConfig builds a real *viewconfig.Provider from a minimal Fabric
+// configuration. Using the production config implementation (rather than a hand-rolled
+// fake) keeps the test exercising the same DynamicConfigService the wiring depends on.
+func fabricEnabledConfig(t *testing.T) *viewconfig.Provider {
+	t.Helper()
+	p, err := (&viewconfig.Provider{}).ProvideFromRaw([]byte(`
+fabric:
+  enabled: true
+`))
+	require.NoError(t, err)
+	return p
+}
+
+// TestNewProvider drives the fns.NewProvider dig constructor directly. dig.DryRun (used by
+// TestWiring in the parent package) validates the graph without running constructor bodies,
+// so a direct call is the only way to cover this one. With a network-less config and empty
+// driver/validator groups it must return a usable *core.FSNProvider that reports no networks
+// and has an empty driver map.
+func TestNewProvider(t *testing.T) {
+	t.Parallel()
+
+	provider, err := NewProvider(struct {
+		dig.In
+		ConfigService core.DynamicConfigService
+		Drivers       []core.NamedDriver            `group:"fabric-platform-drivers"`
+		Validators    []core.NetworkConfigValidator `group:"fabric-network-config-validators"`
+	}{
+		ConfigService: fabricEnabledConfig(t),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+	require.Empty(t, provider.Names())
+	require.Empty(t, provider.Drivers())
+}
+
+// TestNewProviderFoldsDrivers covers the branch that folds the injected driver group into the
+// provider's internal driver map and asserts the resulting map state.
+func TestNewProviderFoldsDrivers(t *testing.T) {
+	t.Parallel()
+
+	fakeD := &fakeDriver{}
+	provider, err := NewProvider(struct {
+		dig.In
+		ConfigService core.DynamicConfigService
+		Drivers       []core.NamedDriver            `group:"fabric-platform-drivers"`
+		Validators    []core.NetworkConfigValidator `group:"fabric-network-config-validators"`
+	}{
+		ConfigService: fabricEnabledConfig(t),
+		Drivers:       []core.NamedDriver{{Name: "generic", Driver: fakeD}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+	namedDriver := core.NamedDriver{Name: "generic", Driver: fakeD}
+	require.Equal(t, map[string]driver.Driver{"generic": namedDriver}, provider.Drivers())
+}

--- a/platform/fabric/sdk/dig/generic/providers_test.go
+++ b/platform/fabric/sdk/dig/generic/providers_test.go
@@ -1,0 +1,343 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package generic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"go.uber.org/dig"
+
+	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic"
+	config2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/driver/config"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/driver/identity"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	dbdriver "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/db/driver/multiplexed"
+	endorsermock "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/endorser/mock"
+	viewconfig "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/config"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/events"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics/disabled"
+	driver3 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/kvs"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/tracing"
+)
+
+// fabricEnabledConfig builds a real *viewconfig.Provider from a minimal Fabric configuration.
+// The config declares no networks, so the constructors under test build their (network-less)
+// singletons without touching a ledger.
+func fabricEnabledConfig(t *testing.T) *viewconfig.Provider {
+	t.Helper()
+	p, err := (&viewconfig.Provider{}).ProvideFromRaw([]byte(`
+fabric:
+  enabled: true
+`))
+	require.NoError(t, err)
+	return p
+}
+
+// fabricEnabledConfigWithNetwork builds a *viewconfig.Provider that configures a network with a channel.
+func fabricEnabledConfigWithNetwork(t *testing.T) *viewconfig.Provider {
+	t.Helper()
+	p, err := (&viewconfig.Provider{}).ProvideFromRaw([]byte(`
+fabric:
+  enabled: true
+  testnet:
+    default: true
+    driver: generic
+    channels:
+      - name: default-channel
+        default: true
+`))
+	require.NoError(t, err)
+	return p
+}
+
+type fakeVaultReader struct {
+	driver2.LockedVaultReader
+}
+
+func (*fakeVaultReader) Done() error { return nil }
+
+type fakeVaultStore struct {
+	driver2.VaultStore
+}
+
+func (*fakeVaultStore) NewGlobalLockVaultReader(context.Context) (driver2.LockedVaultReader, error) {
+	return &fakeVaultReader{}, nil
+}
+
+func (*fakeVaultStore) GetTxStatus(context.Context, driver2.TxID) (*driver2.TxStatus, error) {
+	return nil, nil
+}
+
+func (*fakeVaultStore) Close() error { return nil }
+
+type fakeDBDriver struct {
+	endorseTxStore dbdriver.EndorseTxStore
+	metadataStore  dbdriver.MetadataStore
+	envelopeStore  dbdriver.EnvelopeStore
+	vaultStore     driver2.VaultStore
+}
+
+func (f *fakeDBDriver) NewEndorseTx(driver3.PersistenceName, ...string) (dbdriver.EndorseTxStore, error) {
+	return f.endorseTxStore, nil
+}
+
+func (f *fakeDBDriver) NewMetadata(driver3.PersistenceName, ...string) (dbdriver.MetadataStore, error) {
+	return f.metadataStore, nil
+}
+
+func (f *fakeDBDriver) NewEnvelope(driver3.PersistenceName, ...string) (dbdriver.EnvelopeStore, error) {
+	return f.envelopeStore, nil
+}
+
+func (f *fakeDBDriver) NewVault(driver3.PersistenceName, ...string) (driver2.VaultStore, error) {
+	if f.vaultStore != nil {
+		return f.vaultStore, nil
+	}
+	return &fakeVaultStore{}, nil
+}
+
+// fakeMultiplexedDriver builds a multiplexed driver over a fake DB driver by exercising
+// the NewMultiplexedDriver dig constructor.
+func fakeMultiplexedDriver(t *testing.T, cfg *viewconfig.Provider) multiplexed.Driver {
+	t.Helper()
+	return NewMultiplexedDriver(struct {
+		dig.In
+		Config  driver2.ConfigService
+		Drivers []dbdriver.NamedDriver `group:"fabric-db-drivers" optional:"false"`
+	}{
+		Config: cfg,
+		Drivers: []dbdriver.NamedDriver{
+			{
+				Name:   "memory",
+				Driver: &fakeDBDriver{},
+			},
+		},
+	})
+}
+
+// fakeOrdering implements both driver.Ordering and committer.OrderingService.
+type fakeOrdering struct{}
+
+func (*fakeOrdering) Broadcast(context.Context, any) error             { return nil }
+func (*fakeOrdering) SetConsensusType(string) error                    { return nil }
+func (*fakeOrdering) Configure(string, []*grpc.ConnectionConfig) error { return nil }
+
+// fakeSigningIdentity implements driver.SigningIdentity.
+type fakeSigningIdentity struct{}
+
+func (*fakeSigningIdentity) Serialize() ([]byte, error)  { return []byte("fake-id"), nil }
+func (*fakeSigningIdentity) Sign([]byte) ([]byte, error) { return []byte("fake-sig"), nil }
+
+// fakeProcessorManager is a minimal implementation of driver.ProcessorManager.
+type fakeProcessorManager struct{}
+
+func (*fakeProcessorManager) AddProcessor(string, driver.Processor) error { return nil }
+func (*fakeProcessorManager) SetDefaultProcessor(driver.Processor) error  { return nil }
+func (*fakeProcessorManager) AddChannelProcessor(string, string, driver.Processor) error {
+	return nil
+}
+func (*fakeProcessorManager) ProcessByID(context.Context, string, string) error { return nil }
+
+// TestNewEndorserTransactionHandlerProvider covers the trivial-but-uncovered handler-provider
+// constructor: dig.DryRun never runs constructor bodies, so a direct call is the only way to reach
+// it. It must advertise the endorser-transaction header type with a non-nil handler factory.
+func TestNewEndorserTransactionHandlerProvider(t *testing.T) {
+	t.Parallel()
+
+	res := NewEndorserTransactionHandlerProvider()
+	require.Equal(t, common.HeaderType_ENDORSER_TRANSACTION, res.Type)
+	require.NotNil(t, res.New)
+}
+
+// TestStoreProviders exercises NewMultiplexedDriver together with the three storage-provider
+// constructors over a fake DB driver backend.
+func TestStoreProviders(t *testing.T) {
+	t.Parallel()
+
+	cfg := fabricEnabledConfig(t)
+	d := fakeMultiplexedDriver(t, cfg)
+
+	endorseTxStore, err := NewEndorseTxStore(cfg, d)
+	require.NoError(t, err)
+	require.NotNil(t, endorseTxStore)
+
+	metadataStore, err := NewMetadataStore(cfg, d)
+	require.NoError(t, err)
+	require.NotNil(t, metadataStore)
+
+	envelopeStore, err := NewEnvelopeStore(cfg, d)
+	require.NoError(t, err)
+	require.NotNil(t, envelopeStore)
+}
+
+// TestNewDriver exercises the NewDriver dig constructor. gdriver.NewProvider (and the sig/identity
+// sub-constructors it calls) only store their dependencies at construction, so typed-nil deps are
+// enough to drive the body and confirm it returns the generic driver under the expected name.
+func TestNewDriver(t *testing.T) {
+	t.Parallel()
+
+	d := NewDriver(struct {
+		dig.In
+		ConfigProvider  config.Provider
+		MetricsProvider metrics.Provider
+		EndpointService identity.EndpointService
+		IDProvider      identity.ViewIdentityProvider
+		KVS             *kvs.KVS
+		AuditInfoKVS    driver2.AuditInfoStore
+		SignerKVS       driver2.SignerInfoStore
+		TracerProvider  tracing.Provider
+		ChannelProvider generic.ChannelProvider        `name:"generic-channel-provider"`
+		IdentityLoaders []identity.NamedIdentityLoader `group:"identity-loaders"`
+	}{
+		MetricsProvider: &disabled.Provider{},
+	})
+
+	require.Equal(t, config2.GenericDriver, d.Name)
+	require.NotNil(t, d.Driver)
+}
+
+// TestNewChannelProvider exercises the NewChannelProvider dig constructor and asserts that the
+// returned generic.ChannelProvider correctly wires the channel's vault, ledger, committer,
+// delivery service, and RWSet loader.
+func TestNewChannelProvider(t *testing.T) {
+	t.Parallel()
+
+	cfg := fabricEnabledConfigWithNetwork(t)
+	d := fakeMultiplexedDriver(t, cfg)
+
+	endorseTxStore, err := NewEndorseTxStore(cfg, d)
+	require.NoError(t, err)
+
+	metadataStore, err := NewMetadataStore(cfg, d)
+	require.NoError(t, err)
+
+	envelopeStore, err := NewEnvelopeStore(cfg, d)
+	require.NoError(t, err)
+
+	configProvider, err := config.NewProvider(cfg)
+	require.NoError(t, err)
+
+	confService, err := configProvider.GetConfig("testnet")
+	require.NoError(t, err)
+
+	channelProvider := NewChannelProvider(struct {
+		dig.In
+		ConfigProvider  config.Provider
+		EnvelopeKVS     driver.EnvelopeStore
+		MetadataKVS     driver.MetadataStore
+		EndorseTxKVS    driver.EndorseTxStore
+		Publisher       events.Publisher
+		TracerProvider  tracing.Provider
+		Drivers         multiplexed.Driver
+		MetricsProvider metrics.Provider
+	}{
+		ConfigProvider:  configProvider,
+		EnvelopeKVS:     envelopeStore,
+		MetadataKVS:     metadataStore,
+		EndorseTxKVS:    endorseTxStore,
+		TracerProvider:  &noop.TracerProvider{},
+		Drivers:         d,
+		MetricsProvider: &disabled.Provider{},
+	})
+	require.NotNil(t, channelProvider)
+
+	lmMock := &endorsermock.LocalMembership{}
+	lmMock.DefaultSigningIdentityReturns(&fakeSigningIdentity{})
+
+	pm := &fakeProcessorManager{}
+	tmMock := &endorsermock.TransactionManager{}
+
+	fnsMock := &endorsermock.FabricNetworkService{}
+	fnsMock.NameReturns("testnet")
+	fnsMock.ConfigServiceReturns(confService)
+	fnsMock.OrderingServiceReturns(&fakeOrdering{})
+	fnsMock.LocalMembershipReturns(lmMock)
+	fnsMock.ProcessorManagerReturns(pm)
+	fnsMock.TransactionManagerReturns(tmMock)
+	fnsMock.SignerServiceReturns(nil)
+
+	ch, err := channelProvider.NewChannel(fnsMock, "default-channel", false)
+	require.NoError(t, err)
+	require.NotNil(t, ch)
+	t.Cleanup(func() {
+		require.NoError(t, ch.Close())
+	})
+	require.Equal(t, "default-channel", ch.Name())
+	require.NotNil(t, ch.Vault())
+	require.NotNil(t, ch.Ledger())
+	require.NotNil(t, ch.Committer())
+	require.NotNil(t, ch.Delivery())
+	require.NotNil(t, ch.RWSetLoader())
+}
+
+// TestNewChannelProvider_InvalidOrdering verifies that NewChannel returns an error when
+// the network's OrderingService does not implement committer.OrderingService.
+func TestNewChannelProvider_InvalidOrdering(t *testing.T) {
+	t.Parallel()
+
+	cfg := fabricEnabledConfigWithNetwork(t)
+	d := fakeMultiplexedDriver(t, cfg)
+
+	endorseTxStore, err := NewEndorseTxStore(cfg, d)
+	require.NoError(t, err)
+
+	metadataStore, err := NewMetadataStore(cfg, d)
+	require.NoError(t, err)
+
+	envelopeStore, err := NewEnvelopeStore(cfg, d)
+	require.NoError(t, err)
+
+	configProvider, err := config.NewProvider(cfg)
+	require.NoError(t, err)
+
+	confService, err := configProvider.GetConfig("testnet")
+	require.NoError(t, err)
+
+	channelProvider := NewChannelProvider(struct {
+		dig.In
+		ConfigProvider  config.Provider
+		EnvelopeKVS     driver.EnvelopeStore
+		MetadataKVS     driver.MetadataStore
+		EndorseTxKVS    driver.EndorseTxStore
+		Publisher       events.Publisher
+		TracerProvider  tracing.Provider
+		Drivers         multiplexed.Driver
+		MetricsProvider metrics.Provider
+	}{
+		ConfigProvider:  configProvider,
+		EnvelopeKVS:     envelopeStore,
+		MetadataKVS:     metadataStore,
+		EndorseTxKVS:    endorseTxStore,
+		TracerProvider:  &noop.TracerProvider{},
+		Drivers:         d,
+		MetricsProvider: &disabled.Provider{},
+	})
+	require.NotNil(t, channelProvider)
+
+	lmMock := &endorsermock.LocalMembership{}
+	lmMock.DefaultSigningIdentityReturns(&fakeSigningIdentity{})
+
+	fnsMock := &endorsermock.FabricNetworkService{}
+	fnsMock.NameReturns("testnet")
+	fnsMock.ConfigServiceReturns(confService)
+	fnsMock.OrderingServiceReturns(&endorsermock.Ordering{})
+	fnsMock.LocalMembershipReturns(lmMock)
+
+	ch, err := channelProvider.NewChannel(fnsMock, "default-channel", false)
+	require.ErrorContains(t, err, "ordering service is not a committer.OrderingService")
+	require.Nil(t, ch)
+}

--- a/platform/fabric/sdk/dig/sdk.go
+++ b/platform/fabric/sdk/dig/sdk.go
@@ -176,7 +176,7 @@ func registerProcessorsForDrivers(in struct {
 		}
 		if c.Driver != d.Name {
 			logger.Infof("Skipping registration of default network, because its driver is %s. We are registering %s", c.Driver, d.Name)
-			return nil
+			continue
 		}
 		defaultFns, err := in.NetworkServiceProvider.FabricNetworkService("")
 		if err != nil {

--- a/platform/fabric/sdk/dig/sdk_test.go
+++ b/platform/fabric/sdk/dig/sdk_test.go
@@ -7,16 +7,25 @@ SPDX-License-Identifier: Apache-2.0
 package sdk
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/dig"
 
+	dig2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/sdk/dig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core"
+	rwsetmock "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/rwset/mock"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	generic2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk/dig/generic"
+	endorsermock "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/endorser/mock"
 	sdk "github.com/hyperledger-labs/fabric-smart-client/platform/view/sdk/dig"
 	viewconfig "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/config"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/view"
 )
 
 func TestWiring(t *testing.T) {
@@ -24,23 +33,202 @@ func TestWiring(t *testing.T) {
 	assert.NoError(t, sdk.DryRunWiring(NewFrom, sdk.WithBool("fabric.enabled", true)))
 }
 
+func TestWiring_Disabled(t *testing.T) {
+	t.Parallel()
+	assert.NoError(t, sdk.DryRunWiring(NewFrom, sdk.WithBool("fabric.enabled", false)))
+}
+
+func TestNewSDK(t *testing.T) {
+	t.Parallel()
+	registry := view.NewServiceProvider()
+	cfgProvider, err := (&viewconfig.Provider{}).ProvideFromRaw([]byte(`
+fabric:
+  enabled: false
+`))
+	require.NoError(t, err)
+	require.NoError(t, registry.RegisterService(cfgProvider))
+
+	s := NewSDK(registry)
+	require.NotNil(t, s)
+	assert.False(t, s.FabricEnabled())
+}
+
+func TestSDK_Lifecycle_FabricDisabled(t *testing.T) {
+	t.Parallel()
+	cfgProvider, err := (&viewconfig.Provider{}).ProvideFromRaw([]byte(`
+fabric:
+  enabled: false
+`))
+	require.NoError(t, err)
+	baseSDK := dig2.NewBaseSDK(sdk.NewContainer(), cfgProvider)
+	s := NewFrom(baseSDK)
+	assert.False(t, s.FabricEnabled())
+
+	require.NoError(t, s.Install())
+	require.NoError(t, s.Start(t.Context()))
+	require.NoError(t, s.PostStart(t.Context()))
+}
+
+func TestSDK_PostStart_NoFNSProvider(t *testing.T) {
+	t.Parallel()
+	cfgProvider, err := (&viewconfig.Provider{}).ProvideFromRaw([]byte(`
+fabric:
+  enabled: true
+`))
+	require.NoError(t, err)
+	baseSDK := dig2.NewBaseSDK(sdk.NewContainer(), cfgProvider)
+	s := NewFrom(baseSDK)
+	assert.True(t, s.FabricEnabled())
+
+	err = s.PostStart(t.Context())
+	require.ErrorContains(t, err, "no fabric network provider found")
+}
+
+func TestSDK_PostStart_Success(t *testing.T) {
+	t.Parallel()
+	cfgProvider, err := (&viewconfig.Provider{}).ProvideFromRaw([]byte(`
+fabric:
+  enabled: true
+`))
+	require.NoError(t, err)
+	baseSDK := dig2.NewBaseSDK(sdk.NewContainer(), cfgProvider)
+	s := NewFrom(baseSDK)
+
+	fnsProvider, err := core.NewFabricNetworkServiceProvider(cfgProvider, nil, nil)
+	require.NoError(t, err)
+	s.fnsProvider = fnsProvider
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	// PostStart spawns a goroutine that stops fnsProvider when ctx is cancelled; t.Cleanup
+	// cancels ctx so that goroutine unwinds instead of leaking past the test. fnsProvider is a
+	// concrete *core.FSNProvider (not an interface), so its Stop() has no unit-observable effect
+	// to assert on here — the shutdown wiring is covered by integration tests.
+	require.NoError(t, s.PostStart(ctx))
+}
+
+func TestSDK_PostStart_StartError(t *testing.T) {
+	t.Parallel()
+	cfgProvider, err := (&viewconfig.Provider{}).ProvideFromRaw([]byte(`
+fabric:
+  enabled: true
+  badnet:
+    driver: non-existent-driver
+`))
+	require.NoError(t, err)
+	baseSDK := dig2.NewBaseSDK(sdk.NewContainer(), cfgProvider)
+	s := NewFrom(baseSDK)
+
+	fnsProvider, err := core.NewFabricNetworkServiceProvider(cfgProvider, nil, nil)
+	require.NoError(t, err)
+	s.fnsProvider = fnsProvider
+
+	err = s.PostStart(t.Context())
+	require.ErrorContains(t, err, "failed starting fabric network service provider")
+}
+
+// configWithNetwork builds a *core.Config that has a network named "testnet" with driver "generic".
+func configWithNetwork(t *testing.T) *core.Config {
+	t.Helper()
+	p, err := (&viewconfig.Provider{}).ProvideFromRaw([]byte(`
+fabric:
+  enabled: true
+  testnet:
+    default: true
+    driver: generic
+`))
+	require.NoError(t, err)
+	cfg, err := core.NewConfig(p)
+	require.NoError(t, err)
+	require.Equal(t, []string{"testnet"}, cfg.Names())
+	return cfg
+}
+
+// configWithMultipleNetworks builds a *core.Config with two networks with different drivers.
+func configWithMultipleNetworks(t *testing.T) *core.Config {
+	t.Helper()
+	p, err := (&viewconfig.Provider{}).ProvideFromRaw([]byte(`
+fabric:
+  enabled: true
+  net1:
+    default: true
+    driver: generic
+  net2:
+    driver: other
+`))
+	require.NoError(t, err)
+	cfg, err := core.NewConfig(p)
+	require.NoError(t, err)
+	return cfg
+}
+
+// emptyConfig builds a *core.Config with no Fabric networks.
+func emptyConfig(t *testing.T) *core.Config {
+	t.Helper()
+	p, err := (&viewconfig.Provider{}).ProvideFromRaw([]byte(`
+fabric:
+  enabled: true
+`))
+	require.NoError(t, err)
+	cfg, err := core.NewConfig(p)
+	require.NoError(t, err)
+	return cfg
+}
+
+// fakeProcessorManager is a minimal implementation of driver.ProcessorManager that records calls.
+type fakeProcessorManager struct {
+	defaultProcessor driver.Processor
+	err              error
+}
+
+func (*fakeProcessorManager) AddProcessor(string, driver.Processor) error { return nil }
+
+func (f *fakeProcessorManager) SetDefaultProcessor(p driver.Processor) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.defaultProcessor = p
+	return nil
+}
+
+func (*fakeProcessorManager) AddChannelProcessor(string, string, driver.Processor) error {
+	return nil
+}
+
+func (*fakeProcessorManager) ProcessByID(context.Context, string, string) error { return nil }
+
+// fakeConfigService is a minimal implementation of driver.ConfigService that only provides ChannelIDs.
+type fakeConfigService struct {
+	driver.ConfigService
+	channelIDs []string
+}
+
+func (f *fakeConfigService) ChannelIDs() []string { return f.channelIDs }
+
+// fakeDriverForFSN implements driver.Driver to inject a pre-built FNS into FSNProvider.
+type fakeDriverForFSN struct {
+	fns driver.FabricNetworkService
+}
+
+func (f *fakeDriverForFSN) New(string, bool) (driver.FabricNetworkService, error) {
+	return f.fns, nil
+}
+
+// ---------------------------------------------------------------------------
+// registerProcessorsForDrivers tests
+// ---------------------------------------------------------------------------
+
 // TestRegisterProcessorsForDrivers_NoOpOnEmptyConfig exercises registerProcessorsForDrivers
 // directly (bypassing dig.DryRun, which never runs constructor bodies) to confirm it no-ops
 // cleanly when the node started with zero Fabric networks configured (e.g. networks are only
 // added later, at runtime, via core.FSNProvider.AddNetwork).
 func TestRegisterProcessorsForDrivers_NoOpOnEmptyConfig(t *testing.T) {
 	t.Parallel()
-	p, err := (&viewconfig.Provider{}).ProvideFromRaw([]byte(`
-fabric:
-  enabled: true
-`))
-	require.NoError(t, err)
-
-	cfg, err := core.NewConfig(p)
-	require.NoError(t, err)
+	cfg := emptyConfig(t)
 	require.Empty(t, cfg.Names())
 
-	err = registerProcessorsForDrivers(struct {
+	err := registerProcessorsForDrivers(struct {
 		dig.In
 		CoreConfig             *core.Config
 		NetworkServiceProvider *fabric.NetworkServiceProvider
@@ -49,4 +237,426 @@ fabric:
 		CoreConfig: cfg,
 	})
 	require.NoError(t, err)
+}
+
+// TestRegisterProcessorsForDrivers_WithNetwork exercises the happy path where the processor
+// registration loops execute for a configured network. It uses a counterfeiter mock for the
+// FNS provider and verifies that SetDefaultProcessor is called.
+func TestRegisterProcessorsForDrivers_WithNetwork(t *testing.T) {
+	t.Parallel()
+	cfg := configWithNetwork(t)
+
+	pm := &fakeProcessorManager{}
+
+	fnsMock := &endorsermock.FabricNetworkService{}
+	fnsMock.NameReturns("testnet")
+	fnsMock.ProcessorManagerReturns(pm)
+
+	fnspMock := &endorsermock.FabricNetworkServiceProvider{}
+	fnspMock.FabricNetworkServiceStub = func(_ string) (driver.FabricNetworkService, error) {
+		return fnsMock, nil
+	}
+	fnspMock.DefaultNameReturns("testnet")
+	fnspMock.NamesReturns([]string{"testnet"})
+
+	nsp := fabric.NewNetworkServiceProvider(fnspMock, nil)
+
+	err := registerProcessorsForDrivers(struct {
+		dig.In
+		CoreConfig             *core.Config
+		NetworkServiceProvider *fabric.NetworkServiceProvider
+		Drivers                []core.NamedDriver `group:"fabric-platform-drivers"`
+	}{
+		CoreConfig:             cfg,
+		NetworkServiceProvider: nsp,
+		Drivers:                []core.NamedDriver{{Name: "generic"}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, pm.defaultProcessor, "SetDefaultProcessor must have been called")
+}
+
+// TestRegisterProcessorsForDrivers_DriverMismatch exercises the loop over drivers when a driver
+// does not match the default network's configured driver. The mismatching driver must be skipped
+// via 'continue' so that any subsequent matching driver in the list is still processed.
+func TestRegisterProcessorsForDrivers_DriverMismatch(t *testing.T) {
+	t.Parallel()
+	cfg := configWithNetwork(t)
+
+	pm := &fakeProcessorManager{}
+
+	fnsMock := &endorsermock.FabricNetworkService{}
+	fnsMock.NameReturns("testnet")
+	fnsMock.ProcessorManagerReturns(pm)
+
+	fnspMock := &endorsermock.FabricNetworkServiceProvider{}
+	fnspMock.FabricNetworkServiceStub = func(_ string) (driver.FabricNetworkService, error) {
+		return fnsMock, nil
+	}
+	fnspMock.DefaultNameReturns("testnet")
+	fnspMock.NamesReturns([]string{"testnet"})
+
+	nsp := fabric.NewNetworkServiceProvider(fnspMock, nil)
+
+	err := registerProcessorsForDrivers(struct {
+		dig.In
+		CoreConfig             *core.Config
+		NetworkServiceProvider *fabric.NetworkServiceProvider
+		Drivers                []core.NamedDriver `group:"fabric-platform-drivers"`
+	}{
+		CoreConfig:             cfg,
+		NetworkServiceProvider: nsp,
+		Drivers: []core.NamedDriver{
+			{Name: "some-other-driver"},
+			{Name: "generic"},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, pm.defaultProcessor, "subsequent matching driver must be registered even if prior driver mismatched")
+}
+
+// TestRegisterProcessorsForDrivers_NoDrivers exercises the case with no drivers at all.
+func TestRegisterProcessorsForDrivers_NoDrivers(t *testing.T) {
+	t.Parallel()
+	cfg := configWithNetwork(t)
+
+	err := registerProcessorsForDrivers(struct {
+		dig.In
+		CoreConfig             *core.Config
+		NetworkServiceProvider *fabric.NetworkServiceProvider
+		Drivers                []core.NamedDriver `group:"fabric-platform-drivers"`
+	}{
+		CoreConfig: cfg,
+		Drivers:    []core.NamedDriver{},
+	})
+	require.NoError(t, err)
+}
+
+func TestRegisterProcessorsForDrivers_DefaultFNSError(t *testing.T) {
+	t.Parallel()
+	cfg := configWithNetwork(t)
+
+	fnspMock := &endorsermock.FabricNetworkServiceProvider{}
+	fnspMock.FabricNetworkServiceStub = func(_ string) (driver.FabricNetworkService, error) {
+		return nil, errors.New("default-fns-error")
+	}
+	fnspMock.DefaultNameReturns("testnet")
+	fnspMock.NamesReturns([]string{"testnet"})
+
+	nsp := fabric.NewNetworkServiceProvider(fnspMock, nil)
+
+	err := registerProcessorsForDrivers(struct {
+		dig.In
+		CoreConfig             *core.Config
+		NetworkServiceProvider *fabric.NetworkServiceProvider
+		Drivers                []core.NamedDriver `group:"fabric-platform-drivers"`
+	}{
+		CoreConfig:             cfg,
+		NetworkServiceProvider: nsp,
+		Drivers:                []core.NamedDriver{{Name: "generic"}},
+	})
+	require.ErrorContains(t, err, "could not find default FNS")
+}
+
+// configWithTwoGenericNetworks builds a *core.Config with two networks both using generic driver.
+func configWithTwoGenericNetworks(t *testing.T) *core.Config {
+	t.Helper()
+	p, err := (&viewconfig.Provider{}).ProvideFromRaw([]byte(`
+fabric:
+  enabled: true
+  net1:
+    default: true
+    driver: generic
+  net2:
+    driver: generic
+`))
+	require.NoError(t, err)
+	cfg, err := core.NewConfig(p)
+	require.NoError(t, err)
+	return cfg
+}
+
+func TestRegisterProcessorsForDrivers_NetworkFNSError(t *testing.T) {
+	t.Parallel()
+	cfg := configWithTwoGenericNetworks(t)
+
+	pm := &fakeProcessorManager{}
+	fnsMock := &endorsermock.FabricNetworkService{}
+	fnsMock.NameReturns("net1")
+	fnsMock.ProcessorManagerReturns(pm)
+
+	fnspMock := &endorsermock.FabricNetworkServiceProvider{}
+	fnspMock.FabricNetworkServiceStub = func(id string) (driver.FabricNetworkService, error) {
+		if id == "" || id == "net1" {
+			return fnsMock, nil
+		}
+		return nil, errors.New("network-fns-error")
+	}
+	fnspMock.DefaultNameReturns("net1")
+	fnspMock.NamesReturns([]string{"net1", "net2"})
+
+	nsp := fabric.NewNetworkServiceProvider(fnspMock, nil)
+
+	err := registerProcessorsForDrivers(struct {
+		dig.In
+		CoreConfig             *core.Config
+		NetworkServiceProvider *fabric.NetworkServiceProvider
+		Drivers                []core.NamedDriver `group:"fabric-platform-drivers"`
+	}{
+		CoreConfig:             cfg,
+		NetworkServiceProvider: nsp,
+		Drivers:                []core.NamedDriver{{Name: "generic"}},
+	})
+	require.ErrorContains(t, err, "could not find FNS [net2]")
+}
+
+func TestRegisterProcessorsForDrivers_SetDefaultProcessorError(t *testing.T) {
+	t.Parallel()
+	cfg := configWithNetwork(t)
+
+	pm := &fakeProcessorManager{err: errors.New("set-processor-error")}
+
+	fnsMock := &endorsermock.FabricNetworkService{}
+	fnsMock.NameReturns("testnet")
+	fnsMock.ProcessorManagerReturns(pm)
+
+	fnspMock := &endorsermock.FabricNetworkServiceProvider{}
+	fnspMock.FabricNetworkServiceStub = func(_ string) (driver.FabricNetworkService, error) {
+		return fnsMock, nil
+	}
+	fnspMock.DefaultNameReturns("testnet")
+	fnspMock.NamesReturns([]string{"testnet"})
+
+	nsp := fabric.NewNetworkServiceProvider(fnspMock, nil)
+
+	err := registerProcessorsForDrivers(struct {
+		dig.In
+		CoreConfig             *core.Config
+		NetworkServiceProvider *fabric.NetworkServiceProvider
+		Drivers                []core.NamedDriver `group:"fabric-platform-drivers"`
+	}{
+		CoreConfig:             cfg,
+		NetworkServiceProvider: nsp,
+		Drivers:                []core.NamedDriver{{Name: "generic"}},
+	})
+	require.ErrorContains(t, err, "failed setting state processor for fabric network [testnet]")
+}
+
+func TestRegisterProcessorsForDrivers_MultiNetwork_SkipNonMatching(t *testing.T) {
+	t.Parallel()
+	cfg := configWithMultipleNetworks(t)
+
+	pm := &fakeProcessorManager{}
+
+	fnsMock := &endorsermock.FabricNetworkService{}
+	fnsMock.NameReturns("net1")
+	fnsMock.ProcessorManagerReturns(pm)
+
+	fnspMock := &endorsermock.FabricNetworkServiceProvider{}
+	fnspMock.FabricNetworkServiceStub = func(_ string) (driver.FabricNetworkService, error) {
+		return fnsMock, nil
+	}
+	fnspMock.DefaultNameReturns("net1")
+	fnspMock.NamesReturns([]string{"net1", "net2"})
+
+	nsp := fabric.NewNetworkServiceProvider(fnspMock, nil)
+
+	err := registerProcessorsForDrivers(struct {
+		dig.In
+		CoreConfig             *core.Config
+		NetworkServiceProvider *fabric.NetworkServiceProvider
+		Drivers                []core.NamedDriver `group:"fabric-platform-drivers"`
+	}{
+		CoreConfig:             cfg,
+		NetworkServiceProvider: nsp,
+		Drivers:                []core.NamedDriver{{Name: "generic"}},
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, pm.defaultProcessor)
+}
+
+// ---------------------------------------------------------------------------
+// registerRWSetLoaderHandlerProviders tests
+// ---------------------------------------------------------------------------
+
+// TestRegisterRWSetLoaderHandlerProviders_NoOpOnEmptyConfig exercises registerRWSetLoaderHandlerProviders
+// directly to confirm it no-ops cleanly when no networks are configured.
+func TestRegisterRWSetLoaderHandlerProviders_NoOpOnEmptyConfig(t *testing.T) {
+	t.Parallel()
+	p, err := (&viewconfig.Provider{}).ProvideFromRaw([]byte(`
+fabric:
+  enabled: true
+`))
+	require.NoError(t, err)
+	cfg, err := core.NewConfig(p)
+	require.NoError(t, err)
+
+	err = registerRWSetLoaderHandlerProviders(struct {
+		dig.In
+		FSNProvider      *core.FSNProvider
+		CoreConfig       *core.Config
+		HandlerProviders []generic2.RWSetPayloadHandlerProvider `group:"handler-providers"`
+	}{
+		CoreConfig: cfg,
+	})
+	require.NoError(t, err)
+}
+
+// TestRegisterRWSetLoaderHandlerProviders_WithNetwork exercises the happy path where the handler
+// providers are registered for each channel of each configured network. It creates a real
+// FSNProvider with a mock FNS injected, and verifies AddHandlerProvider is called.
+func TestRegisterRWSetLoaderHandlerProviders_WithNetwork(t *testing.T) {
+	t.Parallel()
+	p, err := (&viewconfig.Provider{}).ProvideFromRaw([]byte(`
+fabric:
+  enabled: true
+  testnet:
+    default: true
+    driver: generic
+`))
+	require.NoError(t, err)
+	cfg, err := core.NewConfig(p)
+	require.NoError(t, err)
+
+	loader := &rwsetmock.RWSetLoader{}
+
+	channelMock := &endorsermock.Channel{}
+	channelMock.RWSetLoaderReturns(loader)
+
+	fnsMock := &endorsermock.FabricNetworkService{}
+	fnsMock.ConfigServiceReturns(&fakeConfigService{channelIDs: []string{"mychannel"}})
+	fnsMock.ChannelReturns(channelMock, nil)
+
+	fakeDriver := &fakeDriverForFSN{fns: fnsMock}
+	fnsProvider, err := core.NewFabricNetworkServiceProvider(
+		p,
+		[]core.NamedDriver{{Name: "generic", Driver: fakeDriver}},
+		nil,
+	)
+	require.NoError(t, err)
+
+	err = registerRWSetLoaderHandlerProviders(struct {
+		dig.In
+		FSNProvider      *core.FSNProvider
+		CoreConfig       *core.Config
+		HandlerProviders []generic2.RWSetPayloadHandlerProvider `group:"handler-providers"`
+	}{
+		FSNProvider: fnsProvider,
+		CoreConfig:  cfg,
+		HandlerProviders: []generic2.RWSetPayloadHandlerProvider{
+			{Type: common.HeaderType_ENDORSER_TRANSACTION},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, loader.AddHandlerProviderCallCount(), "AddHandlerProvider must have been called once")
+}
+
+func TestRegisterRWSetLoaderHandlerProviders_FNSError(t *testing.T) {
+	t.Parallel()
+	p, err := (&viewconfig.Provider{}).ProvideFromRaw([]byte(`
+fabric:
+  enabled: true
+  testnet:
+    default: true
+    driver: unknown-driver
+`))
+	require.NoError(t, err)
+	cfg, err := core.NewConfig(p)
+	require.NoError(t, err)
+
+	fnsProvider, err := core.NewFabricNetworkServiceProvider(p, nil, nil)
+	require.NoError(t, err)
+
+	err = registerRWSetLoaderHandlerProviders(struct {
+		dig.In
+		FSNProvider      *core.FSNProvider
+		CoreConfig       *core.Config
+		HandlerProviders []generic2.RWSetPayloadHandlerProvider `group:"handler-providers"`
+	}{
+		FSNProvider: fnsProvider,
+		CoreConfig:  cfg,
+	})
+	require.ErrorContains(t, err, "could not find network service for testnet")
+}
+
+func TestRegisterRWSetLoaderHandlerProviders_ChannelError(t *testing.T) {
+	t.Parallel()
+	p, err := (&viewconfig.Provider{}).ProvideFromRaw([]byte(`
+fabric:
+  enabled: true
+  testnet:
+    default: true
+    driver: generic
+`))
+	require.NoError(t, err)
+	cfg, err := core.NewConfig(p)
+	require.NoError(t, err)
+
+	fnsMock := &endorsermock.FabricNetworkService{}
+	fnsMock.ConfigServiceReturns(&fakeConfigService{channelIDs: []string{"error-chan"}})
+	fnsMock.ChannelReturns(nil, errors.New("channel-not-found"))
+
+	fakeDriver := &fakeDriverForFSN{fns: fnsMock}
+	fnsProvider, err := core.NewFabricNetworkServiceProvider(
+		p,
+		[]core.NamedDriver{{Name: "generic", Driver: fakeDriver}},
+		nil,
+	)
+	require.NoError(t, err)
+
+	err = registerRWSetLoaderHandlerProviders(struct {
+		dig.In
+		FSNProvider      *core.FSNProvider
+		CoreConfig       *core.Config
+		HandlerProviders []generic2.RWSetPayloadHandlerProvider `group:"handler-providers"`
+	}{
+		FSNProvider: fnsProvider,
+		CoreConfig:  cfg,
+	})
+	require.ErrorContains(t, err, "could not find channel error-chan for network testnet")
+}
+
+func TestRegisterRWSetLoaderHandlerProviders_AddHandlerError(t *testing.T) {
+	t.Parallel()
+	p, err := (&viewconfig.Provider{}).ProvideFromRaw([]byte(`
+fabric:
+  enabled: true
+  testnet:
+    default: true
+    driver: generic
+`))
+	require.NoError(t, err)
+	cfg, err := core.NewConfig(p)
+	require.NoError(t, err)
+
+	loader := &rwsetmock.RWSetLoader{}
+	loader.AddHandlerProviderReturns(errors.New("add-handler-failed"))
+
+	channelMock := &endorsermock.Channel{}
+	channelMock.RWSetLoaderReturns(loader)
+
+	fnsMock := &endorsermock.FabricNetworkService{}
+	fnsMock.ConfigServiceReturns(&fakeConfigService{channelIDs: []string{"mychannel"}})
+	fnsMock.ChannelReturns(channelMock, nil)
+
+	fakeDriver := &fakeDriverForFSN{fns: fnsMock}
+	fnsProvider, err := core.NewFabricNetworkServiceProvider(
+		p,
+		[]core.NamedDriver{{Name: "generic", Driver: fakeDriver}},
+		nil,
+	)
+	require.NoError(t, err)
+
+	err = registerRWSetLoaderHandlerProviders(struct {
+		dig.In
+		FSNProvider      *core.FSNProvider
+		CoreConfig       *core.Config
+		HandlerProviders []generic2.RWSetPayloadHandlerProvider `group:"handler-providers"`
+	}{
+		FSNProvider: fnsProvider,
+		CoreConfig:  cfg,
+		HandlerProviders: []generic2.RWSetPayloadHandlerProvider{
+			{Type: common.HeaderType_ENDORSER_TRANSACTION},
+		},
+	})
+	require.ErrorContains(t, err, "failed to add handler to channel mychannel")
 }


### PR DESCRIPTION
Resolves #1773
### Description

This PR increases the unit test coverage for the `platform/fabric/sdk/dig` package family (`sdk/dig`, `generic`, and `fns`) by addressing testing gaps in DI constructors, lifecycle hooks, and provider closures.

### Implementation Steps

- [x] **`sdk_test.go`** : Added tests for `NewSDK`, lifecycle hooks (`Install`, `Start`, `PostStart` with/without Fabric enabled), FSN provider cleanup, and all error/edge paths in `registerProcessorsForDrivers` and `registerRWSetLoaderHandlerProviders`.
- [x] **`generic/providers_test.go`** : Tested store constructors and implemented channel instantiation via `generic.ChannelProvider.NewChannel` to exercise all factory closures (`Vault`, `Ledger`, `RWSetLoader`, `Committer`, `Delivery`, `Membership`), along with ordering service validation.
- [x] **`fns/providers_test.go`** : Tested `NewProvider` constructor and driver group folding logic (achieving 100% coverage).
