### PR TITLE
docs: document how to write and maintain documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,45 @@ Read these on demand — don't load them up front.
 | Architecture overview & concepts | [`docs/core-concepts.md`](docs/core-concepts.md) |
 | Contribution workflow | [`docs/dev/workflow.md`](docs/dev/workflow.md), [`CONTRIBUTING.md`](CONTRIBUTING.md) |
 
+## Documentation
+
+Documentation — Godoc comments and standalone docs alike — describes the
+**current implementation as a self-contained system**. Write for a developer who
+cloned the repository today: never saw the previous implementation, does not know
+the git history, has not read the PR or issue. If a doc only makes sense to
+someone who does, rewrite it.
+
+- **Not a changelog.** Never write "previously", "before this change", "we
+  changed/moved from X to Y", "formerly", "now instead of", "this replaces",
+  "the old implementation", "after the refactor". Don't explain a design by
+  describing what the code used to do.
+- **Explain WHY the current design exists**, in terms of today's requirements —
+  correctness, concurrency, ordering, lifecycle, security, performance, resource
+  ownership, API guarantees, compatibility, failure handling — and only when that
+  rationale helps understand or maintain the code. Prefer *"The client uses X to
+  coordinate concurrent requests and preserve ordering."* over *"We previously
+  used Y, but changed it to X."*
+- **History is an input, not a subject.** Inspect commits, PRs, and issues freely
+  while investigating why the code looks the way it does; document the resulting
+  design, not the investigation. Linking an issue for extra context is fine as
+  long as the doc still explains the behavior on its own.
+- **Godoc** covers what an exported package/type/function represents, its
+  responsibilities, guarantees, preconditions, concurrency and lifecycle
+  requirements, error behavior, and semantics not obvious from the signature —
+  never why the code changed, what the old version did, or which PR introduced
+  it. Comments must stay useful with no git history available. Details:
+  [`docs/agents/conventions.md`](docs/agents/conventions.md#godoc).
+- **Write for maintainers**: responsibilities and ownership, component
+  relationships, important execution flows, invariants, lifecycle, concurrency
+  model, error handling, resource management, extension points, and assumptions
+  that must remain true. Don't narrate obvious code.
+- **Keep docs aligned with the code** in the same commit: update Godoc when
+  behavior or semantics change, update standalone docs when architecture or
+  externally visible behavior changes, and delete documentation for behavior that
+  no longer exists. Historical wording is not preserved just because it was once
+  accurate.
+- **Style**: precise, concise, technical, factual, present tense; no narrative.
+
 ## Conventions in one line
 
 - **Errors**: use `pkg/utils/errors` (`errors.New/Errorf/Wrap/Wrapf/WithMessage/WithMessagef/Join`); do not build or wrap errors with `fmt.Errorf`.
@@ -81,7 +120,7 @@ Read these on demand — don't load them up front.
 - **DI**: register in the platform's `sdk/dig/sdk.go` (e.g. `platform/view/sdk/dig/sdk.go`); `Install()` must call the parent `p.SDK.Install()`.
 - **Mocks**: `counterfeiter` via `make generate-mocks` (see [`docs/dev/mocks.md`](docs/dev/mocks.md)).
 - **Git**: run `make checks` before committing; sign off every commit (`git commit -s`, DCO); rebase, don't merge. Fixups during review, then autosquash: a PR merges as one commit whose message describes the PR. See [`docs/dev/workflow.md`](docs/dev/workflow.md#commit-hygiene), [`docs/dev/signing.md`](docs/dev/signing.md), [`docs/dev/rebasing.md`](docs/dev/rebasing.md).
-- **Docs**: a change that leaves [`docs/agents/`](docs/agents/) or [`docs/dev/`](docs/dev/) wrong is not finished — update the affected guide in the same commit.
+- **Docs**: a change that leaves [`docs/agents/`](docs/agents/) or [`docs/dev/`](docs/dev/) wrong is not finished — update the affected guide in the same commit; see [Documentation](#documentation).
 
 ## Related projects
 


### PR DESCRIPTION
### What

Adds a `## Documentation` section to `AGENTS.md` (which `CLAUDE.md` symlinks to), establishing how documentation and Godoc comments are written and maintained in this repository.

The guiding rule: documentation describes the **current implementation as a self-contained system**, readable by a developer who cloned the repository today — one who never saw the previous implementation, does not know the git history, and has not read the PR or issue that introduced the code.

### Why

Docs and comments in a long-lived repository tend to accumulate changelog language — "previously", "we moved from X to Y", "after the refactor". That wording is meaningful only to whoever was present for the change. For everyone who arrives later it describes a system that no longer exists, and it goes stale in a way that is hard to detect during review.

Writing the rule down puts it where every contributor and coding agent already reads project conventions, so it applies by default instead of surfacing as review feedback each time.

### Guidelines added

- **Not a changelog** — no implementation-history phrasing; don't explain a design by describing what the code used to do.
- **Explain why the current design exists** — in terms of today's requirements (correctness, concurrency, ordering, lifecycle, security, performance, resource ownership, API guarantees, compatibility, failure handling), and only where that rationale helps understand or maintain the code.
- **History is an input, not a subject** — inspect commits, PRs, and issues freely while investigating; document the resulting design, not the investigation. Linking an issue for extra context is fine as long as the doc still explains the behavior on its own.
- **Godoc** — covers what an exported package/type/function represents, its responsibilities, guarantees, preconditions, concurrency and lifecycle requirements, error behavior, and semantics not obvious from the signature. Not why the code changed, what the old version did, or which PR introduced it. Comments stay useful with no git history available.
- **Write for maintainers** — ownership, component relationships, execution flows, invariants, lifecycle, concurrency model, error handling, resource management, extension points, and assumptions that must remain true. Don't narrate obvious code.
- **Keep docs aligned with the code** in the same commit, including deleting documentation for behavior that no longer exists.
- **Style** — precise, concise, technical, factual, present tense.
