### PR TITLE
refactor(fabric): simplify CFTBroadcaster retry loop, fix connection-pool leak

### DIFF
--- a/platform/fabric/core/generic/ordering/cft.go
+++ b/platform/fabric/core/generic/ordering/cft.go
@@ -45,57 +45,55 @@ func NewCFTBroadcaster(configService driver.ConfigService, clientFactory Service
 func (o *CFTBroadcaster) Broadcast(ctx context.Context, env *common2.Envelope) error {
 	logger.DebugfContext(ctx, "Start CFT Broadcast")
 	defer logger.DebugfContext(ctx, "End CFT Broadcast")
-	// send the envelope for ordering
-	var status *ab.BroadcastResponse
-	var connection *Connection
+
 	retries := o.ConfigService.BroadcastNumRetries()
 	retryInterval := o.ConfigService.BroadcastRetryInterval()
-	forceConnect := true
-	var err error
+	// Every failure path assigns lastErr; the initial value only survives when
+	// retries is zero, in which case no attempt is made at all and Broadcast
+	// must still report a failure.
+	lastErr := errors.Errorf("no attempt made to send transaction to orderer (retries=%d)", retries)
 	for i := range retries {
-		if connection != nil {
-			// throw away this connection
-			logger.DebugfContext(ctx, "Discard connection")
-			o.discardConnection(connection)
-		}
 		if i > 0 {
 			logger.Debugf("broadcast, retry [%d]...", i)
 			// wait a bit
 			time.Sleep(retryInterval)
 		}
-		if i > 0 || forceConnect {
-			forceConnect = false
-			connection, err = o.getConnection(ctx)
-			if err != nil {
-				logger.WarnfContext(ctx, "failed to get connection to orderer [%s]", err)
-				continue
-			}
+
+		connection, err := o.getConnection(ctx)
+		if err != nil {
+			logger.WarnfContext(ctx, "failed to get connection to orderer [%s]", err)
+			lastErr = err
+			continue
 		}
 
-		err = connection.Send(env)
+		status, err := sendAndRecv(connection, env)
 		if err != nil {
+			// the connection is broken, throw it away and retry with a fresh one
+			logger.DebugfContext(ctx, "Discard connection")
+			o.discardConnection(connection)
+			lastErr = err
 			continue
 		}
-		status, err = connection.Recv()
-		if err != nil {
-			continue
-		}
+
+		logger.DebugfContext(ctx, "Release connection")
+		o.releaseConnection(connection)
 		if status.GetStatus() != common2.Status_SUCCESS {
-			logger.DebugfContext(ctx, "Release connection")
-			o.releaseConnection(connection)
+			// the orderer rejected the envelope, retrying will not help
 			return errors.Errorf("failed broadcasting, status %s", common2.Status_name[int32(status.GetStatus())])
 		}
-
-		labels := []string{
-			"network", o.NetworkID,
-		}
-		o.metrics.OrderedTransactions.With(labels...).Add(1)
-		o.releaseConnection(connection)
+		o.metrics.OrderedTransactions.With("network", o.NetworkID).Add(1)
 
 		return nil
 	}
-	o.discardConnection(connection)
-	return errors.Wrap(err, "failed to send transaction to orderer")
+	return errors.Wrap(lastErr, "failed to send transaction to orderer")
+}
+
+// sendAndRecv sends env on connection and waits for the orderer's acknowledgement.
+func sendAndRecv(connection *Connection, env *common2.Envelope) (*ab.BroadcastResponse, error) {
+	if err := connection.Send(env); err != nil {
+		return nil, err
+	}
+	return connection.Recv()
 }
 
 func (o *CFTBroadcaster) getConnection(ctx context.Context) (*Connection, error) {
@@ -120,19 +118,25 @@ func (o *CFTBroadcaster) getConnection(ctx context.Context) (*Connection, error)
 			cancel()
 			logger.DebugfContext(ctx, "Got a semaphore")
 
-			// create connection
+			// create connection. The semaphore slot acquired above is only meant to be held
+			// for the lifetime of a Connection, so every failure path from here on must
+			// release it back before returning, or the pool permanently loses a slot.
 			to := o.ConfigService.PickOrderer()
 			if to == nil {
+				o.connSem.Release(1)
 				return nil, errors.New("no orderer configured")
 			}
 
 			client, err := o.ClientFactory.NewOrdererClient(*to)
 			if err != nil {
+				o.connSem.Release(1)
 				return nil, errors.Wrapf(err, "failed creating orderer client for %s", to.Address)
 			}
 
 			oClient, err := client.OrdererClient()
 			if err != nil {
+				o.connSem.Release(1)
+				client.Close()
 				rpcStatus, _ := status.FromError(err)
 				return nil, errors.Wrapf(err, "failed to new a broadcast for %s, rpcStatus=%+v", to.Address, rpcStatus)
 			}
@@ -141,6 +145,7 @@ func (o *CFTBroadcaster) getConnection(ctx context.Context) (*Connection, error)
 			// Notice that this stream is shared, therefore its context must be something different from the context of the current broadcast request
 			stream, err := oClient.Broadcast(context.Background()) //nolint:contextcheck // documented above: this stream is shared across broadcasts, so it deliberately does not use the current request's context
 			if err != nil {
+				o.connSem.Release(1)
 				client.Close()
 				return nil, errors.Wrapf(err, "failed creating orderer stream for %s", to.Address)
 			}

--- a/platform/fabric/core/generic/ordering/cft_test.go
+++ b/platform/fabric/core/generic/ordering/cft_test.go
@@ -34,10 +34,12 @@ func newTestMetrics() *metrics.Metrics {
 
 // fakeCFTServices provides orderer clients for testing
 type fakeCFTServices struct {
-	shouldFailClient bool
-	shouldFailStream bool
-	clientError      error
-	streamError      error
+	shouldFailClient    bool
+	shouldFailStream    bool
+	shouldFailBroadcast bool
+	clientError         error
+	streamError         error
+	broadcastError      error
 }
 
 func (f *fakeCFTServices) NewOrdererClient(grpc.ConnectionConfig) (Client, error) {
@@ -48,16 +50,20 @@ func (f *fakeCFTServices) NewOrdererClient(grpc.ConnectionConfig) (Client, error
 		return nil, errors.New("client creation failed")
 	}
 	return &fakeCFTClient{
-		shouldFailStream: f.shouldFailStream,
-		streamError:      f.streamError,
+		shouldFailStream:    f.shouldFailStream,
+		shouldFailBroadcast: f.shouldFailBroadcast,
+		streamError:         f.streamError,
+		broadcastError:      f.broadcastError,
 	}, nil
 }
 
 type fakeCFTClient struct {
 	Client
-	shouldFailStream bool
-	streamError      error
-	closed           bool
+	shouldFailStream    bool
+	shouldFailBroadcast bool
+	streamError         error
+	broadcastError      error
+	closed              bool
 }
 
 func (f *fakeCFTClient) OrdererClient() (ab.AtomicBroadcastClient, error) {
@@ -67,16 +73,28 @@ func (f *fakeCFTClient) OrdererClient() (ab.AtomicBroadcastClient, error) {
 		}
 		return nil, errors.New("stream creation failed")
 	}
-	return &fakeCFTAB{}, nil
+	return &fakeCFTAB{
+		shouldFailBroadcast: f.shouldFailBroadcast,
+		broadcastError:      f.broadcastError,
+	}, nil
 }
 
 func (f *fakeCFTClient) Close() {
 	f.closed = true
 }
 
-type fakeCFTAB struct{}
+type fakeCFTAB struct {
+	shouldFailBroadcast bool
+	broadcastError      error
+}
 
-func (fakeCFTAB) Broadcast(context.Context, ...ggrpc.CallOption) (ggrpc.BidiStreamingClient[common.Envelope, ab.BroadcastResponse], error) {
+func (f fakeCFTAB) Broadcast(context.Context, ...ggrpc.CallOption) (ggrpc.BidiStreamingClient[common.Envelope, ab.BroadcastResponse], error) {
+	if f.shouldFailBroadcast {
+		if f.broadcastError != nil {
+			return nil, f.broadcastError
+		}
+		return nil, errors.New("broadcast stream creation failed")
+	}
 	return &fakeCFTStream{status: common.Status_SUCCESS}, nil
 }
 
@@ -314,6 +332,27 @@ func TestCFTBroadcaster_Broadcast_Retries(t *testing.T) {
 	})
 }
 
+// TestCFTBroadcaster_Broadcast_ZeroRetries is a regression test: when
+// BroadcastNumRetries returns 0, the retry loop body never runs, so nothing
+// ever assigns lastErr. errors.Wrap(err, ...) with a nil err returns nil (per
+// github.com/pkg/errors semantics), which used to make Broadcast silently
+// report success without ever attempting to send.
+func TestCFTBroadcaster_Broadcast_ZeroRetries(t *testing.T) {
+	t.Parallel()
+
+	cfg := &fake.ConfigService{
+		PoolSizeValue:    4,
+		RetriesValue:     0,
+		NetworkNameValue: "test-network",
+		OrderersValue:    []*grpc.ConnectionConfig{{Address: "orderer-1"}},
+	}
+	b := NewCFTBroadcaster(cfg, &fakeCFTServices{}, nil)
+
+	err := b.Broadcast(t.Context(), &common.Envelope{})
+	require.Error(t, err, "zero configured retries must not be reported as success")
+	require.Contains(t, err.Error(), "no attempt made to send transaction to orderer")
+}
+
 // TestCFTBroadcaster_Broadcast_OrdererRejection is a regression test: when the
 // orderer responds with a non-SUCCESS status but Send/Recv return no
 // transport error, Broadcast used to call errors.Wrapf(err, ...) with a nil
@@ -449,6 +488,77 @@ func TestCFTBroadcaster_GetConnection(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to new a broadcast")
 	})
+}
+
+// TestCFTBroadcaster_GetConnection_SemaphoreNotLeakedOnFailure is a regression
+// test: every error return in getConnection after a successful
+// connSem.Acquire ("no orderer configured", client creation, broadcast-client
+// creation, stream creation) used to skip releasing the acquired slot. Enough
+// consecutive failures of a given kind permanently shrank the pool by that
+// many slots, and exhausting the whole pool this way would deadlock every
+// future call waiting on the semaphore.
+func TestCFTBroadcaster_GetConnection_SemaphoreNotLeakedOnFailure(t *testing.T) {
+	t.Parallel()
+
+	const poolSize = 3
+
+	newBroadcaster := func(services Services, hasOrderer bool) *CFTBroadcaster {
+		cfg := &fake.ConfigService{
+			PoolSizeValue:    poolSize,
+			NetworkNameValue: "test-network",
+		}
+		if hasOrderer {
+			cfg.OrderersValue = []*grpc.ConnectionConfig{{Address: "orderer-1"}}
+		}
+		return NewCFTBroadcaster(cfg, services, nil)
+	}
+
+	tests := []struct {
+		name       string
+		services   Services
+		hasOrderer bool
+	}{
+		{
+			name:       "no orderer configured",
+			services:   &fakeCFTServices{},
+			hasOrderer: false,
+		},
+		{
+			name:       "client creation fails",
+			services:   &fakeCFTServices{shouldFailClient: true, clientError: errors.New("connection refused")},
+			hasOrderer: true,
+		},
+		{
+			name:       "broadcast client creation fails",
+			services:   &fakeCFTServices{shouldFailStream: true, streamError: errors.New("stream error")},
+			hasOrderer: true,
+		},
+		{
+			name:       "broadcast stream creation fails",
+			services:   &fakeCFTServices{shouldFailBroadcast: true, broadcastError: errors.New("broadcast error")},
+			hasOrderer: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			b := newBroadcaster(tt.services, tt.hasOrderer)
+
+			for range poolSize {
+				_, err := b.getConnection(t.Context())
+				require.Error(t, err)
+			}
+
+			// Every failed attempt above acquired a semaphore slot. If any
+			// leaked, fewer than poolSize slots remain and this Acquire times out.
+			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+			defer cancel()
+			err := b.connSem.Acquire(ctx, poolSize)
+			require.NoError(t, err, "connection-creation failure must release its semaphore slot")
+			b.connSem.Release(poolSize)
+		})
+	}
 }
 
 // TestCFTBroadcaster_DiscardConnection tests connection cleanup


