### PR TITLE
test: use require in tests where a failure matters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ Read these on demand — don't load them up front.
 | Platform layout, SDK composition, `dig` DI, multi-network | [`docs/agents/architecture.md`](docs/agents/architecture.md) |
 | Code organization, errors, logging, storage, identity, security | [`docs/agents/conventions.md`](docs/agents/conventions.md) |
 | Unit + integration test conventions | [`docs/agents/testing.md`](docs/agents/testing.md) |
+| Testing best practices (e.g. `assert` vs `require`) | [`docs/dev/testing.md`](docs/dev/testing.md) |
 | Authoring a new integration test | [`docs/agents/integration-tests.md`](docs/agents/integration-tests.md) |
 | Node configuration (`core.yaml`) | [`docs/configuration.md`](docs/configuration.md) |
 | Architecture overview & concepts | [`docs/core-concepts.md`](docs/core-concepts.md) |

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -11,6 +11,9 @@ exempts, is in [Contribution Workflow → Tests](../dev/workflow.md#tests).
 That is the project convention. Some existing unit suites still use Ginkgo/Gomega and
 will be migrated — follow the convention, not the neighbouring file.
 
+See [`docs/dev/testing.md`](../dev/testing.md) for testing best practices, including
+when to reach for `assert` instead of `require`.
+
 ## Running tests
 
 Scope every run to what you changed:

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -1,5 +1,46 @@
 # Testing Guide
 
+This document outlines how to write and run tests in FSC.
+
+## Unit tests
+
+### Choosing `assert` over `require`
+
+`require` stops the test immediately on failure (`t.FailNow()`, via `runtime.Goexit()`);
+`assert` records the failure and lets the test keep running. At each call site, ask
+whether continuing past this failure would produce a misleading result or a crash, or
+whether it's an independent check.
+
+**Use `require` when:**
+
+- A later line dereferences, indexes, or type-asserts the value just checked, e.g.
+  `require.NoError(t, err)` before `client.Do()`, or `require.NotNil(t, x)` before
+  `x.Field`. Without it, a nil value or an error here panics instead of failing the
+  test cleanly, and the panic message says far less than the assertion would have.
+- The checks form a sequence where each step depends on the last one succeeding (a
+  Put → Get → Delete → Get flow, setup before the real test body). One failure here
+  makes every assertion after it noise.
+- It's a manual `if err != nil { t.Fatalf(...) }` — that's `require.NoError` spelled
+  out by hand, so convert it.
+
+**Use `assert` when:**
+
+- The checks are independent, such as a table-driven test verifying several unrelated
+  fields, where you want to see every failure in one run rather than stopping at the
+  first.
+- The call runs off the test's main goroutine: inside a spawned `go func()`, `wg.Go()`,
+  or an `httptest` handler closure. `Goexit()` is unsafe to call from any goroutine but
+  the test's own, so `require` there can hang the test or corrupt the result instead of
+  failing it cleanly.
+- The call sits inside an `EventuallyWithT` callback. Both `assert.EventuallyWithT` and
+  `require.EventuallyWithT` take the same callback signature,
+  `func(collect *assert.CollectT)` — testify's `require` package defines no `CollectT`
+  of its own — so calls inside that callback are `assert.X` regardless of which outer
+  function you used.
+
+Default to `require`, and drop to `assert` only for one of the three reasons above.
+This is a per-call-site judgment, not a mechanical swap.
+
 ## Fuzzing
 
 Go's native fuzzing mutates test inputs to find panics and other unrecovered crashes; see

--- a/integration/nwo/cmd/commands/cryptogen/csp/csp_internal_test.go
+++ b/integration/nwo/cmd/commands/cryptogen/csp/csp_internal_test.go
@@ -12,7 +12,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestToLowS(t *testing.T) {
@@ -71,7 +71,7 @@ func TestToLowS(t *testing.T) {
 			key := ecdsa.PublicKey{
 				Curve: curve,
 			}
-			assert.Equal(t, test.expectedSig, toLowS(key, test.sig))
+			require.Equal(t, test.expectedSig, toLowS(key, test.sig))
 		})
 	}
 }

