### PR TITLE
fix(fabric): bound the remote finality probe by the caller's context

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -583,6 +583,10 @@ fabric:
         numRetries: 3 # number of retries on a chaincode operation failure
         retrySleep: 1s # waiting time before retry again a failed chaincode operation
         # section about the finality service
+        # The remote peer probe and the local event wait run in sequence, so
+        # finality.waitForEventTimeout and committer.waitForEventTimeout add up
+        # rather than being alternatives: size a caller's context for the sum.
+        # Both are ceilings under the caller's context, which wins when shorter.
         finality:
           waitForEventTimeout: 20s
           forPartiesWaitTimeout: 1m

--- a/platform/fabric/core/generic/committer/committer.go
+++ b/platform/fabric/core/generic/committer/committer.go
@@ -56,7 +56,7 @@ type (
 )
 
 type FabricFinality interface {
-	IsFinal(txID string) error
+	IsFinal(ctx context.Context, txID string) error
 }
 
 type CommitTx struct {
@@ -395,7 +395,7 @@ func (c *Committer) IsFinal(ctx context.Context, txID string) error {
 			if logger.IsEnabledFor(zapcore.DebugLevel) {
 				c.logger.Debugf("Tx [%s] is unknown with no deps, remote check [%d][%s]", txID, iter, debug.Stack())
 			}
-			err := c.FabricFinality.IsFinal(txID)
+			err := c.FabricFinality.IsFinal(ctx, txID)
 			if err == nil {
 				c.logger.Debugf("Tx [%s] is final, remote check succeeded", txID)
 				return nil

--- a/platform/fabric/core/generic/committer/fake/fakes.go
+++ b/platform/fabric/core/generic/committer/fake/fakes.go
@@ -310,7 +310,7 @@ type FabricFinality struct {
 	Err error
 }
 
-func (f *FabricFinality) IsFinal(string) error {
+func (f *FabricFinality) IsFinal(context.Context, string) error {
 	return f.Err
 }
 

--- a/platform/fabric/core/generic/finality/fabric.go
+++ b/platform/fabric/core/generic/finality/fabric.go
@@ -63,10 +63,12 @@ func NewFabricFinality(
 
 // IsFinal probes a peer configured for finality for the given transaction,
 // returning an error if no peer is configured for that role.
-func (d *FabricFinality) IsFinal(txID string) error {
+//
+// ctx bounds the whole probe: WaitForEventTimeout applies as a ceiling on top of
+// it, so an earlier caller deadline wins.
+func (d *FabricFinality) IsFinal(ctx context.Context, txID string) error {
 	d.Logger.Debugf("remote checking if transaction [%s] is final in channel [%s]", txID, d.Channel)
 	var eventCh chan delivery.TxEvent
-	var ctx context.Context
 	var cancelFunc context.CancelFunc
 
 	peerConnConf := d.ConfigService.PickPeer(driver.PeerForFinality)
@@ -86,7 +88,7 @@ func (d *FabricFinality) IsFinal(txID string) error {
 		return errors.WithMessagef(err, "failed creating deliver client for address [%s]", address)
 	}
 
-	ctx, cancelFunc = context.WithTimeout(context.Background(), d.WaitForEventTimeout)
+	ctx, cancelFunc = context.WithTimeout(ctx, d.WaitForEventTimeout)
 	defer cancelFunc()
 	var deliverStream delivery.DeliverFiltered
 	if d.useFiltered {

--- a/platform/fabric/core/generic/finality/fabric_test.go
+++ b/platform/fabric/core/generic/finality/fabric_test.go
@@ -247,7 +247,7 @@ func TestFabricFinality_IsFinal(t *testing.T) {
 				}
 			}
 
-			err = f.IsFinal("tx1")
+			err = f.IsFinal(t.Context(), "tx1")
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.expectedError != "" {
@@ -282,7 +282,57 @@ func TestFabricFinality_IsFinal_noPeerConfigured(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotPanics(t, func() {
-		err := f.IsFinal("tx1")
+		err := f.IsFinal(t.Context(), "tx1")
 		require.ErrorContains(t, err, "no peer configured for finality")
 	})
+}
+
+// The caller's context bounds the probe. WaitForEventTimeout is generous here
+// and the peer never delivers, so a call that honours a 100ms context returns
+// promptly while one bounded only by WaitForEventTimeout does not.
+func TestFabricFinality_IsFinal_honoursCallerContext(t *testing.T) {
+	t.Parallel()
+
+	mockConfig := &fake.ConfigService{}
+	mockConfig.On("PickPeer", mock.Anything).Return(&viewgrpc.ConnectionConfig{Address: "peer1"})
+
+	mockPeerClient := &fake.PeerClient{}
+	mockPeerClient.On("Close").Return()
+	mockPeerClient.On("Certificate").Return(tls.Certificate{})
+	mockPeerClient.On("Address").Return("peer1")
+
+	mockDeliverClient := &fake.DeliverClient{}
+	mockPeerClient.On("DeliverClient").Return(mockDeliverClient, nil)
+
+	mockStream := &fake.DeliverFilteredStream{}
+	mockDeliverClient.On("DeliverFiltered", mock.Anything, mock.Anything).Return(mockStream, nil)
+	mockStream.On("CloseSend").Return(nil)
+	mockStream.On("Send", mock.Anything).Return(nil)
+	// The peer accepts the seek and then goes quiet: only a context ends the wait.
+	mockStream.On("Recv").Return(nil, context.DeadlineExceeded).After(30 * time.Second)
+
+	mockIdentity := &fake.SigningIdentity{}
+	mockIdentity.On("Serialize").Return([]byte("creator"), nil)
+	mockIdentity.On("Sign", mock.Anything).Return([]byte("signature"), nil)
+
+	mockServices := &fake.Services{}
+	mockServices.On("NewPeerClient", mock.Anything).Return(mockPeerClient, nil)
+
+	f, err := NewFabricFinality(
+		logging.MustGetLogger("test"), "testchannel",
+		mockConfig, mockServices, mockIdentity,
+		30*time.Second, true,
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err = f.IsFinal(ctx, "tx1")
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Less(t, elapsed, 5*time.Second,
+		"took %s: the caller's 100ms context must bound the probe, not WaitForEventTimeout", elapsed)
 }


### PR DESCRIPTION
### Description

`Committer.IsFinal(ctx, txID)` documents the caller's context as bounding the whole wait, and its local status check and its `listenTo` wait both honour it. The remote peer probe did not: `FabricFinality.IsFinal` built its own context from `context.Background()` (`finality/fabric.go:89`), so the probe ran its full `finality.waitForEventTimeout` regardless of the caller's deadline, and cancelling the caller's context did not reach it. A caller with a 5s deadline on a channel configured `waitForEventTimeout: 120s` blocked for ~120s and then returned a deadline error indistinguishable from a slow orderer.

- Threads the context through `committer.FabricFinality` (`committer.go:59`), its call site (`committer.go:398`), the implementation, and the test fake, and derives the probe's context from it: `context.WithTimeout(ctx, d.WaitForEventTimeout)`. `WaitForEventTimeout` stays a ceiling that an earlier caller deadline wins against.
- The derived context reaches both the Deliver stream (`NewDeliver`/`NewDeliverFiltered`, which pass it to the gRPC call) and `DeliverWaitForResponse`, so a cancelled caller tears the stream down instead of leaving it running to its own budget.
- `docs/configuration.md`: records that the probe and the local event wait run in sequence, so `finality.waitForEventTimeout` and `committer.waitForEventTimeout` add up rather than being alternatives — 320s at the defaults. Sizing a caller's context as if they were alternatives under-provisions it.

Compatibility: `committer.FabricFinality` is exported but consumed only in-tree — `channelprovider.go`, the committer itself, the dig provider at `providers.go:149`, and a test fake. The public `driver.Finality.IsFinal(ctx, txID)` already carries a context and is untouched, so this brings the internal seam into line with it. Panurus does not reference `FabricFinality`; it reaches finality through `ch.Finality()`.

Closes #1735.

### Test plan

- [x] `finality/fabric_test.go`: a peer that accepts the seek and then goes quiet, `WaitForEventTimeout` at 30s, caller context at 100ms — asserts the call returns in under 5s.
- [x] Mutation-checked: restoring `context.Background()` on that one line makes the same test take **30.00s** while ignoring the 100ms deadline, so the assertion is load-bearing.
- [x] `-count=5` on the new test — stable; the 5s bound against a 100ms deadline leaves margin for loaded CI.
- [x] `go test -race` across `committer`, `finality`, `delivery`, and `platform/fabricx/...` (which has its own `IsFinal` implementations) — all pass.
- [x] `integration/` module builds (separate `go.mod`).
- [x] `golangci-lint run platform/fabric/...` — 0 issues.
- [x] `gofmt`, `go vet`, `go build ./...` clean.
- [x] Full `platform/fabric/...` passes except the two Postgres tests needing a local Docker daemon, which fail identically on an unmodified tree.
