### PR TITLE
fix(fabric): guard the nil PickPeer returns

### DIFF
--- a/platform/fabric/core/generic/chaincode/discovery.go
+++ b/platform/fabric/core/generic/chaincode/discovery.go
@@ -215,7 +215,11 @@ func (d *Discovery) query(req *discovery.Request) (discovery.Response, error) {
 			pCli.Close()
 		}
 	}()
-	pc, err := d.chaincode.Services.NewPeerClient(*d.chaincode.ConfigService.PickPeer(driver.PeerForDiscovery))
+	peerConnConf := d.chaincode.ConfigService.PickPeer(driver.PeerForDiscovery)
+	if peerConnConf == nil {
+		return nil, errors.New("no peer configured for discovery")
+	}
+	pc, err := d.chaincode.Services.NewPeerClient(*peerConnConf)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/fabric/core/generic/committer/committer.go
+++ b/platform/fabric/core/generic/committer/committer.go
@@ -56,7 +56,7 @@ type (
 )
 
 type FabricFinality interface {
-	IsFinal(txID, address string) error
+	IsFinal(txID string) error
 }
 
 type CommitTx struct {
@@ -395,15 +395,14 @@ func (c *Committer) IsFinal(ctx context.Context, txID string) error {
 			if logger.IsEnabledFor(zapcore.DebugLevel) {
 				c.logger.Debugf("Tx [%s] is unknown with no deps, remote check [%d][%s]", txID, iter, debug.Stack())
 			}
-			peerForFinality := c.ConfigService.PickPeer(driver.PeerForFinality).Address
-			err := c.FabricFinality.IsFinal(txID, peerForFinality)
+			err := c.FabricFinality.IsFinal(txID)
 			if err == nil {
-				c.logger.Debugf("Tx [%s] is final, remote check on [%s]", txID, peerForFinality)
+				c.logger.Debugf("Tx [%s] is final, remote check succeeded", txID)
 				return nil
 			}
 
 			if vd, _, err2 := c.Status(ctx, txID); err2 == nil && vd == driver.Unknown {
-				c.logger.Debugf("Tx [%s] is not final for remote [%s], return [%s], [%d][%s]", txID, peerForFinality, err, vd, err2)
+				c.logger.Debugf("Tx [%s] is not final remotely, return [%s], [%d][%s]", txID, err, vd, err2)
 				return err
 			}
 		default:

--- a/platform/fabric/core/generic/committer/fake/fakes.go
+++ b/platform/fabric/core/generic/committer/fake/fakes.go
@@ -310,7 +310,7 @@ type FabricFinality struct {
 	Err error
 }
 
-func (f *FabricFinality) IsFinal(string, string) error {
+func (f *FabricFinality) IsFinal(string) error {
 	return f.Err
 }
 

--- a/platform/fabric/core/generic/config/service_test.go
+++ b/platform/fabric/core/generic/config/service_test.go
@@ -244,6 +244,9 @@ func TestCreatePeerMapAndPickPeer(t *testing.T) {
 	// pick a peer for query — ensure non-nil
 	p := svc.PickPeer(driver.PeerForQuery)
 	require.NotNil(t, p)
+
+	// No peer declares usage: finality, and PeerForAnything is empty too.
+	require.Nil(t, svc.PickPeer(driver.PeerForFinality))
 }
 
 func TestPickOrderer_nilAndSetConfigOrderers(t *testing.T) {

--- a/platform/fabric/core/generic/delivery/delivery.go
+++ b/platform/fabric/core/generic/delivery/delivery.go
@@ -370,6 +370,9 @@ func (d *Delivery) connect(ctx context.Context) (DeliverStream, context.CancelFu
 	d.cleanup()
 
 	peerConnConf := d.ConfigService.PickPeer(driver.PeerForDelivery)
+	if peerConnConf == nil {
+		return nil, nil, errors.New("no peer configured for delivery")
+	}
 
 	address := peerConnConf.Address
 	logger.Debugf("connecting to deliver service at [%s] for [%s:%s]", address, d.NetworkName, d.channel)

--- a/platform/fabric/core/generic/finality/fabric.go
+++ b/platform/fabric/core/generic/finality/fabric.go
@@ -61,13 +61,22 @@ func NewFabricFinality(
 	return d, nil
 }
 
-func (d *FabricFinality) IsFinal(txID, address string) error {
+// IsFinal probes a peer configured for finality for the given transaction. The
+// peer is chosen here rather than supplied by the caller, so that the address
+// reported in errors and events is always the peer actually probed.
+func (d *FabricFinality) IsFinal(txID string) error {
 	d.Logger.Debugf("remote checking if transaction [%s] is final in channel [%s]", txID, d.Channel)
 	var eventCh chan delivery.TxEvent
 	var ctx context.Context
 	var cancelFunc context.CancelFunc
 
-	client, err := d.Services.NewPeerClient(*d.ConfigService.PickPeer(driver.PeerForFinality))
+	peerConnConf := d.ConfigService.PickPeer(driver.PeerForFinality)
+	if peerConnConf == nil {
+		return errors.New("no peer configured for finality")
+	}
+	address := peerConnConf.Address
+
+	client, err := d.Services.NewPeerClient(*peerConnConf)
 	if err != nil {
 		return errors.WithMessagef(err, "failed creating peer client for address [%s]", address)
 	}

--- a/platform/fabric/core/generic/finality/fabric.go
+++ b/platform/fabric/core/generic/finality/fabric.go
@@ -61,9 +61,8 @@ func NewFabricFinality(
 	return d, nil
 }
 
-// IsFinal probes a peer configured for finality for the given transaction. The
-// peer is chosen here rather than supplied by the caller, so that the address
-// reported in errors and events is always the peer actually probed.
+// IsFinal probes a peer configured for finality for the given transaction,
+// returning an error if no peer is configured for that role.
 func (d *FabricFinality) IsFinal(txID string) error {
 	d.Logger.Debugf("remote checking if transaction [%s] is final in channel [%s]", txID, d.Channel)
 	var eventCh chan delivery.TxEvent

--- a/platform/fabric/core/generic/finality/fabric_test.go
+++ b/platform/fabric/core/generic/finality/fabric_test.go
@@ -247,7 +247,7 @@ func TestFabricFinality_IsFinal(t *testing.T) {
 				}
 			}
 
-			err = f.IsFinal("tx1", "peer1")
+			err = f.IsFinal("tx1")
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.expectedError != "" {
@@ -258,4 +258,31 @@ func TestFabricFinality_IsFinal(t *testing.T) {
 			}
 		})
 	}
+}
+
+// PickPeer returns nil when no peer is configured for finality. FabricFinality
+// dereferenced it to build the peer client, panicking the node; it must report
+// an error instead. DeliverReceive runs from a bare goroutine with no panic
+// recovery, so this is a crash rather than a failed call.
+func TestFabricFinality_IsFinal_noPeerConfigured(t *testing.T) {
+	t.Parallel()
+
+	mockConfig := &fake.ConfigService{}
+	mockConfig.On("PickPeer", mock.Anything).Return(nil)
+
+	f, err := NewFabricFinality(
+		logging.MustGetLogger("test"),
+		"testchannel",
+		mockConfig,
+		&fake.Services{},
+		&fake.SigningIdentity{},
+		5*time.Second,
+		true,
+	)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		err := f.IsFinal("tx1")
+		require.ErrorContains(t, err, "no peer configured for finality")
+	})
 }

--- a/platform/fabric/core/generic/ledger/ledger.go
+++ b/platform/fabric/core/generic/ledger/ledger.go
@@ -102,10 +102,14 @@ func (c *Ledger) queryChaincode(function string, param any) ([]byte, error) {
 	if param != nil {
 		params = append(params, param)
 	}
+	peerConnConf := c.ConfigService.PickPeer(driver.PeerForQuery)
+	if peerConnConf == nil {
+		return nil, errors.New("no peer configured for query")
+	}
 	return c.ChaincodeManager.Chaincode(QuerySystemChaincode).
 		NewInvocation(function, params...).
 		WithSignerIdentity(c.LocalMembership.DefaultIdentity()).
-		WithEndorsersByConnConfig(c.ConfigService.PickPeer(driver.PeerForQuery)).
+		WithEndorsersByConnConfig(peerConnConf).
 		Query()
 }
 

--- a/platform/fabric/core/generic/ledger/ledger_test.go
+++ b/platform/fabric/core/generic/ledger/ledger_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/ledger/mock"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/grpc"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
 
@@ -91,7 +92,7 @@ func TestGetLedgerInfo(t *testing.T) {
 
 			mockCM.ChaincodeReturns(mockCC)
 			mockLM.DefaultIdentityReturns(view.Identity("alice"))
-			mockCS.PickPeerReturns(nil)
+			mockCS.PickPeerReturns(&grpc.ConnectionConfig{Address: "peer0:7051"})
 
 			info, err := l.GetLedgerInfo()
 			if tt.wantErr {
@@ -144,7 +145,7 @@ func TestGetTransactionByID(t *testing.T) {
 
 			mockCM.ChaincodeReturns(mockCC)
 			mockLM.DefaultIdentityReturns(view.Identity("alice"))
-			mockCS.PickPeerReturns(nil)
+			mockCS.PickPeerReturns(&grpc.ConnectionConfig{Address: "peer0:7051"})
 
 			mockPT := &mock.ProcessedTransaction{}
 			mockTM.NewProcessedTransactionReturns(mockPT, nil)
@@ -205,7 +206,7 @@ func TestGetBlockNumberByTxID(t *testing.T) {
 
 			mockCM.ChaincodeReturns(mockCC)
 			mockLM.DefaultIdentityReturns(view.Identity("alice"))
-			mockCS.PickPeerReturns(nil)
+			mockCS.PickPeerReturns(&grpc.ConnectionConfig{Address: "peer0:7051"})
 
 			res, err := l.GetBlockNumberByTxID("tx1")
 			if tt.wantErr {
@@ -269,7 +270,7 @@ func TestGetBlockByNumber(t *testing.T) {
 
 			mockCM.ChaincodeReturns(mockCC)
 			mockLM.DefaultIdentityReturns(view.Identity("alice"))
-			mockCS.PickPeerReturns(nil)
+			mockCS.PickPeerReturns(&grpc.ConnectionConfig{Address: "peer0:7051"})
 
 			res, err := l.GetBlockByNumber(10)
 			if tt.wantErr {
@@ -451,4 +452,46 @@ func TestBlock(t *testing.T) {
 			require.Nil(t, b.DataAt(5))
 		})
 	})
+}
+
+// PickPeer returns nil when no peer is configured for queries. The nil used to
+// be handed to WithEndorsersByConnConfig, where it survives the
+// len(EndorsersByConnConfig) != 0 guard - one nil passed to a variadic is a
+// slice of length one - and is dereferenced at chaincode/invoke.go:283. Every
+// query entry point must report the misconfiguration instead.
+func TestQueryChaincode_noPeerConfiguredForQuery(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		call func(l *Ledger) error
+	}{
+		{"GetLedgerInfo", func(l *Ledger) error { _, err := l.GetLedgerInfo(); return err }},
+		{"GetTransactionByID", func(l *Ledger) error { _, err := l.GetTransactionByID("tx1"); return err }},
+		{"GetBlockNumberByTxID", func(l *Ledger) error { _, err := l.GetBlockNumberByTxID("tx1"); return err }},
+		{"GetBlockByNumber", func(l *Ledger) error { _, err := l.GetBlockByNumber(1); return err }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			l, mockCM, mockLM, mockCS, _ := setupTestLedger(t)
+
+			// A real invocation dereferences each config; the mock would not, so
+			// assert on the error rather than merely on the absence of a panic.
+			mockInvocation := &mock.ChaincodeInvocation{}
+			mockInvocation.WithSignerIdentityReturns(mockInvocation)
+			mockInvocation.WithEndorsersByConnConfigReturns(mockInvocation)
+			mockInvocation.QueryReturns([]byte("unused"), nil)
+
+			mockCC := &mock.Chaincode{}
+			mockCC.NewInvocationReturns(mockInvocation)
+			mockCM.ChaincodeReturns(mockCC)
+			mockLM.DefaultIdentityReturns(view.Identity("alice"))
+			mockCS.PickPeerReturns(nil)
+
+			err := tc.call(l)
+			require.ErrorContains(t, err, "no peer configured for query")
+			require.Equal(t, 0, mockInvocation.QueryCallCount(),
+				"must fail before invoking the chaincode")
+		})
+	}
 }


### PR DESCRIPTION
### Description

`ConfigService.PickPeer(role)` returns `nil` when neither the requested peer-function bucket nor the `PeerForAnything` fallback has an entry (`config/service.go:342`) — a deliberate "no peer for this role" signal. Three callers dereferenced it without checking, so a node whose peers all declare some *other* role panics on first use. It is reachable from a plain `core.yaml`: `peerMapping` only gains a key for a role some peer explicitly declared, and a peer lands in `PeerForAnything` only if its `usage:` field is empty — so a single peer with `usage: delivery` is enough to make `PickPeer(PeerForFinality)` return nil. Startup does not catch it: `createPeerMap` warns only for an *unrecognised* usage string, so a recognised-but-wrong one passes silently and the crash arrives later under traffic.

- Guards the three dereference sites: `finality/fabric.go:70` (peer client for the finality probe), `delivery/delivery.go:372` (`connect`), and `chaincode/discovery.go:218` (`query`).
- Follows the shape already in the tree for the sibling `PickOrderer` at `ordering/cft.go:124` — guarded at the call site rather than inside `PickPeer`, since only the caller knows which role it asked for and what to say when there isn't one.
- `ledger.go:108` also calls `PickPeer` - we use the same pattern.
- Drops the unused `address` parameter from `FabricFinality.IsFinal`. It was never used to connect — the implementation called `PickPeer` again — so with more than one finality peer the address the committer logged need not be the peer actually probed, which misleads in exactly the logs read when debugging a finality timeout. The implementation now reports the peer it picked, and the committer's debug lines no longer name a peer they cannot vouch for.
- Skipped the optional startup warning the issue mentions: the guards already turn a crash into a clear error, and a startup check is a second place to keep in sync. Worth adding if operators actually hit this.

Closes #1732.

### Test plan

- [x] `finality/fabric_test.go`: `PickPeer` returns nil, asserts an error rather than a panic. Before the fix this test **panicked** with `nil pointer dereference` — the bug itself.
- [x] `config/service_test.go`: one line asserting `PickPeer(PeerForFinality) == nil` for the `usage: query` / `usage: delivery` fixture already in that test — the reachability proof, without which the other test looks hypothetical.
- [x] Mutation-checked: flipping the finality guard to `if false` brings the panic straight back, so the test is load-bearing.
- [x] `go test -race` across `committer`, `finality`, `delivery`, `chaincode`, `config` — all pass.
- [x] `golangci-lint run platform/fabric/...` — 0 issues.
- [x] `gofmt`, `go vet`, `go build ./...` clean.