### PR DESCRIPTION
## Summary
- `Broadcast` tracked retry state through a `forceConnect` flag and a `connection` variable reused across loop iterations, so a single logical step (get a connection, send, receive) was split across four different branches. Extracts the send/receive pair into a `sendAndRecv` helper and has each retry acquire its own connection, so the loop body reads as one attempt per iteration instead of a state machine.
- Fixes connection-pool resource leaks in `getConnection`: all four error returns after a successful `connSem.Acquire` (no orderer configured, client creation, broadcast-client creation, stream creation) never released the acquired semaphore slot, and the broadcast-client-creation failure additionally never closed the already-created client, unlike its sibling stream-creation failure a few lines below. Each lost slot permanently shrinks the pool, and enough connection failures would eventually deadlock every future `Broadcast` call waiting on the semaphore.
- Adds a regression test (`TestCFTBroadcaster_GetConnection_SemaphoreNotLeakedOnFailure`) that drives `poolSize` consecutive failures of each of the four `getConnection` failure kinds and confirms the pool still yields `poolSize` semaphore slots afterward. Verified it fails against the pre-fix `getConnection`.
- Adds a regression test (`TestCFTBroadcaster_Broadcast_ZeroRetries`) for the zero-retries case: the old code left its error variable uninitialized when the retry loop never ran, and `errors.Wrap(nil, ...)` returns `nil`, so `Broadcast` silently reported success without ever attempting to send.

## Test plan
- [x] `go build ./platform/fabric/...`
- [x] `go vet ./platform/fabric/core/generic/ordering/...`
- [x] `go test ./platform/fabric/core/generic/ordering/... -race -count=1`