### PR TITLE
fix(fabric): check the validation code on non-filtered delivery

### DIFF
--- a/platform/fabric/core/generic/delivery/deliverclient.go
+++ b/platform/fabric/core/generic/delivery/deliverclient.go
@@ -226,6 +226,21 @@ read:
 					event.Err = errors.Wrapf(err, "error parsing transaction [%d,%d]", r.Block.Header.Number, i)
 					break read
 				} else if chdr.TxId == txid {
+					// A full block carries its verdicts in TRANSACTIONS_FILTER metadata
+					// rather than inline, so matching the transaction ID only proves the
+					// transaction was included in the block - Fabric includes rejected
+					// transactions too. Read the verdict before reporting it committed,
+					// matching the FilteredBlock branch above.
+					code, err := validationCodeAt(r.Block, i)
+					if err != nil {
+						event.Err = err
+						break read
+					}
+					if pb.TxValidationCode(code) != pb.TxValidationCode_VALID {
+						logger.Debugf("transaction [%s] in block [%d] is not valid [%s]", txid, r.Block.Header.Number, pb.TxValidationCode(code))
+						event.Err = errors.Errorf("transaction [%s] status is not valid: %s", txid, pb.TxValidationCode(code))
+						break read
+					}
 					event.Committed = true
 					event.Block = r.Block.Header.Number
 					event.IndexInBlock = i

--- a/platform/fabric/core/generic/delivery/deliverclient_test.go
+++ b/platform/fabric/core/generic/delivery/deliverclient_test.go
@@ -384,22 +384,10 @@ func TestDeliverReceive(t *testing.T) {
 
 	t.Run("DeliverResponse_Block VALID", func(t *testing.T) {
 		t.Parallel()
-		chdr := &cb.ChannelHeader{TxId: "tx1"}
-		chdrBytes, _ := proto.Marshal(chdr)
-		payload := &cb.Payload{Header: &cb.Header{ChannelHeader: chdrBytes}}
-		payloadBytes, _ := proto.Marshal(payload)
-		env := &cb.Envelope{Payload: payloadBytes}
-		envBytes, _ := proto.Marshal(env)
-
 		df := &mockDeliverStream{
 			recvResp: &pb.DeliverResponse{
 				Type: &pb.DeliverResponse_Block{
-					Block: &cb.Block{
-						Header: &cb.BlockHeader{Number: 11},
-						Data: &cb.BlockData{
-							Data: [][]byte{envBytes},
-						},
-					},
+					Block: blockWithTx(11, []string{"tx1"}, pb.TxValidationCode_VALID),
 				},
 			},
 		}
@@ -410,6 +398,97 @@ func TestDeliverReceive(t *testing.T) {
 		require.True(t, event.Committed)
 		require.Equal(t, uint64(11), event.Block)
 		require.Equal(t, 0, event.IndexInBlock)
+	})
+
+	// A full block carries its verdicts in TRANSACTIONS_FILTER metadata rather
+	// than inline, so matching the transaction ID only proves the transaction was
+	// included in the block - Fabric includes rejected transactions too. The
+	// verdict must be read before reporting the transaction as committed,
+	// matching the FilteredBlock branch.
+	t.Run("DeliverResponse_Block INVALID", func(t *testing.T) {
+		t.Parallel()
+		df := &mockDeliverStream{
+			recvResp: &pb.DeliverResponse{
+				Type: &pb.DeliverResponse_Block{
+					Block: blockWithTx(11, []string{"tx1"}, pb.TxValidationCode_MVCC_READ_CONFLICT),
+				},
+			},
+		}
+		ch := make(chan TxEvent, 1)
+		err := DeliverReceive(df, "peer0", "tx1", ch)
+		require.ErrorContains(t, err, "status is not valid: MVCC_READ_CONFLICT")
+		require.False(t, (<-ch).Committed, "an invalid transaction must not be reported as committed")
+	})
+
+	// Fail closed: a block whose validity information is absent or too short to
+	// cover the matched transaction must not be reported as committed. Matches
+	// how Service.Scan and Service.ScanFromBlock already treat validationCodeAt
+	// errors. A malicious peer can send either shape.
+	t.Run("DeliverResponse_Block missing validation metadata", func(t *testing.T) {
+		t.Parallel()
+		block := blockWithTx(11, []string{"tx1"}, pb.TxValidationCode_VALID)
+		block.Metadata = nil
+
+		df := &mockDeliverStream{
+			recvResp: &pb.DeliverResponse{
+				Type: &pb.DeliverResponse_Block{Block: block},
+			},
+		}
+		ch := make(chan TxEvent, 1)
+		err := DeliverReceive(df, "peer0", "tx1", ch)
+		require.ErrorContains(t, err, "metadata lacks transaction filter")
+		require.False(t, (<-ch).Committed, "a block without validity information must not be reported as committed")
+	})
+
+	t.Run("DeliverResponse_Block truncated validation metadata", func(t *testing.T) {
+		t.Parallel()
+		// Two transactions, but validity flags cover only the first, so the
+		// matched transaction at index 1 has no verdict.
+		block := blockWithTx(11, []string{"tx0", "tx1"}, pb.TxValidationCode_VALID)
+		block.Metadata.Metadata[cb.BlockMetadataIndex_TRANSACTIONS_FILTER] = []byte{uint8(pb.TxValidationCode_VALID)}
+
+		df := &mockDeliverStream{
+			recvResp: &pb.DeliverResponse{
+				Type: &pb.DeliverResponse_Block{Block: block},
+			},
+		}
+		ch := make(chan TxEvent, 1)
+		err := DeliverReceive(df, "peer0", "tx1", ch)
+		require.ErrorContains(t, err, "out of range")
+		require.False(t, (<-ch).Committed, "a transaction with no verdict must not be reported as committed")
+	})
+
+	// The issue's stated expectation is that both branches agree. An invalid
+	// transaction must produce the same error regardless of stream type.
+	t.Run("both branches report an invalid transaction alike", func(t *testing.T) {
+		t.Parallel()
+		filtered := &mockDeliverStream{
+			recvResp: &pb.DeliverResponse{
+				Type: &pb.DeliverResponse_FilteredBlock{
+					FilteredBlock: &pb.FilteredBlock{
+						Number: 11,
+						FilteredTransactions: []*pb.FilteredTransaction{
+							{Txid: "tx1", TxValidationCode: pb.TxValidationCode_MVCC_READ_CONFLICT},
+						},
+					},
+				},
+			},
+		}
+		full := &mockDeliverStream{
+			recvResp: &pb.DeliverResponse{
+				Type: &pb.DeliverResponse_Block{
+					Block: blockWithTx(11, []string{"tx1"}, pb.TxValidationCode_MVCC_READ_CONFLICT),
+				},
+			},
+		}
+
+		filteredErr := DeliverReceive(filtered, "peer0", "tx1", make(chan TxEvent, 1))
+		fullErr := DeliverReceive(full, "peer0", "tx1", make(chan TxEvent, 1))
+
+		require.Error(t, filteredErr)
+		require.Error(t, fullErr)
+		require.Equal(t, filteredErr.Error(), fullErr.Error(),
+			"the two stream types must report an invalid transaction identically")
 	})
 
 	t.Run("DeliverResponse_Block invalid envelope", func(t *testing.T) {
@@ -430,4 +509,38 @@ func TestDeliverReceive(t *testing.T) {
 		err := DeliverReceive(df, "peer0", "tx1", ch)
 		require.ErrorContains(t, err, "error parsing transaction")
 	})
+}
+
+// blockWithTx builds a full block containing the given transaction IDs, with a
+// TRANSACTIONS_FILTER metadata entry marking every one of them with code. The
+// filter lives at index BlockMetadataIndex_TRANSACTIONS_FILTER (2), so the
+// earlier entries are padding.
+func blockWithTx(number uint64, txIDs []string, code pb.TxValidationCode) *cb.Block {
+	data := make([][]byte, 0, len(txIDs))
+	flags := make([]byte, 0, len(txIDs))
+	for _, txID := range txIDs {
+		chdrBytes, err := proto.Marshal(&cb.ChannelHeader{TxId: txID})
+		if err != nil {
+			panic(err)
+		}
+		payloadBytes, err := proto.Marshal(&cb.Payload{Header: &cb.Header{ChannelHeader: chdrBytes}})
+		if err != nil {
+			panic(err)
+		}
+		envBytes, err := proto.Marshal(&cb.Envelope{Payload: payloadBytes})
+		if err != nil {
+			panic(err)
+		}
+		data = append(data, envBytes)
+		flags = append(flags, uint8(code))
+	}
+
+	metadata := make([][]byte, cb.BlockMetadataIndex_TRANSACTIONS_FILTER+1)
+	metadata[cb.BlockMetadataIndex_TRANSACTIONS_FILTER] = flags
+
+	return &cb.Block{
+		Header:   &cb.BlockHeader{Number: number},
+		Data:     &cb.BlockData{Data: data},
+		Metadata: &cb.BlockMetadata{Metadata: metadata},
+	}
 }


### PR DESCRIPTION
### Description

`DeliverReceive` has one branch per stream shape. The `FilteredBlock` branch reads each matched transaction's `TxValidationCode` before declaring it committed; the full-`Block` branch matched the transaction ID and set `Committed = true` without ever consulting the block's `TRANSACTIONS_FILTER` metadata. Matching a transaction ID only proves the transaction was *included* in the block — Fabric includes rejected transactions too — so the branch conflated "present in a block" with "committed successfully". Nothing downstream revalidates, so `ch.Finality().IsFinal()` reported "final and valid" for a transaction Fabric rejected on an MVCC conflict or a failed endorsement policy: a silent false positive.

- Reads the verdict via `validationCodeAt` before reporting the transaction committed, matching the filtered branch. That helper already lives in this package (`delivery/service.go:35`) with the bounds checks a malformed or malicious block needs, and already has two production callers in `Service.Scan` and `Service.ScanFromBlock` — both of which fail closed on a metadata error, so this follows the package's existing convention rather than introducing one.
- Behaviour change: a block whose `TRANSACTIONS_FILTER` is absent, or too short to cover the matched transaction, previously reported committed and now reports an error. Failing closed is the point — a block carrying no validity information for a transaction cannot be said to have committed it.
- Fixes a pre-existing test that asserted the buggy behaviour: `"DeliverResponse_Block VALID"` built a block with no `Metadata` at all, so it required a block with *no validity information* to be treated as valid. It now builds a block with a `VALID` filter entry, via a `blockWithTx` helper the new cases share.
- Latent on `main`: the only caller of `generic.NewChannelProvider` passes `useFilteredDelivery: true` (`sdk/dig/generic/providers.go:209`), and `fabricx` constructs no `FabricFinality` at all. It sits behind a boolean that exists to be flipped, and whoever flips it will be reaching for a performance knob with no reason to suspect it also turns off validity checking.

Closes #1737.

### Test plan

- [x] Four cases added, each failing before the fix: invalid transaction rejected; missing validation metadata fails closed; truncated filter fails closed; and both branches report an invalid transaction with byte-identical errors (the issue's stated expectation that the two branches agree).
- [x] `go test -race` across `delivery`, `finality` and `committer` — all pass.
- [x] `golangci-lint run platform/fabric/core/generic/delivery/...` — 0 issues, including the newly-enabled `revive`.
- [x] `gofmt`, `go vet`, `go build ./...` clean.
- [x] Full `platform/fabric/...` passes except the two Postgres tests needing a local Docker daemon, which fail identically on an unmodified tree.