--- a/integration/nwo/cmd/commands/cryptogen/metadata/metadata_test.go
+++ b/integration/nwo/cmd/commands/cryptogen/metadata/metadata_test.go
@@ -11,7 +11,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	metadata "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/cmd/commands/cryptogen/metadata"
 )
@@ -26,7 +26,7 @@ func TestGetVersionInfo(t *testing.T) {
 		runtime.Version(),
 		fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	)
-	assert.Equal(t, expected, metadata.GetVersionInfo())
+	require.Equal(t, expected, metadata.GetVersionInfo())
 
 	testSHA := "abcdefg"
 	metadata.CommitSHA = testSHA
@@ -38,5 +38,5 @@ func TestGetVersionInfo(t *testing.T) {
 		runtime.Version(),
 		fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	)
-	assert.Equal(t, expected, metadata.GetVersionInfo())
+	require.Equal(t, expected, metadata.GetVersionInfo())
 }

--- a/integration/nwo/fabricx/network/network_test.go
+++ b/integration/nwo/fabricx/network/network_test.go
@@ -9,7 +9,7 @@ package network
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseNamespaceList(t *testing.T) {
@@ -84,7 +84,7 @@ func TestParseNamespaceList(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			result := parseNamespaceList(tt.output)
-			assert.Equal(t, tt.expected, result)
+			require.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/integration/nwo/fsc/node/node_test.go
+++ b/integration/nwo/fsc/node/node_test.go
@@ -9,7 +9,7 @@ package node
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc/node/fake/sdk1"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc/node/fake/sdk2"
@@ -20,16 +20,16 @@ func TestNode_AddSDKWithBase(t *testing.T) {
 	t.Parallel()
 	node := NewNode("pineapple")
 	n := node.AddSDKWithBase(&sdk1.DummySDK{}, &sdk2.DummySDK{}, &sdk3.DummySDK{})
-	assert.NotNil(t, n)
-	assert.Equal(t, "sdk2.NewFrom(sdk3.NewFrom(sdk1.NewDummySDK(n)))", n.SDKs[0].Type)
+	require.NotNil(t, n)
+	require.Equal(t, "sdk2.NewFrom(sdk3.NewFrom(sdk1.NewDummySDK(n)))", n.SDKs[0].Type)
 
 	node = NewNode("pineapple")
 	n = node.AddSDKWithBase(&sdk1.DummySDK{}, &sdk2.DummySDK{})
-	assert.NotNil(t, n)
-	assert.Equal(t, "sdk2.NewFrom(sdk1.NewDummySDK(n))", n.SDKs[0].Type)
+	require.NotNil(t, n)
+	require.Equal(t, "sdk2.NewFrom(sdk1.NewDummySDK(n))", n.SDKs[0].Type)
 
 	node = NewNode("pineapple")
 	n = node.AddSDKWithBase(&sdk3.DummySDK{})
-	assert.NotNil(t, n)
-	assert.Equal(t, "sdk3.NewDummySDK(n)", n.SDKs[0].Type)
+	require.NotNil(t, n)
+	require.Equal(t, "sdk3.NewDummySDK(n)", n.SDKs[0].Type)
 }

--- a/integration/nwo/fsc/nodecmdpackage_test.go
+++ b/integration/nwo/fsc/nodecmdpackage_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc/node"
@@ -58,7 +57,7 @@ func TestNodeCmdPackage_ResolvesViaGoModRegardlessOfCheckoutDirName(t *testing.T
 	got := p.NodeCmdPackage(replica)
 
 	want := "github.com/LFDT-Panurus/panurus/integration/token/fungible/dlogx/out/cmd/lib-p2p-bootstrap-node"
-	assert.Equal(t, want, got)
+	require.Equal(t, want, got)
 }
 
 func TestNodeCmdPackage_MatchesCanonicalCheckoutDirName(t *testing.T) { //nolint:paralleltest
@@ -77,7 +76,7 @@ func TestNodeCmdPackage_MatchesCanonicalCheckoutDirName(t *testing.T) { //nolint
 	got := p.NodeCmdPackage(replica)
 
 	want := "github.com/LFDT-Panurus/panurus/integration/token/fungible/dlogx/out/cmd/lib-p2p-bootstrap-node"
-	assert.Equal(t, want, got)
+	require.Equal(t, want, got)
 }
 
 func TestNodeCmdPackage_FallsBackWhenNoGoModResolvable(t *testing.T) { //nolint:paralleltest
@@ -95,7 +94,7 @@ func TestNodeCmdPackage_FallsBackWhenNoGoModResolvable(t *testing.T) { //nolint:
 	got := p.NodeCmdPackage(replica)
 
 	want := "./out/cmd/lib-p2p-bootstrap-node"
-	assert.Equal(t, want, got)
+	require.Equal(t, want, got)
 }
 
 func TestGoModuleInfo(t *testing.T) { //nolint:paralleltest
@@ -104,19 +103,19 @@ func TestGoModuleInfo(t *testing.T) { //nolint:paralleltest
 	modPath, modDir, err := goModuleInfo(nested)
 	require.NoError(t, err)
 
-	assert.Equal(t, "github.com/example/proj", modPath)
+	require.Equal(t, "github.com/example/proj", modPath)
 
 	rootDir := filepath.Dir(filepath.Dir(nested)) // strip "pkg/sub"
 	resolvedRoot, err := filepath.EvalSymlinks(rootDir)
 	require.NoError(t, err)
 	resolvedModDir, err := filepath.EvalSymlinks(modDir)
 	require.NoError(t, err)
-	assert.Equal(t, resolvedRoot, resolvedModDir)
+	require.Equal(t, resolvedRoot, resolvedModDir)
 }
 
 func TestGoModuleInfo_ErrorsOutsideModule(t *testing.T) { //nolint:paralleltest
 	dir := t.TempDir()
 
 	_, _, err := goModuleInfo(dir)
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/integration/nwo/fsc/topology_test.go
+++ b/integration/nwo/fsc/topology_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTopology_SetLogging(t *testing.T) {
@@ -79,7 +80,7 @@ func TestNewTopology_DefaultsToWebSocket(t *testing.T) {
 	t.Parallel()
 	// websocket is the primary comm implementation, so a topology that does not
 	// state a transport must get websocket rather than the optional libp2p host.
-	assert.Equal(t, WebSocket, NewTopology().P2PCommunicationType)
+	require.Equal(t, WebSocket, NewTopology().P2PCommunicationType)
 }
 
 func TestPlatform_P2PCommunicationType(t *testing.T) {
@@ -97,7 +98,7 @@ func TestPlatform_P2PCommunicationType(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			p := &Platform{Topology: tt.topology}
-			assert.Equal(t, tt.want, p.P2PCommunicationType())
+			require.Equal(t, tt.want, p.P2PCommunicationType())
 		})
 	}
 }

--- a/platform/common/utils/cache/timeout_test.go
+++ b/platform/common/utils/cache/timeout_test.go
@@ -46,25 +46,25 @@ func TestTimeoutSimple(t *testing.T) {
 	}
 
 	mu.RLock()
-	assert.Empty(t, allEvicted)
-	assert.Equal(t, 5, c.Len())
+	require.Empty(t, allEvicted)
+	require.Equal(t, 5, c.Len())
 	for k, expected := range input {
 		actual, _ := c.Get(k)
-		assert.Equal(t, expected, actual)
+		require.Equal(t, expected, actual)
 	}
 	mu.RUnlock()
 
-	assert.EventuallyWithT(t, func(a *assert.CollectT) {
+	require.EventuallyWithT(t, func(a *assert.CollectT) {
 		// eventually our cache is empty again due to eviction
 		assert.Equal(a, 0, c.Len())
 	}, timeout, tick)
 
 	mu.RLock()
-	assert.Equal(t, input, allEvicted)
+	require.Equal(t, input, allEvicted)
 	mu.RUnlock()
 
 	_, ok := c.Get(1)
-	assert.False(t, ok)
+	require.False(t, ok)
 }
 
 func TestTimeoutParallel(t *testing.T) {
@@ -89,18 +89,18 @@ func TestTimeoutParallel(t *testing.T) {
 	initialLen := c.Len()
 	initialEvicted := int(evictedCount.Load())
 
-	assert.GreaterOrEqual(t, initialLen, 0)
-	assert.LessOrEqual(t, initialLen, numItem)
-	assert.GreaterOrEqual(t, initialEvicted, 0)
-	assert.LessOrEqual(t, initialEvicted, numItem)
+	require.GreaterOrEqual(t, initialLen, 0)
+	require.LessOrEqual(t, initialLen, numItem)
+	require.GreaterOrEqual(t, initialEvicted, 0)
+	require.LessOrEqual(t, initialEvicted, numItem)
 
-	assert.EventuallyWithT(t, func(a *assert.CollectT) {
+	require.EventuallyWithT(t, func(a *assert.CollectT) {
 		// eventually our cache is empty again due to eviction
 		assert.Equal(a, 0, c.Len())
 	}, timeout, tick)
 
 	// once empty evictedCount should match the number of items we cached before
-	assert.Equal(t, numItem, int(evictedCount.Load()))
+	require.Equal(t, numItem, int(evictedCount.Load()))
 }
 
 // TestTimeoutCache_CleanupGoroutineStopsOnCancel asserts the background eviction

--- a/platform/fabric/core/generic/config/ds_test.go
+++ b/platform/fabric/core/generic/config/ds_test.go
@@ -33,9 +33,9 @@ func TestLoad(t *testing.T) {
 
 	b, err := x509.ToBCCSPOpts(network.MSPs[0].Opts[x509.BCCSPOptField])
 	require.NoError(t, err)
-	assert.NotNil(t, b.SW)
+	require.NotNil(t, b.SW)
 	assert.Equal(t, "SHA2", b.SW.Hash)
-	assert.NotNil(t, b.PKCS11)
+	require.NotNil(t, b.PKCS11)
 	assert.Equal(t, 256, b.PKCS11.Security)
 	assert.Equal(t, "ForFSC", b.PKCS11.Label)
 	assert.Equal(t, "98765432", b.PKCS11.Pin)

--- a/platform/fabric/core/generic/finality/committerflm_test.go
+++ b/platform/fabric/core/generic/finality/committerflm_test.go
@@ -9,8 +9,8 @@ package finality
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/finality/fake"
@@ -34,7 +34,7 @@ func TestCommitterFLM(t *testing.T) {
 		mockCommitter, flm := setup()
 		mockCommitter.On("AddFinalityListener", "tx1", mock.Anything).Return(nil).Once()
 		err := flm.AddFinalityListener("", "tx1", &fake.FinalityListener{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("RemoveFinalityListener", func(t *testing.T) {
@@ -42,6 +42,6 @@ func TestCommitterFLM(t *testing.T) {
 		mockCommitter, flm := setup()
 		mockCommitter.On("RemoveFinalityListener", "tx1", mock.Anything).Return(nil).Once()
 		err := flm.RemoveFinalityListener("tx1", &fake.FinalityListener{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }

--- a/platform/fabric/sdk/dig/sdk_test.go
+++ b/platform/fabric/sdk/dig/sdk_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestWiring(t *testing.T) {
 	t.Parallel()
-	assert.NoError(t, sdk.DryRunWiring(NewFrom, sdk.WithBool("fabric.enabled", true)))
+	require.NoError(t, sdk.DryRunWiring(NewFrom, sdk.WithBool("fabric.enabled", true)))
 }
 
 func TestWiring_Disabled(t *testing.T) {

--- a/platform/fabric/services/db/driver/sql/common/kvstore_test_utils.go
+++ b/platform/fabric/services/db/driver/sql/common/kvstore_test_utils.go
@@ -583,9 +583,7 @@ func TTestNonUTF8keys(t *testing.T, db driver.KeyValueStore) {
 		require.NoError(t, err, "%s should be stored (%v)", name, key)
 	}
 	err = db.Commit()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	err = db.BeginUpdate()
 	require.NoError(t, err)
@@ -594,9 +592,7 @@ func TTestNonUTF8keys(t *testing.T, db driver.KeyValueStore) {
 		require.NoError(t, err, "%s should be updated (%v)", name, key)
 	}
 	err = db.Commit()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	for name, key := range utf8 {
 		v, err := db.GetState(context.Background(), ns, string(key))

--- a/platform/view/services/comm/host/websocket/ws/mtls_enforcement_test.go
+++ b/platform/view/services/comm/host/websocket/ws/mtls_enforcement_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/gorilla/websocket"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
 
@@ -68,7 +67,7 @@ func TestMTLSStrictness(t *testing.T) {
 		if resp != nil {
 			_ = resp.Body.Close()
 		}
-		assert.Error(t, err, "Websocket dial should have failed without client certificate")
+		require.Error(t, err, "Websocket dial should have failed without client certificate")
 	})
 
 	t.Run("Untrusted Client Certificate - Connection Rejected", func(t *testing.T) {
@@ -81,7 +80,7 @@ func TestMTLSStrictness(t *testing.T) {
 		if resp != nil {
 			_ = resp.Body.Close()
 		}
-		assert.Error(t, err, "Websocket dial should have failed with untrusted client certificate")
+		require.Error(t, err, "Websocket dial should have failed with untrusted client certificate")
 	})
 
 	t.Run("Expired Certificate - Connection Rejected", func(t *testing.T) {

--- a/platform/view/services/comm/io/streamio/reader_enhanced_test.go
+++ b/platform/view/services/comm/io/streamio/reader_enhanced_test.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -154,20 +153,20 @@ func TestReader_MultipleMessages(t *testing.T) {
 		// Read first part of first message
 		n, err := reader.Read(buf)
 		require.NoError(t, err)
-		assert.Equal(t, 5, n)
-		assert.Equal(t, []byte("messa"), buf)
+		require.Equal(t, 5, n)
+		require.Equal(t, []byte("messa"), buf)
 
 		// Read rest of first message
 		n, err = reader.Read(buf)
 		require.NoError(t, err)
-		assert.Equal(t, 3, n)
-		assert.Equal(t, []byte("ge1"), buf[:n])
+		require.Equal(t, 3, n)
+		require.Equal(t, []byte("ge1"), buf[:n])
 
 		// Read first part of second message
 		n, err = reader.Read(buf)
 		require.NoError(t, err)
-		assert.Equal(t, 5, n)
-		assert.Equal(t, []byte("messa"), buf)
+		require.Equal(t, 5, n)
+		require.Equal(t, []byte("messa"), buf)
 	})
 }
 

--- a/platform/view/services/comm/io/writer_test.go
+++ b/platform/view/services/comm/io/writer_test.go
@@ -77,7 +77,7 @@ func TestVarintWriter_WriteData(t *testing.T) {
 		w := newVarintWriter(&errorWriter{failOn: 0})
 		err := w.WriteData([]byte("test"))
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "could not write message length")
+		require.Contains(t, err.Error(), "could not write message length")
 	})
 
 	t.Run("write error on data", func(t *testing.T) {

--- a/platform/view/services/config/config_util_test.go
+++ b/platform/view/services/config/config_util_test.go
@@ -68,7 +68,7 @@ test:
 	assert.Equal(t, []string{"a", "b", "c"}, ts.Slice)
 	assert.Equal(t, uint32(10*1024*1024), ts.Size)
 	assert.Equal(t, "hello world", ts.Content)
-	assert.Len(t, ts.Certs, 1)
+	require.Len(t, ts.Certs, 1)
 	assert.Contains(t, ts.Certs[0], "BEGIN CERTIFICATE")
 	assert.Equal(t, 10*time.Second, ts.Duration)
 

--- a/platform/view/services/config/provider_test.go
+++ b/platform/view/services/config/provider_test.go
@@ -94,7 +94,7 @@ func TestEnvSubstitution(t *testing.T) { //nolint:paralleltest
 	var c map[string]any
 	err = p.UnmarshalKey("fsc.kvs", &c)
 	require.NoError(t, err)
-	assert.NotNil(t, c["keyexists"])
+	require.NotNil(t, c["keyexists"])
 	assert.True(t, c["keyexists"].(bool))
 
 	assert.Equal(t, "new", p.GetString("non.existent.key"))

--- a/platform/view/services/endpoint/pki_test.go
+++ b/platform/view/services/endpoint/pki_test.go
@@ -17,7 +17,6 @@ import (
 	"crypto/x509"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/endpoint"
@@ -42,13 +41,13 @@ func TestDefaultPublicKeyIDSynthesizer_PublicKeyID(t *testing.T) {
 		// Verify it's deterministic
 		pkID2, err := synthesizer.PublicKeyID(&privateKey.PublicKey)
 		require.NoError(t, err)
-		assert.Equal(t, pkID, pkID2)
+		require.Equal(t, pkID, pkID2)
 
 		// Verify it's actually the hash of the marshaled key
 		raw, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
 		require.NoError(t, err)
 		expectedHash := sha256.Sum256(raw)
-		assert.Equal(t, expectedHash[:], pkID)
+		require.Equal(t, expectedHash[:], pkID)
 	})
 
 	t.Run("ECDSA public key", func(t *testing.T) {
@@ -66,7 +65,7 @@ func TestDefaultPublicKeyIDSynthesizer_PublicKeyID(t *testing.T) {
 		// Verify it's deterministic
 		pkID2, err := synthesizer.PublicKeyID(&privateKey.PublicKey)
 		require.NoError(t, err)
-		assert.Equal(t, pkID, pkID2)
+		require.Equal(t, pkID, pkID2)
 	})
 
 	t.Run("different keys produce different IDs", func(t *testing.T) {
@@ -82,7 +81,7 @@ func TestDefaultPublicKeyIDSynthesizer_PublicKeyID(t *testing.T) {
 		pkID2, err := synthesizer.PublicKeyID(&key2.PublicKey)
 		require.NoError(t, err)
 
-		assert.NotEqual(t, pkID1, pkID2)
+		require.NotEqual(t, pkID1, pkID2)
 	})
 
 	t.Run("unsupported key type", func(t *testing.T) {
@@ -90,7 +89,7 @@ func TestDefaultPublicKeyIDSynthesizer_PublicKeyID(t *testing.T) {
 		// Test with unsupported key type
 		_, err := synthesizer.PublicKeyID("not a key")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "x509:")
+		require.Contains(t, err.Error(), "x509:")
 	})
 
 	t.Run("nil key", func(t *testing.T) {
@@ -104,6 +103,6 @@ func TestDefaultPublicKeyIDSynthesizer_PublicKeyID(t *testing.T) {
 		// This should fail as x509.MarshalPKIXPublicKey doesn't support []byte
 		_, err := synthesizer.PublicKeyID([]byte("some bytes"))
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "unsupported public key type")
+		require.Contains(t, err.Error(), "unsupported public key type")
 	})
 }

--- a/platform/view/services/endpoint/service_extended_test.go
+++ b/platform/view/services/endpoint/service_extended_test.go
@@ -41,7 +41,7 @@ func TestBind(t *testing.T) {
 		err = service.Bind(context.Background(), longTerm, ephemeral)
 		require.NoError(t, err)
 
-		assert.Equal(t, 1, bindingStore.PutBindingsCallCount())
+		require.Equal(t, 1, bindingStore.PutBindingsCallCount())
 		ctx, lt, ephs := bindingStore.PutBindingsArgsForCall(0)
 		assert.NotNil(t, ctx)
 		assert.Equal(t, longTerm, lt)
@@ -64,7 +64,7 @@ func TestBind(t *testing.T) {
 		err = service.Bind(context.Background(), longTerm, ephemeral1, ephemeral2, ephemeral3)
 		require.NoError(t, err)
 
-		assert.Equal(t, 1, bindingStore.PutBindingsCallCount())
+		require.Equal(t, 1, bindingStore.PutBindingsCallCount())
 		_, _, ephs := bindingStore.PutBindingsArgsForCall(0)
 		assert.Equal(t, []view.Identity{ephemeral1, ephemeral2, ephemeral3}, ephs)
 	})
@@ -85,7 +85,7 @@ func TestBind(t *testing.T) {
 		err = service.Bind(context.Background(), longTerm, ephemeral1, ephemeral2, ephemeral3)
 		require.NoError(t, err)
 
-		assert.Equal(t, 1, bindingStore.PutBindingsCallCount())
+		require.Equal(t, 1, bindingStore.PutBindingsCallCount())
 		_, _, ephs := bindingStore.PutBindingsArgsForCall(0)
 		// ephemeral2 should be filtered out
 		assert.Equal(t, []view.Identity{ephemeral1, ephemeral3}, ephs)
@@ -158,7 +158,7 @@ func TestIsBoundTo(t *testing.T) {
 		result := service.IsBoundTo(context.Background(), id1, id2)
 		assert.True(t, result)
 
-		assert.Equal(t, 1, bindingStore.HaveSameBindingCallCount())
+		require.Equal(t, 1, bindingStore.HaveSameBindingCallCount())
 		ctx, a, b := bindingStore.HaveSameBindingArgsForCall(0)
 		assert.NotNil(t, ctx)
 		assert.Equal(t, id1, a)

--- a/platform/view/services/events/subscribers_test.go
+++ b/platform/view/services/events/subscribers_test.go
@@ -9,7 +9,7 @@ package events_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/events"
 )
@@ -34,10 +34,10 @@ func TestSubscribers(t *testing.T) {
 	s.Set("1", b, a)
 
 	b1, ok := s.Get("0", a)
-	assert.True(t, ok)
-	assert.Equal(t, b, b1)
+	require.True(t, ok)
+	require.Equal(t, b, b1)
 
 	b1, ok = s.Get("0", b)
-	assert.False(t, ok)
-	assert.Nil(t, b1)
+	require.False(t, ok)
+	require.Nil(t, b1)
 }

--- a/platform/view/services/grpc/config_test.go
+++ b/platform/view/services/grpc/config_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
 )
@@ -72,7 +73,7 @@ func TestClientConfigClone(t *testing.T) {
 	clone := origin.Clone()
 
 	// Same content, different inner fields references.
-	assert.Equal(t, origin, clone)
+	require.Equal(t, origin, clone)
 
 	// We change the contents of the fields and ensure it doesn't
 	// propagate across instances.
@@ -106,6 +107,6 @@ func TestClientConfigClone(t *testing.T) {
 		Timeout: time.Second,
 	}
 
-	assert.Equal(t, expectedOriginState, origin)
-	assert.Equal(t, expectedCloneState, clone)
+	require.Equal(t, expectedOriginState, origin)
+	require.Equal(t, expectedCloneState, clone)
 }

--- a/platform/view/services/grpc/server_test.go
+++ b/platform/view/services/grpc/server_test.go
@@ -846,9 +846,7 @@ func TestWithSignedIntermediateCertificates(t *testing.T) {
 		},
 	})
 	// check for error
-	if err != nil {
-		t.Fatalf("Failed to return new GRPC server: %v", err)
-	}
+	require.NoError(t, err, "Failed to return new GRPC server")
 
 	// register the GRPC test server
 	testpb.RegisterEmptyServiceServer(srv.Server(), &emptyServiceServer{})

--- a/platform/view/services/storage/driver/sql/sqlite/binding_test.go
+++ b/platform/view/services/storage/driver/sql/sqlite/binding_test.go
@@ -11,7 +11,7 @@ import (
 	"path"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/common"
@@ -27,7 +27,7 @@ func newBindingStoreForTests(tb testing.TB) *BindingStore {
 	dbs := utils.MustGet(open(o))
 	tables := common.GetTableNames(o.TablePrefix, o.TableNameParams...)
 	db := buildBindingStore(dbs.ReadDB, dbs.WriteDB, tables.Binding)
-	assert.NoError(tb, db.CreateSchema())
+	require.NoError(tb, db.CreateSchema())
 	return db
 }
 

--- a/platform/view/services/storage/driver/sql/sqlite/sql_test.go
+++ b/platform/view/services/storage/driver/sql/sqlite/sql_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	_ "modernc.org/sqlite"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
@@ -27,13 +28,13 @@ func TestSqlite(t *testing.T) {
 	}
 	common.TestCases(t, func(_ string) (driver.KeyValueStore, error) {
 		p, err := NewKeyValueStore(utils.MustGet(open(o)), common.GetTableNames(o.TablePrefix, o.TableNameParams...))
-		assert.NoError(t, err)
-		assert.NoError(t, p.CreateSchema())
+		require.NoError(t, err)
+		require.NoError(t, p.CreateSchema())
 		return p, nil
 	}, func(_ string) (driver.UnversionedNotifier, error) {
 		p, err := NewKeyValueStoreNotifier(utils.MustGet(open(o)), "test")
-		assert.NoError(t, err)
-		assert.NoError(t, p.Persistence.(*KeyValueStore).CreateSchema())
+		require.NoError(t, err)
+		require.NoError(t, p.Persistence.(*KeyValueStore).CreateSchema())
 		return p, nil
 	}, func(p driver.KeyValueStore) *common.KeyValueStore {
 		return p.(*KeyValueStore).KeyValueStore

--- a/platform/view/services/view/sessions_test.go
+++ b/platform/view/services/view/sessions_test.go
@@ -9,7 +9,7 @@ package view
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
@@ -30,18 +30,18 @@ func TestSessions(t *testing.T) {
 	sess := &simpleSession{id: "s1"}
 
 	s.Put("v1", party, sess)
-	assert.Equal(t, sess, s.Get("v1", party))
+	require.Equal(t, sess, s.Get("v1", party))
 
 	s.Delete("v1", party)
-	assert.Nil(t, s.Get("v1", party))
+	require.Nil(t, s.Get("v1", party))
 
 	s.PutDefault(party, sess)
-	assert.Equal(t, sess, s.Get("", party))
+	require.Equal(t, sess, s.Get("", party))
 
 	ids := s.GetSessionIDs()
-	assert.Len(t, ids, 1)
-	assert.Equal(t, "s1", ids[0])
+	require.Len(t, ids, 1)
+	require.Equal(t, "s1", ids[0])
 
 	s.Reset()
-	assert.Empty(t, s.GetSessionIDs())
+	require.Empty(t, s.GetSessionIDs())
 }


### PR DESCRIPTION
Converts `testify/assert` to `testify/require` wherever a failed check would make the rest of the test meaningless: a later line indexes, dereferences, or type-asserts the value just checked, or a later step only makes sense once this one succeeded. Also folds in the handful of manual `if err != nil { t.Fatalf(...) }` patterns that are really the same check spelled out by hand, converting those to `require.NoError` too.

### Scoping

72 files in the repo import `testify/assert`. 12 changed; the rest already split correctly, or their `assert.X` calls exist for a specific reason:
- **Off the test's main goroutine.** `require`'s `t.FailNow()` calls `runtime.Goexit()`, which is unsafe from anywhere but the test's own goroutine. A call inside a spawned `go func()`, `wg.Go()`, or an `httptest` handler closure has to stay `assert`.
- **Inside an `EventuallyWithT` callback.** Its signature is fixed as `func(c *assert.CollectT)` — testify never defined a `require.CollectT` — so those calls stay `assert.X` no matter which outer function, `assert.EventuallyWithT` or `require.EventuallyWithT`, was used.
- **Genuinely independent checks**, mostly table-driven tests verifying several unrelated fields, where seeing every failure in one run beats stopping at the first.

Wrote the resulting rule down in a new `docs/dev/testing.md` (a testing best-practices doc), linked from `docs/agents/testing.md` and from `AGENTS.md`'s "Where to look next" table, so it outlives this PR.

### Verification

`go build`, `go vet`, and a targeted `go test` across every touched package pass clean in both the root and `integration` modules.

### Note for reviewers

This PR carries only the `testify` changes and the new testing-best-practices doc. It's cut from a larger internal cleanup pass that also retired a couple of unrelated helper functions; those aren't included here since they're unrelated to `assert`/`require`.